### PR TITLE
Integrate struct TbVmReq into TbVmInfo, and update RestPostMcisVm

### DIFF
--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -583,69 +583,65 @@ func RestPostMcisVm(c echo.Context) error {
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
 
-	req := &mcis.TbVmReq{}
-	if err := c.Bind(req); err != nil {
+	/*
+		req := &mcis.TbVmReq{}
+		if err := c.Bind(req); err != nil {
+			return err
+		}
+
+		vmInfoData := mcis.TbVmInfo{}
+		//vmInfoData.Id = common.GenUuid()
+		vmInfoData.Id = common.GenId(req.Name)
+		//req.Id = vmInfoData.Id
+		//vmInfoData.CspVmName = req.CspVmName // will be deprecated
+
+		//vmInfoData.Placement_algo = req.Placement_algo
+
+		//vmInfoData.Location = req.Location
+		//vmInfoData.Cloud_id = req.
+		vmInfoData.Description = req.Description
+
+		//vmInfoData.CspSpecId = req.CspSpecId
+
+		//vmInfoData.Vcpu_size = req.Vcpu_size
+		//vmInfoData.Memory_size = req.Memory_size
+		//vmInfoData.Disk_size = req.Disk_size
+		//vmInfoData.Disk_type = req.Disk_type
+
+		//vmInfoData.CspImageName = req.CspImageName
+
+		//vmInfoData.CspSecurityGroupIds = req.CspSecurityGroupIds
+		//vmInfoData.CspVirtualNetworkId = "TBD"
+		//vmInfoData.Subnet = "TBD"
+		//vmInfoData.CspImageName = "TBD"
+		//vmInfoData.CspSpecId = "TBD"
+
+		//vmInfoData.PublicIP = "Not assigned yet"
+		//vmInfoData.CspVmId = "Not assigned yet"
+		//vmInfoData.PublicDNS = "Not assigned yet"
+		vmInfoData.Status = "Creating"
+
+		vmInfoData.Name = req.Name
+		vmInfoData.ConnectionName = req.ConnectionName
+		vmInfoData.SpecId = req.SpecId
+		vmInfoData.ImageId = req.ImageId
+		vmInfoData.VNetId = req.VNetId
+		vmInfoData.SubnetId = req.SubnetId
+		//vmInfoData.Vnic_id = req.Vnic_id
+		//vmInfoData.Public_ip_id = req.Public_ip_id
+		vmInfoData.SecurityGroupIds = req.SecurityGroupIds
+		vmInfoData.SshKeyId = req.SshKeyId
+		vmInfoData.Description = req.Description
+
+		vmInfoData.ConnectionName = req.ConnectionName
+	*/
+
+	vmInfoData := mcis.TbVmInfo{}
+	if err := c.Bind(vmInfoData); err != nil {
 		return err
 	}
 
-	vmInfoData := mcis.TbVmInfo{}
-	//vmInfoData.Id = common.GenUuid()
-	vmInfoData.Id = common.GenId(req.Name)
-	//req.Id = vmInfoData.Id
-	//vmInfoData.CspVmName = req.CspVmName
-
-	//vmInfoData.Placement_algo = req.Placement_algo
-
-	//vmInfoData.Location = req.Location
-	//vmInfoData.Cloud_id = req.
-	vmInfoData.Description = req.Description
-
-	//vmInfoData.CspSpecId = req.CspSpecId
-
-	//vmInfoData.Vcpu_size = req.Vcpu_size
-	//vmInfoData.Memory_size = req.Memory_size
-	//vmInfoData.Disk_size = req.Disk_size
-	//vmInfoData.Disk_type = req.Disk_type
-
-	//vmInfoData.CspImageName = req.CspImageName
-
-	//vmInfoData.CspSecurityGroupIds = req.CspSecurityGroupIds
-	//vmInfoData.CspVirtualNetworkId = "TBD"
-	//vmInfoData.Subnet = "TBD"
-	//vmInfoData.CspImageName = "TBD"
-	//vmInfoData.CspSpecId = "TBD"
-
-	//vmInfoData.PublicIP = "Not assigned yet"
-	//vmInfoData.CspVmId = "Not assigned yet"
-	//vmInfoData.PublicDNS = "Not assigned yet"
 	vmInfoData.Status = "Creating"
-
-	///////////
-	/*
-		Name              string `json:"name"`
-		Config_name       string `json:"config_name"`
-		Spec_id           string `json:"spec_id"`
-		Image_id          string `json:"image_id"`
-		Vnet_id           string `json:"vnet_id"`
-		Vnic_id           string `json:"vnic_id"`
-		Security_group_id string `json:"security_group_id"`
-		Ssh_key_id        string `json:"ssh_key_id"`
-		Description       string `json:"description"`
-	*/
-
-	vmInfoData.Name = req.Name
-	vmInfoData.Config_name = req.Config_name
-	vmInfoData.Spec_id = req.Spec_id
-	vmInfoData.Image_id = req.Image_id
-	vmInfoData.Vnet_id = req.Vnet_id
-	vmInfoData.Subnet_id = req.Subnet_id
-	//vmInfoData.Vnic_id = req.Vnic_id
-	//vmInfoData.Public_ip_id = req.Public_ip_id
-	vmInfoData.Security_group_ids = req.Security_group_ids
-	vmInfoData.Ssh_key_id = req.Ssh_key_id
-	vmInfoData.Description = req.Description
-
-	vmInfoData.Config_name = req.Config_name
 
 	//goroutin
 	var wg sync.WaitGroup

--- a/src/cli/cmd/root.go
+++ b/src/cli/cmd/root.go
@@ -67,7 +67,7 @@ type TbVmReq struct {
 	ConnectionName string `json:"connectionName"`
 
 	// 1. Required by CB-Spider
-	CspVmName string `json:"cspVmName"`
+	//CspVmName string `json:"cspVmName"` // will be deprecated
 
 	CspImageName          string   `json:"cspImageName"`
 	CspVirtualNetworkId   string   `json:"cspVirtualNetworkId"`
@@ -88,18 +88,18 @@ type TbVmReq struct {
 	VMUserId     string `json:"vmUserId"`
 	VMUserPasswd string `json:"vmUserPasswd"`
 
-	Name               string   `json:"name"`
-	Config_name        string   `json:"config_name"`
-	Spec_id            string   `json:"spec_id"`
-	Image_id           string   `json:"image_id"`
-	Vnet_id            string   `json:"vnet_id"`
-	Vnic_id            string   `json:"vnic_id"`
-	Public_ip_id       string   `json:"public_ip_id"`
-	Security_group_ids []string `json:"security_group_ids"`
-	Ssh_key_id         string   `json:"ssh_key_id"`
-	Description        string   `json:"description"`
-	Vm_access_id       string   `json:"vm_access_id"`
-	Vm_access_passwd   string   `json:"vm_access_passwd"`
+	Name             string   `json:"name"`
+	ConnectionName   string   `json:"connectionName"`
+	SpecId           string   `json:"specId"`
+	ImageId          string   `json:"imageId"`
+	VNetId           string   `json:"vNetId"`
+	Vnic_id          string   `json:"vnic_id"`
+	Public_ip_id     string   `json:"public_ip_id"`
+	SecurityGroupIds []string `json:"securityGroupIds"`
+	SshKeyId         string   `json:"sshKeyId"`
+	Description      string   `json:"description"`
+	VmUserAccount    string   `json:"vmUserAccount"`
+	VmUserPassword   string   `json:"vmUserPassword"`
 }
 
 /*
@@ -119,13 +119,13 @@ type McisInfo struct {
 }
 
 type vmOverview struct {
-	Id          string     `json:"id"`
-	Name        string     `json:"name"`
-	Config_name string     `json:"config_name"`
-	Region      RegionInfo `json:"region"` // AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
-	PublicIP    string     `json:"publicIP"`
-	PublicDNS   string     `json:"publicDNS"`
-	Status      string     `json:"status"`
+	Id             string     `json:"id"`
+	Name           string     `json:"name"`
+	ConnectionName string     `json:"connectionName"`
+	Region         RegionInfo `json:"region"` // AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
+	PublicIP       string     `json:"publicIP"`
+	PublicDNS      string     `json:"publicDNS"`
+	Status         string     `json:"status"`
 }
 
 type RegionInfo struct {
@@ -134,19 +134,19 @@ type RegionInfo struct {
 }
 
 type TbVmInfo struct {
-	Id                 string   `json:"id"`
-	Name               string   `json:"name"`
-	Config_name        string   `json:"config_name"`
-	Spec_id            string   `json:"spec_id"`
-	Image_id           string   `json:"image_id"`
-	Vnet_id            string   `json:"vnet_id"`
-	Vnic_id            string   `json:"vnic_id"`
-	Public_ip_id       string   `json:"public_ip_id"`
-	Security_group_ids []string `json:"security_group_ids"`
-	Ssh_key_id         string   `json:"ssh_key_id"`
-	Description        string   `json:"description"`
-	Vm_access_id       string   `json:"vm_access_id"`
-	Vm_access_passwd   string   `json:"vm_access_passwd"`
+	Id               string   `json:"id"`
+	Name             string   `json:"name"`
+	ConnectionName   string   `json:"connectionName"`
+	SpecId           string   `json:"specId"`
+	ImageId          string   `json:"imageId"`
+	VNetId           string   `json:"vNetId"`
+	Vnic_id          string   `json:"vnic_id"`
+	Public_ip_id     string   `json:"public_ip_id"`
+	SecurityGroupIds []string `json:"securityGroupIds"`
+	SshKeyId         string   `json:"sshKeyId"`
+	Description      string   `json:"description"`
+	VmUserAccount    string   `json:"vmUserAccount"`
+	VmUserPassword   string   `json:"vmUserPassword"`
 
 	VmUserId     string `json:"vmUserId"`
 	VmUserPasswd string `json:"vmUserPasswd"`
@@ -197,7 +197,7 @@ type McisStatusInfo struct {
 	Id   string `json:"id"`
 	Name string `json:"name"`
 	//Vm_num string         `json:"vm_num"`
-	Status string         `json:"status"`
+	Status string           `json:"status"`
 	Vm     []TbVmStatusInfo `json:"vm"`
 }
 
@@ -211,9 +211,9 @@ type TbVmStatusInfo struct {
 
 type McisRecommendReq struct {
 	Vm_req          []TbVmRecommendReq `json:"vm_req"`
-	Placement_algo  string           `json:"placement_algo"`
-	Placement_param []KeyValue       `json:"placement_param"`
-	Max_result_num  string           `json:"max_result_num"`
+	Placement_algo  string             `json:"placement_algo"`
+	Placement_param []KeyValue         `json:"placement_param"`
+	Max_result_num  string             `json:"max_result_num"`
 }
 
 type TbVmRecommendReq struct {
@@ -236,8 +236,8 @@ type TbVmPriority struct {
 type TbVmRecommendInfo struct {
 	Vm_req          TbVmRecommendReq `json:"vm_req"`
 	Vm_priority     []TbVmPriority   `json:"vm_priority"`
-	Placement_algo  string         `json:"placement_algo"`
-	Placement_param []KeyValue     `json:"placement_param"`
+	Placement_algo  string           `json:"placement_algo"`
+	Placement_param []KeyValue       `json:"placement_param"`
 }
 
 var cfgFile string

--- a/src/cli/config.json
+++ b/src/cli/config.json
@@ -5,35 +5,35 @@
   "vm_req": [
     {
           "name": "gcp-vmt05",
-          "config_name": "gcp-connection-config-01",
-          "spec_id": "17c12631-d29c-46c9-8390-322ad065cc39",
-          "image_id": "UUID-for-aws-ubuntu-image",
-          "vnet_id": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "connectionName": "gcp-connection-config-01",
+          "specId": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "imageId": "UUID-for-aws-ubuntu-image",
+          "vNetId": "17c12631-d29c-46c9-8390-322ad065cc39",
           "vnic_id": "17c12631-d29c-46c9-8390-322ad065cc39",
           "security_group_id": "17c12631-d29c-46c9-8390-322ad065cc39",
-          "ssh_key_id": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "sshKeyId": "17c12631-d29c-46c9-8390-322ad065cc39",
           "description": "description"
       },
       {
           "name": "azure-t09",
-          "config_name": "azure-connection-config-01",
-          "spec_id": "17c12631-d29c-46c9-8390-322ad065cc39",
-          "image_id": "UUID-for-azure-ubuntu-image",
-          "vnet_id": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "connectionName": "azure-connection-config-01",
+          "specId": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "imageId": "UUID-for-azure-ubuntu-image",
+          "vNetId": "17c12631-d29c-46c9-8390-322ad065cc39",
           "vnic_id": "17c12631-d29c-46c9-8390-322ad065cc39",
           "security_group_id": "17c12631-d29c-46c9-8390-322ad065cc39",
-          "ssh_key_id": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "sshKeyId": "17c12631-d29c-46c9-8390-322ad065cc39",
           "description": "description"
       },
       {
           "name": "aws-vmtest06",
-          "config_name": "aws-connection-config-01",
-          "spec_id": "17c12631-d29c-46c9-8390-322ad065cc39",
-          "image_id": "UUID-for-aws-ubuntu-image",
-          "vnet_id": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "connectionName": "aws-connection-config-01",
+          "specId": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "imageId": "UUID-for-aws-ubuntu-image",
+          "vNetId": "17c12631-d29c-46c9-8390-322ad065cc39",
           "vnic_id": "17c12631-d29c-46c9-8390-322ad065cc39",
           "security_group_id": "17c12631-d29c-46c9-8390-322ad065cc39",
-          "ssh_key_id": "17c12631-d29c-46c9-8390-322ad065cc39",
+          "sshKeyId": "17c12631-d29c-46c9-8390-322ad065cc39",
           "description": "description"
       }
   ]

--- a/src/mcis/control.go
+++ b/src/mcis/control.go
@@ -171,12 +171,13 @@ type TbMcisInfo struct {
 	//Vm             []vmOverview `json:"vm"`
 }
 
+/*
 type TbVmReq struct {
 	//Id             string `json:"id"`
-	ConnectionName string `json:"connectionName"`
+	//ConnectionName string `json:"connectionName"`
 
 	// 1. Required by CB-Spider
-	CspVmName string `json:"cspVmName"`
+	//CspVmName string `json:"cspVmName"` // will be deprecated
 
 	CspImageName        string `json:"cspImageName"`
 	CspVirtualNetworkId string `json:"cspVirtualNetworkId"`
@@ -197,36 +198,37 @@ type TbVmReq struct {
 	VMUserId     string `json:"vmUserId"`
 	VMUserPasswd string `json:"vmUserPasswd"`
 
-	Name        string `json:"name"`
-	Config_name string `json:"config_name"`
-	Spec_id     string `json:"spec_id"`
-	Image_id    string `json:"image_id"`
-	Vnet_id     string `json:"vnet_id"`
-	Subnet_id   string `json:"subnet_id"`
+	Name           string `json:"name"`
+	ConnectionName string `json:"connectionName"`
+	SpecId         string `json:"specId"`
+	ImageId        string `json:"imageId"`
+	VNetId         string `json:"vNetId"`
+	SubnetId       string `json:"subnetId"`
 	//Vnic_id            string   `json:"vnic_id"`
 	//Public_ip_id       string   `json:"public_ip_id"`
-	Security_group_ids []string `json:"security_group_ids"`
-	Ssh_key_id         string   `json:"ssh_key_id"`
-	Description        string   `json:"description"`
-	Vm_access_id       string   `json:"vm_access_id"`
-	Vm_access_passwd   string   `json:"vm_access_passwd"`
+	SecurityGroupIds []string `json:"securityGroupIds"`
+	SshKeyId         string   `json:"sshKeyId"`
+	Description      string   `json:"description"`
+	VmUserAccount    string   `json:"vmUserAccount"`
+	VmUserPassword   string   `json:"vmUserPassword"`
 }
+*/
 
 type TbVmInfo struct {
-	Id          string `json:"id"`
-	Name        string `json:"name"`
-	Config_name string `json:"config_name"`
-	Spec_id     string `json:"spec_id"`
-	Image_id    string `json:"image_id"`
-	Vnet_id     string `json:"vnet_id"`
-	Subnet_id   string `json:"subnet_id"`
+	Id             string `json:"id"`
+	Name           string `json:"name"`
+	ConnectionName string `json:"connectionName"`
+	SpecId         string `json:"specId"`
+	ImageId        string `json:"imageId"`
+	VNetId         string `json:"vNetId"`
+	SubnetId       string `json:"subnetId"`
 	//Vnic_id            string   `json:"vnic_id"`
 	//Public_ip_id       string   `json:"public_ip_id"`
-	Security_group_ids []string `json:"security_group_ids"`
-	Ssh_key_id         string   `json:"ssh_key_id"`
-	Description        string   `json:"description"`
-	Vm_access_id       string   `json:"vm_access_id"`
-	Vm_access_passwd   string   `json:"vm_access_passwd"`
+	SecurityGroupIds []string `json:"securityGroupIds"`
+	SshKeyId         string   `json:"sshKeyId"`
+	Description      string   `json:"description"`
+	VmUserAccount    string   `json:"vmUserAccount"`
+	VmUserPassword   string   `json:"vmUserPassword"`
 
 	VmUserId     string `json:"vmUserId"`
 	VmUserPasswd string `json:"vmUserPasswd"`
@@ -968,29 +970,29 @@ func CreateMcis(nsId string, req *TbMcisInfo) string {
 		///////////
 		/*
 			Name              string `json:"name"`
-			Config_name       string `json:"config_name"`
-			Spec_id           string `json:"spec_id"`
-			Image_id          string `json:"image_id"`
-			Vnet_id           string `json:"vnet_id"`
+			ConnectionName       string `json:"connectionName"`
+			SpecId           string `json:"specId"`
+			ImageId          string `json:"imageId"`
+			VNetId           string `json:"vNetId"`
 			Vnic_id           string `json:"vnic_id"`
 			Security_group_id string `json:"security_group_id"`
-			Ssh_key_id        string `json:"ssh_key_id"`
+			SshKeyId        string `json:"sshKeyId"`
 			Description       string `json:"description"`
 		*/
 
 		vmInfoData.Name = k.Name
-		vmInfoData.Config_name = k.Config_name
-		vmInfoData.Spec_id = k.Spec_id
-		vmInfoData.Image_id = k.Image_id
-		vmInfoData.Vnet_id = k.Vnet_id
-		vmInfoData.Subnet_id = k.Subnet_id
+		vmInfoData.ConnectionName = k.ConnectionName
+		vmInfoData.SpecId = k.SpecId
+		vmInfoData.ImageId = k.ImageId
+		vmInfoData.VNetId = k.VNetId
+		vmInfoData.SubnetId = k.SubnetId
 		//vmInfoData.Vnic_id = k.Vnic_id
 		//vmInfoData.Public_ip_id = k.Public_ip_id
-		vmInfoData.Security_group_ids = k.Security_group_ids
-		vmInfoData.Ssh_key_id = k.Ssh_key_id
+		vmInfoData.SecurityGroupIds = k.SecurityGroupIds
+		vmInfoData.SshKeyId = k.SshKeyId
 		vmInfoData.Description = k.Description
 
-		vmInfoData.Config_name = k.Config_name
+		vmInfoData.ConnectionName = k.ConnectionName
 
 		/////////
 
@@ -1069,32 +1071,32 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 		err := fmt.Errorf("vmInfoData.Name is empty")
 		common.CBLog.Error(err)
 		return err
-	case vmInfoData.Image_id == "":
-		err := fmt.Errorf("vmInfoData.Image_id is empty")
+	case vmInfoData.ImageId == "":
+		err := fmt.Errorf("vmInfoData.ImageId is empty")
 		common.CBLog.Error(err)
 		return err
-	case vmInfoData.Config_name == "":
-		err := fmt.Errorf("vmInfoData.Config_name is empty")
+	case vmInfoData.ConnectionName == "":
+		err := fmt.Errorf("vmInfoData.ConnectionName is empty")
 		common.CBLog.Error(err)
 		return err
-	case vmInfoData.Ssh_key_id == "":
-		err := fmt.Errorf("vmInfoData.Ssh_key_id is empty")
+	case vmInfoData.SshKeyId == "":
+		err := fmt.Errorf("vmInfoData.SshKeyId is empty")
 		common.CBLog.Error(err)
 		return err
-	case vmInfoData.Spec_id == "":
-		err := fmt.Errorf("vmInfoData.Spec_id is empty")
+	case vmInfoData.SpecId == "":
+		err := fmt.Errorf("vmInfoData.SpecId is empty")
 		common.CBLog.Error(err)
 		return err
-	case vmInfoData.Security_group_ids == nil:
-		err := fmt.Errorf("vmInfoData.Security_group_ids is empty")
+	case vmInfoData.SecurityGroupIds == nil:
+		err := fmt.Errorf("vmInfoData.SecurityGroupIds is empty")
 		common.CBLog.Error(err)
 		return err
-	case vmInfoData.Vnet_id == "":
-		err := fmt.Errorf("vmInfoData.Vnet_id is empty")
+	case vmInfoData.VNetId == "":
+		err := fmt.Errorf("vmInfoData.VNetId is empty")
 		common.CBLog.Error(err)
 		return err
-	case vmInfoData.Subnet_id == "":
-		err := fmt.Errorf("vmInfoData.Subnet_id is empty")
+	case vmInfoData.SubnetId == "":
+		err := fmt.Errorf("vmInfoData.SubnetId is empty")
 		common.CBLog.Error(err)
 		return err
 	default:
@@ -1119,38 +1121,38 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 	fmt.Println("url: " + url + " method: " + method)
 
 	tempReq := SpiderVMReqInfoWrapper{}
-	tempReq.ConnectionName = vmInfoData.Config_name
+	tempReq.ConnectionName = vmInfoData.ConnectionName
 
 	tempReq.ReqInfo.Name = vmInfoData.Name
 
 	err := fmt.Errorf("")
 
-	tempReq.ReqInfo.ImageName, err = common.GetCspResourceId(nsId, "image", vmInfoData.Image_id)
+	tempReq.ReqInfo.ImageName, err = common.GetCspResourceId(nsId, "image", vmInfoData.ImageId)
 	if tempReq.ReqInfo.ImageName == "" || err != nil {
 		common.CBLog.Error(err)
 		return err
 	}
 
-	tempReq.ReqInfo.VMSpecName, err = common.GetCspResourceId(nsId, "spec", vmInfoData.Spec_id)
+	tempReq.ReqInfo.VMSpecName, err = common.GetCspResourceId(nsId, "spec", vmInfoData.SpecId)
 	if tempReq.ReqInfo.VMSpecName == "" || err != nil {
 		common.CBLog.Error(err)
 		return err
 	}
 
-	tempReq.ReqInfo.VPCName = vmInfoData.Vnet_id //common.GetCspResourceId(nsId, "vNet", vmInfoData.Vnet_id)
+	tempReq.ReqInfo.VPCName = vmInfoData.VNetId //common.GetCspResourceId(nsId, "vNet", vmInfoData.VNetId)
 	if tempReq.ReqInfo.VPCName == "" {
 		common.CBLog.Error(err)
 		return err
 	}
 
-	tempReq.ReqInfo.SubnetName = vmInfoData.Subnet_id //common.GetCspResourceId(nsId, "vNet", vmInfoData.Subnet_id)
+	tempReq.ReqInfo.SubnetName = vmInfoData.SubnetId //common.GetCspResourceId(nsId, "vNet", vmInfoData.SubnetId)
 	if tempReq.ReqInfo.SubnetName == "" {
 		common.CBLog.Error(err)
 		return err
 	}
 
 	var SecurityGroupIdsTmp []string
-	for _, v := range vmInfoData.Security_group_ids {
+	for _, v := range vmInfoData.SecurityGroupIds {
 		CspSgId := v //common.GetCspResourceId(nsId, "securityGroup", v)
 		if CspSgId == "" {
 			common.CBLog.Error(err)
@@ -1161,14 +1163,14 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 	}
 	tempReq.ReqInfo.SecurityGroupNames = SecurityGroupIdsTmp
 
-	tempReq.ReqInfo.KeyPairName = vmInfoData.Ssh_key_id //common.GetCspResourceId(nsId, "sshKey", vmInfoData.Ssh_key_id)
+	tempReq.ReqInfo.KeyPairName = vmInfoData.SshKeyId //common.GetCspResourceId(nsId, "sshKey", vmInfoData.SshKeyId)
 	if tempReq.ReqInfo.KeyPairName == "" {
 		common.CBLog.Error(err)
 		return err
 	}
 
-	tempReq.ReqInfo.VMUserId = vmInfoData.Vm_access_id
-	tempReq.ReqInfo.VMUserPasswd = vmInfoData.Vm_access_passwd
+	tempReq.ReqInfo.VMUserId = vmInfoData.VmUserAccount
+	tempReq.ReqInfo.VMUserPasswd = vmInfoData.VmUserPassword
 
 	fmt.Printf("\n[Request body to CB-SPIDER for Creating VM]\n")
 	common.PrintJsonPretty(tempReq)
@@ -1232,8 +1234,8 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 
 	vmInfoData.CspViewVmDetail = temp
 
-	vmInfoData.Vm_access_id = temp.VMUserId
-	vmInfoData.Vm_access_passwd = temp.VMUserPasswd
+	vmInfoData.VmUserAccount = temp.VMUserId
+	vmInfoData.VmUserPassword = temp.VMUserPasswd
 
 	//vmInfoData.Location = vmInfoData.Location
 
@@ -1243,7 +1245,6 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 	//vmInfoData.Disk_type = vmInfoData.Disk_type
 
 	//vmInfoData.Placement_algo = vmInfoData.Placement_algo
-	vmInfoData.Description = vmInfoData.Description
 
 	// 2. Provided by CB-Spider
 	//vmInfoData.CspVmId = temp.Id
@@ -1257,7 +1258,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 	vmInfoData.VMBlockDisk = temp.VMBlockDisk
 	//vmInfoData.KeyValueList = temp.KeyValueList
 
-	configTmp, _ := common.GetConnConfig(vmInfoData.Config_name)
+	configTmp, _ := common.GetConnConfig(vmInfoData.ConnectionName)
 	vmInfoData.Location = GetCloudLocation(strings.ToLower(configTmp.ProviderName), strings.ToLower(temp.Region.Region))
 
 	//content.Status = temp.
@@ -1500,7 +1501,7 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 		temp.TargetStatus = StatusTerminated
 		temp.Status = StatusTerminating
 
-		//url = common.SPIDER_URL + "/vm/" + cspVmId + "?connection_name=" + temp.Config_name
+		//url = common.SPIDER_URL + "/vm/" + cspVmId + "?connection_name=" + temp.ConnectionName
 		url = common.SPIDER_URL + "/vm/" + cspVmId
 		method = "DELETE"
 	case ActionReboot:
@@ -1509,7 +1510,7 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 		temp.TargetStatus = StatusRunning
 		temp.Status = StatusRebooting
 
-		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.Config_name + "&action=reboot"
+		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=reboot"
 		url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=reboot"
 		method = "GET"
 	case ActionSuspend:
@@ -1518,7 +1519,7 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 		temp.TargetStatus = StatusSuspended
 		temp.Status = StatusSuspending
 
-		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.Config_name + "&action=suspend"
+		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=suspend"
 		url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=suspend"
 		method = "GET"
 	case ActionResume:
@@ -1527,7 +1528,7 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 		temp.TargetStatus = StatusRunning
 		temp.Status = StatusResuming
 
-		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.Config_name + "&action=resume"
+		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=resume"
 		url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=resume"
 		method = "GET"
 	default:
@@ -1541,7 +1542,7 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 		ConnectionName string
 	}
 	tempReq := ControlVMReqInfo{}
-	tempReq.ConnectionName = temp.Config_name
+	tempReq.ConnectionName = temp.ConnectionName
 	payload, _ := json.MarshalIndent(tempReq, "", "  ")
 	//fmt.Println("payload: " + string(payload)) // for debug
 
@@ -1668,19 +1669,19 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 	method := ""
 	switch action {
 	case ActionTerminate:
-		//url = common.SPIDER_URL + "/vm/" + cspVmId + "?connection_name=" + temp.Config_name
+		//url = common.SPIDER_URL + "/vm/" + cspVmId + "?connection_name=" + temp.ConnectionName
 		url = common.SPIDER_URL + "/vm/" + cspVmId
 		method = "DELETE"
 	case ActionReboot:
-		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.Config_name + "&action=reboot"
+		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=reboot"
 		url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=reboot"
 		method = "GET"
 	case ActionSuspend:
-		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.Config_name + "&action=suspend"
+		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=suspend"
 		url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=suspend"
 		method = "GET"
 	case ActionResume:
-		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.Config_name + "&action=resume"
+		//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=resume"
 		url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=resume"
 		method = "GET"
 	default:
@@ -1692,7 +1693,7 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 		ConnectionName string
 	}
 	tempReq := ControlVMReqInfo{}
-	tempReq.ConnectionName = temp.Config_name
+	tempReq.ConnectionName = temp.ConnectionName
 	payload, _ := json.MarshalIndent(tempReq, "", "  ")
 	//fmt.Println("payload: " + string(payload)) // for debug
 
@@ -1860,7 +1861,7 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 			Cloud_id  string `json:"cloud_id"`
 			Csp_vm_id string `json:"csp_vm_id"`
 			CspVmId   string
-			CspVmName string
+			CspVmName string // will be deprecated
 			PublicIP  string
 		}
 	*/
@@ -1903,7 +1904,7 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 	*/
 	cspVmId := temp.CspViewVmDetail.IId.NameId
 
-	url := common.SPIDER_URL + "/vmstatus/" + cspVmId // + "?connection_name=" + temp.Config_name
+	url := common.SPIDER_URL + "/vmstatus/" + cspVmId // + "?connection_name=" + temp.ConnectionName
 	method := "GET"
 
 	//fmt.Println("url: " + url)
@@ -1912,7 +1913,7 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 		ConnectionName string
 	}
 	tempReq := VMStatusReqInfo{}
-	tempReq.ConnectionName = temp.Config_name
+	tempReq.ConnectionName = temp.ConnectionName
 	payload, _ := json.MarshalIndent(tempReq, "", "  ")
 	//fmt.Println("payload: " + string(payload)) // for debug
 
@@ -2074,14 +2075,14 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 
 	cspVmId := temp.CspViewVmDetail.IId.NameId
 
-	url := common.SPIDER_URL + "/vm/" + cspVmId // + "?connection_name=" + temp.Config_name
+	url := common.SPIDER_URL + "/vm/" + cspVmId // + "?connection_name=" + temp.ConnectionName
 	method := "GET"
 
 	type VMStatusReqInfo struct {
 		ConnectionName string
 	}
 	tempReq := VMStatusReqInfo{}
-	tempReq.ConnectionName = temp.Config_name
+	tempReq.ConnectionName = temp.ConnectionName
 	payload, _ := json.MarshalIndent(tempReq, "", "  ")
 	//fmt.Println("payload: " + string(payload)) // for debug
 
@@ -2147,7 +2148,7 @@ func ValidateStatus() {
 func GetVmSshKey(nsId string, mcisId string, vmId string) (string, string) {
 
 	var content struct {
-		Ssh_key_id string `json:"ssh_key_id"`
+		SshKeyId string `json:"sshKeyId"`
 	}
 
 	fmt.Println("[GetVmIp]" + vmId)
@@ -2160,9 +2161,9 @@ func GetVmSshKey(nsId string, mcisId string, vmId string) (string, string) {
 
 	json.Unmarshal([]byte(keyValue.Value), &content)
 
-	fmt.Printf("%+v\n", content.Ssh_key_id)
+	fmt.Printf("%+v\n", content.SshKeyId)
 
-	sshKey := common.GenResourceKey(nsId, "sshKey", content.Ssh_key_id)
+	sshKey := common.GenResourceKey(nsId, "sshKey", content.SshKeyId)
 	keyValue, _ = common.CBStore.Get(sshKey)
 	var keyContent struct {
 		Username   string `json:"username"`
@@ -2197,7 +2198,7 @@ func GetVmIp(nsId string, mcisId string, vmId string) string {
 func GetVmSpecId(nsId string, mcisId string, vmId string) string {
 
 	var content struct {
-		Spec_id string `json:"spec_id"`
+		SpecId string `json:"specId"`
 	}
 
 	fmt.Println("[getVmSpecID]" + vmId)
@@ -2207,9 +2208,9 @@ func GetVmSpecId(nsId string, mcisId string, vmId string) string {
 
 	json.Unmarshal([]byte(keyValue.Value), &content)
 
-	fmt.Printf("%+v\n", content.Spec_id)
+	fmt.Printf("%+v\n", content.SpecId)
 
-	return content.Spec_id
+	return content.SpecId
 }
 
 func GetCloudLocation(cloudType string, nativeRegion string) GeoLocation {
@@ -2278,7 +2279,7 @@ func GetCloudLocation(cloudType string, nativeRegion string) GeoLocation {
 type vmOverview struct {
 	Id          string      `json:"id"`
 	Name        string      `json:"name"`
-	Config_name string      `json:"config_name"`
+	ConnectionName string      `json:"connectionName"`
 	Region      RegionInfo  `json:"region"` // AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
 	Location    GeoLocation `json:"location"`
 	PublicIP    string      `json:"publicIP"`

--- a/test/obsolete/aws-tester-sh/vm/start_all-test.sh
+++ b/test/obsolete/aws-tester-sh/vm/start_all-test.sh
@@ -183,19 +183,19 @@ do
 	    "vm_req": [
 		{
 		    "name": "aws-jhseo-vm'$num'",
-		    "config_name": "'$NAME'",
-		    "spec_id": "'$SPEC_ID'",
-		    "image_id": "'$IMAGE_ID'",
-		    "vnet_id": "'$VNET_ID'",
+		    "connectionName": "'$NAME'",
+		    "specId": "'$SPEC_ID'",
+		    "imageId": "'$IMAGE_ID'",
+		    "vNetId": "'$VNET_ID'",
 		    "vnic_id": "",
 		    "public_ip_id": "'$PIP_ID'",
-		    "security_group_ids": [
+		    "securityGroupIds": [
 				"'$SG_ID'"
 			],
-		    "ssh_key_id": "'$SSHKEY_ID'",
+		    "sshKeyId": "'$SSHKEY_ID'",
 		    "description": "description",
-		    "vm_access_id": "",
-		    "vm_access_passwd": ""
+		    "vmUserAccount": "",
+		    "vmUserPassword": ""
 		}    
 	    ]
 	}' | json_pp
@@ -204,19 +204,19 @@ do
 		MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
 		curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
 		"name": "aws-jhseo-vm'$num'",
-		    "config_name": "'$NAME'",
-		    "spec_id": "'$SPEC_ID'",
-		    "image_id": "'$IMAGE_ID'",
-		    "vnet_id": "'$VNET_ID'",
+		    "connectionName": "'$NAME'",
+		    "specId": "'$SPEC_ID'",
+		    "imageId": "'$IMAGE_ID'",
+		    "vNetId": "'$VNET_ID'",
 		    "vnic_id": "",
 		    "public_ip_id": "'$PIP_ID'",
-		    "security_group_ids": [
+		    "securityGroupIds": [
 				"'$SG_ID'"
 			],
-		    "ssh_key_id": "'$SSHKEY_ID'",
+		    "sshKeyId": "'$SSHKEY_ID'",
 		    "description": "description",
-		    "vm_access_id": "",
-		    "vm_access_passwd": ""
+		    "vmUserAccount": "",
+		    "vmUserPassword": ""
 		}' | json_pp
 
 	fi

--- a/test/obsolete/azure-tester-sh/vm/start_all-test.sh
+++ b/test/obsolete/azure-tester-sh/vm/start_all-test.sh
@@ -177,19 +177,19 @@ do
 	    "vm_req": [
 		{
 		    "name": "jhseo-vm'$num'",
-		    "config_name": "'$NAME'",
-		    "spec_id": "'$SPEC_ID'",
-		    "image_id": "'$IMAGE_ID'",
-		    "vnet_id": "'$VNET_ID'",
+		    "connectionName": "'$NAME'",
+		    "specId": "'$SPEC_ID'",
+		    "imageId": "'$IMAGE_ID'",
+		    "vNetId": "'$VNET_ID'",
 		    "vnic_id": "",
 		    "public_ip_id": "'$PIP_ID'",
-		    "security_group_ids": [
+		    "securityGroupIds": [
 				"'$SG_ID'"
 			],
-		    "ssh_key_id": "'$SSHKEY_ID'",
+		    "sshKeyId": "'$SSHKEY_ID'",
 		    "description": "description",
-		    "vm_access_id": "cb-user",
-		    "vm_access_passwd": ""
+		    "vmUserAccount": "cb-user",
+		    "vmUserPassword": ""
 		}
 	    ]
 	}' | json_pp
@@ -198,19 +198,19 @@ do
 		MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
 		curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
 		"name": "jhseo-vm'$num'",
-		    "config_name": "'$NAME'",
-		    "spec_id": "'$SPEC_ID'",
-		    "image_id": "'$IMAGE_ID'",
-		    "vnet_id": "'$VNET_ID'",
+		    "connectionName": "'$NAME'",
+		    "specId": "'$SPEC_ID'",
+		    "imageId": "'$IMAGE_ID'",
+		    "vNetId": "'$VNET_ID'",
 		    "vnic_id": "",
 		    "public_ip_id": "'$PIP_ID'",
-		    "security_group_ids": [
+		    "securityGroupIds": [
 				"'$SG_ID'"
 			],
-		    "ssh_key_id": "'$SSHKEY_ID'",
+		    "sshKeyId": "'$SSHKEY_ID'",
 		    "description": "description",
-		    "vm_access_id": "cb-user",
-		    "vm_access_passwd": ""
+		    "vmUserAccount": "cb-user",
+		    "vmUserPassword": ""
 		}' | json_pp
 
 	fi

--- a/test/obsolete/full_test.sh
+++ b/test/obsolete/full_test.sh
@@ -122,17 +122,17 @@ function full_test() {
 			"vm_num": "1",
 			"description": "Tumblebug demo",
 			"vm_req": [ {
-				"image_id": "IMAGE-01",
-				"vm_access_id": "cb-user",
-				"config_name": "aws-us-east-1-config",
-				"ssh_key_id": "KEYPAIR-01",
-				"spec_id": "SPEC-01",
-				"security_group_ids": [
+				"imageId": "IMAGE-01",
+				"vmUserAccount": "cb-user",
+				"connectionName": "aws-us-east-1-config",
+				"sshKeyId": "KEYPAIR-01",
+				"specId": "SPEC-01",
+				"securityGroupIds": [
 					"SG-01"
 				],
-				"vnet_id": "VPC-01",
+				"vNetId": "VPC-01",
 				"description": "description",
-				"vm_access_passwd": "",
+				"vmUserPassword": "",
 				"name": "VM-01"
 			} ]
 		}' | json_pp || return 1

--- a/test/obsolete/gcp-tester-sh/vm/start_all-test.sh
+++ b/test/obsolete/gcp-tester-sh/vm/start_all-test.sh
@@ -179,19 +179,19 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources
             "vm_req": [
                 {
                     "name": "jhseo-shooter-'$num'",
-                    "config_name": "'$NAME'",
-                    "spec_id": "'$SPEC_ID'",
-                    "image_id": "'$IMAGE_ID'",
-                    "vnet_id": "'$VNET_ID'",
+                    "connectionName": "'$NAME'",
+                    "specId": "'$SPEC_ID'",
+                    "imageId": "'$IMAGE_ID'",
+                    "vNetId": "'$VNET_ID'",
                     "vnic_id": "",
                     "public_ip_id": "'$PIP_ID'",
-                    "security_group_ids": [
+                    "securityGroupIds": [
                                 "'$SG_ID'"
                         ],
-                    "ssh_key_id": "'$SSHKEY_ID'",
+                    "sshKeyId": "'$SSHKEY_ID'",
                     "description": "description",
-                    "vm_access_id": "cb-user",
-                    "vm_access_passwd": ""
+                    "vmUserAccount": "cb-user",
+                    "vmUserPassword": ""
                 }
             ]
         }' | json_pp
@@ -200,19 +200,19 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources
                 MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
                 curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
                 "name": "jhseo-shooter-'$num'",
-                    "config_name": "'$NAME'",
-                    "spec_id": "'$SPEC_ID'",
-                    "image_id": "'$IMAGE_ID'",
-                    "vnet_id": "'$VNET_ID'",
+                    "connectionName": "'$NAME'",
+                    "specId": "'$SPEC_ID'",
+                    "imageId": "'$IMAGE_ID'",
+                    "vNetId": "'$VNET_ID'",
                     "vnic_id": "",
                     "public_ip_id": "'$PIP_ID'",
-                    "security_group_ids": [
+                    "securityGroupIds": [
                                 "'$SG_ID'"
                         ],
-                    "ssh_key_id": "'$SSHKEY_ID'",
+                    "sshKeyId": "'$SSHKEY_ID'",
                     "description": "description",
-                    "vm_access_id": "cb-user",
-                    "vm_access_passwd": ""
+                    "vmUserAccount": "cb-user",
+                    "vmUserPassword": ""
                 }' | json_pp
 
         fi

--- a/test/obsolete/shooter-sh-2019/vm/start_all-test.sh
+++ b/test/obsolete/shooter-sh-2019/vm/start_all-test.sh
@@ -180,19 +180,19 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID
             "vm_req": [
                 {
                     "name": "jhseo-vm-'$num'",
-                    "config_name": "'$NAME'",
-                    "spec_id": "'$SPEC_ID'",
-                    "image_id": "'$IMAGE_ID'",
-                    "vnet_id": "'$VNET_ID'",
+                    "connectionName": "'$NAME'",
+                    "specId": "'$SPEC_ID'",
+                    "imageId": "'$IMAGE_ID'",
+                    "vNetId": "'$VNET_ID'",
                     "vnic_id": "",
                     "public_ip_id": "'$PIP_ID'",
-                    "security_group_ids": [
+                    "securityGroupIds": [
                                 "'$SG_ID'"
                         ],
-                    "ssh_key_id": "'$SSHKEY_ID'",
+                    "sshKeyId": "'$SSHKEY_ID'",
                     "description": "description",
-                    "vm_access_id": "cb-user",
-                    "vm_access_passwd": ""
+                    "vmUserAccount": "cb-user",
+                    "vmUserPassword": ""
                 }
             ]
         }' | json_pp
@@ -202,19 +202,19 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID
 #                echo '{
                 curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
                 "name": "jhseo-vm-'$num'",
-                    "config_name": "'$NAME'",
-                    "spec_id": "'$SPEC_ID'",
-                    "image_id": "'$IMAGE_ID'",
-                    "vnet_id": "'$VNET_ID'",
+                    "connectionName": "'$NAME'",
+                    "specId": "'$SPEC_ID'",
+                    "imageId": "'$IMAGE_ID'",
+                    "vNetId": "'$VNET_ID'",
                     "vnic_id": "",
                     "public_ip_id": "'$PIP_ID'",
-                    "security_group_ids": [
+                    "securityGroupIds": [
                                 "'$SG_ID'"
                         ],
-                    "ssh_key_id": "'$SSHKEY_ID'",
+                    "sshKeyId": "'$SSHKEY_ID'",
                     "description": "description",
-                    "vm_access_id": "cb-user",
-                    "vm_access_passwd": ""
+                    "vmUserAccount": "cb-user",
+                    "vmUserPassword": ""
                 }' | json_pp
 
         fi

--- a/test/official/6.mcis/create-mcis.sh
+++ b/test/official/6.mcis/create-mcis.sh
@@ -33,48 +33,48 @@ curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis -H 'Content-Type:
 		"description": "Tumblebug Demo",
 		"vm": [ {
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-01",
-			"image_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"vm_access_id": "cb-user",
-			"config_name": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-			"ssh_key_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"spec_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"security_group_ids": [
+			"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"vmUserAccount": "cb-user",
+			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
+			"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"securityGroupIds": [
 				"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
 			],
-			"vnet_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"subnet_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "description",
-			"vm_access_passwd": ""
+			"vmUserPassword": ""
 		},
 		{
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-02",
-			"image_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"vm_access_id": "cb-user",
-			"config_name": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-			"ssh_key_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"spec_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"security_group_ids": [
+			"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"vmUserAccount": "cb-user",
+			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
+			"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"securityGroupIds": [
 				"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
 			],
-			"vnet_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"subnet_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "description",
-			"vm_access_passwd": ""
+			"vmUserPassword": ""
 		},
 		{
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-03",
-			"image_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"vm_access_id": "cb-user",
-			"config_name": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-			"ssh_key_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"spec_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"security_group_ids": [
+			"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"vmUserAccount": "cb-user",
+			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
+			"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"securityGroupIds": [
 				"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
 			],
-			"vnet_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"subnet_id": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "description",
-			"vm_access_passwd": ""
+			"vmUserPassword": ""
 		} ]
 	}' | json_pp || return 1
 

--- a/test/official/README.md
+++ b/test/official/README.md
@@ -211,7 +211,7 @@ Dozing for 10 : 1 2 3 4 5 6 7 8 9 10 (Back to work)
       {
          "vmUserId" : "",
          "targetStatus" : "None",
-         "subnet_id" : "aws-us-east-1-shson",
+         "subnetId" : "aws-us-east-1-shson",
          "location" : {
             "nativeRegion" : "us-east-1",
             "cloudType" : "aws",
@@ -219,19 +219,19 @@ Dozing for 10 : 1 2 3 4 5 6 7 8 9 10 (Back to work)
             "briefAddr" : "Virginia",
             "longitude" : "-78.4500"
          },
-         "vm_access_id" : "",
+         "vmUserAccount" : "",
          "region" : {
             "Region" : "us-east-1",
             "Zone" : "us-east-1f"
          },
-         "image_id" : "aws-us-east-1-shson",
+         "imageId" : "aws-us-east-1-shson",
          "privateDNS" : "ip-192-168-1-108.ec2.internal",
          "vmBootDisk" : "/dev/sda1",
          "status" : "Running",
-         "security_group_ids" : [
+         "securityGroupIds" : [
             "aws-us-east-1-shson"
          ],
-         "vm_access_passwd" : "",
+         "vmUserPassword" : "",
  .........
             "VMUserId" : "",
             "SecurityGroupIIds" : [
@@ -252,14 +252,14 @@ Dozing for 10 : 1 2 3 4 5 6 7 8 9 10 (Back to work)
          "publicIP" : "35.173.215.4",
          "name" : "aws-us-east-1-shson-01",
          "id" : "aws-us-east-1-shson-01",
-         "vnet_id" : "aws-us-east-1-shson",
-         "ssh_key_id" : "aws-us-east-1-shson",
+         "vNetId" : "aws-us-east-1-shson",
+         "sshKeyId" : "aws-us-east-1-shson",
          "privateIP" : "192.168.1.108",
-         "config_name" : "aws-us-east-1",
+         "connectionName" : "aws-us-east-1",
          "vmBlockDisk" : "/dev/sda1",
          "targetAction" : "None",
          "description" : "description",
-         "spec_id" : "aws-us-east-1-shson",
+         "specId" : "aws-us-east-1-shson",
          "publicDNS" : "",
          "vmUserPasswd" : ""
       },
@@ -267,7 +267,7 @@ Dozing for 10 : 1 2 3 4 5 6 7 8 9 10 (Back to work)
          "vmBlockDisk" : "/dev/sda1",
          "targetAction" : "None",
          "description" : "description",
-         "spec_id" : "aws-us-east-1-shson",
+         "specId" : "aws-us-east-1-shson",
          "vmUserPasswd" : "",
          ..........
       }


### PR DESCRIPTION
- VM REST API JSON field names are changed. (Ref: @jazmandorf @dev4unet)
  - Issue #180: Suggestion: Organize JSON field name
  - Issue #187: Info: JSON input/output of `CreateMcis()` will be changed
- Integrate struct `TbVmReq` into `TbVmInfo`
  - Issue #177: Suggestion: Integrate struct pair `xxxReq` and `xxxInfo`
- Update `RestPostMcisVm()`
  - Related info: #186 Info: Go struct / JSON field name match table

[Logic of `RestPostMcisVm()`]

[Before this PR](https://github.com/cloud-barista/cb-tumblebug/blob/58e51127acfe3fe324dfb0204311c8d537366583/src/api/rest/server/mcis/control.go#L581):

1. POST `{tb_host}:{tb_port}/tumblebug/ns/:nsId/mcis/:mcisId/vm` (in [src/api/rest/server/server.go](https://github.com/cloud-barista/cb-tumblebug/blob/master/src/api/rest/server/server.go))
2. `func RestPostMcisVm(c echo.Context)` (in [src/api/rest/server/mcis/control.go](https://github.com/cloud-barista/cb-tumblebug/blob/master/src/api/rest/server/mcis/control.go))
   1. Create empty `TbVmReq` object (Let's call this `tbVmReq`)
   2. Bind (Unmarshal) JSON to `tbVmReq`
   3. Create empty `TbVmInfo` object (Let's call this `tbVmInfo`)
   4. Fill `tbVmInfo` ← `tbVmReq` field-by-field
   5. Call `mcis.AddVmToMcis(&wg, nsId, mcisId, &tbVmInfo)`

After this PR:
1. POST `{tb_host}:{tb_port}/tumblebug/ns/:nsId/mcis/:mcisId/vm` (in [src/api/rest/server/server.go](https://github.com/cloud-barista/cb-tumblebug/blob/master/src/api/rest/server/server.go))
2. `func RestPostMcisVm(c echo.Context)` (in [src/api/rest/server/mcis/control.go](https://github.com/cloud-barista/cb-tumblebug/blob/master/src/api/rest/server/mcis/control.go))
   1. Create empty `TbVmInfo` object (Let's call this `tbVmInfo`)
   2. Bind (Unmarshal) JSON to `tbVmInfo`
   3. Call `mcis.AddVmToMcis(&wg, nsId, mcisId, &tbVmInfo)`