### PR TITLE
Automate test script to set up connection-conf

### DIFF
--- a/test/2020-04-29/0.settingSpider/delete-test.sh
+++ b/test/2020-04-29/0.settingSpider/delete-test.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 0. Remove Cloud Connction Config"
+echo "## 0. Remove All Cloud Connction Config(s)"
 echo "####################################################################"
 
 INDEX=${1}

--- a/test/2020-04-29/0.settingSpider/delete-test.sh
+++ b/test/2020-04-29/0.settingSpider/delete-test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source ../conf.env
+
+echo "####################################################################"
+echo "## 0. Remove Cloud Connction Config"
+echo "####################################################################"
+
+INDEX=${1}
+
+RESTSERVER=localhost
+
+# for Cloud Connection Config Info
+curl -X DELETE http://$RESTSERVER:1024/spider/connectionconfig/${CONN_CONFIG[INDEX]}
+
+# for Cloud Region Info
+curl -X DELETE http://$RESTSERVER:1024/spider/region/${RegionName[INDEX]}
+
+# for Cloud Credential Info
+curl -X DELETE http://$RESTSERVER:1024/spider/credential/${CredentialName[INDEX]}
+ 
+# for Cloud Driver Info
+curl -X DELETE http://$RESTSERVER:1024/spider/driver/${DriverName[INDEX]}

--- a/test/2020-04-29/0.settingSpider/get-test.sh
+++ b/test/2020-04-29/0.settingSpider/get-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+source ../conf.env
+
+echo "####################################################################"
+echo "## 0. Remove Cloud Connction Config"
+echo "####################################################################"
+
+INDEX=${1}
+
+RESTSERVER=localhost
+
+# for Cloud Connection Config Info
+curl -X GET http://$RESTSERVER:1024/spider/connectionconfig/${CONN_CONFIG[INDEX]} |json_pp
+
+
+# for Cloud Region Info
+curl -X GET http://$RESTSERVER:1024/spider/region/${RegionName[INDEX]} |json_pp
+
+
+# for Cloud Credential Info
+curl -X GET http://$RESTSERVER:1024/spider/credential/${CredentialName[INDEX]} |json_pp
+
+ 
+# for Cloud Driver Info
+curl -X GET http://$RESTSERVER:1024/spider/driver/${DriverName[INDEX]} |json_pp
+

--- a/test/2020-04-29/0.settingSpider/get-test.sh
+++ b/test/2020-04-29/0.settingSpider/get-test.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 0. Remove Cloud Connction Config"
+echo "## 0. Get Cloud Connction Config"
 echo "####################################################################"
 
 INDEX=${1}

--- a/test/2020-04-29/0.settingSpider/insert-test.sh
+++ b/test/2020-04-29/0.settingSpider/insert-test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+source ../conf.env
+
+echo "####################################################################"
+echo "## 0. Create Cloud Connction Config"
+echo "####################################################################"
+
+INDEX=${1}
+
+RESTSERVER=localhost
+
+ # for Cloud Driver Info
+curl -sX POST http://$RESTSERVER:1024/spider/driver -H 'Content-Type: application/json' -d \
+	'{
+        "ProviderName" : "'${ProviderName[INDEX]}'",
+        "DriverLibFileName" : "'${DriverLibFileName[INDEX]}'",
+        "DriverName" : "'${DriverName[INDEX]}'"
+	}' | json_pp
+
+ # for Cloud Credential Info
+curl -sX POST http://$RESTSERVER:1024/spider/credential -H 'Content-Type: application/json' -d \
+    '{
+        "ProviderName" : "'${ProviderName[INDEX]}'",
+        "CredentialName" : "'${CredentialName[INDEX]}'",
+        "KeyValueInfoList" : [
+            {
+                "Key" : "'${CredentialKey01[INDEX]:-NULL}'",
+                "Value" : "'${CredentialVal01[INDEX]:-NULL}'"
+            },
+            {
+                "Key" : "'${CredentialKey02[INDEX]:-NULL}'",
+                "Value" : "'${CredentialVal02[INDEX]:-NULL}'"
+            },
+            {
+                "Key" : "'${CredentialKey03[INDEX]:-NULL}'",
+                "Value" : "'${CredentialVal03[INDEX]:-NULL}'"
+            },
+            {
+                "Key" : "'${CredentialKey04[INDEX]:-NULL}'",
+                "Value" : "'${CredentialVal04[INDEX]:-NULL}'"
+            }
+        ]
+    }' | json_pp
+
+ # for Cloud Region Info
+curl -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d \
+    '{
+        "ProviderName" : "'${ProviderName[INDEX]}'",
+        "KeyValueInfoList" : [
+            {
+                "Key" : "'${RegionKey01[INDEX]:-NULL}'",
+                "Value" : "'${RegionVal01[INDEX]:-NULL}'"
+            }
+        ],
+        "RegionName" : "'${RegionName[INDEX]}'"
+    }' | json_pp
+
+
+ # for Cloud Connection Config Info
+curl -sX POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d \
+    '{
+        "CredentialName" : "'${CredentialName[INDEX]}'",
+        "ConfigName" : "'${CONN_CONFIG[INDEX]}'",
+        "ProviderName" : "'${ProviderName[INDEX]}'",
+        "DriverName" : "'${DriverName[INDEX]}'",
+        "RegionName" : "'${RegionName[INDEX]}'"
+    }' | json_pp

--- a/test/2020-04-29/0.settingSpider/list-test.sh
+++ b/test/2020-04-29/0.settingSpider/list-test.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 0. Remove Cloud Connction Config"
+echo "## 0. List Cloud Connction Config(s)"
 echo "####################################################################"
 
 #INDEX=${1}

--- a/test/2020-04-29/0.settingSpider/list-test.sh
+++ b/test/2020-04-29/0.settingSpider/list-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source ../conf.env
+
+echo "####################################################################"
+echo "## 0. Remove Cloud Connction Config"
+echo "####################################################################"
+
+#INDEX=${1}
+
+RESTSERVER=localhost
+
+# for Cloud Connection Config Info
+curl -X GET http://$RESTSERVER:1024/spider/connectionconfig |json_pp
+
+
+# for Cloud Region Info
+curl -X GET http://$RESTSERVER:1024/spider/region |json_pp
+
+
+# for Cloud Credential Info
+curl -X GET http://$RESTSERVER:1024/spider/credential |json_pp
+
+ 
+# for Cloud Driver Info
+curl -X GET http://$RESTSERVER:1024/spider/driver |json_pp

--- a/test/2020-04-29/conf.env
+++ b/test/2020-04-29/conf.env
@@ -6,13 +6,45 @@ CONN_CONFIG[1]=aws-us-east-1-config
 IMAGE_NAME[1]=ami-085925f297f89fce1
 SPEC_NAME[1]=t2.micro
 
+ProviderName[1]=AWS
+DriverLibFileName[1]=aws-driver-v1.0.so
+DriverName[1]=aws-driver01
+CredentialName[1]=aws-credential01
+CredentialKey01[1]=ClientId
+CredentialVal01[1]={{YOUR AWS Credentidal ID. Ex:SFLEKJEFLJIEIVJOLJSEOIV}}
+CredentialKey02[1]=ClientSecret
+CredentialVal02[1]={{YOUR AWS Credentidal Secret. Ex:fsfdlkfjselSDfjlejklsj/LFJSDLKfjleJKLDJ0}}
+RegionName[1]=aws-region01
+RegionKey01[1]=Region
+RegionVal01[1]=us-east-1
+
 ## Azure
 CONN_CONFIG[2]=azure-northeurope-config
 IMAGE_NAME[2]=Canonical:UbuntuServer:18.04-LTS:latest
 SPEC_NAME[2]=Standard_B1ls
+
+ProviderName[2]=AZURE
+DriverLibFileName[2]=azure-driver-v1.0.so
+DriverName[2]=azure-driver01
+CredentialName[2]=azure-credential01
+CredentialKey01[2]=ClientId
+CredentialVal01[2]={{YOUR AZURE Credentidal ClientId. Ex:2157868b-4c35-4bak-a23c-ckf05a54a824}}
+CredentialKey02[2]=ClientSecret
+CredentialVal02[2]={{YOUR AZURE Credentidal ClientSecret. Ex:2157868b-4c35-4bak-a23c-ckf05a54a824}}
+CredentialKey03[2]=TenantId
+CredentialVal03[2]={{YOUR AZURE Credentidal TenantId. Ex:2157868b-4c35-4bak-a23c-ckf05a54a824}}
+CredentialKey04[2]=SubscriptionId
+CredentialVal04[2]={{YOUR AZURE Credentidal SubscriptionId. Ex:2157868b-4c35-4bak-a23c-ckf05a54a824}}
+RegionName[2]=azure-region01
+RegionKey01[2]=location
+RegionVal01[2]=northeurope
+
 
 ## GCP
 CONN_CONFIG[3]=gcp-asia-east1-a-config
 IMAGE_NAME[3]=ubuntu-1804-bionic-v20191002
 SPEC_NAME[3]=f1-micro
 
+ProviderName[3]=GCP
+DriverLibFileName[3]=gcp-driver-v1.0.so
+DriverName[3]=gcp-driver01

--- a/test/2020-04-29/prettify-json.sh
+++ b/test/2020-04-29/prettify-json.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+STR=${1}
+
+echo $STR | json_pp
+echo "| json_pp"


### PR DESCRIPTION
Automate test script to set up connection-conf

0.settingSpider 디렉터리에 delete-test.sh  get-test.sh  insert-test.sh  list-test.sh 가 추가됨

insert-test.sh 1 은 ../conf.env 에 "1"에 해당하는 CSP에 대한 드라이버, 크리덴셜, 리젼, 커넥션컨피그를 등록함.

conf.env 에는 각 CSP에 해당하는 사용자의 크리덴셜 정보를 입력해야 사용 가능함.