### PR TITLE
Add functions `lookupSpec` and `RestLookupSpec`

### DIFF
--- a/src/apiserver/apiserver.go
+++ b/src/apiserver/apiserver.go
@@ -188,6 +188,8 @@ func ApiServer() {
 	e.GET("/tumblebug/connConfig/:connConfigName", common.RestGetConnConfig)
 	e.GET("/tumblebug/region/:regionName", common.RestGetRegion)
 
+	e.GET("/tumblebug/lookupSpec/:specName", mcir.RestLookupSpec)
+
 	e.Logger.Fatal(e.Start(":1323"))
 
 }

--- a/src/mcir/common.go
+++ b/src/mcir/common.go
@@ -70,7 +70,7 @@ func delResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 		//get related recommend spec
 		keyValue, err := store.Get(key)
-		content := specInfo{}
+		content := SpecInfo{}
 		json.Unmarshal([]byte(keyValue.Value), &content)
 		if err != nil {
 			cblog.Error(err)


### PR DESCRIPTION
Usage of REST API:

[Request]
- GET `{{tb_ip}}:{{tb_port}}/tumblebug/lookupSpec/r5.4xlarge`

```JSON
{
	"connectionName": "{{connection_name}}"	
}
```

---

[Response]
```JSON
{
    "Region": "us-east-1",
    "Name": "r5.4xlarge",
    "VCpu": {
        "Count": "16",
        "Clock": "3.1"
    },
    "Mem": "131072",
    "Gpu": [],
    "KeyValueList": [
        {
            "Key": "SupportedRootDeviceTypes",
            "Value": "[ebs]"
        },
        {
            "Key": "SupportedUsageClasses",
            "Value": "[on-demand spot]"
        },
        {
            "Key": "VCpuInfo",
            "Value": "map[DefaultCores:8 DefaultThreadsPerCore:2 DefaultVCpus:16 ValidCores:[2 4 6 8] ValidThreadsPerCore:[1 2]]"
        },
        {
            "Key": "InstanceStorageSupported",
            "Value": "false"
        },
        {
            "Key": "CurrentGeneration",
            "Value": "true"
        },
        {
            "Key": "DedicatedHostsSupported",
            "Value": "true"
        },
        {
            "Key": "FreeTierEligible",
            "Value": "false"
        },
        {
            "Key": "AutoRecoverySupported",
            "Value": "true"
        },
        {
            "Key": "BurstablePerformanceSupported",
            "Value": "false"
        },
        {
            "Key": "Hypervisor",
            "Value": "nitro"
        },
        {
            "Key": "InstanceType",
            "Value": "r5.4xlarge"
        },
        {
            "Key": "MemoryInfo",
            "Value": "map[SizeInMiB:131072]"
        },
        {
            "Key": "NetworkInfo",
            "Value": "map[EnaSupport:required Ipv4AddressesPerInterface:30 Ipv6AddressesPerInterface:30 Ipv6Supported:true MaximumNetworkInterfaces:8 NetworkPerformance:Up to 10 Gigabit]"
        },
        {
            "Key": "PlacementGroupInfo",
            "Value": "map[SupportedStrategies:[cluster partition spread]]"
        },
        {
            "Key": "BareMetal",
            "Value": "false"
        },
        {
            "Key": "EbsInfo",
            "Value": "map[EbsOptimizedSupport:default EncryptionSupport:supported]"
        },
        {
            "Key": "HibernationSupported",
            "Value": "true"
        },
        {
            "Key": "ProcessorInfo",
            "Value": "map[SupportedArchitectures:[x86_64] SustainedClockSpeedInGhz:3.1]"
        }
    ]
}
```