### PR TITLE
Enhance argument selection for all test script

### DIFF
--- a/test/2020-04-29/1.vNet/create-vNet.sh
+++ b/test/2020-04-29/1.vNet/create-vNet.sh
@@ -6,15 +6,30 @@ echo "####################################################################"
 echo "## 1. VPC: Create"
 echo "####################################################################"
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
 curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
 	'{
-		"name": "VPC-0'$INDEX'",
+		"name": "VPC-'$CSP'-'$POSTFIX'",
 		"connectionName": "'${CONN_CONFIG[INDEX]}'",
 		"cidrBlock": "192.168.0.0/16",
 		"subnetReqInfoList": [ {
-			"Name": "Subnet-0'$INDEX'", 
+			"Name": "Subnet-'$CSP'-'$POSTFIX'",
 			"IPv4_CIDR": "192.168.1.0/24"
 		} ]
 	}' | json_pp #|| return 1

--- a/test/2020-04-29/1.vNet/delete-vNet.sh
+++ b/test/2020-04-29/1.vNet/delete-vNet.sh
@@ -6,9 +6,24 @@ echo "####################################################################"
 echo "## 1. VPC: Delete"
 echo "####################################################################"
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet/VPC-0$INDEX -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet/VPC-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp #|| return 1

--- a/test/2020-04-29/1.vNet/get-vNet.sh
+++ b/test/2020-04-29/1.vNet/get-vNet.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Reboot MCIS"
+echo "## 1. VPC: Get"
 echo "####################################################################"
 
 CSP=${1}
@@ -23,4 +23,8 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=reboot | json_pp
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet/VPC-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
+    '{ 
+        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
+    }' | json_pp #|| return 1
+

--- a/test/2020-04-29/1.vNet/list-vNet.sh
+++ b/test/2020-04-29/1.vNet/list-vNet.sh
@@ -3,7 +3,8 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 5. spec: Fetch"
+echo "## 1. VPC: Get"
 echo "####################################################################"
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs #| json_pp
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet | json_pp #|| return 1
+

--- a/test/2020-04-29/1.vNet/spider-get-vNet.sh
+++ b/test/2020-04-29/1.vNet/spider-get-vNet.sh
@@ -2,6 +2,21 @@
 
 source ../conf.env
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
-curl -sX GET http://localhost:1024/spider/vpc/VPC-0$INDEX -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[INDEX]}'"}' | json_pp
+curl -sX GET http://localhost:1024/spider/vpc/VPC-$CSP-$POSTFIX -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[INDEX]}'"}' | json_pp

--- a/test/2020-04-29/2.securityGroup/create-securityGroup.sh
+++ b/test/2020-04-29/2.securityGroup/create-securityGroup.sh
@@ -6,13 +6,28 @@ echo "####################################################################"
 echo "## 2. SecurityGroup: Create"
 echo "####################################################################"
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
 curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
 	'{
-		"name": "SG-0'$INDEX'",
+		"name": "SG-'$CSP'-'$POSTFIX'",
 		"connectionName": "'${CONN_CONFIG[INDEX]}'",
-		"vNetId": "VPC-0'$INDEX'",
+		"vNetId": "VPC-'$CSP'-'$POSTFIX'",
 		"description": "jhseo test description",
 		    "firewallRules": [
 			    {

--- a/test/2020-04-29/2.securityGroup/delete-securityGroup.sh
+++ b/test/2020-04-29/2.securityGroup/delete-securityGroup.sh
@@ -6,9 +6,24 @@ echo "####################################################################"
 echo "## 2. SecurityGroup: Delete"
 echo "####################################################################"
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup/SG-0$INDEX -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup/SG-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp #|| return 1

--- a/test/2020-04-29/2.securityGroup/get-securityGroup.sh
+++ b/test/2020-04-29/2.securityGroup/get-securityGroup.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Reboot MCIS"
+echo "## 2. SecurityGroup: Get"
 echo "####################################################################"
 
 CSP=${1}
@@ -23,4 +23,8 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=reboot | json_pp
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup/SG-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
+    '{ 
+        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
+    }' | json_pp #|| return 1
+

--- a/test/2020-04-29/2.securityGroup/list-securityGroup.sh
+++ b/test/2020-04-29/2.securityGroup/list-securityGroup.sh
@@ -3,7 +3,9 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 5. spec: Fetch"
+echo "## 2. SecurityGroup: List"
 echo "####################################################################"
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs #| json_pp
+
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup | json_pp #|| return 1
+

--- a/test/2020-04-29/2.securityGroup/spider-get-securityGroup.sh
+++ b/test/2020-04-29/2.securityGroup/spider-get-securityGroup.sh
@@ -2,6 +2,22 @@
 
 source ../conf.env
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
-curl -sX GET http://localhost:1024/spider/securitygroup/SG-0$INDEX -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[INDEX]}'"}' | json_pp
+
+curl -sX GET http://localhost:1024/spider/securitygroup/SG-$CSP-$POSTFIX -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[INDEX]}'"}' | json_pp

--- a/test/2020-04-29/3.sshKey/create-sshKey.sh
+++ b/test/2020-04-29/3.sshKey/create-sshKey.sh
@@ -2,14 +2,29 @@
 
 source ../conf.env
 
-INDEX=${1}
-
 echo "####################################################################"
 echo "## 3. sshKey: Create"
 echo "####################################################################"
 
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
 curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[INDEX]}'", 
-		"name": "KEYPAIR-0'$INDEX'" 
+		"name": "KEYPAIR-'$CSP'-'$POSTFIX'"
 	}' | json_pp #|| return 1

--- a/test/2020-04-29/3.sshKey/delete-sshKey.sh
+++ b/test/2020-04-29/3.sshKey/delete-sshKey.sh
@@ -2,13 +2,28 @@
 
 source ../conf.env
 
-INDEX=${1}
-
 echo "####################################################################"
 echo "## 3. sshKey: Delete"
 echo "####################################################################"
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey/KEYPAIR-0$INDEX -H 'Content-Type: application/json' -d \
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey/KEYPAIR-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp #|| return 1

--- a/test/2020-04-29/3.sshKey/get-sshKey.sh
+++ b/test/2020-04-29/3.sshKey/get-sshKey.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Reboot MCIS"
+echo "## 3. sshKey: Get"
 echo "####################################################################"
 
 CSP=${1}
@@ -23,4 +23,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=reboot | json_pp
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey/KEYPAIR-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
+    '{ 
+        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
+    }' | json_pp #|| return 1

--- a/test/2020-04-29/3.sshKey/list-sshKey.sh
+++ b/test/2020-04-29/3.sshKey/list-sshKey.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source ../conf.env
+
+echo "####################################################################"
+echo "## 3. sshKey: List"
+echo "####################################################################"
+
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
+    '{ 
+        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
+    }' | json_pp #|| return 1

--- a/test/2020-04-29/3.sshKey/spider-get-sshKey.sh
+++ b/test/2020-04-29/3.sshKey/spider-get-sshKey.sh
@@ -2,9 +2,25 @@
 
 source ../conf.env
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
-curl -sX GET http://localhost:1024/spider/keypair/KEYPAIR-0$INDEX -H 'Content-Type: application/json' -d \
+
+curl -sX GET http://localhost:1024/spider/keypair/KEYPAIR-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp

--- a/test/2020-04-29/4.image/get-image.sh
+++ b/test/2020-04-29/4.image/get-image.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Reboot MCIS"
+echo "## 3. image: Get"
 echo "####################################################################"
 
 CSP=${1}
@@ -23,4 +23,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=reboot | json_pp
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/image/IMAGE-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
+    '{ 
+        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
+    }' | json_pp #|| return 1

--- a/test/2020-04-29/4.image/list-image.sh
+++ b/test/2020-04-29/4.image/list-image.sh
@@ -3,7 +3,8 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 5. spec: Fetch"
+echo "## 3. image: List"
 echo "####################################################################"
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs #| json_pp
+
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/image | json_pp #|| return 1

--- a/test/2020-04-29/4.image/register-image.sh
+++ b/test/2020-04-29/4.image/register-image.sh
@@ -2,21 +2,36 @@
 
 source ../conf.env
 
-INDEX=${1}
-
 echo "####################################################################"
 echo "## 4. image: Register"
 echo "####################################################################"
 
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
 curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[INDEX]}'", 
-		"name": "IMAGE-0'$INDEX'",
+		"name": "IMAGE-'$CSP'-'$POSTFIX'",
         "cspImageId": "'${IMAGE_NAME[INDEX]}'",
         "cspImageName": "",
         "creationDate": "",
-        "description": "",
-        "guestOS": "",
+        "description": "Canonical, Ubuntu, 18.04 LTS, amd64 bionic",
+        "guestOS": "Ubuntu",
         "status": "",
         "keyValueList": [
             {

--- a/test/2020-04-29/4.image/unregister-image.sh
+++ b/test/2020-04-29/4.image/unregister-image.sh
@@ -2,13 +2,28 @@
 
 source ../conf.env
 
-INDEX=${1}
-
 echo "####################################################################"
 echo "## 3. image: Unregister"
 echo "####################################################################"
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/image/IMAGE-0$INDEX -H 'Content-Type: application/json' -d \
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/image/IMAGE-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp #|| return 1

--- a/test/2020-04-29/5.spec/get-spec.sh
+++ b/test/2020-04-29/5.spec/get-spec.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Reboot MCIS"
+echo "## 5. spec: Get"
 echo "####################################################################"
 
 CSP=${1}
@@ -23,4 +23,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=reboot | json_pp
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec/SPEC-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
+    '{ 
+        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
+    }' | json_pp #|| return 1

--- a/test/2020-04-29/5.spec/list-spec.sh
+++ b/test/2020-04-29/5.spec/list-spec.sh
@@ -3,7 +3,8 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 5. spec: Fetch"
+echo "## 5. spec: List"
 echo "####################################################################"
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs #| json_pp
+
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec | json_pp #|| return 1

--- a/test/2020-04-29/5.spec/lookupSpec.sh
+++ b/test/2020-04-29/5.spec/lookupSpec.sh
@@ -2,11 +2,27 @@
 
 source ../conf.env
 
-INDEX=${1}
+echo "####################################################################"
+echo "## 5. spec: Lookup Spec"
+echo "####################################################################"
 
-echo "####################################################################"
-echo "## 4. spec: Lookup Spec"
-echo "####################################################################"
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
 
 curl -sX GET http://localhost:1323/tumblebug/lookupSpec/${SPEC_NAME[INDEX]} -H 'Content-Type: application/json' -d \
 	'{ 

--- a/test/2020-04-29/5.spec/lookupSpecList.sh
+++ b/test/2020-04-29/5.spec/lookupSpecList.sh
@@ -2,11 +2,26 @@
 
 source ../conf.env
 
-INDEX=${1}
+echo "####################################################################"
+echo "## 5. spec: Lookup Spec List"
+echo "####################################################################"
 
-echo "####################################################################"
-echo "## 4. spec: Lookup Spec List"
-echo "####################################################################"
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
 curl -sX GET http://localhost:1323/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
 	'{ 

--- a/test/2020-04-29/5.spec/register-spec.sh
+++ b/test/2020-04-29/5.spec/register-spec.sh
@@ -2,15 +2,30 @@
 
 source ../conf.env
 
-INDEX=${1}
+echo "####################################################################"
+echo "## 5. spec: Register"
+echo "####################################################################"
 
-echo "####################################################################"
-echo "## 4. spec: Register"
-echo "####################################################################"
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
 curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[INDEX]}'", 
-		"name": "SPEC-0'$INDEX'",
+		"name": "SPEC-'$CSP'-'$POSTFIX'",
         "cspSpecName": "'${SPEC_NAME[INDEX]}'"
 	}' | json_pp #|| return 1

--- a/test/2020-04-29/5.spec/spider-get-spec.sh
+++ b/test/2020-04-29/5.spec/spider-get-spec.sh
@@ -2,11 +2,26 @@
 
 source ../conf.env
 
-INDEX=${1}
+echo "####################################################################"
+echo "## 5. spec: Fetch"
+echo "####################################################################"
 
-echo "####################################################################"
-echo "## 4. spec: Fetch"
-echo "####################################################################"
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
 curl -sX GET http://localhost:1024/spider/vmspec/${SPEC_NAME[INDEX]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[INDEX]}'" }' | json_pp
 

--- a/test/2020-04-29/5.spec/spider-get-speclist.sh
+++ b/test/2020-04-29/5.spec/spider-get-speclist.sh
@@ -2,11 +2,26 @@
 
 source ../conf.env
 
-INDEX=${1}
+echo "####################################################################"
+echo "## 5. spec: Fetch"
+echo "####################################################################"
 
-echo "####################################################################"
-echo "## 4. spec: Fetch"
-echo "####################################################################"
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
 curl -sX GET http://localhost:1024/spider/vmspec -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[INDEX]}'" }' | json_pp
 

--- a/test/2020-04-29/5.spec/unregister-spec.sh
+++ b/test/2020-04-29/5.spec/unregister-spec.sh
@@ -2,13 +2,28 @@
 
 source ../conf.env
 
-INDEX=${1}
-
 echo "####################################################################"
-echo "## 3. spec: Unregister"
+echo "## 5. spec: Unregister"
 echo "####################################################################"
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec/SPEC-0$INDEX -H 'Content-Type: application/json' -d \
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec/SPEC-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp #|| return 1

--- a/test/2020-04-29/6.mcis/create-mcis.sh
+++ b/test/2020-04-29/6.mcis/create-mcis.sh
@@ -3,30 +3,45 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 4. VM: Create MCIS"
+echo "## 6. VM: Create MCIS"
 echo "####################################################################"
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
 curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d \
 	'{
-		"name": "MCIS-0'$INDEX'",
+		"name": "MCIS-'$CSP'-'$POSTFIX'",
 		"vm_num": "1",
 		"description": "Tumblebug demo",
 		"vm_req": [ {
-			"image_id": "IMAGE-0'$INDEX'",
+			"image_id": "IMAGE-'$CSP'-'$POSTFIX'",
 			"vm_access_id": "cb-user",
 			"config_name": "'${CONN_CONFIG[INDEX]}'",
-			"ssh_key_id": "KEYPAIR-0'$INDEX'",
-			"spec_id": "SPEC-0'$INDEX'",
+			"ssh_key_id": "KEYPAIR-'$CSP'-'$POSTFIX'",
+			"spec_id": "SPEC-'$CSP'-'$POSTFIX'",
 			"security_group_ids": [
-				"SG-0'$INDEX'"
+				"SG-'$CSP'-'$POSTFIX'"
 			],
-			"vnet_id": "VPC-0'$INDEX'",
-			"subnet_id": "Subnet-0'$INDEX'",
+			"vnet_id": "VPC-'$CSP'-'$POSTFIX'",
+			"subnet_id": "Subnet-'$CSP'-'$POSTFIX'",
 			"description": "description",
 			"vm_access_passwd": "",
-			"name": "VM-0'$INDEX'"
+			"name": "VM-'$CSP'-'$POSTFIX'"
 		} ]
 	}' | json_pp || return 1
 

--- a/test/2020-04-29/6.mcis/get-mcis.sh
+++ b/test/2020-04-29/6.mcis/get-mcis.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Reboot MCIS"
+echo "## 6. VM: Get MCIS"
 echo "####################################################################"
 
 CSP=${1}
@@ -23,4 +23,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=reboot | json_pp
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX | json_pp

--- a/test/2020-04-29/6.mcis/just-terminate-mcis.sh
+++ b/test/2020-04-29/6.mcis/just-terminate-mcis.sh
@@ -2,9 +2,25 @@
 
 source ../conf.env
 
-INDEX=${1}
+echo "####################################################################"
+echo "## 6. VM: Just Terminate MCIS"
+echo "####################################################################"
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-0$INDEX?action=terminate -H 'Content-Type: application/json' -d \
-    '{ 
-        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
-    }' | json_pp
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=terminate | json_pp

--- a/test/2020-04-29/6.mcis/list-mcis.sh
+++ b/test/2020-04-29/6.mcis/list-mcis.sh
@@ -3,7 +3,8 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 5. spec: Fetch"
+echo "## 6. VM: List MCIS"
 echo "####################################################################"
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs #| json_pp
+
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis | json_pp

--- a/test/2020-04-29/6.mcis/resume-mcis.sh
+++ b/test/2020-04-29/6.mcis/resume-mcis.sh
@@ -2,9 +2,26 @@
 
 source ../conf.env
 
-INDEX=${1}
+echo "####################################################################"
+echo "## 6. VM: Resume from suspended MCIS"
+echo "####################################################################"
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-0$INDEX?action=resume -H 'Content-Type: application/json' -d \
-    '{ 
-        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
-    }' | json_pp
+
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=resume | json_pp

--- a/test/2020-04-29/6.mcis/spider-create-vm.sh
+++ b/test/2020-04-29/6.mcis/spider-create-vm.sh
@@ -2,18 +2,33 @@
 
 source ../conf.env
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
 curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
 	'{ 
 		"ConnectionName": "'${CONN_CONFIG[INDEX]}'", 
 		"ReqInfo": { 
-			"Name": "VM-0'$INDEX'", 
+			"Name": "VM-'$CSP'-'$POSTFIX'",
 			"ImageName": "'${IMAGE_NAME[INDEX]}'", 
-			"VPCName": "VPC-0'$INDEX'", 
-			"SubnetName": "Subnet-0'$INDEX'", 
-			"SecurityGroupNames": [ "SG-0'$INDEX'" ], 
+			"VPCName": "VPC-'$CSP'-'$POSTFIX'",
+			"SubnetName": "Subnet-'$CSP'-'$POSTFIX'",
+			"SecurityGroupNames": [ "SG-'$CSP'-'$POSTFIX'" ], 
 			"VMSpecName": "'${SPEC_NAME[INDEX]}'", 
-			"KeyPairName": "KEYPAIR-0'$INDEX'"
+			"KeyPairName": "KEYPAIR-'$CSP'-'$POSTFIX'"
 		} 
 	}' | json_pp

--- a/test/2020-04-29/6.mcis/spider-delete-vm.sh
+++ b/test/2020-04-29/6.mcis/spider-delete-vm.sh
@@ -2,9 +2,24 @@
 
 source ../conf.env
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
-curl -sX DELETE http://localhost:1024/spider/vm/VM-0$INDEX -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://localhost:1024/spider/vm/VM-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp

--- a/test/2020-04-29/6.mcis/spider-get-vm.sh
+++ b/test/2020-04-29/6.mcis/spider-get-vm.sh
@@ -2,9 +2,24 @@
 
 source ../conf.env
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
-curl -sX GET http://localhost:1024/spider/vm/VM-0$INDEX -H 'Content-Type: application/json' -d \
+curl -sX GET http://localhost:1024/spider/vm/VM-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp

--- a/test/2020-04-29/6.mcis/spider-get-vmstatus.sh
+++ b/test/2020-04-29/6.mcis/spider-get-vmstatus.sh
@@ -2,9 +2,24 @@
 
 source ../conf.env
 
-INDEX=${1}
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
 
-curl -sX GET http://localhost:1024/spider/vmstatus/VM-0$INDEX -H 'Content-Type: application/json' -d \
+curl -sX GET http://localhost:1024/spider/vmstatus/VM-$CSP-$POSTFIX -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
     }' | json_pp

--- a/test/2020-04-29/6.mcis/status-mcis.sh
+++ b/test/2020-04-29/6.mcis/status-mcis.sh
@@ -3,8 +3,9 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Reboot MCIS"
+echo "## 6. VM: Status MCIS"
 echo "####################################################################"
+
 
 CSP=${1}
 POSTFIX=${2:-developer}
@@ -23,4 +24,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=reboot | json_pp
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=status | json_pp

--- a/test/2020-04-29/6.mcis/suspend-mcis.sh
+++ b/test/2020-04-29/6.mcis/suspend-mcis.sh
@@ -2,9 +2,26 @@
 
 source ../conf.env
 
-INDEX=${1}
+echo "####################################################################"
+echo "## 6. VM: Suspend MCIS"
+echo "####################################################################"
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-0$INDEX?action=suspend -H 'Content-Type: application/json' -d \
-    '{ 
-        "ConnectionName": "'${CONN_CONFIG[INDEX]}'"
-    }' | json_pp
+
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX?action=suspend | json_pp

--- a/test/2020-04-29/6.mcis/terminate-and-delete-mcis.sh
+++ b/test/2020-04-29/6.mcis/terminate-and-delete-mcis.sh
@@ -2,11 +2,26 @@
 
 source ../conf.env
 
-INDEX=${1}
-
 echo "####################################################################"
-echo "## 4. VM: Terminate(Delete)"
+echo "## 6. VM: Terminate and Delete MCIS"
 echo "####################################################################"
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-0$INDEX | json_pp || return 1
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/mcis/MCIS-$CSP-$POSTFIX | json_pp || return 1
 


### PR DESCRIPTION

[개선사항]
- Test 스크립트 실행시, CSP를 지정할 수 있도록 수정 (기존: 1, 2, ... -> 변경: aws, azure, gcp, ...)
- Test 스크립트 사용자를 명시할 수 있음 (예시: "VPC-$ARG01-$ARG02")
  - 예시: create-vNet.sh
     - Default {$ARG01=aws, $ARG02=developer}로 이름 생성하여 수행됨: VPC-aws-developer
  - 예시: create-vNet.sh aws
     - $ARG01=aws, $ARG02=developer 로 수행됨 : VPC-aws-developer
  - 예시: create-vNet.sh azure
     - $ARG01=azure, $ARG02=developer 로 수행됨 : VPC-azure-developer
  - 예시: create-vNet.sh azure shsontest
     - $ARG01=azure, $ARG02=shsontest  로 수행됨 : VPC-azure-shsontest