### PR TITLE
Add gRPC functions for NS mgmt

### DIFF
--- a/src/api/grpc/protobuf/Makefile
+++ b/src/api/grpc/protobuf/Makefile
@@ -2,4 +2,4 @@
 #
 regenerate:
 #	(protoc -I=. -I=$(GOPATH)/src/github.com/gogo/protobuf/protobuf -I=$(GOPATH)/src --gogo_out=. cbtumblebug.proto)
-	protoc -I . -I $(GOPATH)/src/github.com/gogo/protobuf/protobuf -I $(GOPATH)/src --gofast_out=plugins=grpc,paths=source_relative,google/protobuf/timestamp.proto=github.com/gogo/protobuf/types,google/protobuf/duration.proto=github.com/gogo/protobuf/types,google/protobuf/empty.proto=github.com/gogo/protobuf/types:. cbtumblebug.proto
+	protoc -I . -I $(GOPATH)/src/github.com/gogo/protobuf/protobuf -I $(GOPATH)/src --gofast_out=plugins=grpc,paths=source_relative,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types:. cbtumblebug.proto

--- a/src/api/grpc/protobuf/cbtumblebug.pb.go
+++ b/src/api/grpc/protobuf/cbtumblebug.pb.go
@@ -7,11 +7,11 @@ import (
 	context "context"
 	fmt "fmt"
 	_ "github.com/gogo/protobuf/gogoproto"
+	types "github.com/gogo/protobuf/types"
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-//	_ "google/protobuf"
 	io "io"
 	math "math"
 	math_bits "math/bits"
@@ -146,33 +146,238 @@ func (m *NsInfo) GetId() string {
 	return ""
 }
 
+type NsInfoList struct {
+	Items                []*NsInfo `protobuf:"bytes,1,rep,name=items,json=ns,proto3" json:"ns" yaml:"ns"`
+	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
+	XXX_sizecache        int32     `json:"-"`
+}
+
+func (m *NsInfoList) Reset()         { *m = NsInfoList{} }
+func (m *NsInfoList) String() string { return proto.CompactTextString(m) }
+func (*NsInfoList) ProtoMessage()    {}
+func (*NsInfoList) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cfba400c3414516c, []int{2}
+}
+func (m *NsInfoList) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *NsInfoList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_NsInfoList.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *NsInfoList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NsInfoList.Merge(m, src)
+}
+func (m *NsInfoList) XXX_Size() int {
+	return m.Size()
+}
+func (m *NsInfoList) XXX_DiscardUnknown() {
+	xxx_messageInfo_NsInfoList.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_NsInfoList proto.InternalMessageInfo
+
+func (m *NsInfoList) GetItems() []*NsInfo {
+	if m != nil {
+		return m.Items
+	}
+	return nil
+}
+
+type NsIdList struct {
+	//repeated NsId items = 1 [json_name="ns", (gogoproto.jsontag) = "ns", (gogoproto.moretags) = "yaml:\"ns\""];
+	Items                []string `protobuf:"bytes,1,rep,name=items,json=ns,proto3" json:"ns" yaml:"ns"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *NsIdList) Reset()         { *m = NsIdList{} }
+func (m *NsIdList) String() string { return proto.CompactTextString(m) }
+func (*NsIdList) ProtoMessage()    {}
+func (*NsIdList) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cfba400c3414516c, []int{3}
+}
+func (m *NsIdList) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *NsIdList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_NsIdList.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *NsIdList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NsIdList.Merge(m, src)
+}
+func (m *NsIdList) XXX_Size() int {
+	return m.Size()
+}
+func (m *NsIdList) XXX_DiscardUnknown() {
+	xxx_messageInfo_NsIdList.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_NsIdList proto.InternalMessageInfo
+
+func (m *NsIdList) GetItems() []string {
+	if m != nil {
+		return m.Items
+	}
+	return nil
+}
+
+type NsId struct {
+	Id                   string   `protobuf:"bytes,1,opt,name=id,proto3" json:"id" yaml:"id"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *NsId) Reset()         { *m = NsId{} }
+func (m *NsId) String() string { return proto.CompactTextString(m) }
+func (*NsId) ProtoMessage()    {}
+func (*NsId) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cfba400c3414516c, []int{4}
+}
+func (m *NsId) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *NsId) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_NsId.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *NsId) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NsId.Merge(m, src)
+}
+func (m *NsId) XXX_Size() int {
+	return m.Size()
+}
+func (m *NsId) XXX_DiscardUnknown() {
+	xxx_messageInfo_NsId.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_NsId proto.InternalMessageInfo
+
+func (m *NsId) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
+type BooleanResponse struct {
+	Exists               bool     `protobuf:"varint,1,opt,name=exists,proto3" json:"exists" yaml:"exists"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *BooleanResponse) Reset()         { *m = BooleanResponse{} }
+func (m *BooleanResponse) String() string { return proto.CompactTextString(m) }
+func (*BooleanResponse) ProtoMessage()    {}
+func (*BooleanResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_cfba400c3414516c, []int{5}
+}
+func (m *BooleanResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BooleanResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BooleanResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BooleanResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BooleanResponse.Merge(m, src)
+}
+func (m *BooleanResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *BooleanResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_BooleanResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BooleanResponse proto.InternalMessageInfo
+
+func (m *BooleanResponse) GetExists() bool {
+	if m != nil {
+		return m.Exists
+	}
+	return false
+}
+
 func init() {
 	proto.RegisterType((*NsReq)(nil), "cbtumblebug.NsReq")
 	proto.RegisterType((*NsInfo)(nil), "cbtumblebug.NsInfo")
+	proto.RegisterType((*NsInfoList)(nil), "cbtumblebug.NsInfoList")
+	proto.RegisterType((*NsIdList)(nil), "cbtumblebug.NsIdList")
+	proto.RegisterType((*NsId)(nil), "cbtumblebug.NsId")
+	proto.RegisterType((*BooleanResponse)(nil), "cbtumblebug.BooleanResponse")
 }
 
 func init() { proto.RegisterFile("cbtumblebug.proto", fileDescriptor_cfba400c3414516c) }
 
 var fileDescriptor_cfba400c3414516c = []byte{
-	// 281 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x4c, 0x4e, 0x2a, 0x29,
-	0xcd, 0x4d, 0xca, 0x49, 0x4d, 0x2a, 0x4d, 0xd7, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0xe2, 0x46,
-	0x12, 0x92, 0xd2, 0x4d, 0xcf, 0x2c, 0xc9, 0x28, 0x4d, 0xd2, 0x4b, 0xce, 0xcf, 0xd5, 0x4f, 0xcf,
-	0x4f, 0xcf, 0xd7, 0x07, 0xab, 0x49, 0x2a, 0x4d, 0x03, 0xf3, 0xc0, 0x1c, 0x30, 0x0b, 0xa2, 0x57,
-	0x4a, 0x3a, 0x3d, 0x3f, 0x3f, 0x3d, 0x27, 0x15, 0xa1, 0x2a, 0x35, 0xb7, 0xa0, 0xa4, 0x12, 0x22,
-	0xa9, 0x54, 0xcb, 0xc5, 0xea, 0x57, 0x1c, 0x94, 0x5a, 0x28, 0xa4, 0xcd, 0xc5, 0x92, 0x97, 0x98,
-	0x9b, 0x2a, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1, 0xe9, 0x24, 0xfe, 0xea, 0x9e, 0x3c, 0x98, 0xff, 0xe9,
-	0x9e, 0x3c, 0x77, 0x65, 0x62, 0x6e, 0x8e, 0x95, 0x12, 0x88, 0xa7, 0x14, 0x04, 0x16, 0x14, 0x72,
-	0xe7, 0xe2, 0x4e, 0x49, 0x2d, 0x4e, 0x2e, 0xca, 0x2c, 0x28, 0xc9, 0xcc, 0xcf, 0x93, 0x60, 0x02,
-	0xeb, 0x51, 0x7d, 0x75, 0x4f, 0x1e, 0x59, 0xf8, 0xd3, 0x3d, 0x79, 0x21, 0x88, 0x56, 0x24, 0x41,
-	0xa5, 0x20, 0x64, 0x25, 0x4a, 0x8b, 0x19, 0xb9, 0xd8, 0xfc, 0x8a, 0x3d, 0xf3, 0xd2, 0xf2, 0x07,
-	0xc6, 0x01, 0x42, 0xca, 0x5c, 0x4c, 0x99, 0x29, 0x12, 0xcc, 0x60, 0xfd, 0xc2, 0xaf, 0xee, 0xc9,
-	0x33, 0x65, 0xa6, 0x7c, 0xba, 0x27, 0xcf, 0x09, 0xd1, 0x96, 0x99, 0xa2, 0x14, 0xc4, 0x94, 0x99,
-	0x62, 0x64, 0xcd, 0xc5, 0xe4, 0x57, 0x2c, 0x64, 0xca, 0xc5, 0xe1, 0x5c, 0x94, 0x9a, 0x58, 0x92,
-	0xea, 0x17, 0x2c, 0x24, 0xa4, 0x87, 0x1c, 0x47, 0xe0, 0x10, 0x94, 0x12, 0x46, 0x13, 0x03, 0xf9,
-	0x4a, 0x89, 0xc1, 0x49, 0xe0, 0xc4, 0x23, 0x39, 0xc6, 0x0b, 0x8f, 0xe4, 0x18, 0x1f, 0x3c, 0x92,
-	0x63, 0x9c, 0xf1, 0x58, 0x8e, 0x21, 0x89, 0x0d, 0x1c, 0xf4, 0xc6, 0x80, 0x00, 0x00, 0x00, 0xff,
-	0xff, 0xea, 0x6d, 0xde, 0x20, 0xe8, 0x01, 0x00, 0x00,
+	// 480 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x92, 0x41, 0x6e, 0xd3, 0x40,
+	0x14, 0x86, 0x63, 0xa7, 0x09, 0xc9, 0x8b, 0x10, 0x74, 0x2a, 0x68, 0xe4, 0xa2, 0xb8, 0x1a, 0x04,
+	0xaa, 0x54, 0xe1, 0x8a, 0x14, 0x36, 0xb4, 0x1b, 0xd2, 0x42, 0x15, 0x09, 0x79, 0xe1, 0x1b, 0xc4,
+	0xf1, 0xab, 0x3b, 0xc2, 0xf6, 0xa4, 0x79, 0x13, 0x89, 0x2e, 0xb8, 0x07, 0x62, 0xcb, 0x65, 0x58,
+	0x72, 0x02, 0x0b, 0x85, 0x5d, 0x96, 0x39, 0x01, 0xf2, 0x4c, 0x50, 0x4d, 0x88, 0xbb, 0x65, 0xe7,
+	0xff, 0x9f, 0xf7, 0xfd, 0xfe, 0xed, 0x79, 0xb0, 0x3d, 0x0e, 0xd5, 0x2c, 0x0d, 0x13, 0x0c, 0x67,
+	0xb1, 0x37, 0x99, 0x4a, 0x25, 0x59, 0xa7, 0x64, 0x39, 0x2f, 0x62, 0xa1, 0xae, 0x66, 0xa1, 0x37,
+	0x96, 0xe9, 0x51, 0x2c, 0x63, 0x79, 0xa4, 0x67, 0xc2, 0xd9, 0xa5, 0x56, 0x5a, 0xe8, 0x27, 0xc3,
+	0x3a, 0x7b, 0xb1, 0x94, 0x71, 0x82, 0xb7, 0x53, 0x98, 0x4e, 0xd4, 0x8d, 0x39, 0xe4, 0x9f, 0xa1,
+	0xe1, 0x53, 0x80, 0xd7, 0xec, 0x10, 0xb6, 0xb2, 0x51, 0x8a, 0x5d, 0x6b, 0xdf, 0x3a, 0x68, 0x0f,
+	0x76, 0x17, 0xb9, 0xab, 0xf5, 0x32, 0x77, 0x3b, 0x37, 0xa3, 0x34, 0x79, 0xc3, 0x0b, 0xc5, 0x03,
+	0x6d, 0xb2, 0x0b, 0xe8, 0x44, 0x48, 0xe3, 0xa9, 0x98, 0x28, 0x21, 0xb3, 0xae, 0xad, 0x99, 0x67,
+	0x8b, 0xdc, 0x2d, 0xdb, 0xcb, 0xdc, 0x65, 0x06, 0x2d, 0x99, 0x3c, 0x28, 0x8f, 0xf0, 0x6f, 0x16,
+	0x34, 0x7d, 0x1a, 0x66, 0x97, 0xf2, 0xff, 0x14, 0x60, 0x4f, 0xc1, 0x16, 0x51, 0xb7, 0xae, 0xf9,
+	0x9d, 0x45, 0xee, 0xda, 0x22, 0x5a, 0xe6, 0x6e, 0xdb, 0x60, 0x22, 0xe2, 0x81, 0x2d, 0x22, 0x3e,
+	0x04, 0x30, 0x25, 0x3f, 0x08, 0x52, 0xec, 0x04, 0x1a, 0x42, 0x61, 0x4a, 0x5d, 0x6b, 0xbf, 0x7e,
+	0xd0, 0xe9, 0xef, 0x78, 0xe5, 0xeb, 0x32, 0x73, 0x26, 0x2a, 0xa3, 0xdb, 0xa8, 0x8c, 0x78, 0x60,
+	0x67, 0xc4, 0xfb, 0xd0, 0xf2, 0x69, 0x18, 0xe9, 0xa0, 0xe7, 0xe5, 0xa0, 0x76, 0x35, 0x73, 0x08,
+	0x5b, 0x05, 0xb3, 0xea, 0x6a, 0xdd, 0xdd, 0xf5, 0x3d, 0x3c, 0x18, 0x48, 0x99, 0xe0, 0x28, 0x0b,
+	0x90, 0x26, 0x32, 0x23, 0x64, 0xc7, 0xd0, 0xc4, 0x4f, 0x82, 0x14, 0x69, 0xb6, 0x35, 0xd8, 0x5b,
+	0xe4, 0xee, 0xca, 0x59, 0xe6, 0xee, 0x7d, 0xc3, 0x1b, 0xcd, 0x83, 0xd5, 0x41, 0xff, 0x6b, 0x1d,
+	0x6c, 0x9f, 0xd8, 0x29, 0xdc, 0x3b, 0xbb, 0xc2, 0xf1, 0x47, 0x9f, 0xd8, 0xf6, 0xfa, 0x87, 0x46,
+	0xce, 0x93, 0xbf, 0xac, 0xb5, 0xf7, 0xf2, 0x1a, 0x7b, 0x0d, 0xad, 0xb3, 0x29, 0x8e, 0x14, 0xfa,
+	0xc4, 0xd8, 0x1a, 0x1e, 0xe0, 0xb5, 0xb3, 0xe9, 0xdf, 0xf1, 0x1a, 0x3b, 0x85, 0xd6, 0x39, 0x26,
+	0x6f, 0x93, 0xc4, 0x27, 0xf6, 0xd8, 0x33, 0xeb, 0xeb, 0xfd, 0x59, 0x5f, 0xef, 0x5d, 0xb1, 0xbe,
+	0x4e, 0x85, 0xcf, 0x6b, 0xec, 0x15, 0x34, 0xce, 0x31, 0xd9, 0x5c, 0xb8, 0x9a, 0x7a, 0x09, 0x8d,
+	0x0b, 0x54, 0x9b, 0xa9, 0x8a, 0x9a, 0x27, 0xd0, 0x2c, 0xee, 0xf1, 0x8e, 0x92, 0xbb, 0x1b, 0xc0,
+	0x02, 0xd1, 0x70, 0xcb, 0xc0, 0xc3, 0xa8, 0x12, 0x7f, 0xf4, 0x4f, 0x15, 0x03, 0x0f, 0x1e, 0x7e,
+	0x9f, 0xf7, 0xac, 0x1f, 0xf3, 0x9e, 0xf5, 0x73, 0xde, 0xb3, 0xbe, 0xfc, 0xea, 0xd5, 0xc2, 0xa6,
+	0x46, 0x8f, 0x7f, 0x07, 0x00, 0x00, 0xff, 0xff, 0x09, 0x70, 0xdc, 0xb0, 0x3c, 0x04, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -187,7 +392,13 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type NsClient interface {
-	CreateNS(ctx context.Context, in *NsReq, opts ...grpc.CallOption) (*NsInfo, error)
+	CheckNs(ctx context.Context, in *NsId, opts ...grpc.CallOption) (*BooleanResponse, error)
+	CreateNs(ctx context.Context, in *NsReq, opts ...grpc.CallOption) (*NsInfo, error)
+	DelAllNs(ctx context.Context, in *types.Empty, opts ...grpc.CallOption) (*types.Empty, error)
+	DelNs(ctx context.Context, in *NsId, opts ...grpc.CallOption) (*types.Empty, error)
+	GetNs(ctx context.Context, in *NsId, opts ...grpc.CallOption) (*NsInfo, error)
+	ListNs(ctx context.Context, in *types.Empty, opts ...grpc.CallOption) (*NsInfoList, error)
+	ListNsId(ctx context.Context, in *types.Empty, opts ...grpc.CallOption) (*NsIdList, error)
 }
 
 type nsClient struct {
@@ -198,9 +409,63 @@ func NewNsClient(cc *grpc.ClientConn) NsClient {
 	return &nsClient{cc}
 }
 
-func (c *nsClient) CreateNS(ctx context.Context, in *NsReq, opts ...grpc.CallOption) (*NsInfo, error) {
+func (c *nsClient) CheckNs(ctx context.Context, in *NsId, opts ...grpc.CallOption) (*BooleanResponse, error) {
+	out := new(BooleanResponse)
+	err := c.cc.Invoke(ctx, "/cbtumblebug.Ns/CheckNs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nsClient) CreateNs(ctx context.Context, in *NsReq, opts ...grpc.CallOption) (*NsInfo, error) {
 	out := new(NsInfo)
-	err := c.cc.Invoke(ctx, "/cbtumblebug.Ns/CreateNS", in, out, opts...)
+	err := c.cc.Invoke(ctx, "/cbtumblebug.Ns/CreateNs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nsClient) DelAllNs(ctx context.Context, in *types.Empty, opts ...grpc.CallOption) (*types.Empty, error) {
+	out := new(types.Empty)
+	err := c.cc.Invoke(ctx, "/cbtumblebug.Ns/DelAllNs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nsClient) DelNs(ctx context.Context, in *NsId, opts ...grpc.CallOption) (*types.Empty, error) {
+	out := new(types.Empty)
+	err := c.cc.Invoke(ctx, "/cbtumblebug.Ns/DelNs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nsClient) GetNs(ctx context.Context, in *NsId, opts ...grpc.CallOption) (*NsInfo, error) {
+	out := new(NsInfo)
+	err := c.cc.Invoke(ctx, "/cbtumblebug.Ns/GetNs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nsClient) ListNs(ctx context.Context, in *types.Empty, opts ...grpc.CallOption) (*NsInfoList, error) {
+	out := new(NsInfoList)
+	err := c.cc.Invoke(ctx, "/cbtumblebug.Ns/ListNs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *nsClient) ListNsId(ctx context.Context, in *types.Empty, opts ...grpc.CallOption) (*NsIdList, error) {
+	out := new(NsIdList)
+	err := c.cc.Invoke(ctx, "/cbtumblebug.Ns/ListNsId", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -209,35 +474,167 @@ func (c *nsClient) CreateNS(ctx context.Context, in *NsReq, opts ...grpc.CallOpt
 
 // NsServer is the server API for Ns service.
 type NsServer interface {
-	CreateNS(context.Context, *NsReq) (*NsInfo, error)
+	CheckNs(context.Context, *NsId) (*BooleanResponse, error)
+	CreateNs(context.Context, *NsReq) (*NsInfo, error)
+	DelAllNs(context.Context, *types.Empty) (*types.Empty, error)
+	DelNs(context.Context, *NsId) (*types.Empty, error)
+	GetNs(context.Context, *NsId) (*NsInfo, error)
+	ListNs(context.Context, *types.Empty) (*NsInfoList, error)
+	ListNsId(context.Context, *types.Empty) (*NsIdList, error)
 }
 
 // UnimplementedNsServer can be embedded to have forward compatible implementations.
 type UnimplementedNsServer struct {
 }
 
-func (*UnimplementedNsServer) CreateNS(ctx context.Context, req *NsReq) (*NsInfo, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method CreateNS not implemented")
+func (*UnimplementedNsServer) CheckNs(ctx context.Context, req *NsId) (*BooleanResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CheckNs not implemented")
+}
+func (*UnimplementedNsServer) CreateNs(ctx context.Context, req *NsReq) (*NsInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateNs not implemented")
+}
+func (*UnimplementedNsServer) DelAllNs(ctx context.Context, req *types.Empty) (*types.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DelAllNs not implemented")
+}
+func (*UnimplementedNsServer) DelNs(ctx context.Context, req *NsId) (*types.Empty, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DelNs not implemented")
+}
+func (*UnimplementedNsServer) GetNs(ctx context.Context, req *NsId) (*NsInfo, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNs not implemented")
+}
+func (*UnimplementedNsServer) ListNs(ctx context.Context, req *types.Empty) (*NsInfoList, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListNs not implemented")
+}
+func (*UnimplementedNsServer) ListNsId(ctx context.Context, req *types.Empty) (*NsIdList, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListNsId not implemented")
 }
 
 func RegisterNsServer(s *grpc.Server, srv NsServer) {
 	s.RegisterService(&_Ns_serviceDesc, srv)
 }
 
-func _Ns_CreateNS_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Ns_CheckNs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NsId)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NsServer).CheckNs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cbtumblebug.Ns/CheckNs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NsServer).CheckNs(ctx, req.(*NsId))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Ns_CreateNs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(NsReq)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(NsServer).CreateNS(ctx, in)
+		return srv.(NsServer).CreateNs(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/cbtumblebug.Ns/CreateNS",
+		FullMethod: "/cbtumblebug.Ns/CreateNs",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(NsServer).CreateNS(ctx, req.(*NsReq))
+		return srv.(NsServer).CreateNs(ctx, req.(*NsReq))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Ns_DelAllNs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(types.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NsServer).DelAllNs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cbtumblebug.Ns/DelAllNs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NsServer).DelAllNs(ctx, req.(*types.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Ns_DelNs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NsId)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NsServer).DelNs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cbtumblebug.Ns/DelNs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NsServer).DelNs(ctx, req.(*NsId))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Ns_GetNs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(NsId)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NsServer).GetNs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cbtumblebug.Ns/GetNs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NsServer).GetNs(ctx, req.(*NsId))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Ns_ListNs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(types.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NsServer).ListNs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cbtumblebug.Ns/ListNs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NsServer).ListNs(ctx, req.(*types.Empty))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Ns_ListNsId_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(types.Empty)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NsServer).ListNsId(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cbtumblebug.Ns/ListNsId",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NsServer).ListNsId(ctx, req.(*types.Empty))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -247,8 +644,32 @@ var _Ns_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*NsServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "CreateNS",
-			Handler:    _Ns_CreateNS_Handler,
+			MethodName: "CheckNs",
+			Handler:    _Ns_CheckNs_Handler,
+		},
+		{
+			MethodName: "CreateNs",
+			Handler:    _Ns_CreateNs_Handler,
+		},
+		{
+			MethodName: "DelAllNs",
+			Handler:    _Ns_DelAllNs_Handler,
+		},
+		{
+			MethodName: "DelNs",
+			Handler:    _Ns_DelNs_Handler,
+		},
+		{
+			MethodName: "GetNs",
+			Handler:    _Ns_GetNs_Handler,
+		},
+		{
+			MethodName: "ListNs",
+			Handler:    _Ns_ListNs_Handler,
+		},
+		{
+			MethodName: "ListNsId",
+			Handler:    _Ns_ListNsId_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -344,6 +765,154 @@ func (m *NsInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *NsInfoList) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NsInfoList) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *NsInfoList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Items) > 0 {
+		for iNdEx := len(m.Items) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Items[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintCbtumblebug(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *NsIdList) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NsIdList) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *NsIdList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Items) > 0 {
+		for iNdEx := len(m.Items) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Items[iNdEx])
+			copy(dAtA[i:], m.Items[iNdEx])
+			i = encodeVarintCbtumblebug(dAtA, i, uint64(len(m.Items[iNdEx])))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *NsId) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *NsId) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *NsId) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Id) > 0 {
+		i -= len(m.Id)
+		copy(dAtA[i:], m.Id)
+		i = encodeVarintCbtumblebug(dAtA, i, uint64(len(m.Id)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BooleanResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BooleanResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BooleanResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if m.Exists {
+		i--
+		if m.Exists {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintCbtumblebug(dAtA []byte, offset int, v uint64) int {
 	offset -= sovCbtumblebug(v)
 	base := offset
@@ -392,6 +961,73 @@ func (m *NsInfo) Size() (n int) {
 	l = len(m.Id)
 	if l > 0 {
 		n += 1 + l + sovCbtumblebug(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *NsInfoList) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Items) > 0 {
+		for _, e := range m.Items {
+			l = e.Size()
+			n += 1 + l + sovCbtumblebug(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *NsIdList) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Items) > 0 {
+		for _, s := range m.Items {
+			l = len(s)
+			n += 1 + l + sovCbtumblebug(uint64(l))
+		}
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *NsId) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Id)
+	if l > 0 {
+		n += 1 + l + sovCbtumblebug(uint64(l))
+	}
+	if m.XXX_unrecognized != nil {
+		n += len(m.XXX_unrecognized)
+	}
+	return n
+}
+
+func (m *BooleanResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Exists {
+		n += 2
 	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
@@ -648,6 +1284,340 @@ func (m *NsInfo) Unmarshal(dAtA []byte) error {
 			}
 			m.Id = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCbtumblebug(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NsInfoList) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCbtumblebug
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NsInfoList: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NsInfoList: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Items", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCbtumblebug
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Items = append(m.Items, &NsInfo{})
+			if err := m.Items[len(m.Items)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCbtumblebug(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NsIdList) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCbtumblebug
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NsIdList: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NsIdList: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Items", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCbtumblebug
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Items = append(m.Items, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCbtumblebug(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *NsId) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCbtumblebug
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: NsId: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: NsId: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Id", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCbtumblebug
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Id = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCbtumblebug(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthCbtumblebug
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.XXX_unrecognized = append(m.XXX_unrecognized, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BooleanResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCbtumblebug
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BooleanResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BooleanResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exists", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCbtumblebug
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Exists = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := skipCbtumblebug(dAtA[iNdEx:])

--- a/src/api/grpc/protobuf/cbtumblebug.proto
+++ b/src/api/grpc/protobuf/cbtumblebug.proto
@@ -6,16 +6,39 @@ import "google/protobuf/empty.proto";
 package cbtumblebug;
 
 service Ns {
-        rpc CreateNS (NsReq) returns (NsInfo) {}
+    rpc CheckNs (NsId) returns (BooleanResponse) {}
+    rpc CreateNs (NsReq) returns (NsInfo) {}
+    rpc DelAllNs (google.protobuf.Empty) returns (google.protobuf.Empty) {}
+    rpc DelNs (NsId) returns (google.protobuf.Empty) {}
+    rpc GetNs (NsId) returns (NsInfo) {}
+    rpc ListNs (google.protobuf.Empty) returns (NsInfoList) {}
+    rpc ListNsId (google.protobuf.Empty) returns (NsIdList) {}
 }
 
 message NsReq {
-        string name = 1 [json_name="name", (gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
-        string description = 2 [json_name="description", (gogoproto.jsontag) = "description", (gogoproto.moretags) = "yaml:\"description\""];
+    string name = 1 [json_name="name", (gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
+    string description = 2 [json_name="description", (gogoproto.jsontag) = "description", (gogoproto.moretags) = "yaml:\"description\""];
 }
 
 message NsInfo {
-        string name = 1 [json_name="name", (gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
-        string description = 2 [json_name="description", (gogoproto.jsontag) = "description", (gogoproto.moretags) = "yaml:\"description\""];
-        string id = 3 [json_name="id", (gogoproto.jsontag) = "id", (gogoproto.moretags) = "yaml:\"id\""];
+    string name = 1 [json_name="name", (gogoproto.jsontag) = "name", (gogoproto.moretags) = "yaml:\"name\""];
+    string description = 2 [json_name="description", (gogoproto.jsontag) = "description", (gogoproto.moretags) = "yaml:\"description\""];
+    string id = 3 [json_name="id", (gogoproto.jsontag) = "id", (gogoproto.moretags) = "yaml:\"id\""];
+}
+
+message NsInfoList {
+    repeated NsInfo items = 1 [json_name="ns", (gogoproto.jsontag) = "ns", (gogoproto.moretags) = "yaml:\"ns\""];
+}
+
+message NsIdList {
+    //repeated NsId items = 1 [json_name="ns", (gogoproto.jsontag) = "ns", (gogoproto.moretags) = "yaml:\"ns\""];
+    repeated string items = 1 [json_name="ns", (gogoproto.jsontag) = "ns", (gogoproto.moretags) = "yaml:\"ns\""];
+}
+
+message NsId {
+    string id = 1 [json_name="id", (gogoproto.jsontag) = "id", (gogoproto.moretags) = "yaml:\"id\""];
+}
+
+message BooleanResponse {
+    bool exists = 1 [json_name="exists", (gogoproto.jsontag) = "exists", (gogoproto.moretags) = "yaml:\"exists\""];
 }

--- a/src/api/grpc/server/server.go
+++ b/src/api/grpc/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	pb "github.com/cloud-barista/cb-tumblebug/src/api/grpc/protobuf"
+	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
@@ -22,31 +23,133 @@ type server struct{}
 // ProtoBuf의 IDL에 정의되어 있는 함수
 // 함수의 인자와 리턴 값인 HelloRequest, HelloReply, 그리고 아래의 함수들은 모두
 // protoc에서 생성된 skeleton 코드를 그대로 사용한다.
-func (s *server) CreateNS(ctx context.Context, in *pb.NsReq) (*pb.NsInfo, error) {
-	log.Printf("Received: %v", in.Name)
+
+func (s *server) CheckNs(ctx context.Context, in *pb.NsId) (*pb.BooleanResponse, error) {
+	log.Printf("CheckNs Received: %v", in.Id)
+	//	return &pb.NsInfo{Name: in.Name, Description: "CB-TB gRPC PB test"}, nil
+
+	res, err := common.CheckNs(in.Id)
+	if err != nil {
+		//cblog.Error(err)
+		return nil, common.ConvGrpcStatusErr(err, "", "CheckNs()")
+	}
+
+	var pbBool pb.BooleanResponse
+	pbBool.Exists = res
+	return &pbBool, nil
+}
+
+func (s *server) CreateNs(ctx context.Context, in *pb.NsReq) (*pb.NsInfo, error) {
+	log.Printf("CreateNs Received: %v", in.Name)
 	//	return &pb.NsInfo{Name: in.Name, Description: "CB-TB gRPC PB test"}, nil
 
 	var tbNsReq common.NsReq
 	err := common.CopySrcToDest(&in, &tbNsReq)
 	if err != nil {
 		//cblog.Error(err)
-		return nil, common.ConvGrpcStatusErr(err, "", "CreateNS()")
+		return nil, common.ConvGrpcStatusErr(err, "", "CreateNs()")
 	}
 
 	tbNsInfo, err := common.CreateNs(&tbNsReq)
 	if err != nil {
 		//cblog.Error(err)
-		return nil, common.ConvGrpcStatusErr(err, "", "CreateNS()")
+		return nil, common.ConvGrpcStatusErr(err, "", "CreateNs()")
 	}
 
 	var pbNsInfo pb.NsInfo
 	err = common.CopySrcToDest(&tbNsInfo, &pbNsInfo)
 	if err != nil {
 		//cblog.Error(err)
-		return nil, common.ConvGrpcStatusErr(err, "", "CreateNS()")
+		return nil, common.ConvGrpcStatusErr(err, "", "CreateNs()")
 	}
 
 	return &pbNsInfo, nil
+}
+
+func (s *server) DelAllNs(ctx context.Context, req *types.Empty) (*types.Empty, error) {
+	log.Printf("DelAllNs Received")
+
+	err := common.DelAllNs()
+	if err != nil {
+		//cblog.Error(err)
+		return nil, common.ConvGrpcStatusErr(err, "", "DelAllNs()")
+	}
+	return &types.Empty{}, nil
+}
+
+func (s *server) DelNs(ctx context.Context, in *pb.NsId) (*types.Empty, error) {
+	log.Printf("grpc.DelNs Received: %v", in.Id)
+
+	err := common.DelNs(in.Id)
+	if err != nil {
+		//cblog.Error(err)
+		return nil, common.ConvGrpcStatusErr(err, "", "DelNs()")
+	}
+	return &types.Empty{}, nil
+}
+
+func (s *server) GetNs(ctx context.Context, in *pb.NsId) (*pb.NsInfo, error) {
+	log.Printf("GetNs Received: %v", in.Id)
+
+	tbNsInfo, err := common.GetNs(in.Id)
+	if err != nil {
+		//cblog.Error(err)
+		return nil, common.ConvGrpcStatusErr(err, "", "GetNs()")
+	}
+
+	var pbNsInfo pb.NsInfo
+	err = common.CopySrcToDest(&tbNsInfo, &pbNsInfo)
+	if err != nil {
+		//cblog.Error(err)
+		return nil, common.ConvGrpcStatusErr(err, "", "GetNs()")
+	}
+
+	return &pbNsInfo, nil
+}
+
+func (s *server) ListNs(ctx context.Context, req *types.Empty) (*pb.NsInfoList, error) {
+	log.Printf("ListNs Received")
+
+	tbNsInfoList, err := common.ListNs()
+	if err != nil {
+		//cblog.Error(err)
+		return nil, common.ConvGrpcStatusErr(err, "", "ListNs()")
+	}
+
+	//var pbNsInfoList pb.NsInfoList
+	var grpcObj []*pb.NsInfo
+	err = common.CopySrcToDest(&tbNsInfoList, &grpcObj)
+	if err != nil {
+		//cblog.Error(err)
+		return nil, common.ConvGrpcStatusErr(err, "", "ListNs()")
+	}
+
+	resp := &pb.NsInfoList{Items: grpcObj}
+	return resp, nil
+}
+
+func (s *server) ListNsId(ctx context.Context, req *types.Empty) (*pb.NsIdList, error) {
+	log.Printf("ListNsId Received")
+
+	tbNsIdList := common.ListNsId()
+	/*
+		if err != nil {
+			//cblog.Error(err)
+			return nil, common.ConvGrpcStatusErr(err, "", "ListNsId()")
+		}
+	*/
+
+	//var pbNsIdList pb.NsIdList
+	//var grpcObj []*pb.NsId
+	var grpcObj []string
+	err := common.CopySrcToDest(&tbNsIdList, &grpcObj)
+	if err != nil {
+		//cblog.Error(err)
+		return nil, common.ConvGrpcStatusErr(err, "", "ListNsId()")
+	}
+
+	resp := &pb.NsIdList{Items: grpcObj}
+	return resp, nil
 }
 
 func RunServer() {

--- a/src/api/grpc/test-client/test.go
+++ b/src/api/grpc/test-client/test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"time"
 
+	pb "github.com/cloud-barista/cb-tumblebug/src/api/grpc/protobuf"
+	"github.com/gogo/protobuf/types"
 	"google.golang.org/grpc"
-	pb "github.com/cloud-barista/cb-tumblebug/src/grpc/protobuf"
 )
 
 const (
@@ -31,9 +32,133 @@ func main() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	r, err := c.CreateNS(ctx, &pb.NsReq{Name: name})
+
+	// CheckNs
+	log.Printf("")
+	log.Printf("CheckNs()")
+	check, err := c.CheckNs(ctx, &pb.NsId{Id: name})
 	if err != nil {
-		log.Fatalf("NsReq failed: %v", err)
+		log.Fatalf("CheckNs failed: %v", err)
 	}
-	log.Printf("NsReq success: %s", r.GetName())
+	if check.Exists == true {
+		log.Printf("CheckNs success; The namespace " + name + " exists.")
+	} else {
+		log.Printf("CheckNs success; The namespace " + name + " does not exist.")
+	}
+
+	// CreateNs
+	log.Printf("")
+	log.Printf("CreateNs()")
+	r, err := c.CreateNs(ctx, &pb.NsReq{Name: name})
+	if err != nil {
+		log.Printf("CreateNS failed: %v", err)
+	} else {
+		log.Printf("CreateNS success: %s", r.GetName())
+	}
+
+	// CheckNs
+	log.Printf("")
+	log.Printf("CheckNs()")
+	check, err = c.CheckNs(ctx, &pb.NsId{Id: name})
+	if err != nil {
+		log.Fatalf("CheckNs failed: %v", err)
+	}
+	if check.Exists == true {
+		log.Printf("CheckNs success; The namespace " + name + " exists.")
+	} else {
+		log.Printf("CheckNs success; The namespace " + name + " does not exist.")
+	}
+
+	// GetNs
+	log.Printf("")
+	log.Printf("GetNs()")
+	r, err = c.GetNs(ctx, &pb.NsId{Id: name})
+	if err != nil {
+		log.Fatalf("GetNs failed: %v", err)
+	} else {
+		log.Printf("GetNS success: %s", r.GetName())
+	}
+
+	// ListNs
+	log.Printf("")
+	log.Printf("ListNs()")
+	grpcNsList, err := c.ListNs(ctx, &types.Empty{})
+	if err != nil {
+		log.Fatalf("ListNs failed: %v", err)
+	} else {
+		log.Printf("ListNS success")
+		for _, v := range grpcNsList.Items {
+			log.Printf("%s", v.GetName())
+		}
+	}
+
+	// ListNsId
+	log.Printf("")
+	log.Printf("ListNsId()")
+	grpcNsIdList, err := c.ListNsId(ctx, &types.Empty{})
+	if err != nil {
+		log.Fatalf("ListNsId failed: %v", err)
+	} else {
+		log.Printf("ListNSId success")
+		for _, v := range grpcNsIdList.Items {
+			log.Printf("%s", v)
+		}
+	}
+
+	// DelNs
+	log.Printf("")
+	log.Printf("DelNs()")
+	_, err = c.DelNs(ctx, &pb.NsId{Id: name})
+	if err != nil {
+		log.Fatalf("DelNs failed: %v", err)
+	} else {
+		log.Printf("DelNS success: %s", name)
+	}
+
+	// DelNs
+	log.Printf("")
+	log.Printf("DelNs()")
+	_, err = c.DelNs(ctx, &pb.NsId{Id: name})
+	if err != nil {
+		log.Printf("DelNs failed: %v", err)
+	} else {
+		log.Printf("DelNS success: %s", name)
+	}
+
+	// GetNs
+	log.Printf("")
+	log.Printf("GetNs()")
+	r, err = c.GetNs(ctx, &pb.NsId{Id: name})
+	if err != nil {
+		log.Printf("GetNs failed: %v", err)
+	} else {
+		log.Printf("GetNS success: %s", r.GetName())
+	}
+
+	// ListNs
+	log.Printf("")
+	log.Printf("ListNs()")
+	grpcNsList, err = c.ListNs(ctx, &types.Empty{})
+	if err != nil {
+		log.Fatalf("ListNs failed: %v", err)
+	} else {
+		log.Printf("ListNS success")
+		for _, v := range grpcNsList.Items {
+			log.Printf("%s", v.GetName())
+		}
+	}
+
+	// ListNsId
+	log.Printf("")
+	log.Printf("ListNsId()")
+	grpcNsIdList, err = c.ListNsId(ctx, &types.Empty{})
+	if err != nil {
+		log.Fatalf("ListNsId failed: %v", err)
+	} else {
+		log.Printf("ListNSId success")
+		for _, v := range grpcNsIdList.Items {
+			log.Printf("%s", v)
+		}
+	}
+
 }

--- a/src/mcir/common.go
+++ b/src/mcir/common.go
@@ -35,7 +35,7 @@ func init() {
 func DelAllResources(nsId string, resourceType string, forceFlag string) error {
 	resourceIdList := ListResourceId(nsId, resourceType)
 
-	if len(resourceType) == 0 {
+	if len(resourceIdList) == 0 {
 		return nil
 	}
 

--- a/src/mcis/control.go
+++ b/src/mcis/control.go
@@ -3112,7 +3112,7 @@ func getVmNativeIp(nsId string, mcisId string, vmId string) (vmStatusInfo, error
 
 func ValidateStatus() {
 
-	nsList := common.GetNsList()
+	nsList := common.ListNsId()
 
 	for _, v := range nsList {
 		fmt.Println("validateStatus: NS[" + v + "]")


### PR DESCRIPTION
- Renamed & Exported functions
  - `getNsList` -> `ListNsId(nsId string, resourceType string) []string`
  - `checkNs` -> `CheckNs(Id string) (bool, error)`
  - `delNs` -> `DelNs(Id string) error`
- New functions
  - `GetNs(id string) (NsInfo, error)`
  - `ListNs() ([]NsInfo, error)`
  - `DelAllNs() error`
- Updated REST-handling functions (to separate REST and core logic) (for gRPC integration)
  - `RestGetNs(c echo.Context) error`
  - `RestGetAllNs(c echo.Context) error`
  - `RestDelAllNs(c echo.Context) error`
- Renamed & Exported structs
  - `nsInfo` -> `NsInfo`

---

- New gRPC functions
  - `rpc CheckNs (NsId) returns (BooleanResponse) {}`
  - `rpc CreateNs (NsReq) returns (NsInfo) {}`
  - `rpc DelAllNs (google.protobuf.Empty) returns (google.protobuf.Empty) {}`
  - `rpc DelNs (NsId) returns (google.protobuf.Empty) {}`
  - `rpc GetNs (NsId) returns (NsInfo) {}`
  - `rpc ListNs (google.protobuf.Empty) returns (NsInfoList) {}`
  - `rpc ListNsId (google.protobuf.Empty) returns (NsIdList) {}`

---

[Test guide]
1. Run CB-Tumblebug (REST + gRPC) server
```Shell
cd cb-tumblebug
git fetch upstream master
git rebase upstream/master
cd conf
source setup.env
cd ../src
make
make run
```

2. Run gRPC test client
```Shell
cd cb-tumblebug/src/api/grpc/test-client
make
make run
```

---

Ref: @powerkimhub @jmleefree 