### PR TITLE
Add file for setup environment config

### DIFF
--- a/setup.env
+++ b/setup.env
@@ -1,0 +1,4 @@
+export CBSTORE_ROOT=~/go/src/github.com/cloud-barista/cb-store
+export CBLOG_ROOT=~/go/src/github.com/cloud-barista/cb-store
+export MCISM_SERVER=~/go/src/github.com/cloud-barista/cb-tumblebug/mcism_server
+export SPIDER_URL=https://testapi.io/api/jihoon-seo


### PR DESCRIPTION
Add file for setup environment config

setup.env includes following environment variables. 

```
export CBSTORE_ROOT=~/go/src/github.com/cloud-barista/cb-store
export CBLOG_ROOT=~/go/src/github.com/cloud-barista/cb-store
export MCISM_SERVER=~/go/src/github.com/cloud-barista/cb-tumblebug/mcism_server
export SPIDER_URL=https://testapi.io/api/jihoon-seo
```