### PR TITLE
Parallel mcis control and enhance test script

### DIFF
--- a/test/2020-04-29/0.settingSpider/register-cloud.sh
+++ b/test/2020-04-29/0.settingSpider/register-cloud.sh
@@ -59,6 +59,25 @@ curl -sX POST http://$RESTSERVER:1024/spider/credential -H 'Content-Type: applic
     }' | json_pp
 
  # for Cloud Region Info
+
+if [ "${CSP}" == "azure" ]; then
+    # Differenciate Cloud Region Value for Resource Group Name
+	curl -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d \
+    '{
+        "ProviderName" : "'${ProviderName[INDEX]}'",
+        "KeyValueInfoList" : [
+            {
+                "Key" : "'${RegionKey01[INDEX]:-NULL}'",
+                "Value" : "'${RegionVal01[INDEX]:-NULL}'"
+            },
+            {
+                "Key" : "'${RegionKey02[INDEX]:-NULL}'",
+                "Value" : "'${RegionVal02[INDEX]:-NULL}'-'$CSP'-'$POSTFIX'"
+            }
+        ],
+        "RegionName" : "'${RegionName[INDEX]}'"
+    }' | json_pp
+else
 curl -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d \
     '{
         "ProviderName" : "'${ProviderName[INDEX]}'",
@@ -74,6 +93,7 @@ curl -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: applicatio
         ],
         "RegionName" : "'${RegionName[INDEX]}'"
     }' | json_pp
+fi
 
 
  # for Cloud Connection Config Info

--- a/test/2020-04-29/fullTest/cleanAll-mcis-mcir-cloud.sh
+++ b/test/2020-04-29/fullTest/cleanAll-mcis-mcir-cloud.sh
@@ -24,27 +24,27 @@ else
 fi
 
 ../6.mcis/just-terminate-mcis.sh $CSP $POSTFIX
-echo "============== sleep 60 to check MCIS : Start"
+echo "============== sleep 60 before delete MCIS obj"
 sleep 60
-echo "============== sleep 60 to check MCIS : End"
 ../6.mcis/status-mcis.sh $CSP $POSTFIX
 ../6.mcis/terminate-and-delete-mcis.sh $CSP $POSTFIX
 ../5.spec/unregister-spec.sh $CSP $POSTFIX
 ../4.image/unregister-image.sh $CSP $POSTFIX
 ../3.sshKey/delete-sshKey.sh $CSP $POSTFIX
-sleep 10
+sleep 5
 ../2.securityGroup/delete-securityGroup.sh $CSP $POSTFIX
-sleep 10
+sleep 5
 ../1.vNet/delete-vNet.sh $CSP $POSTFIX
-../0.settingTB/delete-ns.sh $CSP $POSTFIX
+#../0.settingTB/delete-ns.sh $CSP $POSTFIX
 ../0.settingSpider/unregister-cloud.sh $CSP $POSTFIX
 
 
+_self="${0##*/}"
 
-
-
-
-
-
-
+echo ""
+echo "[Cleaning related commands in history file executionStatus]"
+sed -i "/${CSP} ${POSTFIX}/d" ./executionStatus
+echo ""
+echo "[Executed Command List]"
+cat  ./executionStatus
 

--- a/test/2020-04-29/fullTest/test-cloud.sh
+++ b/test/2020-04-29/fullTest/test-cloud.sh
@@ -24,19 +24,12 @@ else
 fi
 
 ../0.settingSpider/register-cloud.sh $CSP $POSTFIX
-../0.settingTB/create-ns.sh $CSP $POSTFIX
-../1.vNet/create-vNet.sh $CSP $POSTFIX
-sleep 10
-../2.securityGroup/create-securityGroup.sh $CSP $POSTFIX
-sleep 10
-../3.sshKey/create-sshKey.sh $CSP $POSTFIX
-../4.image/register-image.sh $CSP $POSTFIX
-../5.spec/register-spec.sh $CSP $POSTFIX
-../6.mcis/create-mcis.sh $CSP $POSTFIX
-echo "============== sleep 10 to check MCIS : Start"
-sleep 10
-echo "============== sleep 10 to check MCIS : End"
-../6.mcis/status-mcis.sh $CSP $POSTFIX
 
 
-
+_self="${0##*/}"
+echo ""
+echo "[Logging to notify latest command history]"
+echo "[CMD] ${_self} ${CSP} ${POSTFIX}" >> ./executionStatus
+echo ""
+echo "[Executed Command List]"
+cat  ./executionStatus

--- a/test/2020-04-29/fullTest/test-mcir-ns-cloud.sh
+++ b/test/2020-04-29/fullTest/test-mcir-ns-cloud.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+source ../conf.env
+source ../credentials.conf
+
+echo "####################################################################"
+echo "## Create MCIS from Zero Base"
+echo "####################################################################"
+
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+../0.settingSpider/register-cloud.sh $CSP $POSTFIX
+../0.settingTB/create-ns.sh $CSP $POSTFIX
+../1.vNet/create-vNet.sh $CSP $POSTFIX
+sleep 5
+../2.securityGroup/create-securityGroup.sh $CSP $POSTFIX
+sleep 5
+../3.sshKey/create-sshKey.sh $CSP $POSTFIX
+../4.image/register-image.sh $CSP $POSTFIX
+../5.spec/register-spec.sh $CSP $POSTFIX
+
+
+
+_self="${0##*/}"
+echo ""
+echo "[Logging to notify latest command history]"
+echo "[CMD] ${_self} ${CSP} ${POSTFIX}" >> ./executionStatus
+echo ""
+echo "[Executed Command List]"
+cat  ./executionStatus
+

--- a/test/2020-04-29/fullTest/test-ns-cloud.sh
+++ b/test/2020-04-29/fullTest/test-ns-cloud.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+source ../conf.env
+source ../credentials.conf
+
+echo "####################################################################"
+echo "## Create MCIS from Zero Base"
+echo "####################################################################"
+
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+../0.settingSpider/register-cloud.sh $CSP $POSTFIX
+../0.settingTB/create-ns.sh $CSP $POSTFIX
+
+
+_self="${0##*/}"
+echo ""
+echo "[Logging to notify latest command history]"
+echo "[CMD] ${_self} ${CSP} ${POSTFIX}" >> ./executionStatus
+echo ""
+echo "[Executed Command List]"
+cat  ./executionStatus

--- a/test/2020-04-29/fullTest/testAll-mcis-mcir-ns-cloud.sh
+++ b/test/2020-04-29/fullTest/testAll-mcis-mcir-ns-cloud.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+source ../conf.env
+source ../credentials.conf
+
+echo "####################################################################"
+echo "## Create MCIS from Zero Base"
+echo "####################################################################"
+
+CSP=${1}
+POSTFIX=${2:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, ..). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+../0.settingSpider/register-cloud.sh $CSP $POSTFIX
+../0.settingTB/create-ns.sh $CSP $POSTFIX
+../1.vNet/create-vNet.sh $CSP $POSTFIX
+sleep 5
+../2.securityGroup/create-securityGroup.sh $CSP $POSTFIX
+sleep 5
+../3.sshKey/create-sshKey.sh $CSP $POSTFIX
+../4.image/register-image.sh $CSP $POSTFIX
+../5.spec/register-spec.sh $CSP $POSTFIX
+../6.mcis/create-mcis.sh $CSP $POSTFIX
+sleep 1
+../6.mcis/status-mcis.sh $CSP $POSTFIX
+
+_self="${0##*/}"
+
+echo ""
+echo "[Logging to notify latest command history]"
+echo "[CMD] ${_self} ${CSP} ${POSTFIX}" >> ./executionStatus
+echo ""
+echo "[Executed Command List]"
+cat  ./executionStatus


### PR DESCRIPTION
Parallel mcis control and enhance test script

1. MCIS 내의 VM 제어 처리 병렬화
 - CB-Spider 의 특정 CSP는 VM 제어시 동기 콜을 사용하고 있어서, CB-TB가 MCIS를 생성하는데 시간이 많이 소요됨. CB-TB에서 CB-Spider로의 VM 제어 콜을 병렬로 보내도록 수정.

2. 테스트 스크립트가 보완됨
 - 사용자 명칭만 다르게하면 CSP 쪽 자원이 겹치지 않도록 처리 (특히, azure의 경우 Resource Group 명칭을 동일하게 사용하고 있었음). 
 - 여러 CSP에 대한 동시 테스트 가능

 - 시퀀셜 테스트 스크립트를 단계 형태로 추가
    - testAll-mcis-mcir-ns-cloud.sh  
    - test-mcir-ns-cloud.sh
    - test-ns-cloud.sh
    - test-cloud.sh                  

 - 모든 테슽트 코드 삭제
    - cleanAll-mcis-mcir-cloud.sh  (다만 ns는 CSP간 시험에서 공유할 수 있으므로, 삭제하지 않음)

 - 동일 테스트 중복 실행을 막기 위해서, 커맨드 히스토리를 파일로 남김
    - executionStatus  (커맨드 히스토리 자동 기록)           

3. AWS, Azure 까지 테스트
    - testAll-mcis-mcir-ns-cloud.sh  