### PR TITLE
Modify to read envvar SPIDER_URL

### DIFF
--- a/mcism_server/mcir_image.go
+++ b/mcism_server/mcir_image.go
@@ -215,7 +215,7 @@ func registerImageWithName(nsId string, u *imageReq) (imageInfo, error) {
 	tempReq.Id = u.CspImageId
 
 	// Step 2. Send a req to Spider and save the response.
-	url := "https://testapi.io/api/jihoon-seo/vmimage?connection_name=" + u.ConnectionName
+	url := SPIDER_URL + "/vmimage?connection_name=" + u.ConnectionName
 
 	method := "POST"
 

--- a/mcism_server/mcir_network.go
+++ b/mcism_server/mcir_network.go
@@ -212,7 +212,7 @@ func createNetwork(nsId string, u *networkReq) (networkInfo, error) {
 	// port := "80"
 	// url := ip + ":" + port + "/vnetwork"
 
-	url := "https://testapi.io/api/jihoon-seo/vnetwork?connection_name=" + u.ConnectionName
+	url := SPIDER_URL + "/vnetwork?connection_name=" + u.ConnectionName
 
 	method := "POST"
 
@@ -348,7 +348,7 @@ func delNetwork(nsId string, Id string) error {
 	fmt.Println("temp.CspNetworkId: " + temp.CspNetworkId)
 
 	//url := "https://testapi.io/api/jihoon-seo/vnetwork/" + temp.CspNetworkId + "?connection_name=" + temp.ConnectionName // for CB-Spider
-	url := "https://testapi.io/api/jihoon-seo/vnetwork?connection_name=" + temp.ConnectionName // for testapi.io
+	url := SPIDER_URL + "/vnetwork?connection_name=" + temp.ConnectionName // for testapi.io
 	fmt.Println("url: " + url)
 
 	method := "DELETE"

--- a/mcism_server/mcir_publicip.go
+++ b/mcism_server/mcir_publicip.go
@@ -200,7 +200,7 @@ func createPublicIp(nsId string, u *publicIpReq) (publicIpInfo, error) {
 	}
 	*/
 
-	url := "https://testapi.io/api/jihoon-seo/publicip?connection_name=" + u.ConnectionName
+	url := SPIDER_URL + "/publicip?connection_name=" + u.ConnectionName
 
 	method := "POST"
 
@@ -342,7 +342,7 @@ func delPublicIp(nsId string, Id string) error {
 	fmt.Println("temp.CspPublicIpName: " + temp.CspPublicIpName) // Identifier is subject to change.
 
 	//url := "https://testapi.io/api/jihoon-seo/publicip/" + temp.CspPublicIpName + "?connection_name=" + temp.ConnectionName // for CB-Spider
-	url := "https://testapi.io/api/jihoon-seo/publicip?connection_name=" + temp.ConnectionName // for testapi.io
+	url := SPIDER_URL + "/publicip?connection_name=" + temp.ConnectionName // for testapi.io
 	fmt.Println("url: " + url)
 
 	method := "DELETE"

--- a/mcism_server/mcir_securitygroup.go
+++ b/mcism_server/mcir_securitygroup.go
@@ -218,7 +218,7 @@ func createSecurityGroup(nsId string, u *securityGroupReq) (securityGroupInfo, e
 	}
 	*/
 
-	url := "https://testapi.io/api/jihoon-seo/securitygroup?connection_name=" + u.ConnectionName
+	url := SPIDER_URL + "/securitygroup?connection_name=" + u.ConnectionName
 
 	method := "POST"
 
@@ -363,7 +363,7 @@ func delSecurityGroup(nsId string, Id string) error {
 	fmt.Println("temp.CspSecurityGroupId: " + temp.CspSecurityGroupId)
 
 	//url := "https://testapi.io/api/jihoon-seo/securitygroup/" + temp.CspSecurityGroupId + "?connection_name=" + temp.ConnectionName // for CB-Spider
-	url := "https://testapi.io/api/jihoon-seo/securitygroup?connection_name=" + temp.ConnectionName // for testapi.io
+	url := SPIDER_URL + "/securitygroup?connection_name=" + temp.ConnectionName // for testapi.io
 	fmt.Println("url: " + url)
 
 	method := "DELETE"

--- a/mcism_server/mcir_sshkey.go
+++ b/mcism_server/mcir_sshkey.go
@@ -197,7 +197,7 @@ func createSshKey(nsId string, u *sshKeyReq) (sshKeyInfo, error) {
 	}
 	*/
 
-	url := "https://testapi.io/api/jihoon-seo/keypair?connection_name=" + u.ConnectionName
+	url := SPIDER_URL + "/keypair?connection_name=" + u.ConnectionName
 
 	method := "POST"
 
@@ -329,7 +329,7 @@ func delSshKey(nsId string, Id string) error {
 	fmt.Println("temp.CspSshKeyName: " + temp.CspSshKeyName)
 
 	//url := "https://testapi.io/api/jihoon-seo/keypair/" + temp.CspSshKeyName + "?connection_name=" + temp.ConnectionName // for CB-Spider
-	url := "https://testapi.io/api/jihoon-seo/keypair?connection_name=" + temp.ConnectionName // for testapi.io
+	url := SPIDER_URL + "/keypair?connection_name=" + temp.ConnectionName // for testapi.io
 	fmt.Println("url: " + url)
 
 	method := "DELETE"

--- a/mcism_server/mcir_vnic.go
+++ b/mcism_server/mcir_vnic.go
@@ -209,7 +209,7 @@ func createVNic(nsId string, u *vNicReq) (vNicInfo, error) {
 	}
 	*/
 
-	url := "https://testapi.io/api/jihoon-seo/vnic?connection_name=" + u.ConnectionName
+	url := SPIDER_URL + "/vnic?connection_name=" + u.ConnectionName
 
 	method := "POST"
 
@@ -394,7 +394,7 @@ func delVNic(nsId string, Id string) error {
 	fmt.Println("temp.CspVNicId: " + temp.CspVNicId)
 
 	//url := "https://testapi.io/api/jihoon-seo/vnic/" + temp.CspVNicId + "?connection_name=" + temp.ConnectionName // for CB-Spider
-	url := "https://testapi.io/api/jihoon-seo/vnic?connection_name=" + temp.ConnectionName // for testapi.io
+	url := SPIDER_URL + "/vnic?connection_name=" + temp.ConnectionName // for testapi.io
 	fmt.Println("url: " + url)
 
 	method := "DELETE"

--- a/mcism_server/mcism_mcis.go
+++ b/mcism_server/mcism_mcis.go
@@ -996,7 +996,7 @@ func createVm(vmInfoData vmInfo) ([]*string, []*string) {
 	}
 	*/
 
-	url := "https://testapi.io/api/jihoon-seo/vm?connection_name=" + vmInfoData.ConnectionName
+	url := SPIDER_URL + "/vm?connection_name=" + vmInfoData.ConnectionName
 
 	method := "POST"
 
@@ -1622,7 +1622,7 @@ func terminateVm(nsId string, mcisId string, vmId string) error {
 	fmt.Println("temp.CspVmId: " + temp.CspVmId)
 
 	//url := "https://testapi.io/api/jihoon-seo/vm/" + temp.CspVmId + "?connection_name=" + temp.ConnectionName // for CB-Spider
-	url := "https://testapi.io/api/jihoon-seo/vm?connection_name=" + temp.ConnectionName // for testapi.io
+	url := SPIDER_URL + "/vm?connection_name=" + temp.ConnectionName // for testapi.io
 	fmt.Println("url: " + url)
 
 	method := "DELETE"

--- a/mcism_server/mcism_server.go
+++ b/mcism_server/mcism_server.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/cloud-barista/cb-tumblebug/mcism_server/confighandler"
 
 	"fmt"
@@ -136,11 +138,15 @@ func apiServer() {
 
 }
 
+var SPIDER_URL string
+
 func main() {
 
 	fmt.Println("\n[cb-tumblebug (Multi-Cloud Infra Service Management Framework)]")
 	fmt.Println("\nInitiating REST API Server ...")
 	fmt.Println("\n[REST API call examples]")
+
+	SPIDER_URL = os.Getenv("SPIDER_URL")
 
 	/*
 		fmt.Println("[List MCISs]:\t\t curl <ServerIP>:1323/mcis")


### PR DESCRIPTION
How to run CB-Tumblebug:

1. Set some envvars.
```Shell
export CBSTORE_ROOT=~/go/src/github.com/cloud-barista/cb-store
export CBLOG_ROOT=~/go/src/github.com/cloud-barista/cb-store
export MCISM_SERVER=~/go/src/github.com/cloud-barista/cb-tumblebug/mcism_server
export SPIDER_URL=https://testapi.io/api/jihoon-seo
```

2. Run `mcism_server`
```
./mcism_server
```

---

FYI: https://testapi.io/api/jihoon-seo/* returns some mock API results for MCIRs and VM.
- VM and VM status
1. https://testapi.io/api/jihoon-seo/vm
2. https://testapi.io/api/jihoon-seo/vmstatus
- MCIRs
3. https://testapi.io/api/jihoon-seo/keypair
4. https://testapi.io/api/jihoon-seo/securitygroup
5. https://testapi.io/api/jihoon-seo/vnic
6. https://testapi.io/api/jihoon-seo/publicip
7. https://testapi.io/api/jihoon-seo/vmimage
8. https://testapi.io/api/jihoon-seo/vnetwork

---

Ref:
1. https://github.com/cloud-barista/cb-spider/tree/master/cloud-control-manager/cloud-driver/interfaces/resources
2. https://documenter.getpostman.com/view/9027676/SVtSXpzE