### PR TITLE
Apply changes for API prefix addition of Spider and TB

### DIFF
--- a/conf/setup.env
+++ b/conf/setup.env
@@ -1,3 +1,3 @@
 export CBSTORE_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
 export CBLOG_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
-export SPIDER_URL=http://localhost:1024
+export SPIDER_URL=http://localhost:1024/spider

--- a/src/apiserver/apiserver.go
+++ b/src/apiserver/apiserver.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/common"
 	"github.com/cloud-barista/cb-tumblebug/src/mcir"
 	"github.com/cloud-barista/cb-tumblebug/src/mcis"
-	
+
 	//"os"
 
 	"fmt"
@@ -90,7 +90,6 @@ func ApiServer() {
 		AllowMethods: []string{http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete},
 	}))
 
-
 	fmt.Println("")
 	fmt.Println("")
 	fmt.Println("")
@@ -104,7 +103,7 @@ func ApiServer() {
 	fmt.Println("")
 
 	// Route
-	g := e.Group("/ns", common.NsValidation())
+	g := e.Group("/tumblebug/ns", common.NsValidation())
 
 	g.POST("", common.RestPostNs)
 	g.GET("/:nsId", common.RestGetNs)

--- a/src/mcir/common.go
+++ b/src/mcir/common.go
@@ -1,13 +1,13 @@
 package mcir
 
 import (
-	"strings"
-	"strconv"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
-	"fmt"
-	"encoding/json"
 	"os"
+	"strconv"
+	"strings"
 
 	//uuid "github.com/google/uuid"
 	"github.com/cloud-barista/cb-tumblebug/src/common"
@@ -121,9 +121,9 @@ func delResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the resource with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the resource with given UUID."}
 		mapB, _ := json.Marshal(mapA)
-		err := fmt.Errorf("Failed to find the resource with give UUID.")
+		err := fmt.Errorf("Failed to find the resource with given UUID.")
 		return http.StatusNotFound, mapB, err
 	}
 	//fmt.Println("keyValue: " + keyValue.Key + " / " + keyValue.Value)
@@ -143,7 +143,7 @@ func delResource(nsId string, resourceType string, resourceId string, forceFlag 
 		return http.StatusOK, nil, nil
 	case "spec":
 		// delete spec info
-	
+
 		//get related recommend spec
 		keyValue, err := store.Get(key)
 		content := specInfo{}
@@ -293,7 +293,7 @@ func delResourceById(nsId string, resourceType string, resourceId string, forceF
 		return http.StatusOK, nil, nil
 	case "spec":
 		// delete spec info
-	
+
 		//get related recommend spec
 		keyValue, err := store.Get(key)
 		content := specInfo{}
@@ -418,7 +418,7 @@ func delResourceByName(nsId string, resourceType string, resourceId string, forc
 		return http.StatusOK, nil, nil
 	case "spec":
 		// delete spec info
-	
+
 		//get related recommend spec
 		keyValue, err := store.Get(key)
 		content := specInfo{}
@@ -535,7 +535,7 @@ func getResourceList(nsId string, resourceType string) []string {
 	} else {
 		return []string{"invalid resource type"}
 	}
-	
+
 	fmt.Println("[Get " + resourceType + " list")
 	key := "/ns/" + nsId + "/resources/" + resourceType
 	fmt.Println(key)
@@ -544,7 +544,7 @@ func getResourceList(nsId string, resourceType string) []string {
 	var resourceList []string
 	for _, v := range keyValue {
 		//if !strings.Contains(v.Key, "vm") {
-			resourceList = append(resourceList, strings.TrimPrefix(v.Key, "/ns/"+nsId+"/resources/" + resourceType + "/"))
+		resourceList = append(resourceList, strings.TrimPrefix(v.Key, "/ns/"+nsId+"/resources/"+resourceType+"/"))
 		//}
 	}
 	for _, v := range resourceList {

--- a/src/mcir/image.go
+++ b/src/mcir/image.go
@@ -55,14 +55,14 @@ type imageReq struct {
 }
 
 type imageInfo struct {
-	Id             string     `json:"id"`
-	ConnectionName string     `json:"connectionName"`
-	CspImageId     string     `json:"cspImageId"`
-	CspImageName   string     `json:"cspImageName"`
-	CreationDate   string     `json:"creationDate"`
-	Description    string     `json:"description"`
-	GuestOS        string     `json:"guestOS"` // Windows7, Ubuntu etc.
-	Status         string     `json:"status"`  // available, unavailable
+	Id             string            `json:"id"`
+	ConnectionName string            `json:"connectionName"`
+	CspImageId     string            `json:"cspImageId"`
+	CspImageName   string            `json:"cspImageName"`
+	CreationDate   string            `json:"creationDate"`
+	Description    string            `json:"description"`
+	GuestOS        string            `json:"guestOS"` // Windows7, Ubuntu etc.
+	Status         string            `json:"status"`  // available, unavailable
 	KeyValueList   []common.KeyValue `json:"keyValueList"`
 }
 
@@ -131,7 +131,7 @@ func RestGetImage(c echo.Context) error {
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the image with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the image with given UUID."}
 		return c.JSON(http.StatusNotFound, &mapA)
 	} else {
 		fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
@@ -186,7 +186,7 @@ func RestDelImage(c echo.Context) error {
 	forceFlag := c.QueryParam("force")
 
 	//responseCode, _, err := delImage(nsId, id, forceFlag)
-	
+
 	responseCode, _, err := delResource(nsId, "image", id, forceFlag)
 	if err != nil {
 		cblog.Error(err)

--- a/src/mcir/network.go
+++ b/src/mcir/network.go
@@ -54,8 +54,8 @@ type networkInfo struct {
 	CidrBlock      string `json:"cidrBlock"`
 	//Region         string `json:"region"`
 	//ResourceGroupName string `json:"resourceGroupName"`
-	Description  string     `json:"description"`
-	Status       string     `json:"status"`
+	Description  string            `json:"description"`
+	Status       string            `json:"status"`
 	KeyValueList []common.KeyValue `json:"keyValueList"`
 }
 
@@ -125,7 +125,7 @@ func RestGetNetwork(c echo.Context) error {
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the network with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the network with given UUID."}
 		return c.JSON(http.StatusNotFound, &mapA)
 	} else {
 		fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
@@ -187,7 +187,6 @@ func RestDelNetwork(c echo.Context) error {
 		//mapA := map[string]string{"message": "Failed to delete the network"}
 		return c.JSONBlob(responseCode, body)
 	}
-	
 
 	mapA := map[string]string{"message": "The network has been deleted"}
 	return c.JSON(http.StatusOK, &mapA)
@@ -213,7 +212,7 @@ func RestDelAllNetwork(c echo.Context) error {
 				//mapA := map[string]string{"message": "Failed to delete the network"}
 				return c.JSONBlob(responseCode, body)
 			}
-			
+
 		}
 
 		mapA := map[string]string{"message": "All networks has been deleted"}

--- a/src/mcir/publicip.go
+++ b/src/mcir/publicip.go
@@ -37,7 +37,7 @@ type publicIpReq struct {
 	//PublicIp          string `json:"publicIp"`
 	//OwnedVmId         string `json:"ownedVmId"`
 	//ResourceGroupName string `json:"resourceGroupName"`
-	Description  string     `json:"description"`
+	Description  string            `json:"description"`
 	KeyValueList []common.KeyValue `json:"keyValueList"`
 }
 
@@ -49,8 +49,8 @@ type publicIpInfo struct {
 	PublicIp        string `json:"publicIp"`
 	OwnedVmId       string `json:"ownedVmId"`
 	//ResourceGroupName string `json:"resourceGroupName"`
-	Description  string     `json:"description"`
-	Status       string     `json:"status"`
+	Description  string            `json:"description"`
+	Status       string            `json:"status"`
 	KeyValueList []common.KeyValue `json:"keyValueList"`
 }
 
@@ -120,7 +120,7 @@ func RestGetPublicIp(c echo.Context) error {
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the publicIp with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the publicIp with given UUID."}
 		return c.JSON(http.StatusNotFound, &mapA)
 	} else {
 		fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
@@ -182,7 +182,6 @@ func RestDelPublicIp(c echo.Context) error {
 		//mapA := map[string]string{"message": "Failed to delete the publicIp"}
 		return c.JSONBlob(responseCode, body)
 	}
-	
 
 	mapA := map[string]string{"message": "The publicIp has been deleted"}
 	return c.JSON(http.StatusOK, &mapA)
@@ -208,7 +207,7 @@ func RestDelAllPublicIp(c echo.Context) error {
 				//mapA := map[string]string{"message": "Failed to delete the publicIp"}
 				return c.JSONBlob(responseCode, body)
 			}
-			
+
 		}
 
 		mapA := map[string]string{"message": "All publicIps has been deleted"}

--- a/src/mcir/securitygroup.go
+++ b/src/mcir/securitygroup.go
@@ -62,7 +62,7 @@ type securityGroupInfo struct {
 	//ResourceGroupName  string `json:"resourceGroupName"`
 	Description   string              `json:"description"`
 	FirewallRules *[]firewallRuleInfo `json:"firewallRules"`
-	KeyValueList  []common.KeyValue          `json:"keyValueList"`
+	KeyValueList  []common.KeyValue   `json:"keyValueList"`
 }
 
 /* FYI
@@ -131,7 +131,7 @@ func RestGetSecurityGroup(c echo.Context) error {
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the securityGroup with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the securityGroup with given UUID."}
 		return c.JSON(http.StatusNotFound, &mapA)
 	} else {
 		fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
@@ -193,7 +193,6 @@ func RestDelSecurityGroup(c echo.Context) error {
 		//mapA := map[string]string{"message": "Failed to delete the securityGroup"}
 		return c.JSONBlob(responseCode, body)
 	}
-	
 
 	mapA := map[string]string{"message": "The securityGroup has been deleted"}
 	return c.JSON(http.StatusOK, &mapA)
@@ -219,7 +218,7 @@ func RestDelAllSecurityGroup(c echo.Context) error {
 				//mapA := map[string]string{"message": "Failed to delete the securityGroup"}
 				return c.JSONBlob(responseCode, body)
 			}
-			
+
 		}
 
 		mapA := map[string]string{"message": "All securityGroups has been deleted"}

--- a/src/mcir/spec.go
+++ b/src/mcir/spec.go
@@ -124,7 +124,7 @@ func RestGetSpec(c echo.Context) error {
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the spec with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the spec with given UUID."}
 		return c.JSON(http.StatusNotFound, &mapA)
 	} else {
 		fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)

--- a/src/mcir/sshkey.go
+++ b/src/mcir/sshkey.go
@@ -41,14 +41,14 @@ type sshKeyReq struct {
 }
 
 type sshKeyInfo struct {
-	Id             string     `json:"id"`
-	ConnectionName string     `json:"connectionName"`
-	CspSshKeyName  string     `json:"cspSshKeyName"`
-	Fingerprint    string     `json:"fingerprint"`
-	Username       string     `json:"username"`
-	PublicKey      string     `json:"publicKey"`
-	PrivateKey     string     `json:"privateKey"`
-	Description    string     `json:"description"`
+	Id             string            `json:"id"`
+	ConnectionName string            `json:"connectionName"`
+	CspSshKeyName  string            `json:"cspSshKeyName"`
+	Fingerprint    string            `json:"fingerprint"`
+	Username       string            `json:"username"`
+	PublicKey      string            `json:"publicKey"`
+	PrivateKey     string            `json:"privateKey"`
+	Description    string            `json:"description"`
 	KeyValueList   []common.KeyValue `json:"keyValueList"`
 }
 
@@ -122,7 +122,7 @@ func RestGetSshKey(c echo.Context) error {
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the sshKey with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the sshKey with given UUID."}
 		return c.JSON(http.StatusNotFound, &mapA)
 	} else {
 		fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
@@ -187,7 +187,6 @@ func RestDelSshKey(c echo.Context) error {
 		*/
 		return c.JSONBlob(responseCode, body)
 	}
-	
 
 	mapA := map[string]string{"message": "The sshKey has been deleted"}
 	return c.JSON(http.StatusOK, &mapA)
@@ -217,7 +216,7 @@ func RestDelAllSshKey(c echo.Context) error {
 				*/
 				return c.JSONBlob(responseCode, body)
 			}
-			
+
 		}
 
 		mapA := map[string]string{"message": "All sshKeys has been deleted"}

--- a/src/mcir/subnet.go
+++ b/src/mcir/subnet.go
@@ -100,7 +100,7 @@ func RestGetSubnet(c echo.Context) error {
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the subnet with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the subnet with given UUID."}
 		return c.JSON(http.StatusNotFound, &mapA)
 	} else {
 		fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)

--- a/src/mcir/vnic.go
+++ b/src/mcir/vnic.go
@@ -54,12 +54,12 @@ type vNicInfo struct {
 	CspVNetName    string `json:"cspVNetName"`
 	PublicIpId     string `json:"publicIpId"`
 	//ResourceGroupName string `json:"resourceGroupName"`
-	Description      string     `json:"description"`
-	PublicIp         string     `json:"publicIp"`
-	MacAddress       string     `json:"macAddress"`
-	OwnedVmId        string     `json:"ownedVmId"`
-	Status           string     `json:"status"`
-	SecurityGroupIds []string   `json:"securityGroupIds"`
+	Description      string            `json:"description"`
+	PublicIp         string            `json:"publicIp"`
+	MacAddress       string            `json:"macAddress"`
+	OwnedVmId        string            `json:"ownedVmId"`
+	Status           string            `json:"status"`
+	SecurityGroupIds []string          `json:"securityGroupIds"`
 	KeyValueList     []common.KeyValue `json:"keyValueList"`
 }
 
@@ -129,7 +129,7 @@ func RestGetVNic(c echo.Context) error {
 
 	keyValue, _ := store.Get(key)
 	if keyValue == nil {
-		mapA := map[string]string{"message": "Failed to find the vNic with give UUID."}
+		mapA := map[string]string{"message": "Failed to find the vNic with given UUID."}
 		return c.JSON(http.StatusNotFound, &mapA)
 	} else {
 		fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
@@ -191,7 +191,6 @@ func RestDelVNic(c echo.Context) error {
 		//mapA := map[string]string{"message": "Failed to delete the vNic"}
 		return c.JSONBlob(responseCode, body)
 	}
-	
 
 	mapA := map[string]string{"message": "The vNic has been deleted"}
 	return c.JSON(http.StatusOK, &mapA)
@@ -217,7 +216,7 @@ func RestDelAllVNic(c echo.Context) error {
 				//mapA := map[string]string{"message": "Failed to delete the vNic"}
 				return c.JSONBlob(responseCode, body)
 			}
-			
+
 		}
 
 		mapA := map[string]string{"message": "All vNics has been deleted"}

--- a/test/shooter-sh/insert-all-azure-regions.sh
+++ b/test/shooter-sh/insert-all-azure-regions.sh
@@ -7,7 +7,7 @@ for LOC in "${LOCS[@]}"
 do
 	echo $LOC
 
-	curl -sX POST http://$RESTSERVER:1024/region -H 'Content-Type: application/json' -d '{"RegionName":"azure-'$LOC'","ProviderName":"AZURE", "KeyValueInfoList": [{"Key":"location", "Value":"'$LOC'"}, {"Key":"ResourceGroup", "Value":"jhseo-test-'$LOC'"}]}'
-	curl -sX POST http://$RESTSERVER:1024/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"azure-'$LOC'-config","ProviderName":"AZURE", "DriverName":"azure-driver01", "CredentialName":"azure-credential01", "RegionName":"azure-'$LOC'"}'
+	curl -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"azure-'$LOC'","ProviderName":"AZURE", "KeyValueInfoList": [{"Key":"location", "Value":"'$LOC'"}, {"Key":"ResourceGroup", "Value":"jhseo-test-'$LOC'"}]}'
+	curl -sX POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"azure-'$LOC'-config","ProviderName":"AZURE", "DriverName":"azure-driver01", "CredentialName":"azure-credential01", "RegionName":"azure-'$LOC'"}'
 
 done

--- a/test/shooter-sh/insert-all-gcp-zones-region.sh
+++ b/test/shooter-sh/insert-all-gcp-zones-region.sh
@@ -14,7 +14,7 @@ do
 	#echo $LEN, $NUM, $ZONE, $REGION
 	echo $REGION, $ZONE
 
-	curl -X POST http://$RESTSERVER:1024/region -H 'Content-Type: application/json' -d '{"RegionName":"gcp-'$ZONE'","ProviderName":"GCP", "KeyValueInfoList": [{"Key":"Region", "Value":"'$REGION'"}, {"Key":"Zone", "Value":"'$ZONE'"}]}'
-	curl -X POST http://$RESTSERVER:1024/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"gcp-'$ZONE'-config","ProviderName":"GCP", "DriverName":"gcp-driver01", "CredentialName":"gcp-credential01", "RegionName":"gcp-'$ZONE'"}'
+	curl -X POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"gcp-'$ZONE'","ProviderName":"GCP", "KeyValueInfoList": [{"Key":"Region", "Value":"'$REGION'"}, {"Key":"Zone", "Value":"'$ZONE'"}]}'
+	curl -X POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"gcp-'$ZONE'-config","ProviderName":"GCP", "DriverName":"gcp-driver01", "CredentialName":"gcp-credential01", "RegionName":"gcp-'$ZONE'"}'
 
 done


### PR DESCRIPTION
`/spider` 대응:
`conf/setup.env` 에
`export SPIDER_URL=http://localhost:1024/spider`

(Spider URL 지정이 환경 변수로 되어 있으니
docker, docker-compose 에서 컨테이너 띄울 때에도
환경변수를 바꾸면 돼서 편하고 좋네요)

---

`/tumblebug` 대응:
`src/apiserver/apiserver.go` 에
`g := e.Group("/tumblebug/ns", common.NsValidation())`

---

[TODO]
- test (Shooter) 스크립트에 `/spider`, `/tumblebug` 변경 반영 안 한 파일들이 많음
- 컨테이너 이미지 새로 만들고, Docker Hub 에 올리기
- CB-Deployer 의 docker-compose.yaml 업데이트
- API-GW conf 업데이트
- 등등

---

Related:
- Suggestion: Add `/tumblebug/` prefix for REST APIs #96 
- Spider 의 API 변경에 대한 대응 #97 
