### PR TITLE
Implement function `registerSpecWithCspSpecName`

### DIFF
--- a/src/mcir/spec.go
+++ b/src/mcir/spec.go
@@ -17,8 +17,9 @@ import (
 
 type specReq struct {
 	//Id             string `json:"id"`
-	CspSpecName    string `json:"cspSpecName"`
 	ConnectionName string `json:"connectionName"`
+	CspSpecName    string `json:"cspSpecName"`
+	Name           string `json:"name"`
 	Os_type        string `json:"os_type"`
 	Num_vCPU       string `json:"num_vCPU"`
 	Num_core       string `json:"num_core"`
@@ -29,8 +30,9 @@ type specReq struct {
 
 type SpecInfo struct {
 	Id             string `json:"id"`
-	CspSpecName    string `json:"cspSpecName"`
 	ConnectionName string `json:"connectionName"`
+	CspSpecName    string `json:"cspSpecName"`
+	Name           string `json:"name"`
 	Os_type        string `json:"os_type"`
 	Num_vCPU       string `json:"num_vCPU"`
 	Num_core       string `json:"num_core"`
@@ -49,22 +51,6 @@ type SpecInfo struct {
 	Gpumem_GiB            string `json:"gpumem_GiB"`
 	Gpu_p2p               string `json:"gpu_p2p"`
 }
-
-/*
-type SpecInfo struct {
-	Id             string `json:"id"`
-	Name           string `json:"name"`
-	ConnectionName string `json:"connectionName"`
-	Os_type        string `json:"os_type"`
-	Num_vCPU       string `json:"num_vCPU"`
-	Num_core       string `json:"num_core"`
-	Mem_GiB        string `json:"mem_GiB"`
-	Storage_GiB    string `json:"storage_GiB"`
-	Description    string `json:"description"`
-
-	Cost_per_hour string `json:"cost_per_hour"`
-}
-*/
 
 type SpiderSpecInfo struct {
 	// https://github.com/cloud-barista/cb-spider/blob/master/cloud-control-manager/cloud-driver/interfaces/resources/VMSpecHandler.go
@@ -350,11 +336,11 @@ func registerSpecWithCspSpecName(nsId string, u *specReq) (SpecInfo, error) {
 	}
 	*/
 
-	// Temporary code
 	content := SpecInfo{}
 	content.Id = common.GenUuid()
-	content.CspSpecName = res.Name
 	content.ConnectionName = u.ConnectionName
+	content.CspSpecName = res.Name
+	content.Name = u.Name
 	//content.Os_type = res.Os_type
 	content.Num_vCPU = res.VCpu.Count
 	//content.Num_core = res.Num_core
@@ -366,8 +352,9 @@ func registerSpecWithCspSpecName(nsId string, u *specReq) (SpecInfo, error) {
 	fmt.Println("=========================== PUT registerSpec")
 	Key := common.GenResourceKey(nsId, "spec", content.Id)
 	mapA := map[string]string{
-		"cspSpecName":    content.CspSpecName,
 		"connectionName": content.ConnectionName,
+		"cspSpecName":    content.CspSpecName,
+		"name":           content.Name,
 		"os_type":        content.Os_type,
 		"Num_vCPU":       content.Num_vCPU,
 		"Num_core":       content.Num_core,
@@ -408,37 +395,13 @@ func registerSpecWithInfo(nsId string, content *SpecInfo) (SpecInfo, error) {
 
 	content.Id = common.GenUuid()
 
-	/* FYI
-	type specInfo struct {
-		Id          string `json:"id"`
-		CspSpecName        string `json:"cspSpecName"`
-		ConnectionName         string `json:"connectionName"`
-		Os_type     string `json:"os_type"`
-		Num_vCPU    string `json:"num_vCPU"`
-		Num_core    string `json:"num_core"`
-		Mem_GiB     string `json:"mem_GiB"`
-		Storage_GiB string `json:"storage_GiB"`
-		Description string `json:"description"`
-
-		Cost_per_hour         string `json:"cost_per_hour"`
-		Num_storage           string `json:"num_storage"`
-		Max_num_storage       string `json:"max_num_storage"`
-		Max_total_storage_TiB string `json:"max_total_storage_TiB"`
-		Net_bw_Gbps           string `json:"net_bw_Gbps"`
-		Ebs_bw_Mbps           string `json:"ebs_bw_Mbps"`
-		Gpu_model             string `json:"gpu_model"`
-		Num_gpu               string `json:"num_gpu"`
-		Gpumem_GiB            string `json:"gpumem_GiB"`
-		Gpu_p2p               string `json:"gpu_p2p"`
-	}
-	*/
-
 	// cb-store
 	fmt.Println("=========================== PUT registerSpec")
 	Key := common.GenResourceKey(nsId, "spec", content.Id)
 	mapA := map[string]string{
-		"cspSpecName":    content.CspSpecName,
 		"connectionName": content.ConnectionName,
+		"cspSpecName":    content.CspSpecName,
+		"name":           content.Name,
 		"os_type":        content.Os_type,
 		"Num_vCPU":       content.Num_vCPU,
 		"Num_core":       content.Num_core,


### PR DESCRIPTION
[API changelog]

1. ~~JSON key 중
기존에는 `name` 이었던 것이
`cspSpecName` 으로 변경되었습니다.~~

2. CB-Tumblebug metadata store 에 Spec 을 등록할 때
    1) 기존에는 `name`, `connectionName`, 그리고 spec 의 상세내용을 적어서 POST 하면
Spider 나 CSP 에 lookup 하지 않고 즉시 CB-Tumblebug metadata store 에 저장하는 방식이었습니다.
```JSON
{
    
    "name": "t2.micro",
    "connectionName": "{{connection_name}}",
    "os_type": "",
    "num_vCPU": "",
    "num_core": "",
    "mem_GiB": "",
    "storage_GiB": "",
    "description": "",
    "cost_per_hour": "",
    "num_storage": "",
    "max_num_storage": "",
    "max_total_storage_TiB": "",
    "net_bw_Gbps": "",
    "ebs_bw_Mbps": "",
    "gpu_model": "",
    "num_gpu": "",
    "gpumem_GiB": "",
    "gpu_p2p": ""
}
```

이것이 변경되어서
    2) `cspSpecName` 과 `connectionName` 만 적어서 POST 하면
Spider 에 lookup 하고 그 결과를 이용하여 CB-Tumblebug metadata store 에 저장하는 방식으로 변경되었습니다.
```JSON
{
    
    "cspSpecName": "t2.micro",
    "connectionName": "{{connection_name}}"
}
```

---

위 변경사항에 대해, CB-Webtool 측에 대응 요청을 할 예정입니다.

---

FYI:
위의 `i.` 방식은
POST `{{tb_ip}}:{{tb_port}}/tumblebug/ns/{{ns_id}}/resources/spec?action=registerWithInfo` 와 같이
REST API URL 뒤쪽에
`?action=registerWithInfo` 를 붙여서 계속 이용 가능합니다.
다만, 조만간 deprecate 시킬 예정입니다.