### PR TITLE
Stateless management of MCIS lifecycle

### DIFF
--- a/src/common/namespace.go
+++ b/src/common/namespace.go
@@ -97,7 +97,7 @@ func RestGetAllNs(c echo.Context) error {
 		Ns []nsInfo `json:"ns"`
 	}
 
-	nsList := getNsList()
+	nsList := GetNsList()
 
 	for _, v := range nsList {
 
@@ -143,7 +143,7 @@ func RestDelNs(c echo.Context) error {
 
 func RestDelAllNs(c echo.Context) error {
 
-	nsList := getNsList()
+	nsList := GetNsList()
 
 	for _, v := range nsList {
 		err := delNs(v)
@@ -191,9 +191,9 @@ func createNs(u *nsReq) (nsInfo, error) {
 	return content, nil
 }
 
-func getNsList() []string {
+func GetNsList() []string {
 
-	fmt.Println("[List ns")
+	fmt.Println("[List ns]")
 	key := "/ns"
 	fmt.Println(key)
 

--- a/src/mcism.go
+++ b/src/mcism.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"github.com/cloud-barista/cb-tumblebug/src/apiserver"
+	"github.com/cloud-barista/cb-tumblebug/src/mcis"
 	"os"
+	"time"
+	"fmt"
 )
 
 func main() {
+	
 
 	//fmt.Println("\n[cb-tumblebug (Multi-Cloud Infra Service Management Framework)]")
 	//fmt.Println("\nInitiating REST API Server ...")
@@ -33,6 +37,17 @@ func main() {
 
 	// load config
 	//masterConfigInfos = confighandler.GetMasterConfigInfos()
+
+	//Ticker for MCIS status validation
+	validationDuration := 2000 //ms
+	ticker := time.NewTicker( time.Millisecond * time.Duration(validationDuration) )
+	go func() {
+		for t := range ticker.C {
+			fmt.Println("Tick at", t)
+			mcis.ValidateStatus()
+		}
+	}()
+	defer ticker.Stop()
 
 	// Run API Server
 	apiserver.ApiServer()


### PR DESCRIPTION

기존의 MCIS 및 VM 상태 오류를 보정하는 업데이트.

관련 이슈: spider에서 제공하는 native한 vm의 status는 csp 마다 값과 처리 방식이 다름. MCIS 상태에 오류 발생.

이를 보정하기 위해서, 

- CB-TB는  "targetStatus", "targetAction" 필드를 도입함.
- 사용자에게  MCIS 제어 요청을 받으면, "targetStatus", "targetAction" 을 DB에 저장하고
- 향후, MCIS 상태 조회시, 이를 고려하여 값을 보정함.

상태별로 불가한 제어 명령을 지정 및 기능을 추가하였음 (func checkAllowedTransition)
- Transitional statuses (suspending, resuming, terminating, ...): 상태 전이 완료 전까지 모든 제어 명령 허용하지 않음
- Terminated : 모든 제어 명령 허용하지 않음
- Suspended: Resume, Terminate 만 허용