### PR TITLE
Add fetchSpecs function and API

### DIFF
--- a/src/apiserver/apiserver.go
+++ b/src/apiserver/apiserver.go
@@ -149,7 +149,7 @@ func ApiServer() {
 	g.DELETE("/:nsId/resources/spec/:specId", mcir.RestDelSpec)
 	g.DELETE("/:nsId/resources/spec", mcir.RestDelAllSpec)
 
-	//g.GET("/:nsId/resources/fetchSpecs", mcir.RestFetchSpecs)
+	g.POST("/:nsId/resources/fetchSpecs", mcir.RestFetchSpecs)
 
 	g.POST("/:nsId/resources/securityGroup", mcir.RestPostSecurityGroup)
 	g.GET("/:nsId/resources/securityGroup/:securityGroupId", mcir.RestGetSecurityGroup)
@@ -157,15 +157,6 @@ func ApiServer() {
 	g.PUT("/:nsId/resources/securityGroup/:securityGroupId", mcir.RestPutSecurityGroup)
 	g.DELETE("/:nsId/resources/securityGroup/:securityGroupId", mcir.RestDelSecurityGroup)
 	g.DELETE("/:nsId/resources/securityGroup", mcir.RestDelAllSecurityGroup)
-
-	/*
-		g.POST("/:nsId/resources/subnet", mcir.RestPostSubnet)
-		g.GET("/:nsId/resources/subnet/:subnetId", mcir.RestGetSubnet)
-		g.GET("/:nsId/resources/subnet", mcir.RestGetAllSubnet)
-		g.PUT("/:nsId/resources/subnet/:subnetId", mcir.RestPutSubnet)
-		g.DELETE("/:nsId/resources/subnet/:subnetId", mcir.RestDelSubnet)
-		g.DELETE("/:nsId/resources/subnet", mcir.RestDelAllSubnet)
-	*/
 
 	g.POST("/:nsId/resources/vNet", mcir.RestPostVNet)
 	g.GET("/:nsId/resources/vNet/:vNetId", mcir.RestGetVNet)
@@ -175,6 +166,13 @@ func ApiServer() {
 	g.DELETE("/:nsId/resources/vNet", mcir.RestDelAllVNet)
 
 	/*
+		g.POST("/:nsId/resources/subnet", mcir.RestPostSubnet)
+		g.GET("/:nsId/resources/subnet/:subnetId", mcir.RestGetSubnet)
+		g.GET("/:nsId/resources/subnet", mcir.RestGetAllSubnet)
+		g.PUT("/:nsId/resources/subnet/:subnetId", mcir.RestPutSubnet)
+		g.DELETE("/:nsId/resources/subnet/:subnetId", mcir.RestDelSubnet)
+		g.DELETE("/:nsId/resources/subnet", mcir.RestDelAllSubnet)
+
 		g.POST("/:nsId/resources/publicIp", mcir.RestPostPublicIp)
 		g.GET("/:nsId/resources/publicIp/:publicIpId", mcir.RestGetPublicIp)
 		g.GET("/:nsId/resources/publicIp", mcir.RestGetAllPublicIp)

--- a/src/mcir/common.go
+++ b/src/mcir/common.go
@@ -34,7 +34,7 @@ func init() {
 func delResource(nsId string, resourceType string, resourceId string, forceFlag string) (int, []byte, error) {
 
 	//fmt.Println("[Delete " + resourceType + "] " + resourceId)
-	fmt.Printf("RestDelResource() called; %s %s %s \n", nsId, resourceType, resourceId) // for debug
+	fmt.Printf("delResource() called; %s %s %s \n", nsId, resourceType, resourceId) // for debug
 
 	check, _ := checkResource(nsId, resourceType, resourceId)
 
@@ -271,10 +271,10 @@ func checkResource(nsId string, resourceType string, resourceId string) (bool, e
 		resourceType == "sshKey" ||
 		resourceType == "spec" ||
 		resourceType == "vNet" ||
-		resourceType == "subnet" ||
-		resourceType == "securityGroup" ||
-		resourceType == "publicIp" ||
-		resourceType == "vNic" {
+		resourceType == "securityGroup" {
+		//resourceType == "subnet" ||
+		//resourceType == "publicIp" ||
+		//resourceType == "vNic" {
 		// continue
 	} else {
 		err := fmt.Errorf("invalid resource type")
@@ -321,6 +321,31 @@ func RestCheckResource(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, &content)
 }
+
+/*
+func convertSpiderResourceToTumblebugResource(resourceType string, i interface{}) (interface{}, error) {
+	if resourceType == "" {
+		err := fmt.Errorf("checkResource failed; resourceType given is null.")
+		return nil, err
+	}
+
+	// Check resourceType's validity
+	if resourceType == "image" ||
+		resourceType == "sshKey" ||
+		resourceType == "spec" ||
+		resourceType == "vNet" ||
+		resourceType == "securityGroup" {
+		//resourceType == "subnet" ||
+		//resourceType == "publicIp" ||
+		//resourceType == "vNic" {
+		// continue
+	} else {
+		err := fmt.Errorf("invalid resource type")
+		return nil, err
+	}
+
+}
+*/
 
 /*
 func RestDelResource(c echo.Context) error {

--- a/test/2020-04-29/5.spec/fetch-specs.sh
+++ b/test/2020-04-29/5.spec/fetch-specs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source ../conf.env
+
+INDEX=${1}
+
+echo "####################################################################"
+echo "## 4. spec: Fetch"
+echo "####################################################################"
+
+curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs #| json_pp

--- a/test/2020-04-29/5.spec/lookupSpec.sh
+++ b/test/2020-04-29/5.spec/lookupSpec.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source ../conf.env
+
+INDEX=${1}
+
+echo "####################################################################"
+echo "## 4. spec: Lookup Spec"
+echo "####################################################################"
+
+curl -sX GET http://localhost:1323/tumblebug/lookupSpec/${SPEC_NAME[INDEX]} -H 'Content-Type: application/json' -d \
+	'{ 
+		"connectionName": "'${CONN_CONFIG[INDEX]}'"
+	}' | json_pp #|| return 1

--- a/test/2020-04-29/5.spec/lookupSpecList.sh
+++ b/test/2020-04-29/5.spec/lookupSpecList.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source ../conf.env
+
+INDEX=${1}
+
+echo "####################################################################"
+echo "## 4. spec: Lookup Spec List"
+echo "####################################################################"
+
+curl -sX GET http://localhost:1323/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
+	'{ 
+		"connectionName": "'${CONN_CONFIG[INDEX]}'"
+	}' | json_pp #|| return 1

--- a/test/2020-04-29/5.spec/spider-get-spec.sh
+++ b/test/2020-04-29/5.spec/spider-get-spec.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source ../conf.env
+
+INDEX=${1}
+
+echo "####################################################################"
+echo "## 4. spec: Fetch"
+echo "####################################################################"
+
+curl -sX GET http://localhost:1024/spider/vmspec/${SPEC_NAME[INDEX]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[INDEX]}'" }' | json_pp
+

--- a/test/2020-04-29/5.spec/spider-get-speclist.sh
+++ b/test/2020-04-29/5.spec/spider-get-speclist.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source ../conf.env
+
+INDEX=${1}
+
+echo "####################################################################"
+echo "## 4. spec: Fetch"
+echo "####################################################################"
+
+curl -sX GET http://localhost:1024/spider/vmspec -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[INDEX]}'" }' | json_pp
+

--- a/test/shooter-sh-2019/azure-locations-list.txt
+++ b/test/shooter-sh-2019/azure-locations-list.txt
@@ -219,35 +219,11 @@ $az account list-locations
     "subscriptionId": null
   },
   {
-    "displayName": "France South",
-    "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/francesouth",
-    "latitude": "43.8345",
-    "longitude": "2.1972",
-    "name": "francesouth",
-    "subscriptionId": null
-  },
-  {
     "displayName": "Australia Central",
     "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/australiacentral",
     "latitude": "-35.3075",
     "longitude": "149.1244",
     "name": "australiacentral",
-    "subscriptionId": null
-  },
-  {
-    "displayName": "Australia Central 2",
-    "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/australiacentral2",
-    "latitude": "-35.3075",
-    "longitude": "149.1244",
-    "name": "australiacentral2",
-    "subscriptionId": null
-  },
-  {
-    "displayName": "UAE Central",
-    "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/uaecentral",
-    "latitude": "24.466667",
-    "longitude": "54.366669",
-    "name": "uaecentral",
     "subscriptionId": null
   },
   {
@@ -267,14 +243,6 @@ $az account list-locations
     "subscriptionId": null
   },
   {
-    "displayName": "South Africa West",
-    "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/southafricawest",
-    "latitude": "-34.075691",
-    "longitude": "18.843266",
-    "name": "southafricawest",
-    "subscriptionId": null
-  },
-  {
     "displayName": "Switzerland North",
     "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/switzerlandnorth",
     "latitude": "47.451542",
@@ -283,35 +251,11 @@ $az account list-locations
     "subscriptionId": null
   },
   {
-    "displayName": "Switzerland West",
-    "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/switzerlandwest",
-    "latitude": "46.204391",
-    "longitude": "6.143158",
-    "name": "switzerlandwest",
-    "subscriptionId": null
-  },
-  {
-    "displayName": "Germany North",
-    "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/germanynorth",
-    "latitude": "53.073635",
-    "longitude": "8.806422",
-    "name": "germanynorth",
-    "subscriptionId": null
-  },
-  {
     "displayName": "Germany West Central",
     "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/germanywestcentral",
     "latitude": "50.110924",
     "longitude": "8.682127",
     "name": "germanywestcentral",
-    "subscriptionId": null
-  },
-  {
-    "displayName": "Norway West",
-    "id": "/subscriptions/f1548292-2be3-4acd-84a4-6df079160846/locations/norwaywest",
-    "latitude": "58.969975",
-    "longitude": "5.733107",
-    "name": "norwaywest",
     "subscriptionId": null
   },
   {


### PR DESCRIPTION
[사용법]

[Request]
`test/2020-04-29/5.spec/fetch-specs.sh`
```Shell
curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs
```

---

[결과]

GET `{{tb_ip}}:{{tb_port}}/tumblebug/ns/{{ns_id}}/resources/spec`
```JSON
{
    "spec": [
        {
            "id": "aws-us-east-1-config-a1.large",
            "connectionName": "aws-us-east-1-config",
            "cspSpecName": "a1.large",
            "name": "aws-us-east-1-config-a1.large",
            "os_type": "",
            "num_vCPU": "2",
            "num_core": "",
            "mem_GiB": "4",
            "mem_MiB": "4096",
            "storage_GiB": "",
            "description": "",
            "cost_per_hour": "",
            "num_storage": "",
            "max_num_storage": "",
            "max_total_storage_TiB": "",
            "net_bw_Gbps": "",
            "ebs_bw_Mbps": "",
            "gpu_model": "",
            "num_gpu": "",
            "gpumem_GiB": "",
            "gpu_p2p": ""
        },
        {
            "id": "aws-us-east-1-config-a1.medium",
            "connectionName": "aws-us-east-1-config",
            "cspSpecName": "a1.medium",
            "name": "aws-us-east-1-config-a1.medium",
            "os_type": "",
            "num_vCPU": "1",
            "num_core": "",
            "mem_GiB": "2",
            "mem_MiB": "2048",
            "storage_GiB": "",
            "description": "",
            "cost_per_hour": "",
            "num_storage": "",
            "max_num_storage": "",
            "max_total_storage_TiB": "",
            "net_bw_Gbps": "",
            "ebs_bw_Mbps": "",
            "gpu_model": "",
            "num_gpu": "",
            "gpumem_GiB": "",
            "gpu_p2p": ""
        },
...
```

---

[주의사항]

- AWS, Azure 에 대해 테스트 완료했습니다. GCP 는 테스트 하지 않았습니다.
- Azure 의 경우 다음 Region 에서 에러가 발생합니다.
Spider 의 Connection Config 중 다음 Region 에 해당되는 Connection Config 를 삭제하고 진행하는 것이 좋습니다. (Ref: @powerkimhub )
  - australiacentral2
  - francesouth
  - germanynorth
  - norwaywest
  - southafricawest
  - switzerlandwest
  - uaecentral

- FYI: 에러 메시지
```JSON
{"message":"resources.GroupsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code=\"LocationNotAvailableForResourceGroup\" Message=\"The provided location 'southafricawest' is not available for resource group. List of available regions is 'centralus,eastasia,southeastasia,eastus,eastus2,westus,westus2,northcentralus,southcentralus,westcentralus,northeurope,westeurope,japaneast,japanwest,brazilsouth,australiasoutheast,australiaeast,westindia,southindia,centralindia,canadacentral,canadaeast,uksouth,ukwest,koreacentral,koreasouth,francecentral,southafricanorth,uaenorth,australiacentral,switzerlandnorth,germanywestcentral,norwayeast'.\""}
```

---

- FYI: Azure, GCP 의 모든 Region & Connection Config 를 Spider 에 등록하고 싶으면
다음 스크립트를 실행하면 됩니다.
  - `test/shooter-sh-2019/insert-all-azure-regions.sh`
  - `test/shooter-sh-2019/insert-all-gcp-zones-region.sh`

---

[From **CB-TB 설계 개선 및 기능 추가** (2020-04-20)]
- 자동 업데이트 주기 (안)
  - CB-TB 시스템 초기 로딩시에 수행 --> 현재는 미구현 // 이슈: TB 초기 실행 시 Spider 에 Connection Config 가 0개 저장되어 있을 수도 있습니다.
  - 주기적으로 수행 --> 현재는 미구현
  - 사용자 온디맨드 --> POST `http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs` 를 호출하여 트리거 가능