### PR TITLE
Update some commented codes

### DIFF
--- a/src/apiserver/apiserver.go
+++ b/src/apiserver/apiserver.go
@@ -149,6 +149,8 @@ func ApiServer() {
 	g.DELETE("/:nsId/resources/spec/:specId", mcir.RestDelSpec)
 	g.DELETE("/:nsId/resources/spec", mcir.RestDelAllSpec)
 
+	//g.GET("/:nsId/resources/fetchSpecs", mcir.RestFetchSpecs)
+
 	g.POST("/:nsId/resources/securityGroup", mcir.RestPostSecurityGroup)
 	g.GET("/:nsId/resources/securityGroup/:securityGroupId", mcir.RestGetSecurityGroup)
 	g.GET("/:nsId/resources/securityGroup", mcir.RestGetAllSecurityGroup)
@@ -183,6 +185,11 @@ func ApiServer() {
 	g.PUT("/:nsId/resources/vNic/:vNicId", mcir.RestPutVNic)
 	g.DELETE("/:nsId/resources/vNic/:vNicId", mcir.RestDelVNic)
 	g.DELETE("/:nsId/resources/vNic", mcir.RestDelAllVNic)
+
+	// We cannot use these wildcard method below.
+	// https://github.com/labstack/echo/issues/382
+	//g.DELETE("/:nsId/resources/:resourceType/:resourceId", mcir.RestDelResource)
+	//g.DELETE("/:nsId/resources/:resourceType", mcir.RestDelAllResources)
 
 	g.GET("/:nsId/checkResource/:resourceType/:resourceId", mcir.RestCheckResource)
 	g.GET("/:nsId/checkMcis/:mcisId", mcis.RestCheckMcis)

--- a/src/mcir/common.go
+++ b/src/mcir/common.go
@@ -33,7 +33,8 @@ func init() {
 
 func delResource(nsId string, resourceType string, resourceId string, forceFlag string) (int, []byte, error) {
 
-	fmt.Println("[Delete " + resourceType + "] " + resourceId)
+	//fmt.Println("[Delete " + resourceType + "] " + resourceId)
+	fmt.Printf("RestDelResource() called; %s %s %s \n", nsId, resourceType, resourceId) // for debug
 
 	check, _ := checkResource(nsId, resourceType, resourceId)
 
@@ -320,6 +321,55 @@ func RestCheckResource(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, &content)
 }
+
+/*
+func RestDelResource(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+	resourceType := c.Param("resourceType")
+	resourceId := c.Param("resourceId")
+	forceFlag := c.QueryParam("force")
+
+	fmt.Printf("RestDelResource() called; %s %s %s \n", nsId, resourceType, resourceId) // for debug
+
+	responseCode, _, err := delResource(nsId, resourceType, resourceId, forceFlag)
+	if err != nil {
+		cblog.Error(err)
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(responseCode, &mapA)
+	}
+
+	mapA := map[string]string{"message": "The " + resourceType + " " + resourceId + " has been deleted"}
+	return c.JSON(http.StatusOK, &mapA)
+}
+
+func RestDelAllResources(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+	resourceType := c.Param("resourceType")
+	forceFlag := c.QueryParam("force")
+
+	resourceList := getResourceList(nsId, resourceType)
+
+	if len(resourceList) == 0 {
+		mapA := map[string]string{"message": "There is no " + resourceType + " element in this namespace."}
+		return c.JSON(http.StatusNotFound, &mapA)
+	} else {
+		for _, v := range resourceList {
+			responseCode, _, err := delResource(nsId, resourceType, v, forceFlag)
+			if err != nil {
+				cblog.Error(err)
+				mapA := map[string]string{"message": err.Error()}
+				return c.JSON(responseCode, &mapA)
+			}
+
+		}
+
+		mapA := map[string]string{"message": "All " + resourceType + "s has been deleted"}
+		return c.JSON(http.StatusOK, &mapA)
+	}
+}
+*/
 
 // https://stackoverflow.com/questions/45139954/dynamic-struct-as-parameter-golang
 

--- a/src/mcir/sshkey.go
+++ b/src/mcir/sshkey.go
@@ -174,10 +174,10 @@ func RestDelSshKey(c echo.Context) error {
 	responseCode, body, err := delResource(nsId, "sshKey", id, forceFlag)
 	if err != nil {
 		cblog.Error(err)
-		/*
-			mapA := map[string]string{"message": "Failed to delete the sshKey"}
-			return c.JSON(http.StatusFailedDependency, &mapA)
-		*/
+
+		//mapA := map[string]string{"message": "Failed to delete the sshKey"}
+		//return c.JSON(http.StatusFailedDependency, &mapA)
+
 		return c.JSONBlob(responseCode, body)
 	}
 


### PR DESCRIPTION
- We cannot use these wildcard methods.
  - `g.DELETE("/:nsId/resources/:resourceType/:resourceId", mcir.RestDelResource)`
  - `g.DELETE("/:nsId/resources/:resourceType", mcir.RestDelAllResources)`
- Reason: https://github.com/labstack/echo/issues/382