### PR TITLE
Fix VM IP no renewal and test script enhancement

### DIFF
--- a/test/official/0.settingSpider/get-cloud.sh
+++ b/test/official/0.settingSpider/get-cloud.sh
@@ -30,17 +30,17 @@ fi
 RESTSERVER=localhost
 
 # for Cloud Connection Config Info
-curl -sX GET http://$RESTSERVER:1024/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | json_pp
+curl -sX GET http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | json_pp
 
 
 # for Cloud Region Info
-curl -sX GET http://$RESTSERVER:1024/spider/region/${RegionName[$INDEX,$REGION]} | json_pp
+curl -sX GET http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]} | json_pp
 
 
 # for Cloud Credential Info
-curl -sX GET http://$RESTSERVER:1024/spider/credential/${CredentialName[INDEX]} | json_pp
+curl -sX GET http://$SpiderServer/spider/credential/${CredentialName[INDEX]} | json_pp
 
  
 # for Cloud Driver Info
-curl -sX GET http://$RESTSERVER:1024/spider/driver/${DriverName[INDEX]} | json_pp
+curl -sX GET http://$SpiderServer/spider/driver/${DriverName[INDEX]} | json_pp
 

--- a/test/official/0.settingSpider/list-cloud.sh
+++ b/test/official/0.settingSpider/list-cloud.sh
@@ -12,16 +12,16 @@ echo "####################################################################"
 RESTSERVER=localhost
 
 # for Cloud Connection Config Info
-curl -sX GET http://$RESTSERVER:1024/spider/connectionconfig | json_pp
+curl -sX GET http://$SpiderServer/spider/connectionconfig | json_pp
 
 
 # for Cloud Region Info
-curl -sX GET http://$RESTSERVER:1024/spider/region | json_pp
+curl -sX GET http://$SpiderServer/spider/region | json_pp
 
 
 # for Cloud Credential Info
-curl -sX GET http://$RESTSERVER:1024/spider/credential | json_pp
+curl -sX GET http://$SpiderServer/spider/credential | json_pp
 
  
 # for Cloud Driver Info
-curl -sX GET http://$RESTSERVER:1024/spider/driver | json_pp
+curl -sX GET http://$SpiderServer/spider/driver | json_pp

--- a/test/official/0.settingSpider/register-cloud.sh
+++ b/test/official/0.settingSpider/register-cloud.sh
@@ -30,7 +30,7 @@ fi
 RESTSERVER=localhost
 
  # for Cloud Driver Info
-curl -sX POST http://$RESTSERVER:1024/spider/driver -H 'Content-Type: application/json' -d \
+curl -sX POST http://$SpiderServer/spider/driver -H 'Content-Type: application/json' -d \
 	'{
         "ProviderName" : "'${ProviderName[INDEX]}'",
         "DriverLibFileName" : "'${DriverLibFileName[INDEX]}'",
@@ -38,7 +38,7 @@ curl -sX POST http://$RESTSERVER:1024/spider/driver -H 'Content-Type: applicatio
 	}' | json_pp
 
  # for Cloud Credential Info
-curl -sX POST http://$RESTSERVER:1024/spider/credential -H 'Content-Type: application/json' -d \
+curl -sX POST http://$SpiderServer/spider/credential -H 'Content-Type: application/json' -d \
     "{
         \"ProviderName\" : \"${ProviderName[INDEX]}\",
         \"CredentialName\" : \"${CredentialName[INDEX]}\",
@@ -66,7 +66,7 @@ curl -sX POST http://$RESTSERVER:1024/spider/credential -H 'Content-Type: applic
 
 if [ "${CSP}" == "azure" ]; then
     # Differenciate Cloud Region Value for Resource Group Name
-	curl -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d \
+	curl -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d \
     '{
         "ProviderName" : "'${ProviderName[INDEX]}'",
         "KeyValueInfoList" : [
@@ -82,7 +82,7 @@ if [ "${CSP}" == "azure" ]; then
         "RegionName" : "'${RegionName[$INDEX,$REGION]}'"
     }' | json_pp
 else
-curl -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d \
+curl -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d \
     '{
         "ProviderName" : "'${ProviderName[INDEX]}'",
         "KeyValueInfoList" : [
@@ -101,7 +101,7 @@ fi
 
 
  # for Cloud Connection Config Info
-curl -sX POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d \
+curl -sX POST http://$SpiderServer/spider/connectionconfig -H 'Content-Type: application/json' -d \
     '{
         "CredentialName" : "'${CredentialName[INDEX]}'",
         "ConfigName" : "'${CONN_CONFIG[$INDEX,$REGION]}'",

--- a/test/official/0.settingSpider/unregister-cloud.sh
+++ b/test/official/0.settingSpider/unregister-cloud.sh
@@ -27,16 +27,23 @@ else
 	INDEX=1
 fi
 
+OPTION=${4:-none}
+
 RESTSERVER=localhost
 
 # for Cloud Connection Config Info
-curl -sX DELETE http://$RESTSERVER:1024/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]}
+curl -sX DELETE http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]}
 
 # for Cloud Region Info
-curl -sX DELETE http://$RESTSERVER:1024/spider/region/${RegionName[$INDEX,$REGION]}
+curl -sX DELETE http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]}
+
+if [ "${OPTION}" == "leave" ]; then
+	echo "[Leave Cloud Credential and Cloud Driver for other Regions]"
+	exit
+fi
 
 # for Cloud Credential Info
-curl -sX DELETE http://$RESTSERVER:1024/spider/credential/${CredentialName[INDEX]}
+curl -sX DELETE http://$SpiderServer/spider/credential/${CredentialName[INDEX]}
  
 # for Cloud Driver Info
-curl -sX DELETE http://$RESTSERVER:1024/spider/driver/${DriverName[INDEX]}
+curl -sX DELETE http://$SpiderServer/spider/driver/${DriverName[INDEX]}

--- a/test/official/0.settingTB/create-ns.sh
+++ b/test/official/0.settingTB/create-ns.sh
@@ -8,7 +8,7 @@ echo "####################################################################"
 
 INDEX=${1}
 
-curl -sX POST http://localhost:1323/tumblebug/ns -H 'Content-Type: application/json' -d \
+curl -sX POST http://$TumblebugServer/tumblebug/ns -H 'Content-Type: application/json' -d \
 	'{
 		"name": "'$NS_ID'",
 		"description": "NameSpace for General Testing"

--- a/test/official/0.settingTB/delete-ns.sh
+++ b/test/official/0.settingTB/delete-ns.sh
@@ -8,4 +8,4 @@ echo "####################################################################"
 
 INDEX=${1}
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID | json_pp #|| return 1
+curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID | json_pp #|| return 1

--- a/test/official/0.settingTB/get-ns.sh
+++ b/test/official/0.settingTB/get-ns.sh
@@ -8,4 +8,4 @@ echo "####################################################################"
 
 INDEX=${1}
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID | json_pp #|| return 1
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID | json_pp #|| return 1

--- a/test/official/0.settingTB/list-ns.sh
+++ b/test/official/0.settingTB/list-ns.sh
@@ -8,4 +8,4 @@ echo "####################################################################"
 
 INDEX=${1}
 
-curl -sX GET http://localhost:1323/tumblebug/ns | json_pp #|| return 1
+curl -sX GET http://$TumblebugServer/tumblebug/ns | json_pp #|| return 1

--- a/test/official/1.vNet/create-vNet.sh
+++ b/test/official/1.vNet/create-vNet.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
 	'{
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",

--- a/test/official/1.vNet/delete-vNet.sh
+++ b/test/official/1.vNet/delete-vNet.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/1.vNet/get-vNet.sh
+++ b/test/official/1.vNet/get-vNet.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/1.vNet/list-vNet.sh
+++ b/test/official/1.vNet/list-vNet.sh
@@ -6,5 +6,5 @@ echo "####################################################################"
 echo "## 1. VPC: Get"
 echo "####################################################################"
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet | json_pp #|| return 1
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet | json_pp #|| return 1
 

--- a/test/official/1.vNet/spider-get-vNet.sh
+++ b/test/official/1.vNet/spider-get-vNet.sh
@@ -23,4 +23,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1024/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp
+curl -sX GET http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp

--- a/test/official/2.securityGroup/create-securityGroup.sh
+++ b/test/official/2.securityGroup/create-securityGroup.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
 	'{
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",

--- a/test/official/2.securityGroup/delete-securityGroup.sh
+++ b/test/official/2.securityGroup/delete-securityGroup.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/2.securityGroup/get-securityGroup.sh
+++ b/test/official/2.securityGroup/get-securityGroup.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/2.securityGroup/list-securityGroup.sh
+++ b/test/official/2.securityGroup/list-securityGroup.sh
@@ -7,5 +7,5 @@ echo "## 2. SecurityGroup: List"
 echo "####################################################################"
 
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup | json_pp #|| return 1
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup | json_pp #|| return 1
 

--- a/test/official/2.securityGroup/spider-get-securityGroup.sh
+++ b/test/official/2.securityGroup/spider-get-securityGroup.sh
@@ -24,4 +24,4 @@ else
 fi
 
 
-curl -sX GET http://localhost:1024/spider/securitygroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp
+curl -sX GET http://$SpiderServer/spider/securitygroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp

--- a/test/official/3.sshKey/create-sshKey.sh
+++ b/test/official/3.sshKey/create-sshKey.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'", 

--- a/test/official/3.sshKey/delete-sshKey.sh
+++ b/test/official/3.sshKey/delete-sshKey.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/3.sshKey/get-sshKey.sh
+++ b/test/official/3.sshKey/get-sshKey.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/3.sshKey/list-sshKey.sh
+++ b/test/official/3.sshKey/list-sshKey.sh
@@ -6,7 +6,7 @@ echo "####################################################################"
 echo "## 3. sshKey: List"
 echo "####################################################################"
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/3.sshKey/spider-delete-sshKey.sh
+++ b/test/official/3.sshKey/spider-delete-sshKey.sh
@@ -24,7 +24,7 @@ else
 fi
 
 
-curl -sX DELETE http://localhost:1024/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/3.sshKey/spider-get-sshKey.sh
+++ b/test/official/3.sshKey/spider-get-sshKey.sh
@@ -24,7 +24,7 @@ else
 fi
 
 
-curl -sX GET http://localhost:1024/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/4.image/get-image.sh
+++ b/test/official/4.image/get-image.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/4.image/list-image.sh
+++ b/test/official/4.image/list-image.sh
@@ -7,4 +7,4 @@ echo "## 4. image: List"
 echo "####################################################################"
 
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/image | json_pp #|| return 1
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image | json_pp #|| return 1

--- a/test/official/4.image/register-image.sh
+++ b/test/official/4.image/register-image.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d \
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/4.image/unregister-image.sh
+++ b/test/official/4.image/unregister-image.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/5.spec/fetch-specs.sh
+++ b/test/official/5.spec/fetch-specs.sh
@@ -6,4 +6,4 @@ echo "####################################################################"
 echo "## 5. spec: Fetch"
 echo "####################################################################"
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/fetchSpecs | json_pp #|| return 1
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/fetchSpecs | json_pp #|| return 1

--- a/test/official/5.spec/get-spec.sh
+++ b/test/official/5.spec/get-spec.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/5.spec/list-spec.sh
+++ b/test/official/5.spec/list-spec.sh
@@ -7,4 +7,4 @@ echo "## 5. spec: List"
 echo "####################################################################"
 
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec | json_pp #|| return 1
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec | json_pp #|| return 1

--- a/test/official/5.spec/lookupSpec.sh
+++ b/test/official/5.spec/lookupSpec.sh
@@ -28,7 +28,7 @@ else
 fi
 
 
-curl -sX GET http://localhost:1323/tumblebug/lookupSpec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$TumblebugServer/tumblebug/lookupSpec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
 	}' | json_pp #|| return 1

--- a/test/official/5.spec/lookupSpecList.sh
+++ b/test/official/5.spec/lookupSpecList.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
+curl -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
 	}' | json_pp #|| return 1

--- a/test/official/5.spec/register-spec.sh
+++ b/test/official/5.spec/register-spec.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d \
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/5.spec/spider-get-spec.sh
+++ b/test/official/5.spec/spider-get-spec.sh
@@ -27,5 +27,5 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1024/spider/vmspec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
+curl -sX GET http://$SpiderServer/spider/vmspec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
 

--- a/test/official/5.spec/spider-get-speclist.sh
+++ b/test/official/5.spec/spider-get-speclist.sh
@@ -27,5 +27,5 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1024/spider/vmspec -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
+curl -sX GET http://$SpiderServer/spider/vmspec -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
 

--- a/test/official/5.spec/unregister-spec.sh
+++ b/test/official/5.spec/unregister-spec.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/6.mcis/create-mcis.sh
+++ b/test/official/6.mcis/create-mcis.sh
@@ -27,7 +27,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d \
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d \
 	'{
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 		"description": "Tumblebug Demo",

--- a/test/official/6.mcis/get-mcis.sh
+++ b/test/official/6.mcis/get-mcis.sh
@@ -27,4 +27,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp

--- a/test/official/6.mcis/list-mcis.sh
+++ b/test/official/6.mcis/list-mcis.sh
@@ -7,4 +7,4 @@ echo "## 6. VM: List MCIS"
 echo "####################################################################"
 
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis | json_pp
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis | json_pp

--- a/test/official/6.mcis/reboot-mcis.sh
+++ b/test/official/6.mcis/reboot-mcis.sh
@@ -27,4 +27,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=reboot | json_pp
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=reboot | json_pp

--- a/test/official/6.mcis/resume-mcis.sh
+++ b/test/official/6.mcis/resume-mcis.sh
@@ -28,4 +28,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=resume | json_pp
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=resume | json_pp

--- a/test/official/6.mcis/spider-create-vm.sh
+++ b/test/official/6.mcis/spider-create-vm.sh
@@ -23,11 +23,11 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://localhost:1024/spider/vm -H 'Content-Type: application/json' -d \
+curl -sX POST http://$SpiderServer/spider/vm -H 'Content-Type: application/json' -d \
 	'{ 
 		"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"ReqInfo": { 
-			"Name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"Name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-01",
 			"ImageName": "'${IMAGE_NAME[$INDEX,$REGION]}'", 
 			"VPCName": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"SubnetName": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/6.mcis/spider-delete-vm.sh
+++ b/test/official/6.mcis/spider-delete-vm.sh
@@ -22,8 +22,8 @@ else
 	CSP="aws"
 	INDEX=1
 fi
-#curl -sX DELETE http://localhost:1024/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H
-curl -sX DELETE http://localhost:1024/spider/vm/alibaba-ap-northeast-1-shson-01 -H 'Content-Type: application/json' -d \
+#curl -sX DELETE http://$SpiderServer/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H
+curl -sX DELETE http://$SpiderServer/spider/vm/alibaba-ap-northeast-1-shson-01 -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/6.mcis/spider-get-vm.sh
+++ b/test/official/6.mcis/spider-get-vm.sh
@@ -23,7 +23,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1024/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$SpiderServer/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01 -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/6.mcis/spider-get-vmstatus.sh
+++ b/test/official/6.mcis/spider-get-vmstatus.sh
@@ -23,7 +23,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1024/spider/vmstatus/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -sX GET http://$SpiderServer/spider/vmstatus/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01 -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/6.mcis/status-mcis.sh
+++ b/test/official/6.mcis/status-mcis.sh
@@ -28,4 +28,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=status | json_pp
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=status | json_pp

--- a/test/official/6.mcis/suspend-mcis.sh
+++ b/test/official/6.mcis/suspend-mcis.sh
@@ -28,4 +28,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=suspend | json_pp
+curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=suspend | json_pp

--- a/test/official/6.mcis/terminate-and-delete-mcis.sh
+++ b/test/official/6.mcis/terminate-and-delete-mcis.sh
@@ -27,5 +27,5 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://localhost:1323/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp || return 1
+curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp || return 1
 

--- a/test/official/README.md
+++ b/test/official/README.md
@@ -1,0 +1,445 @@
+# CB-Tumblebug (Multi-Cloud Infra Service Management)
+
+이 디렉토리는 CB-Tumblebug의 기본적인 테스트 수행을 위한 테스트 스크립트를 포함
+
+***
+
+## [목차]
+
+1. [실행 환경](#실행-환경)
+2. [실행 방법](#실행-방법)
+
+***
+
+## [실행 환경]
+- Linux (검증시험: Ubuntu 18.04)
+
+
+## [실행 방법]
+
+### (0) 클라우드 인증 정보, 테스트 기본 정보 입력
+- credentials.conf  # Cloud 정보 등록을 위한 CSP별 인증정보 (사용자에 맞게 수정 필요)
+  - 기본적인 클라우드 타입 (AWS, GCP, AZURE, ALIBABA)에 대해 템플릿 제공
+- conf.env  # CB-Spider 및 Tumblebug 서버 위치, 클라우드 리젼, 테스트용 이미지명, 테스트용 스팩명 등 테스트 기본 정보 제공
+  - 특별한 상황이 아니면 수정이 불필요함. (CB-Spider와 CB-TB의 위치가 localhost가 아닌 경우 수정 필요)
+  - 클라우드 타입(CSP)별 약 1~3개의 기본 리전이 입력되어 있음
+    - 이미지와 스팩은 리전에 의존성이 있는 경우가 많으므로, 리전별로 지정이 필요
+
+### (1) 클라우드정보, Namespace, MCIR, MCIS 등 개별 제어 시험
+- 제어하고 싶은 리소스 오브젝트에 대해, 해당 디렉토리로 이동하여 필요한 시험 수행
+  - 오브젝트는 서로 의존성이 있으므로, 번호를 참고하여 오름차순으로 수행하는 것이 바람직함
+    - 0.settingSpider  # 클라우드 정보 등록 관련 스크립트 모음
+    - 0.settingTB  # 네임스페이스 관련 스크립트 모음
+    - 1.vNet  # MCIR vNet 생성 관련 스크립트 모음
+    - 2.securityGroup  # MCIR securityGroup 생성 관련 스크립트 모음
+    - 3.sshKey  # MCIR sshKey 생성 관련 스크립트 모음
+    - 4.image  # MCIR image 등록 관련 스크립트 모음
+    - 5.spec  # MCIR spec 등록 관련 스크립트 모음
+    - 6.mcis  # MCIS 생성 및 제어 관련 스크립트 모음
+
+### (2) 한꺼번에 통합 시험 
+- sequentialFullTest 에 포함된 cleanAll-mcis-mcir-ns-cloud.sh 을 수행하면 모든 것을 한번에 테스트 가능
+```
+└── sequentialFullTest  # Cloud 정보 등록, NS 생성, MCIR 생성, MCIS 생성까지 한번에 자동 테스트
+    ├── cleanAll-mcis-mcir-ns-cloud.sh  # 모든 오브젝트 역으로 제어
+    ├── command-mcis.sh  # 생성된 MCIS(다중VM)에 원격 명령 수행
+    ├── deploy-nginx-mcis.sh  # 생성된 MCIS(다중VM)에 Nginx 자동 배포
+    ├── executionStatus  # 수행이 진행된 테스트 로그 (testAll 수행시 정보가 추가되며, cleanAll 수행시 정보가 제거됨)
+    ├── testAll-mcis-mcir-ns-cloud.sh  # Cloud 정보 등록, NS 생성, MCIR 생성, MCIS 생성까지 한번에 자동 테스트
+    ├── test-cloud.sh
+    ├── test-mcir-ns-cloud.sh
+    └── test-ns-cloud.sh
+```
+- 사용 예시
+  - 생성 테스트
+    - ./testAll-mcis-mcir-ns-cloud.sh aws 1 shson       # aws의 1번 리전에 shson이라는 개발자명으로 테스트 수행
+    - ./testAll-mcis-mcir-ns-cloud.sh aws 2 shson       # aws의 2번 리전에 shson이라는 개발자명으로 테스트 수행
+    - ./testAll-mcis-mcir-ns-cloud.sh aws 3 shson       # aws의 3번 리전에 shson이라는 개발자명으로 테스트 수행
+    - ./testAll-mcis-mcir-ns-cloud.sh gcp 1 shson       # gcp의 1번 리전에 shson이라는 개발자명으로 테스트 수행
+    - ./testAll-mcis-mcir-ns-cloud.sh gcp 2 shson       # gcp의 2번 리전에 shson이라는 개발자명으로 테스트 수행
+    - ./testAll-mcis-mcir-ns-cloud.sh azure 1 shson     # azure의 1번 리전에 shson이라는 개발자명으로 테스트 수행
+    - ./testAll-mcis-mcir-ns-cloud.sh alibaba 1 shson   # alibaba의 1번 리전에 shson이라는 개발자명으로 테스트 수행
+  - 제거 테스트 (이미 수행이 진행된 클라우드타입/리전/개발자명 으로만 삭제 진행이 필요)
+    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 1 shson       # aws의 1번 리전에 shson이라는 개발자명으로 제거 테스트 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 2 shson       # aws의 2번 리전에 shson이라는 개발자명으로 제거 테스트 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 3 shson       # aws의 3번 리전에 shson이라는 개발자명으로 제거 테스트 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh gcp 1 shson       # gcp의 1번 리전에 shson이라는 개발자명으로 제거 테스트 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh gcp 2 shson       # gcp의 2번 리전에 shson이라는 개발자명으로 제거 테스트 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh azure 1 shson     # azure의 1번 리전에 shson이라는 개발자명으로 제거 테스트 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh alibaba 1 shson   # alibaba의 1번 리전에 shson이라는 개발자명으로 제거 테스트 수행
+
+```
+~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./testAll-mcis-mcir-ns-cloud.sh aws 1 shson
+####################################################################
+## Create MCIS from Zero Base
+####################################################################
+[Test for AWS]
+####################################################################
+## 0. Create Cloud Connction Config
+####################################################################
+[Test for AWS]
+{
+   "ProviderName" : "AWS",
+   "DriverLibFileName" : "aws-driver-v1.0.so",
+   "DriverName" : "aws-driver01"
+}
+..........
+   "RegionName" : "aws-us-east-1"
+}
+{
+   "CredentialName" : "aws-credential01",
+   "RegionName" : "aws-us-east-1",
+   "DriverName" : "aws-driver01",
+   "ConfigName" : "aws-us-east-1",
+   "ProviderName" : "AWS"
+}
+####################################################################
+## 0. Namespace: Create
+####################################################################
+{
+   "message" : "The namespace NS-01 already exists."
+}
+####################################################################
+## 1. vpc: Create
+####################################################################
+[Test for AWS]
+{
+   "subnetInfoList" : [
+      {
+         "IId" : {
+            "SystemId" : "subnet-0ab25b7090afa97b7",
+            "NameId" : "aws-us-east-1-shson"
+         },
+................
+   "status" : "",
+   "name" : "aws-us-east-1-shson",
+   "keyValueList" : null,
+   "connectionName" : "aws-us-east-1",
+   "cspVNetId" : "vpc-0e3004f28e8a89057"
+}
+Dozing for 10 : 1 2 3 4 5 6 7 8 9 10 (Back to work)
+####################################################################
+## 2. SecurityGroup: Create
+####################################################################
+[Test for AWS]
+{
+   "keyValueList" : [
+      {
+         "Value" : "aws-us-east-1-shson-delimiter-aws-us-east-1-shson",
+         "Key" : "GroupName"
+      },
+      {
+         "Key" : "VpcID",
+...........
+   "name" : "aws-us-east-1-shson",
+   "description" : "test description",
+   "cspSecurityGroupId" : "sg-033e4b7c42671873c",
+   "id" : "aws-us-east-1-shson"
+}
+Dozing for 10 : 1 2 3 4 5 6 7 8 9 10 (Back to work)
+####################################################################
+## 3. sshKey: Create
+####################################################################
+[Test for AWS]
+{
+   "name" : "aws-us-east-1-shson",
+   "fingerprint" : "d2:1a:a0:6d:b3:f7:8e:b7:44:9f:13:9c:d6:e3:a8:c3:58:8c:de:27",
+..............
+   "id" : "aws-us-east-1-shson",
+   "description" : "",
+   "privateKey" : "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEAopGlO3dUrB4AMcBr4XZg0OVrveecA9Hv0/a9GmxgXU5dx42YV4DwW7oq/+Dq\nPaCSXvGGtdVHuL0hoOKdGYOx89qzi+nUgNQup+pKLbQw4aU2gVbV1/3/ejt7tYRUeWNU9c4b7m7E\nfs3A0xgfmak90eoQen+TJYhkfdWcSwkmJSH61bEFRbdeyijEODCu0TAGDrtRZzdCRUzbA/N7FjsC\ns0a1C...LpszE9J0bfhLOqgmkYNGSw4oR+gPRIsipUK6SzaRH7nFnOSw=\n-----END RSA PRIVATE KEY-----",
+   "username" : ""
+}
+####################################################################
+## 4. image: Register
+####################################################################
+[Test for AWS]
+{
+   "keyValueList" : [
+      {
+         "Key" : "",
+         "Value" : ""
+      },
+      {
+         "Value" : "",
+         "Key" : ""
+      }
+   ],
+   "description" : "Canonical, Ubuntu, 18.04 LTS, amd64 bionic",
+   "cspImageName" : "",
+   "connectionName" : "aws-us-east-1",
+   "status" : "",
+   "creationDate" : "",
+   "cspImageId" : "ami-085925f297f89fce1",
+   "name" : "aws-us-east-1-shson",
+   "guestOS" : "Ubuntu",
+   "id" : "aws-us-east-1-shson"
+}
+####################################################################
+## 5. spec: Register
+####################################################################
+[Test for AWS]
+{
+   "mem_MiB" : "1024",
+   "max_num_storage" : "",
+........
+   "mem_GiB" : "1",
+   "id" : "aws-us-east-1-shson",
+   "num_core" : "",
+   "cspSpecName" : "t2.micro",
+   "storage_GiB" : "",
+   "ebs_bw_Mbps" : "",
+   "connectionName" : "aws-us-east-1",
+   "net_bw_Gbps" : "",
+   "gpu_model" : "",
+   "cost_per_hour" : "",
+   "name" : "aws-us-east-1-shson"
+}
+####################################################################
+## 6. vm: Create MCIS
+####################################################################
+[Test for AWS]
+{
+   "targetAction" : "Create",
+   "status" : "Running-(3/3)",
+   "id" : "aws-us-east-1-shson",
+   "name" : "aws-us-east-1-shson",
+   "description" : "Tumblebug Demo",
+   "targetStatus" : "Running",
+   "placement_algo" : "",
+   "vm" : [
+      {
+         "vmUserId" : "",
+         "targetStatus" : "None",
+         "subnet_id" : "aws-us-east-1-shson",
+         "location" : {
+            "nativeRegion" : "us-east-1",
+            "cloudType" : "aws",
+            "latitude" : "38.1300",
+            "briefAddr" : "Virginia",
+            "longitude" : "-78.4500"
+         },
+         "vm_access_id" : "",
+         "region" : {
+            "Region" : "us-east-1",
+            "Zone" : "us-east-1f"
+         },
+         "image_id" : "aws-us-east-1-shson",
+         "privateDNS" : "ip-192-168-1-108.ec2.internal",
+         "vmBootDisk" : "/dev/sda1",
+         "status" : "Running",
+         "security_group_ids" : [
+            "aws-us-east-1-shson"
+         ],
+         "vm_access_passwd" : "",
+ .........
+            "VMUserId" : "",
+            "SecurityGroupIIds" : [
+               {
+                  "SystemId" : "sg-033e4b7c42671873c",
+                  "NameId" : "aws-us-east-1-shson"
+               }
+            ],
+            "VMBootDisk" : "/dev/sda1",
+            "PrivateDNS" : "ip-192-168-1-108.ec2.internal",
+            "StartTime" : "2020-05-30T18:33:42Z",
+            "VMBlockDisk" : "/dev/sda1",
+            "ImageIId" : {
+               "SystemId" : "ami-085925f297f89fce1",
+               "NameId" : "ami-085925f297f89fce1"
+            }
+         },
+         "publicIP" : "35.173.215.4",
+         "name" : "aws-us-east-1-shson-01",
+         "id" : "aws-us-east-1-shson-01",
+         "vnet_id" : "aws-us-east-1-shson",
+         "ssh_key_id" : "aws-us-east-1-shson",
+         "privateIP" : "192.168.1.108",
+         "config_name" : "aws-us-east-1",
+         "vmBlockDisk" : "/dev/sda1",
+         "targetAction" : "None",
+         "description" : "description",
+         "spec_id" : "aws-us-east-1-shson",
+         "publicDNS" : "",
+         "vmUserPasswd" : ""
+      },
+      {
+         "vmBlockDisk" : "/dev/sda1",
+         "targetAction" : "None",
+         "description" : "description",
+         "spec_id" : "aws-us-east-1-shson",
+         "vmUserPasswd" : "",
+         ..........
+      }
+   ]
+}
+Dozing for 1 : 1 (Back to work)
+####################################################################
+## 6. VM: Status MCIS
+####################################################################
+[Test for AWS]
+{
+   "targetStatus" : "None",
+   "id" : "aws-us-east-1-shson",
+   "targetAction" : "None",
+   "vm" : [
+      {
+         "public_ip" : "35.173.215.4",
+         "native_status" : "Running",
+         "csp_vm_id" : "aws-us-east-1-shson-01",
+         "name" : "aws-us-east-1-shson-01",
+         "status" : "Running",
+         "targetAction" : "None",
+         "targetStatus" : "None",
+         "id" : "aws-us-east-1-shson-01"
+      },
+      {
+         "name" : "aws-us-east-1-shson-02",
+         "status" : "Running",
+         "targetAction" : "None",
+         "targetStatus" : "None",
+         "id" : "aws-us-east-1-shson-02",
+         "public_ip" : "18.206.13.233",
+         "csp_vm_id" : "aws-us-east-1-shson-02",
+         "native_status" : "Running"
+      },
+      {
+         "targetAction" : "None",
+         "id" : "aws-us-east-1-shson-03",
+         "targetStatus" : "None",
+         "name" : "aws-us-east-1-shson-03",
+         "status" : "Running",
+         "csp_vm_id" : "aws-us-east-1-shson-03",
+         "native_status" : "Running",
+         "public_ip" : "18.232.53.134"
+      }
+   ],
+   "status" : "Running-(3/3)",
+   "name" : "aws-us-east-1-shson"
+}
+
+[Logging to notify latest command history]
+
+[Executed Command List]
+[CMD] testAll-mcis-mcir-ns-cloud.sh gcp 1 shson
+[CMD] testAll-mcis-mcir-ns-cloud.sh alibaba 1 shson
+[CMD] testAll-mcis-mcir-ns-cloud.sh aws 1 shson
+```
+
+마지막의 [Executed Command List] 에는 수행한 커맨드의 히스토리가 포함됨. 
+(cat ./executionStatus 를 통해 다시 확인 가능)
+
+
+- MCIS 응용 기반 최종 검증
+  - SSH 원격 커맨드 실행을 통해서 접속 여부 등을 확인 가능
+    - command-mcis.sh  # 생성된 MCIS(다중VM)에 원격 명령 수행
+    - 예시: command-mcis.sh aws 1 shson # aws의 1번 리전에 배치된 MCIS의 모든 VM에 IP 및 Hostname 조회를 수행
+  - Nginx를 분산 배치하여, 웹서버 접속 시험이 가능
+    - deploy-nginx-mcis.sh  # 생성된 MCIS(다중VM)에 Nginx 자동 배포
+    - 예시: command-mcis.sh aws 1 shson # aws의 1번 리전에 배치된 MCIS의 모든 VM에 Nginx 및 웹페이지 설치 (접속 테스트 가능)
+      ```
+      ~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./deploy-nginx-mcis.sh aws 1 shson
+      ####################################################################
+      ## Command (SSH) to MCIS 
+      ####################################################################
+      [Test for AWS]
+      {
+        "result_array" : [
+            {
+              "vm_ip" : "35.173.215.4",
+              "vm_id" : "aws-us-east-1-shson-01",
+              "result" : "WebServer is ready. Access http://35.173.215.4",
+              "mcis_id" : "aws-us-east-1-shson"
+            },
+            {
+              "vm_ip" : "18.206.13.233",
+              "vm_id" : "aws-us-east-1-shson-02",
+              "result" : "WebServer is ready. Access http://18.206.13.233",
+              "mcis_id" : "aws-us-east-1-shson"
+            },
+            {
+              "mcis_id" : "aws-us-east-1-shson",
+              "result" : "WebServer is ready. Access http://18.232.53.134",
+              "vm_id" : "aws-us-east-1-shson-03",
+              "vm_ip" : "18.232.53.134"
+            }
+        ]
+      }
+      ```
+
+
+## [테스트 코드 파일 트리 설명]
+```
+~/go/src/github.com/cloud-barista/cb-tumblebug/test/official$ tree
+.
+├── 0.settingSpider  # 클라우드 정보 등록 관련 스크립트 모음
+│   ├── get-cloud.sh
+│   ├── list-cloud.sh
+│   ├── register-cloud.sh
+│   └── unregister-cloud.sh
+├── 0.settingTB  # 네임스페이스 관련 스크립트 모음
+│   ├── create-ns.sh
+│   ├── delete-ns.sh
+│   ├── get-ns.sh
+│   └── list-ns.sh
+├── 1.vNet  # MCIR vNet 생성 관련 스크립트 모음
+│   ├── create-vNet.sh
+│   ├── delete-vNet.sh
+│   ├── get-vNet.sh
+│   ├── list-vNet.sh
+│   └── spider-get-vNet.sh
+├── 2.securityGroup  # MCIR securityGroup 생성 관련 스크립트 모음
+│   ├── create-securityGroup.sh
+│   ├── delete-securityGroup.sh
+│   ├── get-securityGroup.sh
+│   ├── list-securityGroup.sh
+│   └── spider-get-securityGroup.sh
+├── 3.sshKey  # MCIR sshKey 생성 관련 스크립트 모음
+│   ├── create-sshKey.sh
+│   ├── delete-sshKey.sh
+│   ├── get-sshKey.sh
+│   ├── list-sshKey.sh
+│   ├── spider-delete-sshKey.sh
+│   └── spider-get-sshKey.sh
+├── 4.image  # MCIR image 등록 관련 스크립트 모음
+│   ├── get-image.sh
+│   ├── list-image.sh
+│   ├── register-image.sh
+│   └── unregister-image.sh
+├── 5.spec  # MCIR spec 등록 관련 스크립트 모음
+│   ├── fetch-specs.sh
+│   ├── get-spec.sh
+│   ├── list-spec.sh
+│   ├── lookupSpecList.sh
+│   ├── lookupSpec.sh
+│   ├── register-spec.sh
+│   ├── spider-get-speclist.sh
+│   ├── spider-get-spec.sh
+│   └── unregister-spec.sh
+├── 6.mcis  # MCIS 생성 및 제어 관련 스크립트 모음
+│   ├── create-mcis.sh
+│   ├── get-mcis.sh
+│   ├── just-terminate-mcis.sh
+│   ├── list-mcis.sh
+│   ├── reboot-mcis.sh
+│   ├── resume-mcis.sh
+│   ├── spider-create-vm.sh
+│   ├── spider-delete-vm.sh
+│   ├── spider-get-vm.sh
+│   ├── spider-get-vmstatus.sh
+│   ├── status-mcis.sh
+│   ├── suspend-mcis.sh
+│   └── terminate-and-delete-mcis.sh
+├── conf.env  # CB-Spider 및 Tumblebug 서버 위치, 클라우드 리젼, 테스트용 이미지명, 테스트용 스팩명 등 테스트 기본 정보 제공
+├── credentials.conf  # Cloud 정보 등록을 위한 CSP별 인증정보 (사용자에 맞게 수정 필요)
+├── README.md
+└── sequentialFullTest  # Cloud 정보 등록, NS 생성, MCIR 생성, MCIS 생성까지 한번에 자동 테스트
+    ├── cleanAll-mcis-mcir-ns-cloud.sh  # 모든 오브젝트 역으로 제어
+    ├── command-mcis.sh  # 생성된 MCIS(다중VM)에 원격 명령 수행
+    ├── deploy-nginx-mcis.sh  # 생성된 MCIS(다중VM)에 Nginx 자동 배포
+    ├── executionStatus  # 수행이 진행된 테스트 로그 (testAll 수행시 정보가 추가되며, cleanAll 수행시 정보가 제거됨)
+    ├── testAll-mcis-mcir-ns-cloud.sh  # Cloud 정보 등록, NS 생성, MCIR 생성, MCIS 생성까지 한번에 자동 테스트
+    ├── test-cloud.sh
+    ├── test-mcir-ns-cloud.sh
+    └── test-ns-cloud.sh
+```

--- a/test/official/conf.env
+++ b/test/official/conf.env
@@ -1,7 +1,14 @@
+## Cloud-Barista API Server Address
+# CB-Spider API Server
+SpiderServer=localhost:1024
+# CB-Tumblebug API Server
+TumblebugServer=localhost:1323
+
+
 ## NS_ID for Tumblebug
 NS_ID=NS-01
 
-## Declare Array-like
+## Declare Array-like (You don't need to change)
 declare -A RegionName
 declare -A RegionKey01
 declare -A RegionVal01

--- a/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
@@ -150,8 +150,8 @@ OUTPUT=$(echo "${OUTPUT}" | grep -c -e 'Error' -e 'error' -e 'dependency' -e 'de
 echo "${OUTPUT}"
 if [ "${OUTPUT}" != 0 ]; then
 
-	echo "Retry delete-vNet 20 times"
-	for (( c=1; c<=20; c++ ))
+	echo "Retry delete-vNet 40 times"
+	for (( c=1; c<=40; c++ ))
 	do
 		echo "Trial: ${c}. Sleep 5 before retry delete-vNet"
 		dozing 5
@@ -176,8 +176,14 @@ if [ "${OUTPUT}" != 0 ]; then
 fi
 
 #../0.settingTB/delete-ns.sh $CSP $REGION $POSTFIX
-../0.settingSpider/unregister-cloud.sh $CSP $REGION $POSTFIX
 
+CNT=$(grep -c "${CSP}" ./executionStatus)
+if [ "${CNT}" -ge 2 ]; then
+	../0.settingSpider/unregister-cloud.sh $CSP $REGION $POSTFIX leave
+else
+	echo "[No dependancy, this CSP can be removed.]"
+	../0.settingSpider/unregister-cloud.sh $CSP $REGION $POSTFIX
+fi
 
 _self="${0##*/}"
 

--- a/test/official/sequentialFullTest/command-mcis.sh
+++ b/test/official/sequentialFullTest/command-mcis.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Just Terminate MCIS"
+echo "## Command (SSH) to MCIS "
 echo "####################################################################"
 
 CSP=${1}
@@ -27,4 +27,8 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=terminate | json_pp
+MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
+	'{
+		"command": "echo -n [CMD] Works! [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname ; echo -n ]"
+	}' | json_pp #|| return 1

--- a/test/official/sequentialFullTest/deploy-nginx-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-nginx-mcis.sh
@@ -3,7 +3,7 @@
 source ../conf.env
 
 echo "####################################################################"
-echo "## 6. VM: Just Terminate MCIS"
+echo "## Command (SSH) to MCIS "
 echo "####################################################################"
 
 CSP=${1}
@@ -27,4 +27,9 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=terminate | json_pp
+MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+
+curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
+	'{
+		"command": "wget https://gist.githubusercontent.com/seokho-son/92f757bd4caf50127803833787b5a77d/raw/4f6ced2d04c05910f444af4f202bcef475db73ce/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
+	}' | json_pp #|| return 1


### PR DESCRIPTION
Fix VM IP no renewal and test script enhancement (related issue: #157)

- VM재시작 액션 후, VM IP 업데이트 지원
- 테스트 스크립트의 spider, TB의 접속 주소 변수 글로벌화
- 테스트 스크립트 중 오브젝트 삭제시 리전간 영향성 고려하지 않고 클라우드 정보 삭제하는 케이스 방지
- MCIS단위의 원격 커맨드 시행 스크립트 추가 (간단한 응용 테스트 용도)
- MCIS단위의 원격 Nginx 및 웹페이지 분산 배포 스크립트 추가 (간단한 응용 테스트 용도)
- CB-Spider 통합 테스트 완료
