### PR TITLE
Add and apply BasicAuth for all REST API resources

### DIFF
--- a/conf/setup.env
+++ b/conf/setup.env
@@ -1,7 +1,11 @@
 export CBSTORE_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
 export CBLOG_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
 export SPIDER_URL=http://localhost:1024/spider
+
 export DB_URL=localhost:3306
 export DB_DATABASE=cb_tumblebug
 export DB_USER=cb_tumblebug
 export DB_PASSWORD=cb_tumblebug
+
+export API_USERNAME=default-api-username
+export API_PASSWORD=default-api-password

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -8,9 +8,9 @@ import (
 	rest_mcir "github.com/cloud-barista/cb-tumblebug/src/api/rest/server/mcir"
 	rest_mcis "github.com/cloud-barista/cb-tumblebug/src/api/rest/server/mcis"
 
-	//"os"
-
+	"os"
 	"fmt"
+	"crypto/subtle"
 
 	// REST API (echo)
 	"net/http"
@@ -78,6 +78,18 @@ func ApiServer() {
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},
 		AllowMethods: []string{http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete},
+	}))
+
+	API_USERNAME := os.Getenv("API_USERNAME")
+	API_PASSWORD := os.Getenv("API_PASSWORD")
+	fmt.Println(API_USERNAME, API_PASSWORD)
+	e.Use(middleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
+		// Be careful to use constant time comparison to prevent timing attacks
+		if subtle.ConstantTimeCompare([]byte(username), []byte(API_USERNAME)) == 1 &&
+			subtle.ConstantTimeCompare([]byte(password), []byte(API_PASSWORD)) == 1 {
+			return true, nil
+		}
+		return false, nil
 	}))
 
 	fmt.Println("")

--- a/test/obsolete/aws-tester-sh/image/create-test.sh
+++ b/test/obsolete/aws-tester-sh/image/create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image?action=registerWithId -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image?action=registerWithId -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
 	"cspImageId": "'${IMG_IDS[num]}'"
 	}' | json_pp
 

--- a/test/obsolete/aws-tester-sh/image/delete-test.sh
+++ b/test/obsolete/aws-tester-sh/image/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 #echo $TB_IMAGE_IDS | json_pp
 
 if [ -n "$TB_IMAGE_IDS" ]
 then
-        #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         for TB_IMAGE_ID in ${TB_IMAGE_IDS}
         do
                 echo ....Delete ${TB_IMAGE_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
         done
 else
         echo ....no images found

--- a/test/obsolete/aws-tester-sh/image/get-test.sh
+++ b/test/obsolete/aws-tester-sh/image/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 #echo $TB_IMAGE_IDS | json_pp
 
 if [ -n "$TB_IMAGE_IDS" ]
 then
-        #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         for TB_IMAGE_ID in ${TB_IMAGE_IDS}
         do
                 echo ....Get ${TB_IMAGE_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
         done
 else
         echo ....no images found

--- a/test/obsolete/aws-tester-sh/image/list-test.sh
+++ b/test/obsolete/aws-tester-sh/image/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/image | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/image | json_pp &
 #done

--- a/test/obsolete/aws-tester-sh/image/spider-get-test.sh
+++ b/test/obsolete/aws-tester-sh/image/spider-get-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
 	num=`expr $num + 1`
 done

--- a/test/obsolete/aws-tester-sh/keypair/create-test.sh
+++ b/test/obsolete/aws-tester-sh/keypair/create-test.sh
@@ -3,7 +3,7 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	KEY=`curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspSshKeyName\":\"jhseo-test\"}" |json_pp | grep privateKey |sed 's/"privateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
+	KEY=`curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspSshKeyName\":\"jhseo-test\"}" |json_pp | grep privateKey |sed 's/"privateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
 	echo -e ${KEY}
 	echo -e ${KEY} > ./${NAME}.key
 	chmod 600 ./${NAME}.key

--- a/test/obsolete/aws-tester-sh/keypair/delete-test.sh
+++ b/test/obsolete/aws-tester-sh/keypair/delete-test.sh
@@ -3,18 +3,18 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	curl -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp
 #done
 
-TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 
 if [ -n "$TB_SSHKEY_IDS" ]
 then
-        #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
         do
                 echo ....Delete ${TB_SSHKEY_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID}
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID}
         done
 else
         echo ....no sshKeys found

--- a/test/obsolete/aws-tester-sh/keypair/get-test.sh
+++ b/test/obsolete/aws-tester-sh/keypair/get-test.sh
@@ -3,19 +3,19 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	curl -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done
 
-TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 #echo $TB_SSHKEY_IDS | json_pp
 
 if [ -n "$TB_SSHKEY_IDS" ]
 then
-        #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
         do
                 echo ....Get ${TB_SSHKEY_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | json_pp
         done
 else
         echo ....no sshKeys found

--- a/test/obsolete/aws-tester-sh/keypair/list-test.sh
+++ b/test/obsolete/aws-tester-sh/keypair/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/sshKey |json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/sshKey |json_pp &
 #done

--- a/test/obsolete/aws-tester-sh/keypair/spider-create-test.sh
+++ b/test/obsolete/aws-tester-sh/keypair/spider-create-test.sh
@@ -3,7 +3,7 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	KEY=`curl -sX POST http://$RESTSERVER:1024/keypair?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "mcb-keypair-powerkim" }' |json_pp | grep PrivateKey |sed 's/"PrivateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
+	KEY=`curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/keypair?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "mcb-keypair-powerkim" }' |json_pp | grep PrivateKey |sed 's/"PrivateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
 	echo -e ${KEY}
 	echo -e ${KEY} > ./${NAME}.key
 	chmod 600 ./${NAME}.key

--- a/test/obsolete/aws-tester-sh/keypair/spider-delete-test.sh
+++ b/test/obsolete/aws-tester-sh/keypair/spider-delete-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp
 done

--- a/test/obsolete/aws-tester-sh/keypair/spider-get-test.sh
+++ b/test/obsolete/aws-tester-sh/keypair/spider-get-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/keypair/spider-list-test.sh
+++ b/test/obsolete/aws-tester-sh/keypair/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/keypair?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/publicip/create-test.sh
+++ b/test/obsolete/aws-tester-sh/publicip/create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspPublicIpName\":\"jhseo-test\"}" | json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspPublicIpName\":\"jhseo-test\"}" | json_pp &
 done

--- a/test/obsolete/aws-tester-sh/publicip/delete-test.sh
+++ b/test/obsolete/aws-tester-sh/publicip/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Delete ${TB_PUBLICIP_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
         done
 else
         echo ....no publicIps found

--- a/test/obsolete/aws-tester-sh/publicip/get-test.sh
+++ b/test/obsolete/aws-tester-sh/publicip/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
         done
 else
         echo ....no publicIps found

--- a/test/obsolete/aws-tester-sh/publicip/list-test.sh
+++ b/test/obsolete/aws-tester-sh/publicip/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/publicIp | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/publicIp | json_pp &
 #done

--- a/test/obsolete/aws-tester-sh/publicip/spider-create-test.sh
+++ b/test/obsolete/aws-tester-sh/publicip/spider-create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt01-powerkim" }' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt01-powerkim" }' |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/publicip/spider-delete-test.sh
+++ b/test/obsolete/aws-tester-sh/publicip/spider-delete-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-	curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 done

--- a/test/obsolete/aws-tester-sh/publicip/spider-get-test.sh
+++ b/test/obsolete/aws-tester-sh/publicip/spider-get-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-	curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/publicip/spider-list-test.sh
+++ b/test/obsolete/aws-tester-sh/publicip/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/security/create-test.sh
+++ b/test/obsolete/aws-tester-sh/security/create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\",  \"cspSecurityGroupName\": \"jhseo-test\", \"firewallRules\": [ {\"FromPort\": \"20\", \"ToPort\" : \"200\", \"IPProtocol\" : \"tcp\", \"Direction\" : \"inbound\"} ] }" | json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\",  \"cspSecurityGroupName\": \"jhseo-test\", \"firewallRules\": [ {\"FromPort\": \"20\", \"ToPort\" : \"200\", \"IPProtocol\" : \"tcp\", \"Direction\" : \"inbound\"} ] }" | json_pp &
 done

--- a/test/obsolete/aws-tester-sh/security/delete-test.sh
+++ b/test/obsolete/aws-tester-sh/security/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME}
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME}
 #done
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 #echo $TB_SECURITYGROUP_IDS | json_pp
 
 if [ -n "$TB_SECURITYGROUP_IDS" ]
 then
-        #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
         do
                 echo ....Delete ${TB_SECURITYGROUP_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
         done
 else
         echo ....no securityGroups found

--- a/test/obsolete/aws-tester-sh/security/get-test.sh
+++ b/test/obsolete/aws-tester-sh/security/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 #echo $TB_SECURITYGROUP_IDS | json_pp
 
 if [ -n "$TB_SECURITYGROUP_IDS" ]
 then
-        #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
         do
                 echo ....Get ${TB_SECURITYGROUP_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
         done
 else
         echo ....no securityGroups found

--- a/test/obsolete/aws-tester-sh/security/list-test.sh
+++ b/test/obsolete/aws-tester-sh/security/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/securityGroup | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/securityGroup | json_pp &
 #done

--- a/test/obsolete/aws-tester-sh/security/spider-create-test.sh
+++ b/test/obsolete/aws-tester-sh/security/spider-create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "20", "ToPort" : "200", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "20", "ToPort" : "200", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/security/spider-delete-test.sh
+++ b/test/obsolete/aws-tester-sh/security/spider-delete-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
-	curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME}
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME}
 done

--- a/test/obsolete/aws-tester-sh/security/spider-delete2-test.sh
+++ b/test/obsolete/aws-tester-sh/security/spider-delete2-test.sh
@@ -3,7 +3,7 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-	curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} 
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} 
 done
 

--- a/test/obsolete/aws-tester-sh/security/spider-get-test.sh
+++ b/test/obsolete/aws-tester-sh/security/spider-get-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-	curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/security/spider-get2-test.sh
+++ b/test/obsolete/aws-tester-sh/security/spider-get2-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
-	curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/security/spider-list-test.sh
+++ b/test/obsolete/aws-tester-sh/security/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/spec/create-test.sh
+++ b/test/obsolete/aws-tester-sh/spec/create-test.sh
@@ -3,7 +3,7 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
 	"name": "t2.micro",
     "os_type": "ubuntu",
     "num_vCPU": "1",

--- a/test/obsolete/aws-tester-sh/spec/delete-test.sh
+++ b/test/obsolete/aws-tester-sh/spec/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 #echo $TB_SPEC_IDS | json_pp
 
 if [ -n "$TB_SPEC_IDS" ]
 then
-        #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         for TB_SPEC_ID in ${TB_SPEC_IDS}
         do
                 echo ....Delete ${TB_SPEC_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
         done
 else
         echo ....no specs found

--- a/test/obsolete/aws-tester-sh/spec/get-test.sh
+++ b/test/obsolete/aws-tester-sh/spec/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 #echo $TB_SPEC_IDS | json_pp
 
 if [ -n "$TB_SPEC_IDS" ]
 then
-        #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         for TB_SPEC_ID in ${TB_SPEC_IDS}
         do
                 echo ....Get ${TB_SPEC_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
         done
 else
         echo ....no specs found

--- a/test/obsolete/aws-tester-sh/spec/list-test.sh
+++ b/test/obsolete/aws-tester-sh/spec/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/spec | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/spec | json_pp &
 #done

--- a/test/obsolete/aws-tester-sh/vm/1.service_cp_run.sh
+++ b/test/obsolete/aws-tester-sh/vm/1.service_cp_run.sh
@@ -5,7 +5,7 @@ source ../setup.env
 CONNECT_NAME=${CONNECT_NAMES[0]}
 
 #echo ========================== $CONNECT_NAME
-#PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/publicip/publicipt01-powerkim?connection_name=azure-northeu-config |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/publicipt01-powerkim?connection_name=azure-northeu-config |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 #for PUBLIC_IP in ${PUBLIC_IPS}
 #do
 #        echo $CONNECT_NAME : copy testsvc into ${PUBLIC_IP} ...
@@ -14,19 +14,19 @@ CONNECT_NAME=${CONNECT_NAMES[0]}
 #        scp -i ../keypair/${CONNECT_NAME}.key -o "StrictHostKeyChecking no" -r ./testsvc/conf cb-user@$PUBLIC_IP:/tmp
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-	#TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+	#TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 	for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
 	do
 		echo ....Get ${TB_PUBLICIP_ID} ...
-		PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+		PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
 		if [ "$PIPS_CONN_NAME" == "$CONNECT_NAME" ]
 		then
-			PUBLIC_IP=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
+			PUBLIC_IP=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
 			echo $CONNECT_NAME : copy testsvc into ${PUBLIC_IP} ...
 			ssh-keygen -f "/root/.ssh/known_hosts" -R ${PUBLIC_IP}
 			scp -i ../keypair/${CONNECT_NAME}.key -o "StrictHostKeyChecking no" ./testsvc/TESTSvc ./testsvc/setup.env ubuntu@$PUBLIC_IP:/tmp

--- a/test/obsolete/aws-tester-sh/vm/2.shooter_cp_run.sh
+++ b/test/obsolete/aws-tester-sh/vm/2.shooter_cp_run.sh
@@ -8,7 +8,7 @@ source ../setup.env
 #		echo .... first vm skipped!!
 #	else
 #		echo ========================== $NAME
-#		PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#		PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 #		for PUBLIC_IP in ${PUBLIC_IPS}
 #		do
 #			echo $NAME: copy shooter into ${PUBLIC_IP} ...
@@ -21,22 +21,22 @@ source ../setup.env
 #	fi
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-	#TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+	#TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 	for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
 	do
 		echo ....Get ${TB_PUBLICIP_ID} ...
-		PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+		PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
 		if [ "$PIPS_CONN_NAME" == "${CONNECT_NAMES[0]}" ]
 		then
 			echo Skipping first VM
 			continue
 		else
-			PUBLIC_IP=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
+			PUBLIC_IP=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
 			echo $PIPS_CONN_NAME: copy shooter into ${PUBLIC_IP} ...
 			ssh-keygen -f "/root/.ssh/known_hosts" -R ${PUBLIC_IP}
 			scp -i ../keypair/$PIPS_CONN_NAME.key -o "StrictHostKeyChecking no" ./shooter/shooter.sh ubuntu@$PUBLIC_IP:/tmp

--- a/test/obsolete/aws-tester-sh/vm/delete-mcis-info.sh
+++ b/test/obsolete/aws-tester-sh/vm/delete-mcis-info.sh
@@ -4,21 +4,21 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	VM_IDS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME}`
+#	VM_IDS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME}`
 #
 #	if [ $VM_IDS != "null" ]
 #	then 
-#		VM_IDS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#		VM_IDS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 #		for VM_ID in ${VM_IDS}
 #		do
 #			echo ....terminate ${VM_ID} ...
-#			curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} 
+#			curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} 
 #		done
 #	else
 #		echo ....no VMs
 #	fi
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID
 

--- a/test/obsolete/aws-tester-sh/vm/get-test_all.sh
+++ b/test/obsolete/aws-tester-sh/vm/get-test_all.sh
@@ -4,8 +4,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	curl -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID | json_pp
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID | json_pp

--- a/test/obsolete/aws-tester-sh/vm/list-status_all-test.sh
+++ b/test/obsolete/aws-tester-sh/vm/list-status_all-test.sh
@@ -4,8 +4,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	curl -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=status | json_pp
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=status | json_pp

--- a/test/obsolete/aws-tester-sh/vm/shooter/shooter.sh
+++ b/test/obsolete/aws-tester-sh/vm/shooter/shooter.sh
@@ -8,6 +8,6 @@ while :
 do
 	DT=`date`
 	DT=`echo $DT |sed 's/ /%20/g'`
-	curl -sX GET http://$SERVER:119/test -H 'Content-Type: application/json' -d '{"Date": "'${DT}'", "HostName": "'${HN}'"}'
+	curl -H "${AUTH}" -sX GET http://$SERVER:119/test -H 'Content-Type: application/json' -d '{"Date": "'${DT}'", "HostName": "'${HN}'"}'
 	sleep 5
 done

--- a/test/obsolete/aws-tester-sh/vm/spider-1.service_cp_run.sh
+++ b/test/obsolete/aws-tester-sh/vm/spider-1.service_cp_run.sh
@@ -5,7 +5,7 @@ source ../setup.env
 CONNECT_NAME=${CONNECT_NAMES[0]}
 
 echo ========================== $CONNECT_NAME
-PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/publicip/publicipt01-powerkim?connection_name=azure-northeu-config |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/publicipt01-powerkim?connection_name=azure-northeu-config |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 for PUBLIC_IP in ${PUBLIC_IPS}
 do
         echo $CONNECT_NAME : copy testsvc into ${PUBLIC_IP} ...

--- a/test/obsolete/aws-tester-sh/vm/spider-2.shooter_cp_run.sh
+++ b/test/obsolete/aws-tester-sh/vm/spider-2.shooter_cp_run.sh
@@ -8,7 +8,7 @@ do
 		echo .... first vm skipped!!
 	else
 		echo ========================== $NAME
-		PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+		PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 		for PUBLIC_IP in ${PUBLIC_IPS}
 		do
 			echo $NAME: copy shooter into ${PUBLIC_IP} ...

--- a/test/obsolete/aws-tester-sh/vm/spider-get-test_all.sh
+++ b/test/obsolete/aws-tester-sh/vm/spider-get-test_all.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	curl -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
 done

--- a/test/obsolete/aws-tester-sh/vm/spider-list-status_all-test.sh
+++ b/test/obsolete/aws-tester-sh/vm/spider-list-status_all-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	curl -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp
 done

--- a/test/obsolete/aws-tester-sh/vm/spider-start_all-test.sh
+++ b/test/obsolete/aws-tester-sh/vm/spider-start_all-test.sh
@@ -5,15 +5,15 @@ num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	VNET_ID=`curl -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
-	PIP_ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-	SG_ID1=` curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-	SG_ID2=`curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
-	VNIC_ID=`curl -sX GET http://$RESTSERVER:1024/vnic?connection_name=${NAME} |json_pp |grep "eni" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+	VNET_ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+	PIP_ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+	SG_ID1=` curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+	SG_ID2=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
+	VNIC_ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vnic?connection_name=${NAME} |json_pp |grep "eni" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 
 	#echo ${VNET_ID}, ${PIP_ID}, ${SG_ID}, ${VNIC_ID}
 
-	curl -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
 	    "VMName": "vm-powerkim01",
 		"ImageId": "'${IMG_IDS[num]}'",
 		"VirtualNetworkId": "'${VNET_ID}'",

--- a/test/obsolete/aws-tester-sh/vm/spider-terminate_all-test.sh
+++ b/test/obsolete/aws-tester-sh/vm/spider-terminate_all-test.sh
@@ -4,15 +4,15 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	VM_IDS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME}`
+	VM_IDS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME}`
 
 	if [ $VM_IDS != "null" ]
 	then 
-		VM_IDS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+		VM_IDS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 		for VM_ID in ${VM_IDS}
 		do
 			echo ....terminate ${VM_ID} ...
-			curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} 
+			curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} 
 		done
 	else
 		echo ....no VMs

--- a/test/obsolete/aws-tester-sh/vm/start_all-test.sh
+++ b/test/obsolete/aws-tester-sh/vm/start_all-test.sh
@@ -6,24 +6,24 @@ num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-#	VNET_ID=`curl -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
-#	PIP_ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	SG_ID1=` curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	SG_ID2=`curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
-#	VNIC_ID=`curl -sX GET http://$RESTSERVER:1024/vnic?connection_name=${NAME} |json_pp |grep "eni" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#	VNET_ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#	PIP_ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	SG_ID1=` curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	SG_ID2=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp |grep "\"Id\" :" |awk '{print $3}' |awk '{if(NR==2) print $1}' |sed 's/"//g' |sed 's/,//g'`
+#	VNIC_ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vnic?connection_name=${NAME} |json_pp |grep "eni" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 
 #############################################################################################################################################
 
-	TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+	TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 	#echo $TB_NETWORK_IDS | json_pp
 
 	if [ -n "$TB_NETWORK_IDS" ]
 	then
-		#TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+		#TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 		for TB_NETWORK_ID in ${TB_NETWORK_IDS}
 		do
 			echo ....Get ${TB_NETWORK_ID} ...
-			NETWORKS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | jq -r '.connectionName'`
+			NETWORKS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | jq -r '.connectionName'`
 			if [ "$NETWORKS_CONN_NAME" == "$NAME" ]
 			then
 				VNET_ID=$TB_NETWORK_ID
@@ -38,16 +38,16 @@ do
 
 #############################################################################################################################################
 
-	TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+	TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 	#echo $TB_PUBLICIP_IDS | json_pp
 
 	if [ -n "$TB_PUBLICIP_IDS" ]
 	then
-		#TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+		#TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 		for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
 		do
 			echo ....Get ${TB_PUBLICIP_ID} ...
-			PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+			PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                         if [ "$PIPS_CONN_NAME" == "$NAME" ]
                         then
                                 PIP_ID=$TB_PUBLICIP_ID
@@ -62,16 +62,16 @@ do
 
 #############################################################################################################################################
 
-	TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+	TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 	#echo $TB_SECURITYGROUP_IDS | json_pp
 
 	if [ -n "$TB_SECURITYGROUP_IDS" ]
 	then
-		#TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+		#TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 		for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
 		do
 			echo ....Get ${TB_SECURITYGROUP_ID} ...
-			SGS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | jq -r '.connectionName'`
+			SGS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | jq -r '.connectionName'`
 			if [ "$SGS_CONN_NAME" == "$NAME" ]
                         then
                                 SG_ID=$TB_SECURITYGROUP_ID
@@ -86,16 +86,16 @@ do
 
 #############################################################################################################################################
 
-	TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+	TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 	#echo $TB_SSHKEY_IDS | json_pp
 
 	if [ -n "$TB_SSHKEY_IDS" ]
 	then
-		#TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+		#TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 		for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
 		do
 			echo ....Get ${TB_SSHKEY_ID} ...
-			SSHKEYS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | jq -r '.connectionName'`
+			SSHKEYS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | jq -r '.connectionName'`
 			if [ "$SSHKEYS_CONN_NAME" == "$NAME" ]
                         then
                                 SSHKEY_ID=$TB_SSHKEY_ID
@@ -110,16 +110,16 @@ do
 
 #############################################################################################################################################
 
-	TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+	TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 	#echo $TB_SPEC_IDS | json_pp
 
 	if [ -n "$TB_SPEC_IDS" ]
 	then
-		#TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+		#TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 		for TB_SPEC_ID in ${TB_SPEC_IDS}
 		do
 			echo ....Get ${TB_SPEC_ID} ...
-			SPECS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | jq -r '.connectionName'`
+			SPECS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | jq -r '.connectionName'`
 			if [ "$SPECS_CONN_NAME" == "$NAME" ]
 			then
 				SPEC_ID=$TB_SPEC_ID
@@ -134,16 +134,16 @@ do
 
 #############################################################################################################################################
 
-	TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+	TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 	#echo $TB_IMAGE_IDS | json_pp
 
 	if [ -n "$TB_IMAGE_IDS" ]
 	then
-		#TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+		#TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 		for TB_IMAGE_ID in ${TB_IMAGE_IDS}
 		do
 			echo ....Get ${TB_IMAGE_ID} ...
-			IMAGES_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | jq -r '.connectionName'`
+			IMAGES_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | jq -r '.connectionName'`
 			if [ "$IMAGES_CONN_NAME" == "$NAME" ]
                         then
                                 IMAGE_ID=$TB_IMAGE_ID
@@ -160,7 +160,7 @@ do
 
 	#echo ${VNET_ID}, ${PIP_ID}, ${SG_ID}, ${VNIC_ID}, $SSHKEY_ID, $SPEC_ID, $IMAGE_ID
 
-#	curl -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
+#	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
 #	    "VMName": "vm-powerkim01",
 #		"ImageId": "'${IMG_IDS[num]}'",
 #		"VirtualNetworkId": "'${VNET_ID}'",
@@ -177,7 +177,7 @@ do
 
 	if [ $num == 0 ]
 	then
-		curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d '{
+		curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d '{
 	    "name": "mcis-t01",
 	    "description": "Test description",
 	    "vm_req": [
@@ -201,8 +201,8 @@ do
 	}' | json_pp
 
 	else
-		MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-		curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
+		MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+		curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
 		"name": "aws-jhseo-vm'$num'",
 		    "connectionName": "'$NAME'",
 		    "specId": "'$SPEC_ID'",

--- a/test/obsolete/aws-tester-sh/vm/terminate_all-test.sh
+++ b/test/obsolete/aws-tester-sh/vm/terminate_all-test.sh
@@ -4,21 +4,21 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	VM_IDS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME}`
+#	VM_IDS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME}`
 #
 #	if [ $VM_IDS != "null" ]
 #	then 
-#		VM_IDS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#		VM_IDS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 #		for VM_ID in ${VM_IDS}
 #		do
 #			echo ....terminate ${VM_ID} ...
-#			curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} 
+#			curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} 
 #		done
 #	else
 #		echo ....no VMs
 #	fi
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=terminate
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=terminate
 

--- a/test/obsolete/aws-tester-sh/vnetwork/create-test.sh
+++ b/test/obsolete/aws-tester-sh/vnetwork/create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspNetworkName\":\"CB-VNet-jhseo\"}" |json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspNetworkName\":\"CB-VNet-jhseo\"}" |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/vnetwork/delete-test.sh
+++ b/test/obsolete/aws-tester-sh/vnetwork/delete-test.sh
@@ -3,19 +3,19 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet |json_pp |grep "\"id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/$ID |json_pp
+#	ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet |json_pp |grep "\"id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/$ID |json_pp
 #done
 
-TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 
 if [ -n "$TB_NETWORK_IDS" ]
 then
-        #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         for TB_NETWORK_ID in ${TB_NETWORK_IDS}
         do
                 echo ....Delete ${TB_NETWORK_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID}
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID}
         done
 else
         echo ....no vNets found

--- a/test/obsolete/aws-tester-sh/vnetwork/get-test.sh
+++ b/test/obsolete/aws-tester-sh/vnetwork/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet |json_pp |grep "\"id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/$ID |json_pp &
+#	ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet |json_pp |grep "\"id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/$ID |json_pp &
 #done
 
-TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 #echo $TB_NETWORK_IDS | json_pp
 
 if [ -n "$TB_NETWORK_IDS" ]
 then
-	#TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+	#TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 	for TB_NETWORK_ID in ${TB_NETWORK_IDS}
 	do
 		echo ....Get ${TB_NETWORK_ID} ...
-		curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | json_pp
+		curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | json_pp
 	done
 else
 	echo ....no vNets found

--- a/test/obsolete/aws-tester-sh/vnetwork/list-test.sh
+++ b/test/obsolete/aws-tester-sh/vnetwork/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/vNet | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/vNet | json_pp &
 #done

--- a/test/obsolete/aws-tester-sh/vnetwork/spider-create-test.sh
+++ b/test/obsolete/aws-tester-sh/vnetwork/spider-create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"CB-VNet-powerkim"}' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"CB-VNet-powerkim"}' |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/vnetwork/spider-delete-test.sh
+++ b/test/obsolete/aws-tester-sh/vnetwork/spider-delete-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
-	curl -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp
 done

--- a/test/obsolete/aws-tester-sh/vnetwork/spider-get-test.sh
+++ b/test/obsolete/aws-tester-sh/vnetwork/spider-get-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
-	curl -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp |grep "\"Id\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/aws-tester-sh/vnetwork/spider-list-test.sh
+++ b/test/obsolete/aws-tester-sh/vnetwork/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/azure-tester-sh/delete-all-azure-regions.sh
+++ b/test/obsolete/azure-tester-sh/delete-all-azure-regions.sh
@@ -7,6 +7,6 @@ for LOC in "${LOCS[@]}"
 do
 	echo $LOC
 
-	curl -sX DELETE http://$RESTSERVER:1024/region/azure-$LOC
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/region/azure-$LOC
 
 done

--- a/test/obsolete/azure-tester-sh/image/create-test.sh
+++ b/test/obsolete/azure-tester-sh/image/create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
+        curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
         "cspImageId": "Canonical:UbuntuServer:18.04-LTS:latest",
         "cspImageName": "Canonical:UbuntuServer:18.04-LTS:latest"
         }' | json_pp

--- a/test/obsolete/azure-tester-sh/image/delete-test.sh
+++ b/test/obsolete/azure-tester-sh/image/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do 
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 #echo $TB_IMAGE_IDS | json_pp
 
 if [ -n "$TB_IMAGE_IDS" ]
 then
-        #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         for TB_IMAGE_ID in ${TB_IMAGE_IDS}
         do
                 echo ....Delete ${TB_IMAGE_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
         done
 else
         echo ....no images found

--- a/test/obsolete/azure-tester-sh/image/get-test.sh
+++ b/test/obsolete/azure-tester-sh/image/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 #echo $TB_IMAGE_IDS | json_pp
 
 if [ -n "$TB_IMAGE_IDS" ]
 then
-        #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         for TB_IMAGE_ID in ${TB_IMAGE_IDS}
         do
                 echo ....Get ${TB_IMAGE_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
         done
 else
         echo ....no images found

--- a/test/obsolete/azure-tester-sh/image/list-test.sh
+++ b/test/obsolete/azure-tester-sh/image/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-        curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/image | json_pp &
+        curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/image | json_pp &
 #done

--- a/test/obsolete/azure-tester-sh/image/spider-get-test.sh
+++ b/test/obsolete/azure-tester-sh/image/spider-get-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
 	num=`expr $num + 1`
 done

--- a/test/obsolete/azure-tester-sh/insert-all-azure-regions.sh
+++ b/test/obsolete/azure-tester-sh/insert-all-azure-regions.sh
@@ -7,7 +7,7 @@ for LOC in "${LOCS[@]}"
 do
 	echo $LOC
 
-	curl -sX POST http://$RESTSERVER:1024/region -H 'Content-Type: application/json' -d '{"RegionName":"azure-'$LOC'","ProviderName":"AZURE", "KeyValueInfoList": [{"Key":"location", "Value":"'$LOC'"}, {"Key":"ResourceGroup", "Value":"jhseo-test-'$LOC'"}]}'
-	curl -sX POST http://$RESTSERVER:1024/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"azure-'$LOC'-config","ProviderName":"AZURE", "DriverName":"azure-driver01", "CredentialName":"azure-credential01", "RegionName":"azure-'$LOC'"}'
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/region -H 'Content-Type: application/json' -d '{"RegionName":"azure-'$LOC'","ProviderName":"AZURE", "KeyValueInfoList": [{"Key":"location", "Value":"'$LOC'"}, {"Key":"ResourceGroup", "Value":"jhseo-test-'$LOC'"}]}'
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"azure-'$LOC'-config","ProviderName":"AZURE", "DriverName":"azure-driver01", "CredentialName":"azure-credential01", "RegionName":"azure-'$LOC'"}'
 
 done

--- a/test/obsolete/azure-tester-sh/keypair/create-test.sh
+++ b/test/obsolete/azure-tester-sh/keypair/create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-	KEY=`curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspSshKeyName\":\"jhseo-test\"}" |json_pp | grep privateKey |sed 's/"privateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
+	KEY=`curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspSshKeyName\":\"jhseo-test\"}" |json_pp | grep privateKey |sed 's/"privateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
 	echo -e ${KEY}
 	echo -e ${KEY} > ./${NAME}.key
 

--- a/test/obsolete/azure-tester-sh/keypair/delete-test.sh
+++ b/test/obsolete/azure-tester-sh/keypair/delete-test.sh
@@ -4,18 +4,18 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	NAME=${CONNECT_NAMES[0]}
-#	curl -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp
 #done
 
-TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 
 if [ -n "$TB_SSHKEY_IDS" ]
 then
-        #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
         do
                 echo ....Delete ${TB_SSHKEY_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID}
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID}
         done
 else
         echo ....no sshKeys found

--- a/test/obsolete/azure-tester-sh/keypair/get-test.sh
+++ b/test/obsolete/azure-tester-sh/keypair/get-test.sh
@@ -4,19 +4,19 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	NAME=${CONNECT_NAMES[0]}
-#	curl -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done
 
-TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 #echo $TB_SSHKEY_IDS | json_pp
 
 if [ -n "$TB_SSHKEY_IDS" ]
 then
-        #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
         do
                 echo ....Get ${TB_SSHKEY_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | json_pp
         done
 else
         echo ....no sshKeys found

--- a/test/obsolete/azure-tester-sh/keypair/list-test.sh
+++ b/test/obsolete/azure-tester-sh/keypair/list-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	NAME=${CONNECT_NAMES[0]}
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/sshKey |json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/sshKey |json_pp &
 #done

--- a/test/obsolete/azure-tester-sh/keypair/spider-create-test.sh
+++ b/test/obsolete/azure-tester-sh/keypair/spider-create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-	KEY=`curl -sX POST http://$RESTSERVER:1024/keypair?connection_name=$NAME -H 'Content-Type: application/json' -d '{ "Name": "mcb-keypair-powerkim" }' |json_pp | grep PrivateKey |sed 's/"PrivateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
+	KEY=`curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/keypair?connection_name=$NAME -H 'Content-Type: application/json' -d '{ "Name": "mcb-keypair-powerkim" }' |json_pp | grep PrivateKey |sed 's/"PrivateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
 	echo -e ${KEY}
 	echo -e ${KEY} > ./${NAME}.key
 

--- a/test/obsolete/azure-tester-sh/keypair/spider-delete-test.sh
+++ b/test/obsolete/azure-tester-sh/keypair/spider-delete-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-	curl -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp
 #done

--- a/test/obsolete/azure-tester-sh/keypair/spider-get-test.sh
+++ b/test/obsolete/azure-tester-sh/keypair/spider-get-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-	curl -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done

--- a/test/obsolete/azure-tester-sh/keypair/spider-list-test.sh
+++ b/test/obsolete/azure-tester-sh/keypair/spider-list-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-	curl -sX GET http://$RESTSERVER:1024/keypair?connection_name=${NAME} #|json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair?connection_name=${NAME} #|json_pp &
 #done

--- a/test/obsolete/azure-tester-sh/publicip/create-test.sh
+++ b/test/obsolete/azure-tester-sh/publicip/create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspPublicIpName":"jhseo-test"}' | json_pp
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspPublicIpName":"jhseo-test"}' | json_pp
 done

--- a/test/obsolete/azure-tester-sh/publicip/delete-test.sh
+++ b/test/obsolete/azure-tester-sh/publicip/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Delete ${TB_PUBLICIP_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
         done
 else
         echo ....no publicIps found

--- a/test/obsolete/azure-tester-sh/publicip/get-test.sh
+++ b/test/obsolete/azure-tester-sh/publicip/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#	curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
         done
 else
         echo ....no publicIps found

--- a/test/obsolete/azure-tester-sh/publicip/list-test.sh
+++ b/test/obsolete/azure-tester-sh/publicip/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/publicIp | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/publicIp | json_pp &
 #done

--- a/test/obsolete/azure-tester-sh/publicip/spider-create-test.sh
+++ b/test/obsolete/azure-tester-sh/publicip/spider-create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt01-powerkim" }' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt01-powerkim" }' |json_pp &
 done

--- a/test/obsolete/azure-tester-sh/publicip/spider-delete-test.sh
+++ b/test/obsolete/azure-tester-sh/publicip/spider-delete-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-	curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 done

--- a/test/obsolete/azure-tester-sh/publicip/spider-get-test.sh
+++ b/test/obsolete/azure-tester-sh/publicip/spider-get-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-	curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+	ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/azure-tester-sh/publicip/spider-list-test.sh
+++ b/test/obsolete/azure-tester-sh/publicip/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} #|json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} #|json_pp &
 done

--- a/test/obsolete/azure-tester-sh/security/create-test.sh
+++ b/test/obsolete/azure-tester-sh/security/create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'",  "cspSecurityGroupName": "jhseo-test", "firewallRules": [ {"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "*", "Direction" : "inbound"} ] }' | json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'",  "cspSecurityGroupName": "jhseo-test", "firewallRules": [ {"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "*", "Direction" : "inbound"} ] }' | json_pp &
 done

--- a/test/obsolete/azure-tester-sh/security/delete-test.sh
+++ b/test/obsolete/azure-tester-sh/security/delete-test.sh
@@ -4,19 +4,19 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	ID=security01-powerkim
-#	curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME}
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME}
 #done
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 #echo $TB_SECURITYGROUP_IDS | json_pp
 
 if [ -n "$TB_SECURITYGROUP_IDS" ]
 then
-        #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
         do
                 echo ....Delete ${TB_SECURITYGROUP_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
         done
 else
         echo ....no securityGroups found

--- a/test/obsolete/azure-tester-sh/security/get-test.sh
+++ b/test/obsolete/azure-tester-sh/security/get-test.sh
@@ -4,19 +4,19 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	ID=security01-powerkim
-#	curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 #echo $TB_SECURITYGROUP_IDS | json_pp
 
 if [ -n "$TB_SECURITYGROUP_IDS"  ]
 then
-        #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
         do
                 echo ....Get ${TB_SECURITYGROUP_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
         done
 else
         echo ....no securityGroups found

--- a/test/obsolete/azure-tester-sh/security/list-test.sh
+++ b/test/obsolete/azure-tester-sh/security/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/securityGroup | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/securityGroup | json_pp &
 #done

--- a/test/obsolete/azure-tester-sh/security/spider-create-test.sh
+++ b/test/obsolete/azure-tester-sh/security/spider-create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "*", "Direction" : "inbound"} ] }' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "0", "ToPort" : "65535", "IPProtocol" : "*", "Direction" : "inbound"} ] }' |json_pp &
 done

--- a/test/obsolete/azure-tester-sh/security/spider-delete-test.sh
+++ b/test/obsolete/azure-tester-sh/security/spider-delete-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	ID=security01-powerkim
-	curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME}
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME}
 done

--- a/test/obsolete/azure-tester-sh/security/spider-get-test.sh
+++ b/test/obsolete/azure-tester-sh/security/spider-get-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	ID=security01-powerkim
-	curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/azure-tester-sh/security/spider-list-test.sh
+++ b/test/obsolete/azure-tester-sh/security/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} #|json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} #|json_pp &
 done

--- a/test/obsolete/azure-tester-sh/spec/create-test.sh
+++ b/test/obsolete/azure-tester-sh/spec/create-test.sh
@@ -3,7 +3,7 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
+        curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
         "name": "Standard_B1ls",
     "os_type": "",
     "num_vCPU": "",

--- a/test/obsolete/azure-tester-sh/spec/delete-test.sh
+++ b/test/obsolete/azure-tester-sh/spec/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 #echo $TB_SPEC_IDS | json_pp
 
 if [ -n "$TB_SPEC_IDS" ]
 then
-        #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         for TB_SPEC_ID in ${TB_SPEC_IDS}
         do
                 echo ....Delete ${TB_SPEC_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
         done
 else
         echo ....no specs found

--- a/test/obsolete/azure-tester-sh/spec/get-test.sh
+++ b/test/obsolete/azure-tester-sh/spec/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 #echo $TB_SPEC_IDS | json_pp
 
 if [ -n "$TB_SPEC_IDS" ]
 then
-        #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         for TB_SPEC_ID in ${TB_SPEC_IDS}
         do
                 echo ....Get ${TB_SPEC_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
         done
 else
         echo ....no specs found

--- a/test/obsolete/azure-tester-sh/spec/list-test.sh
+++ b/test/obsolete/azure-tester-sh/spec/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-        curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/spec | json_pp &
+        curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/spec | json_pp &
 #done

--- a/test/obsolete/azure-tester-sh/vm/1.service_cp_run.sh
+++ b/test/obsolete/azure-tester-sh/vm/1.service_cp_run.sh
@@ -5,7 +5,7 @@ source ../setup.env
 CONNECT_NAME=${CONNECT_NAMES[0]}
 
 #echo ========================== $CONNECT_NAME
-#PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/publicip/publicipt01-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/publicipt01-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 # 137.135.167.9
 #for PUBLIC_IP in ${PUBLIC_IPS}
 #do
@@ -15,19 +15,19 @@ CONNECT_NAME=${CONNECT_NAMES[0]}
 #        scp -i ../keypair/${CONNECT_NAME}.key -o "StrictHostKeyChecking no" -r ./testsvc/conf cb-user@$PUBLIC_IP:/tmp
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-	#TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+	#TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 	for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
 	do
 		echo ....Get ${TB_PUBLICIP_ID} ...
-		PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+		PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
 		if [ "$PIPS_CONN_NAME" == "$CONNECT_NAME" ]
 		then
-			PUBLIC_IP=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
+			PUBLIC_IP=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
 			echo $CONNECT_NAME : copy testsvc into ${PUBLIC_IP} ...
 			ssh-keygen -f "/root/.ssh/known_hosts" -R ${PUBLIC_IP}
 			scp -i ../keypair/${CONNECT_NAME}.key -o "StrictHostKeyChecking no" ./testsvc/TESTSvc ./testsvc/setup.env cb-user@$PUBLIC_IP:/tmp

--- a/test/obsolete/azure-tester-sh/vm/2.shooter_cp_run.sh
+++ b/test/obsolete/azure-tester-sh/vm/2.shooter_cp_run.sh
@@ -10,7 +10,7 @@ KEY_NAME=${CONNECT_NAMES[0]}
 #		echo .... first vm skipped!!
 #	else
 #		echo ========================== $NAME
-#		PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#		PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 #		for PUBLIC_IP in ${PUBLIC_IPS}
 #		do
 #			echo $NAME: copy shooter into ${PUBLIC_IP} ...
@@ -23,22 +23,22 @@ KEY_NAME=${CONNECT_NAMES[0]}
 #	num=`expr $num + 1`
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+                PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                 if [ "$PIPS_CONN_NAME" == "${CONNECT_NAMES[0]}" ]
                 then
                         echo Skipping first VM
                         continue
                 else
-                        PUBLIC_IP=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
+                        PUBLIC_IP=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
                         echo $PIPS_CONN_NAME: copy shooter into ${PUBLIC_IP} ...
                         ssh-keygen -f "/root/.ssh/known_hosts" -R ${PUBLIC_IP}
                         scp -i ../keypair/$KEY_NAME.key -o "StrictHostKeyChecking no" ./shooter/shooter.sh cb-user@$PUBLIC_IP:/tmp

--- a/test/obsolete/azure-tester-sh/vm/get-test_all.sh
+++ b/test/obsolete/azure-tester-sh/vm/get-test_all.sh
@@ -4,8 +4,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	curl -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID | json_pp
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID | json_pp

--- a/test/obsolete/azure-tester-sh/vm/list-status_all-test.sh
+++ b/test/obsolete/azure-tester-sh/vm/list-status_all-test.sh
@@ -4,8 +4,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	curl -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=status | json_pp
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=status | json_pp

--- a/test/obsolete/azure-tester-sh/vm/shooter/shooter.sh
+++ b/test/obsolete/azure-tester-sh/vm/shooter/shooter.sh
@@ -8,6 +8,6 @@ while :
 do
 	DT=`date`
 	DT=`echo $DT |sed 's/ /%20/g'`
-	curl -sX GET http://$SERVER:119/test -H 'Content-Type: application/json' -d '{"Date": "'${DT}'", "HostName": "'${HN}'"}'
+	curl -H "${AUTH}" -sX GET http://$SERVER:119/test -H 'Content-Type: application/json' -d '{"Date": "'${DT}'", "HostName": "'${HN}'"}'
 	sleep 5
 done

--- a/test/obsolete/azure-tester-sh/vm/spider-1.service_cp_run.sh
+++ b/test/obsolete/azure-tester-sh/vm/spider-1.service_cp_run.sh
@@ -5,7 +5,7 @@ source ../setup.env
 CONNECT_NAME=${CONNECT_NAMES[0]}
 
 echo ========================== $CONNECT_NAME
-PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/publicip/publicipt01-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/publicipt01-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 # 137.135.167.9
 for PUBLIC_IP in ${PUBLIC_IPS}
 do

--- a/test/obsolete/azure-tester-sh/vm/spider-2.shooter_cp_run.sh
+++ b/test/obsolete/azure-tester-sh/vm/spider-2.shooter_cp_run.sh
@@ -10,7 +10,7 @@ do
 		echo .... first vm skipped!!
 	else
 		echo ========================== $NAME
-		PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+		PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 		for PUBLIC_IP in ${PUBLIC_IPS}
 		do
 			echo $NAME: copy shooter into ${PUBLIC_IP} ...

--- a/test/obsolete/azure-tester-sh/vm/spider-get-test_all.sh
+++ b/test/obsolete/azure-tester-sh/vm/spider-get-test_all.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	curl -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
 done

--- a/test/obsolete/azure-tester-sh/vm/spider-list-status_all-test.sh
+++ b/test/obsolete/azure-tester-sh/vm/spider-list-status_all-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	curl -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
 done

--- a/test/obsolete/azure-tester-sh/vm/spider-start_all-test.sh
+++ b/test/obsolete/azure-tester-sh/vm/spider-start_all-test.sh
@@ -11,7 +11,7 @@ do
 	SG_ID1=security01-powerkim
 	#echo ${VNET_ID}, ${PIP_ID}, ${SG_ID}, ${VNIC_ID}
 
-	curl -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
 	    "VMName": "vm-powerkim01",
 		"ImageId": "'${IMG_IDS[num]}'",
 		"VirtualNetworkId": "'${VNET_ID}'",

--- a/test/obsolete/azure-tester-sh/vm/spider-terminate_all-test.sh
+++ b/test/obsolete/azure-tester-sh/vm/spider-terminate_all-test.sh
@@ -8,7 +8,7 @@ do
 
 	VM_ID=jhseo-test
 	echo ....terminate ${VM_ID} ...
-	curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/azure-tester-sh/vm/start_all-test.sh
+++ b/test/obsolete/azure-tester-sh/vm/start_all-test.sh
@@ -14,16 +14,16 @@ do
 
 #############################################################################################################################################
 
-        TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         #echo $TB_NETWORK_IDS | json_pp
 
         if [ -n "$TB_NETWORK_IDS" ]
         then
-                #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+                #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
                 for TB_NETWORK_ID in ${TB_NETWORK_IDS}
                 do
                         echo ....Get ${TB_NETWORK_ID} ...
-                        NETWORKS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | jq -r '.connectionName'`
+                        NETWORKS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | jq -r '.connectionName'`
                         if [ "$NETWORKS_CONN_NAME" == "$NAME" ]
                         then
                                 VNET_ID=$TB_NETWORK_ID
@@ -38,16 +38,16 @@ do
 
 #############################################################################################################################################
 
-        TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         #echo $TB_PUBLICIP_IDS | json_pp
 
         if [ -n "$TB_PUBLICIP_IDS" ]
         then
-                #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+                #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
                 for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
                 do
                         echo ....Get ${TB_PUBLICIP_ID} ...
-                        PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+                        PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                         if [ "$PIPS_CONN_NAME" == "$NAME" ]
                         then
                                 PIP_ID=$TB_PUBLICIP_ID
@@ -62,16 +62,16 @@ do
 
 #############################################################################################################################################
 
-        TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         #echo $TB_SECURITYGROUP_IDS | json_pp
 
         if [ -n "$TB_SECURITYGROUP_IDS" ]
         then
-                #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+                #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
                 for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
                 do
                         echo ....Get ${TB_SECURITYGROUP_ID} ...
-                        SGS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | jq -r '.connectionName'`
+                        SGS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | jq -r '.connectionName'`
                         if [ "$SGS_CONN_NAME" == "$NAME" ]
                         then
                                 SG_ID=$TB_SECURITYGROUP_ID
@@ -86,16 +86,16 @@ do
 
 #############################################################################################################################################
 
-        TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         #echo $TB_SSHKEY_IDS | json_pp
 
         if [ -n "$TB_SSHKEY_IDS" ]
         then
-                #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+                #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
                 for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
                 do
                         echo ....Get ${TB_SSHKEY_ID} ...
-                        SSHKEYS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | jq -r '.connectionName'`
+                        SSHKEYS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | jq -r '.connectionName'`
                         if [ "$SSHKEYS_CONN_NAME" == "$NAME" ]
                         then
                                 SSHKEY_ID=$TB_SSHKEY_ID
@@ -110,16 +110,16 @@ do
 
 #############################################################################################################################################
 
-        TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         #echo $TB_SPEC_IDS | json_pp
 
         if [ -n "$TB_SPEC_IDS" ]
         then
-                #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+                #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
                 for TB_SPEC_ID in ${TB_SPEC_IDS}
                 do
                         echo ....Get ${TB_SPEC_ID} ...
-                        SPECS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | jq -r '.connectionName'`
+                        SPECS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | jq -r '.connectionName'`
                         if [ "$SPECS_CONN_NAME" == "$NAME" ]
                         then
                                 SPEC_ID=$TB_SPEC_ID
@@ -134,16 +134,16 @@ do
 
 #############################################################################################################################################
 
-        TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         #echo $TB_IMAGE_IDS | json_pp
 
         if [ -n "$TB_IMAGE_IDS" ]
         then
-                #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+                #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
                 for TB_IMAGE_ID in ${TB_IMAGE_IDS}
                 do
                         echo ....Get ${TB_IMAGE_ID} ...
-                        IMAGES_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | jq -r '.connectionName'`
+                        IMAGES_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | jq -r '.connectionName'`
                         if [ "$IMAGES_CONN_NAME" == "$NAME" ]
                         then
                                 IMAGE_ID=$TB_IMAGE_ID
@@ -158,7 +158,7 @@ do
 
 #############################################################################################################################################
 
-#	curl -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
+#	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
 #	    "VMName": "vm-powerkim01",
 #		"ImageId": "'${IMG_IDS[num]}'",
 #		"VirtualNetworkId": "'${VNET_ID}'",
@@ -171,7 +171,7 @@ do
 
 	if [ $num == 0 ]
 	then
-		curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d '{
+		curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d '{
 	    "name": "mcis-t01",
 	    "description": "Test description",
 	    "vm_req": [
@@ -195,8 +195,8 @@ do
 	}' | json_pp
 
 	else
-		MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-		curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
+		MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+		curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
 		"name": "jhseo-vm'$num'",
 		    "connectionName": "'$NAME'",
 		    "specId": "'$SPEC_ID'",

--- a/test/obsolete/azure-tester-sh/vm/terminate_all-test.sh
+++ b/test/obsolete/azure-tester-sh/vm/terminate_all-test.sh
@@ -7,8 +7,8 @@ source ../setup.env
 #
 #	VM_ID=vm-powerkim01
 #	echo ....terminate ${VM_ID} ...
-#	curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=terminate
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=terminate

--- a/test/obsolete/azure-tester-sh/vnetwork/create-test.sh
+++ b/test/obsolete/azure-tester-sh/vnetwork/create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspNetworkName":"jhseo-test"}' | json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspNetworkName":"jhseo-test"}' | json_pp &
 done

--- a/test/obsolete/azure-tester-sh/vnetwork/delete-test.sh
+++ b/test/obsolete/azure-tester-sh/vnetwork/delete-test.sh
@@ -4,18 +4,18 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	ID=CB-VNet-powerkim
-#	curl -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp
 #done
 
-TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 
 if [ -n "$TB_NETWORK_IDS" ]
 then
-        #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         for TB_NETWORK_ID in ${TB_NETWORK_IDS}
         do
                 echo ....Delete ${TB_NETWORK_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID}
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID}
         done
 else
         echo ....no vNets found

--- a/test/obsolete/azure-tester-sh/vnetwork/get-test.sh
+++ b/test/obsolete/azure-tester-sh/vnetwork/get-test.sh
@@ -4,19 +4,19 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	ID=CB-VNet-powerkim
-#	curl -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 #echo $TB_NETWORK_IDS | json_pp
 
 if [ -n "$TB_NETWORK_IDS" ]
 then
-        #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         for TB_NETWORK_ID in ${TB_NETWORK_IDS}
         do
                 echo ....Get ${TB_NETWORK_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | json_pp
         done
 else
         echo ....no vNets found

--- a/test/obsolete/azure-tester-sh/vnetwork/list-test.sh
+++ b/test/obsolete/azure-tester-sh/vnetwork/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/vNet | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/vNet | json_pp &
 #done

--- a/test/obsolete/azure-tester-sh/vnetwork/spider-create-test.sh
+++ b/test/obsolete/azure-tester-sh/vnetwork/spider-create-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"CB-VNet-powerkim"}' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"CB-VNet-powerkim"}' |json_pp &
 done

--- a/test/obsolete/azure-tester-sh/vnetwork/spider-delete-test.sh
+++ b/test/obsolete/azure-tester-sh/vnetwork/spider-delete-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	ID=CB-VNet-powerkim
-	curl -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp
 done

--- a/test/obsolete/azure-tester-sh/vnetwork/spider-get-test.sh
+++ b/test/obsolete/azure-tester-sh/vnetwork/spider-get-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	ID=CB-VNet-powerkim
-	curl -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/azure-tester-sh/vnetwork/spider-list-test.sh
+++ b/test/obsolete/azure-tester-sh/vnetwork/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-	curl -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} #|json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} #|json_pp &
 done

--- a/test/obsolete/clear-tools/all_delete.sh
+++ b/test/obsolete/clear-tools/all_delete.sh
@@ -10,20 +10,20 @@ echo "####################################################################"
 echo "####################################################################"
 echo "## 4. VM: Terminate(Delete)"
 echo "####################################################################"
-curl -sX DELETE http://localhost:1024/spider/vm/VM-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' |json_pp
+curl -H "${AUTH}" -sX DELETE http://localhost:1024/spider/vm/VM-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' |json_pp
 echo "============== sleep 15 after delete VM"
 sleep 15 
 
 echo "####################################################################"
 echo "## 3. KeyPair: Delete"
 echo "####################################################################"
-curl -sX DELETE http://localhost:1024/spider/keypair/KEYPAIR-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' |json_pp
+curl -H "${AUTH}" -sX DELETE http://localhost:1024/spider/keypair/KEYPAIR-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' |json_pp
 echo "####################################################################"
 echo "## 2. SecurityGroup: Delete"
 echo "####################################################################"
-curl -sX DELETE http://localhost:1024/spider/securitygroup/SG-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' |json_pp
+curl -H "${AUTH}" -sX DELETE http://localhost:1024/spider/securitygroup/SG-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' |json_pp
 echo "####################################################################"
 echo "## 1. VPC: Delete"
 echo "####################################################################"
-curl -sX DELETE http://localhost:1024/spider/vpc/VPC-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' |json_pp
+curl -H "${AUTH}" -sX DELETE http://localhost:1024/spider/vpc/VPC-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' |json_pp
 

--- a/test/obsolete/full_test.sh
+++ b/test/obsolete/full_test.sh
@@ -19,10 +19,10 @@ function full_test() {
 	echo "####################################################################"
 
 #	echo "## 1. VPC: Delete"
-#	curl -sX DELETE http://localhost:1024/spider/vpc/VPC-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+#	curl -H "${AUTH}" -sX DELETE http://localhost:1024/spider/vpc/VPC-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 
 	echo "## 1. VPC: Create"
-	curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
 		'{
 			"name": "VPC-01",
 			"connectionName": "'${CONN_CONFIG}'",
@@ -35,13 +35,13 @@ function full_test() {
 		}' | json_pp || return 1
 
 #	echo "## 1. VPC: List"
-#	curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
+#	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
 #		'{ 
 #			"connectionName": "'${CONN_CONFIG}'"
 #		}' | json_pp || return 1
 
 	echo "## 1. VPC: Get"
-	curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet/VPC-01 | json_pp || return 1 #-H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/vNet/VPC-01 | json_pp || return 1 #-H 'Content-Type: application/json' -d \
 #		'{ 
 #			"connectionName": "'${CONN_CONFIG}'"
 #		}' | json_pp || return 1
@@ -56,7 +56,7 @@ function full_test() {
 	echo "####################################################################"
 
 	echo "## 2. SecurityGroup: Create"
-	curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
 		'{
 			"name": "SG-01",
 			"connectionName": "'${CONN_CONFIG}'",
@@ -76,13 +76,13 @@ function full_test() {
 #		'{ "ConnectionName": "'${CONN_CONFIG}'", "ReqInfo": { "Name": "SG-01", "VPCName": "VPC-01", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] } }' | json_pp || return 1
 
 #	echo "## 2. SecurityGroup: List"
-#	curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
+#	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
 #		'{ 
 #			"ConnectionName": "'${CONN_CONFIG}'"
 #		}' | json_pp || return 1
 
 	echo "## 2. SecurityGroup: Get"
-	curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup/SG-01 | json_pp || return 1 #-H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/securityGroup/SG-01 | json_pp || return 1 #-H 'Content-Type: application/json' -d \
 #		'{ 
 #			"ConnectionName": "'${CONN_CONFIG}'"
 #		}' | json_pp || return 1
@@ -94,17 +94,17 @@ function full_test() {
 	echo "####################################################################"
 
 	echo "## 3. KeyPair: Create"
-	curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
 		'{ 
 			"connectionName": "'${CONN_CONFIG}'", 
 			"name": "KEYPAIR-01" 
 		}' || return 1
 
 #	echo "## 3. KeyPair: Create"
-#	curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+#	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 
 	echo "## 3. KeyPair: Get"
-	curl -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey/KEYPAIR-01 | json_pp || return 1 #-H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/ns/$NS_ID/resources/sshKey/KEYPAIR-01 | json_pp || return 1 #-H 'Content-Type: application/json' -d \
 #		'{ 
 #			"connectionName": "'${CONN_CONFIG}'"
 #		}' | json_pp || return 1
@@ -116,7 +116,7 @@ function full_test() {
 	echo "####################################################################"
 
 	echo "## 4. VM: Create MCIS"
-	curl -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX POST http://localhost:1323/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d \
 		'{
 			"name": "MCIS-01",
 			"vm_num": "1",
@@ -140,17 +140,17 @@ function full_test() {
 
 	echo "============== sleep 30 after start VM"
 	sleep 30
-	curl -sX GET http://localhost:1323/tumblebug/vm -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
-	curl -sX GET http://localhost:1323/tumblebug/vm/VM-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
-	curl -sX GET http://localhost:1323/tumblebug/vmstatus -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
-	curl -sX GET http://localhost:1323/tumblebug/vmstatus/VM-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
-	curl -sX GET http://localhost:1323/tumblebug/controlvm/VM-01?action=suspend -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/vm -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/vm/VM-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/vmstatus -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/vmstatus/VM-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/controlvm/VM-01?action=suspend -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 	echo "============== sleep 50 after suspend VM"
 	sleep 50
-	curl -sX GET http://localhost:1323/tumblebug/controlvm/VM-01?action=resume -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/controlvm/VM-01?action=resume -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 	echo "============== sleep 30 after resume VM"
 	sleep 30
-	curl -sX GET http://localhost:1323/tumblebug/controlvm/VM-01?action=reboot -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX GET http://localhost:1323/tumblebug/controlvm/VM-01?action=reboot -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 	echo "============== sleep 60 after reboot VM"
 	sleep 60 
 	echo "#-----------------------------"
@@ -163,22 +163,22 @@ function full_test() {
 	echo "####################################################################"
 	echo "## 4. VM: Terminate(Delete)"
 	echo "####################################################################"
-	curl -sX DELETE http://localhost:1323/tumblebug/vm/VM-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX DELETE http://localhost:1323/tumblebug/vm/VM-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 	echo "============== sleep 60 after delete VM"
 	sleep 60 
 
 	echo "####################################################################"
 	echo "## 3. KeyPair: Delete"
 	echo "####################################################################"
-	curl -sX DELETE http://localhost:1323/tumblebug/keypair/KEYPAIR-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX DELETE http://localhost:1323/tumblebug/keypair/KEYPAIR-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 	echo "####################################################################"
 	echo "## 2. SecurityGroup: Delete"
 	echo "####################################################################"
-	curl -sX DELETE http://localhost:1323/tumblebug/securitygroup/SG-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX DELETE http://localhost:1323/tumblebug/securitygroup/SG-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 	echo "####################################################################"
 	echo "## 1. VPC: Delete"
 	echo "####################################################################"
-	curl -sX DELETE http://localhost:1323/tumblebug/vNet/VPC-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
+	curl -H "${AUTH}" -sX DELETE http://localhost:1323/tumblebug/vNet/VPC-01 -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG}'"}' | json_pp || return 1
 
 END
 	echo This is the end of the block comment

--- a/test/obsolete/gcp-tester-sh/image/create-test.sh
+++ b/test/obsolete/gcp-tester-sh/image/create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
+        curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
         "cspImageId": "'${IMG_IDS[num]}'",
         "cspImageName": "'${IMG_IDS[num]}'"
         }' | json_pp

--- a/test/obsolete/gcp-tester-sh/image/delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/image/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do 
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 #echo $TB_IMAGE_IDS | json_pp
 
 if [ -n "$TB_IMAGE_IDS" ]
 then
-        #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         for TB_IMAGE_ID in ${TB_IMAGE_IDS}
         do
                 echo ....Delete ${TB_IMAGE_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
         done
 else
         echo ....no images found

--- a/test/obsolete/gcp-tester-sh/image/get-test.sh
+++ b/test/obsolete/gcp-tester-sh/image/get-test.sh
@@ -5,20 +5,20 @@ source ../setup.env
 #num=0
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#        curl -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
 #        num=`expr $num + 1`
 #done
 
-TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 #echo $TB_IMAGE_IDS | json_pp
 
 if [ -n "$TB_IMAGE_IDS" ]
 then
-        #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         for TB_IMAGE_ID in ${TB_IMAGE_IDS}
         do
                 echo ....Get ${TB_IMAGE_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
         done
 else
         echo ....no images found

--- a/test/obsolete/gcp-tester-sh/image/list-test.sh
+++ b/test/obsolete/gcp-tester-sh/image/list-test.sh
@@ -6,8 +6,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #for NAME in "${CONNECT_NAMES[0]}"
 #do
-#        curl -sX GET http://$RESTSERVER:1024/vmimage?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmimage?connection_name=${NAME} |json_pp &
 #        num=`expr $num + 1`
 #done
 
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/image | json_pp &
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/image | json_pp &

--- a/test/obsolete/gcp-tester-sh/image/spider-get-test.sh
+++ b/test/obsolete/gcp-tester-sh/image/spider-get-test.sh
@@ -5,7 +5,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
         num=`expr $num + 1`
 done
 

--- a/test/obsolete/gcp-tester-sh/image/spider-list-test.sh
+++ b/test/obsolete/gcp-tester-sh/image/spider-list-test.sh
@@ -6,7 +6,7 @@ num=0
 #for NAME in "${CONNECT_NAMES[@]}"
 for NAME in "${CONNECT_NAMES[0]}"
 do
-        curl -sX GET http://$RESTSERVER:1024/vmimage?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmimage?connection_name=${NAME} |json_pp &
         num=`expr $num + 1`
 done
 

--- a/test/obsolete/gcp-tester-sh/keypair/create-test.sh
+++ b/test/obsolete/gcp-tester-sh/keypair/create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
         NAME=${CONNECT_NAMES[0]}
-	KEY=`curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspSshKeyName\":\"jhseo-shooter\"}" | json_pp | grep privateKey | sed 's/"privateKey" : "//g' | sed 's/-----",/-----/g' | sed 's/-----"/-----/g'`
+	KEY=`curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspSshKeyName\":\"jhseo-shooter\"}" | json_pp | grep privateKey | sed 's/"privateKey" : "//g' | sed 's/-----",/-----/g' | sed 's/-----"/-----/g'`
         echo -e ${KEY}
         echo -e ${KEY} > ./${NAME}.key
 

--- a/test/obsolete/gcp-tester-sh/keypair/delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/keypair/delete-test.sh
@@ -4,18 +4,18 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        NAME=${CONNECT_NAMES[0]}
-#        curl -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done
 
-TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 
 if [ -n "$TB_SSHKEY_IDS" ]
 then
-        #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
         do
                 echo ....Delete ${TB_SSHKEY_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID}
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID}
         done
 else
         echo ....no sshKeys found

--- a/test/obsolete/gcp-tester-sh/keypair/get-test.sh
+++ b/test/obsolete/gcp-tester-sh/keypair/get-test.sh
@@ -4,19 +4,19 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        NAME=${CONNECT_NAMES[0]}
-#        curl -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done
 
-TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 #echo $TB_SSHKEY_IDS | json_pp
 
 if [ -n "$TB_SSHKEY_IDS" ]
 then
-        #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
         do
                 echo ....Get ${TB_SSHKEY_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | json_pp
         done
 else
         echo ....no sshKeys found

--- a/test/obsolete/gcp-tester-sh/keypair/list-test.sh
+++ b/test/obsolete/gcp-tester-sh/keypair/list-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	NAME=${CONNECT_NAMES[0]}
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/sshKey |json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/sshKey |json_pp &
 #done
 

--- a/test/obsolete/gcp-tester-sh/keypair/spider-create-test.sh
+++ b/test/obsolete/gcp-tester-sh/keypair/spider-create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
         NAME=${CONNECT_NAMES[0]}
-        KEY=`curl -sX POST http://$RESTSERVER:1024/keypair?connection_name=$NAME -H 'Content-Type: application/json' -d '{ "Name": "mcb-keypair-powerkim" }' |json_pp | grep PrivateKey |sed 's/"PrivateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
+        KEY=`curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/keypair?connection_name=$NAME -H 'Content-Type: application/json' -d '{ "Name": "mcb-keypair-powerkim" }' |json_pp | grep PrivateKey |sed 's/"PrivateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
         echo -e ${KEY}
         echo -e ${KEY} > ./${NAME}.key
 

--- a/test/obsolete/gcp-tester-sh/keypair/spider-delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/keypair/spider-delete-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
         NAME=${CONNECT_NAMES[0]}
-        curl -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done

--- a/test/obsolete/gcp-tester-sh/keypair/spider-get-test.sh
+++ b/test/obsolete/gcp-tester-sh/keypair/spider-get-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
         NAME=${CONNECT_NAMES[0]}
-        curl -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done
 

--- a/test/obsolete/gcp-tester-sh/keypair/spider-list-test.sh
+++ b/test/obsolete/gcp-tester-sh/keypair/spider-list-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-        curl -sX GET http://$RESTSERVER:1024/keypair?connection_name=${NAME} #|json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair?connection_name=${NAME} #|json_pp &
 #done
 

--- a/test/obsolete/gcp-tester-sh/publicip/create-test.sh
+++ b/test/obsolete/gcp-tester-sh/publicip/create-test.sh
@@ -5,8 +5,8 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-#        curl -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt'${num}'-powerkim" }' |json_pp &
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspPublicIpName":"jhseo-shooter'${num}'"}' | json_pp
+#        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt'${num}'-powerkim" }' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspPublicIpName":"jhseo-shooter'${num}'"}' | json_pp
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/gcp-tester-sh/publicip/delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/publicip/delete-test.sh
@@ -4,23 +4,23 @@ source ../setup.env
 #num=0
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#        #ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#        #ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 #	ID=publicipt${num}-powerkim
-#        curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} &
+#        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} &
 #
 #	num=`expr $num + 1`
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Delete ${TB_PUBLICIP_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
         done
 else
         echo ....no publicIps found

--- a/test/obsolete/gcp-tester-sh/publicip/get-test.sh
+++ b/test/obsolete/gcp-tester-sh/publicip/get-test.sh
@@ -5,23 +5,23 @@ source ../setup.env
 #num=0
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#        #ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#        #ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 #	ID=publicipt${num}-powerkim
-#        curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #
 #	num=`expr $num + 1`
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
         done
 else
         echo ....no publicIps found

--- a/test/obsolete/gcp-tester-sh/publicip/list-test.sh
+++ b/test/obsolete/gcp-tester-sh/publicip/list-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/publicIp | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/publicIp | json_pp &
 #done
 

--- a/test/obsolete/gcp-tester-sh/publicip/spider-create-test.sh
+++ b/test/obsolete/gcp-tester-sh/publicip/spider-create-test.sh
@@ -5,7 +5,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt'${num}'-powerkim" }' |json_pp &
+        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt'${num}'-powerkim" }' |json_pp &
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/gcp-tester-sh/publicip/spider-delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/publicip/spider-delete-test.sh
@@ -4,9 +4,9 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        #ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+        #ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 	ID=publicipt${num}-powerkim
-        curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} &
+        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} &
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/gcp-tester-sh/publicip/spider-get-test.sh
+++ b/test/obsolete/gcp-tester-sh/publicip/spider-get-test.sh
@@ -5,9 +5,9 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        #ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+        #ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 	ID=publicipt${num}-powerkim
-        curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/gcp-tester-sh/publicip/spider-list-test.sh
+++ b/test/obsolete/gcp-tester-sh/publicip/spider-list-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} #|json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} #|json_pp &
 done
 

--- a/test/obsolete/gcp-tester-sh/security/create-test.sh
+++ b/test/obsolete/gcp-tester-sh/security/create-test.sh
@@ -5,8 +5,8 @@ num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	#NAME=${CONNECT_NAMES[0]}
-#        curl -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'",  "cspSecurityGroupName": "jhseo-shooter'$num'", "firewallRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' | json_pp &
+#        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'",  "cspSecurityGroupName": "jhseo-shooter'$num'", "firewallRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' | json_pp &
 
 	num=`expr $num + 1`
 

--- a/test/obsolete/gcp-tester-sh/security/delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/security/delete-test.sh
@@ -6,19 +6,19 @@ source ../setup.env
 #	NAME=${CONNECT_NAMES[0]}
 
 #        ID=security01-powerkim
-#        curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} &
+#        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} &
 #done
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 #echo $TB_SECURITYGROUP_IDS | json_pp
 
 if [ -n "$TB_SECURITYGROUP_IDS" ]
 then
-        #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
         do
                 echo ....Delete ${TB_SECURITYGROUP_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
         done
 else
         echo ....no securityGroups found

--- a/test/obsolete/gcp-tester-sh/security/get-test.sh
+++ b/test/obsolete/gcp-tester-sh/security/get-test.sh
@@ -6,19 +6,19 @@ source ../setup.env
 #	NAME=${CONNECT_NAMES[0]}
 
 #        ID=security01-powerkim
-#        curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 #echo $TB_SECURITYGROUP_IDS | json_pp
 
 if [ -n "$TB_SECURITYGROUP_IDS" ]
 then
-        #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
         do
                 echo ....Get ${TB_SECURITYGROUP_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
         done
 else
         echo ....no securityGroups found

--- a/test/obsolete/gcp-tester-sh/security/list-test.sh
+++ b/test/obsolete/gcp-tester-sh/security/list-test.sh
@@ -5,7 +5,7 @@ source ../setup.env
 #do
 	#NAME=${CONNECT_NAMES[0]}
 
-        #curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
-	curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/securityGroup | json_pp &
+        #curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/securityGroup | json_pp &
 #done
 

--- a/test/obsolete/gcp-tester-sh/security/spider-create-test.sh
+++ b/test/obsolete/gcp-tester-sh/security/spider-create-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-        curl -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
+        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
 
 #done

--- a/test/obsolete/gcp-tester-sh/security/spider-delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/security/spider-delete-test.sh
@@ -6,6 +6,6 @@ source ../setup.env
 	NAME=${CONNECT_NAMES[0]}
 
         ID=security01-powerkim
-        curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} &
+        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} &
 #done
 

--- a/test/obsolete/gcp-tester-sh/security/spider-get-test.sh
+++ b/test/obsolete/gcp-tester-sh/security/spider-get-test.sh
@@ -6,6 +6,6 @@ source ../setup.env
 	NAME=${CONNECT_NAMES[0]}
 
         ID=security01-powerkim
-        curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 #done
 

--- a/test/obsolete/gcp-tester-sh/security/spider-list-test.sh
+++ b/test/obsolete/gcp-tester-sh/security/spider-list-test.sh
@@ -5,6 +5,6 @@ source ../setup.env
 #do
 	NAME=${CONNECT_NAMES[0]}
 
-        curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
 #done
 

--- a/test/obsolete/gcp-tester-sh/spec/create-test.sh
+++ b/test/obsolete/gcp-tester-sh/spec/create-test.sh
@@ -3,7 +3,7 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
+        curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
         "name": "f1-micro",
     "os_type": "",
     "num_vCPU": "",

--- a/test/obsolete/gcp-tester-sh/spec/delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/spec/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 #echo $TB_SPEC_IDS | json_pp
 
 if [ -n "$TB_SPEC_IDS" ]
 then
-        #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         for TB_SPEC_ID in ${TB_SPEC_IDS}
         do
                 echo ....Delete ${TB_SPEC_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
         done
 else
         echo ....no specs found

--- a/test/obsolete/gcp-tester-sh/spec/get-test.sh
+++ b/test/obsolete/gcp-tester-sh/spec/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 #echo $TB_SPEC_IDS | json_pp
 
 if [ -n "$TB_SPEC_IDS" ]
 then
-        #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         for TB_SPEC_ID in ${TB_SPEC_IDS}
         do
                 echo ....Get ${TB_SPEC_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
         done
 else
         echo ....no specs found

--- a/test/obsolete/gcp-tester-sh/spec/list-test.sh
+++ b/test/obsolete/gcp-tester-sh/spec/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-        curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/spec | json_pp &
+        curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/spec | json_pp &
 #done

--- a/test/obsolete/gcp-tester-sh/vm/1.service_cp_run.sh
+++ b/test/obsolete/gcp-tester-sh/vm/1.service_cp_run.sh
@@ -7,7 +7,7 @@ CONNECT_NAME=${CONNECT_NAMES[0]}
 #num=0
 
 #echo ========================== $CONNECT_NAME
-#PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/publicip/publicipt${num}-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/publicipt${num}-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 ## 137.135.167.9
 #for PUBLIC_IP in ${PUBLIC_IPS}
 #do
@@ -17,19 +17,19 @@ CONNECT_NAME=${CONNECT_NAMES[0]}
 #        scp -i ../keypair/${CONNECT_NAME}.key -o "StrictHostKeyChecking no" -r ./testsvc/conf cb-user@$PUBLIC_IP:/tmp
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+                PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                 if [ "$PIPS_CONN_NAME" == "$CONNECT_NAME" ]
                 then
-                        PUBLIC_IP=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
+                        PUBLIC_IP=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
                         echo $CONNECT_NAME : copy testsvc into ${PUBLIC_IP} ...
                         ssh-keygen -f "/root/.ssh/known_hosts" -R ${PUBLIC_IP}
                         scp -i ../keypair/${CONNECT_NAME}.key -o "StrictHostKeyChecking no" ./testsvc/TESTSvc ./testsvc/setup.env cb-user@$PUBLIC_IP:/tmp

--- a/test/obsolete/gcp-tester-sh/vm/2.shooter_cp_run.sh
+++ b/test/obsolete/gcp-tester-sh/vm/2.shooter_cp_run.sh
@@ -10,7 +10,7 @@ KEY_NAME=${CONNECT_NAMES[0]}
 #		echo .... first vm skipped!!
 #	else
 #		echo ========================== $NAME
-#		PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#		PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 #		for PUBLIC_IP in ${PUBLIC_IPS}
 #		do
 #			echo $NAME: copy shooter into ${PUBLIC_IP} ...
@@ -23,22 +23,22 @@ KEY_NAME=${CONNECT_NAMES[0]}
 #	num=`expr $num + 1`
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+                PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                 if [ "$PIPS_CONN_NAME" == "${CONNECT_NAMES[0]}" ]
                 then
                         echo Skipping first VM
                         continue
                 else
-                        PUBLIC_IP=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
+                        PUBLIC_IP=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
                         echo $PIPS_CONN_NAME: copy shooter into ${PUBLIC_IP} ...
                         ssh-keygen -f "/root/.ssh/known_hosts" -R ${PUBLIC_IP}
                         scp -i ../keypair/$KEY_NAME.key -o "StrictHostKeyChecking no" ./shooter/shooter.sh cb-user@$PUBLIC_IP:/tmp

--- a/test/obsolete/gcp-tester-sh/vm/delete-mcis-info.sh
+++ b/test/obsolete/gcp-tester-sh/vm/delete-mcis-info.sh
@@ -7,8 +7,8 @@ source ../setup.env
 #
 #	VM_ID=vm-powerkim01
 #	echo ....terminate ${VM_ID} ...
-#	curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID

--- a/test/obsolete/gcp-tester-sh/vm/get-test_all.sh
+++ b/test/obsolete/gcp-tester-sh/vm/get-test_all.sh
@@ -4,8 +4,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	curl -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID | json_pp
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID | json_pp

--- a/test/obsolete/gcp-tester-sh/vm/list-status_all-test.sh
+++ b/test/obsolete/gcp-tester-sh/vm/list-status_all-test.sh
@@ -4,8 +4,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	curl -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=status | json_pp
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=status | json_pp

--- a/test/obsolete/gcp-tester-sh/vm/shooter/shooter.sh
+++ b/test/obsolete/gcp-tester-sh/vm/shooter/shooter.sh
@@ -4,13 +4,13 @@ SERVER=35.229.49.221
 
 HN=`hostname`
 IP=`curl -s ifconfig.so`
-COUNTRY=`curl -sX GET https://api.ipgeolocationapi.com/geolocate/$IP | json_pp |grep "\"name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+COUNTRY=`curl -H "${AUTH}" -sX GET https://api.ipgeolocationapi.com/geolocate/$IP | json_pp |grep "\"name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 
 while : 
 do
 	DT=`date`
 	DT=`echo $DT |sed 's/ /%20/g'`
-	curl -sX GET http://$SERVER:119/test -H 'Content-Type: application/json' -d '{
+	curl -H "${AUTH}" -sX GET http://$SERVER:119/test -H 'Content-Type: application/json' -d '{
 		"Date": "'${DT}'", 
 		"HostName": "'${HN}'", 
 		"IP": "'$IP'",

--- a/test/obsolete/gcp-tester-sh/vm/spider-1.service_cp_run.sh
+++ b/test/obsolete/gcp-tester-sh/vm/spider-1.service_cp_run.sh
@@ -7,7 +7,7 @@ CONNECT_NAME=${CONNECT_NAMES[0]}
 num=0
 
 echo ========================== $CONNECT_NAME
-PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/publicip/publicipt${num}-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/publicipt${num}-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 # 137.135.167.9
 for PUBLIC_IP in ${PUBLIC_IPS}
 do

--- a/test/obsolete/gcp-tester-sh/vm/spider-2.shooter_cp_run.sh
+++ b/test/obsolete/gcp-tester-sh/vm/spider-2.shooter_cp_run.sh
@@ -10,7 +10,7 @@ do
 		echo .... first vm skipped!!
 	else
 		echo ========================== $NAME
-		PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+		PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 		for PUBLIC_IP in ${PUBLIC_IPS}
 		do
 			echo $NAME: copy shooter into ${PUBLIC_IP} ...

--- a/test/obsolete/gcp-tester-sh/vm/spider-get-test_all.sh
+++ b/test/obsolete/gcp-tester-sh/vm/spider-get-test_all.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	curl -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
 done

--- a/test/obsolete/gcp-tester-sh/vm/spider-list-status_all-test.sh
+++ b/test/obsolete/gcp-tester-sh/vm/spider-list-status_all-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	curl -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
 done

--- a/test/obsolete/gcp-tester-sh/vm/spider-start_all-test.sh
+++ b/test/obsolete/gcp-tester-sh/vm/spider-start_all-test.sh
@@ -13,7 +13,7 @@ do
         SG_ID1=security01-powerkim
         #echo ${VNET_ID}, ${PIP_ID}, ${SG_ID}, ${VNIC_ID}
 
-        curl -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
+        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
             "VMName": "vm-powerkim01",
                 "ImageId": "'${IMG_ID}'",
                 "VirtualNetworkId": "'${VNET_ID}'",

--- a/test/obsolete/gcp-tester-sh/vm/spider-terminate_all-test.sh
+++ b/test/obsolete/gcp-tester-sh/vm/spider-terminate_all-test.sh
@@ -7,6 +7,6 @@ do
 
 	VM_ID=jhseo-vm0
 	echo ....terminate ${VM_ID} ...
-	curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
 done
 

--- a/test/obsolete/gcp-tester-sh/vm/start_all-test.sh
+++ b/test/obsolete/gcp-tester-sh/vm/start_all-test.sh
@@ -15,16 +15,16 @@ do
 
 #############################################################################################################################################
 
-        TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         #echo $TB_NETWORK_IDS | json_pp
 
         if [ -n "$TB_NETWORK_IDS" ]
         then
-                #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+                #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
                 for TB_NETWORK_ID in ${TB_NETWORK_IDS}
                 do
                         echo ....Get ${TB_NETWORK_ID} ...
-                        NETWORKS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | jq -r '.connectionName'`
+                        NETWORKS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | jq -r '.connectionName'`
                         if [ "$NETWORKS_CONN_NAME" == "$NAME" ]
                         then
                                 VNET_ID=$TB_NETWORK_ID
@@ -39,16 +39,16 @@ do
 
 #############################################################################################################################################
 
-        TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         #echo $TB_PUBLICIP_IDS | json_pp
 
         if [ -n "$TB_PUBLICIP_IDS" ]
         then
-                #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+                #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
                 for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
                 do
                         echo ....Get ${TB_PUBLICIP_ID} ...
-                        PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+                        PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                         if [ "$PIPS_CONN_NAME" == "$NAME" ]
                         then
                                 PIP_ID=$TB_PUBLICIP_ID
@@ -63,16 +63,16 @@ do
 
 #############################################################################################################################################
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         #echo $TB_SECURITYGROUP_IDS | json_pp
 
         if [ -n "$TB_SECURITYGROUP_IDS" ]
         then
-                #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+                #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
                 for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
                 do
                         echo ....Get ${TB_SECURITYGROUP_ID} ...
-                        SGS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | jq -r '.connectionName'`
+                        SGS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | jq -r '.connectionName'`
                         if [ "$SGS_CONN_NAME" == "$NAME" ]
                         then
                                 SG_ID=$TB_SECURITYGROUP_ID
@@ -87,16 +87,16 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources
 
 #############################################################################################################################################
 
-        TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         #echo $TB_SSHKEY_IDS | json_pp
 
         if [ -n "$TB_SSHKEY_IDS" ]
         then
-                #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+                #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
                 for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
                 do
                         echo ....Get ${TB_SSHKEY_ID} ...
-                        SSHKEYS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | jq -r '.connectionName'`
+                        SSHKEYS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | jq -r '.connectionName'`
                         if [ "$SSHKEYS_CONN_NAME" == "$NAME" ]
                         then
                                 SSHKEY_ID=$TB_SSHKEY_ID
@@ -111,16 +111,16 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources
 
 #############################################################################################################################################
 
-        TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         #echo $TB_SPEC_IDS | json_pp
 
         if [ -n "$TB_SPEC_IDS" ]
         then
-                #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+                #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
                 for TB_SPEC_ID in ${TB_SPEC_IDS}
                 do
                         echo ....Get ${TB_SPEC_ID} ...
-                        SPECS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | jq -r '.connectionName'`
+                        SPECS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | jq -r '.connectionName'`
                         if [ "$SPECS_CONN_NAME" == "$NAME" ]
                         then
                                 SPEC_ID=$TB_SPEC_ID
@@ -135,16 +135,16 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources
 
 #############################################################################################################################################
 
-        TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         #echo $TB_IMAGE_IDS | json_pp
 
         if [ -n "$TB_IMAGE_IDS" ]
         then
-                #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+                #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image | jq -r '.image[].id'`
                 for TB_IMAGE_ID in ${TB_IMAGE_IDS}
                 do
                         echo ....Get ${TB_IMAGE_ID} ...
-                        IMAGES_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | jq -r '.connectionName'`
+                        IMAGES_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | jq -r '.connectionName'`
                         if [ "$IMAGES_CONN_NAME" == "$NAME" ]
                         then
                                 IMAGE_ID=$TB_IMAGE_ID
@@ -159,7 +159,7 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources
 
 #############################################################################################################################################
 
-#        curl -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
+#        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
 #            "VMName": "vm-powerkim01",
 #                "ImageId": "'${IMG_ID}'",
 #                "VirtualNetworkId": "'${VNET_ID}'",
@@ -173,7 +173,7 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources
 
         if [ $num == 0 ]
         then
-                curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d '{
+                curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d '{
             "name": "mcis-t01",
             "description": "Test description",
             "vm_req": [
@@ -197,8 +197,8 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources
         }' | json_pp
 
         else
-                MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-                curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
+                MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+                curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
                 "name": "jhseo-shooter-'$num'",
                     "connectionName": "'$NAME'",
                     "specId": "'$SPEC_ID'",

--- a/test/obsolete/gcp-tester-sh/vm/terminate_all-test.sh
+++ b/test/obsolete/gcp-tester-sh/vm/terminate_all-test.sh
@@ -7,8 +7,8 @@ source ../setup.env
 #
 #	VM_ID=vm-powerkim01
 #	echo ....terminate ${VM_ID} ...
-#	curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=terminate
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/mcis/$MCIS_ID?action=terminate

--- a/test/obsolete/gcp-tester-sh/vnetwork/create-test.sh
+++ b/test/obsolete/gcp-tester-sh/vnetwork/create-test.sh
@@ -3,8 +3,8 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-#        curl -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"cb-vnet"}' |json_pp &
-	curl -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspNetworkName":"jhseo-shooter"}' | json_pp 
+#        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"cb-vnet"}' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspNetworkName":"jhseo-shooter"}' | json_pp 
 	sleep 10
 done
 

--- a/test/obsolete/gcp-tester-sh/vnetwork/delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/vnetwork/delete-test.sh
@@ -4,18 +4,18 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        ID=cb-vnet
-#        curl -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 
 if [ -n "$TB_NETWORK_IDS" ]
 then
-        #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         for TB_NETWORK_ID in ${TB_NETWORK_IDS}
         do
                 echo ....Delete ${TB_NETWORK_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID}
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID}
         done
 else
         echo ....no vNets found

--- a/test/obsolete/gcp-tester-sh/vnetwork/get-test.sh
+++ b/test/obsolete/gcp-tester-sh/vnetwork/get-test.sh
@@ -4,19 +4,19 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        ID=cb-vnet
-#        curl -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 #echo $TB_NETWORK_IDS | json_pp
 
 if [ -n "$TB_NETWORK_IDS" ]
 then
-        #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         for TB_NETWORK_ID in ${TB_NETWORK_IDS}
         do
                 echo ....Get ${TB_NETWORK_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | json_pp
         done
 else
         echo ....no vNets found

--- a/test/obsolete/gcp-tester-sh/vnetwork/list-test.sh
+++ b/test/obsolete/gcp-tester-sh/vnetwork/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-        curl -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/vNet | json_pp &
+        curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/ns/${NS_ID}/resources/vNet | json_pp &
 #done

--- a/test/obsolete/gcp-tester-sh/vnetwork/spider-create-test.sh
+++ b/test/obsolete/gcp-tester-sh/vnetwork/spider-create-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"cb-vnet"}' |json_pp &
+        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"cb-vnet"}' |json_pp &
 done
 

--- a/test/obsolete/gcp-tester-sh/vnetwork/spider-delete-test.sh
+++ b/test/obsolete/gcp-tester-sh/vnetwork/spider-delete-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
         ID=cb-vnet
-        curl -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 done
 

--- a/test/obsolete/gcp-tester-sh/vnetwork/spider-get-test.sh
+++ b/test/obsolete/gcp-tester-sh/vnetwork/spider-get-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
         ID=cb-vnet
-        curl -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 done
 

--- a/test/obsolete/gcp-tester-sh/vnetwork/spider-list-test.sh
+++ b/test/obsolete/gcp-tester-sh/vnetwork/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp &
 done

--- a/test/obsolete/shooter-sh-2019/delete-all-azure-regions.sh
+++ b/test/obsolete/shooter-sh-2019/delete-all-azure-regions.sh
@@ -7,6 +7,6 @@ for LOC in "${LOCS[@]}"
 do
 	echo $LOC
 
-	curl -sX DELETE http://$RESTSERVER:1024/region/azure-$LOC
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/region/azure-$LOC
 
 done

--- a/test/obsolete/shooter-sh-2019/image/create-test.sh
+++ b/test/obsolete/shooter-sh-2019/image/create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
+        curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
         "cspImageId": "'${IMG_IDS[num]}'",
         "cspImageName": "'${IMG_IDS[num]}'"
         }' | json_pp

--- a/test/obsolete/shooter-sh-2019/image/delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/image/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do 
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 #echo $TB_IMAGE_IDS | json_pp
 
 if [ -n "$TB_IMAGE_IDS" ]
 then
-        #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         for TB_IMAGE_ID in ${TB_IMAGE_IDS}
         do
                 echo ....Delete ${TB_IMAGE_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
         done
 else
         echo ....no images found

--- a/test/obsolete/shooter-sh-2019/image/get-test.sh
+++ b/test/obsolete/shooter-sh-2019/image/get-test.sh
@@ -5,20 +5,20 @@ source ../setup.env
 #num=0
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#        curl -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
 #        num=`expr $num + 1`
 #done
 
-TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
 #echo $TB_IMAGE_IDS | json_pp
 
 if [ -n "$TB_IMAGE_IDS" ]
 then
-        #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         for TB_IMAGE_ID in ${TB_IMAGE_IDS}
         do
                 echo ....Get ${TB_IMAGE_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | json_pp
         done
 else
         echo ....no images found

--- a/test/obsolete/shooter-sh-2019/image/list-test.sh
+++ b/test/obsolete/shooter-sh-2019/image/list-test.sh
@@ -6,8 +6,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #for NAME in "${CONNECT_NAMES[0]}"
 #do
-#        curl -sX GET http://$RESTSERVER:1024/vmimage?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmimage?connection_name=${NAME} |json_pp &
 #        num=`expr $num + 1`
 #done
 
-curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/image | json_pp &
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/image | json_pp &

--- a/test/obsolete/shooter-sh-2019/image/spider-get-test.sh
+++ b/test/obsolete/shooter-sh-2019/image/spider-get-test.sh
@@ -5,7 +5,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX GET http://$RESTSERVER:1024/spider/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/spider/vmimage/${IMG_IDS[num]}?connection_name=${NAME} |json_pp &
         num=`expr $num + 1`
 done
 

--- a/test/obsolete/shooter-sh-2019/image/spider-list-test.sh
+++ b/test/obsolete/shooter-sh-2019/image/spider-list-test.sh
@@ -6,7 +6,7 @@ num=0
 #for NAME in "${CONNECT_NAMES[@]}"
 for NAME in "${CONNECT_NAMES[0]}"
 do
-        curl -sX GET http://$RESTSERVER:1024/spider/vmimage?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/spider/vmimage?connection_name=${NAME} |json_pp &
         num=`expr $num + 1`
 done
 

--- a/test/obsolete/shooter-sh-2019/insert-all-azure-regions.sh
+++ b/test/obsolete/shooter-sh-2019/insert-all-azure-regions.sh
@@ -7,7 +7,7 @@ for LOC in "${LOCS[@]}"
 do
 	echo $LOC
 
-	curl -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"azure-'$LOC'","ProviderName":"AZURE", "KeyValueInfoList": [{"Key":"location", "Value":"'$LOC'"}, {"Key":"ResourceGroup", "Value":"jhseo-test-'$LOC'"}]}'
-	curl -sX POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"azure-'$LOC'-config","ProviderName":"AZURE", "DriverName":"azure-driver01", "CredentialName":"azure-credential01", "RegionName":"azure-'$LOC'"}'
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/spider/region -H 'Content-Type: application/json' -d '{"RegionName":"azure-'$LOC'","ProviderName":"AZURE", "KeyValueInfoList": [{"Key":"location", "Value":"'$LOC'"}, {"Key":"ResourceGroup", "Value":"jhseo-test-'$LOC'"}]}'
+	curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/spider/connectionconfig -H 'Content-Type: application/json' -d '{"ConfigName":"azure-'$LOC'-config","ProviderName":"AZURE", "DriverName":"azure-driver01", "CredentialName":"azure-credential01", "RegionName":"azure-'$LOC'"}'
 
 done

--- a/test/obsolete/shooter-sh-2019/keypair/create-test.sh
+++ b/test/obsolete/shooter-sh-2019/keypair/create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        NAME=${CONNECT_NAMES[0]}
-#	KEY=`curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspSshKeyName\":\"jhseo-test\"}" | json_pp | grep privateKey | sed 's/"privateKey" : "//g' | sed 's/-----",/-----/g' | sed 's/-----"/-----/g'`
+#	KEY=`curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d "{\"connectionName\":\"$NAME\", \"cspSshKeyName\":\"jhseo-test\"}" | json_pp | grep privateKey | sed 's/"privateKey" : "//g' | sed 's/-----",/-----/g' | sed 's/-----"/-----/g'`
 #        echo -e ${KEY}
 #        echo -e ${KEY} > ./${NAME}.key
 
@@ -14,7 +14,7 @@ source ../setup.env
 INDICES="0 1 2 3 4 5 6 7"
 for i in $INDICES
 do
-	KEY=`curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d '{"connectionName":"'${CONNECT_NAMES[i]}'", "cspSshKeyName":"jhseo-test"}' | json_pp | grep privateKey | sed 's/"privateKey" : "//g' | sed 's/-----",/-----/g' | sed 's/-----"/-----/g'`
+	KEY=`curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d '{"connectionName":"'${CONNECT_NAMES[i]}'", "cspSshKeyName":"jhseo-test"}' | json_pp | grep privateKey | sed 's/"privateKey" : "//g' | sed 's/-----",/-----/g' | sed 's/-----"/-----/g'`
 	echo -e ${KEY}
         echo -e ${KEY} > ./${CONNECT_NAMES[i]}.key
 

--- a/test/obsolete/shooter-sh-2019/keypair/delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/keypair/delete-test.sh
@@ -4,18 +4,18 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        NAME=${CONNECT_NAMES[0]}
-#        curl -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done
 
-TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 
 if [ -n "$TB_SSHKEY_IDS" ]
 then
-        #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
         do
                 echo ....Delete ${TB_SSHKEY_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID}
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID}
         done
 else
         echo ....no sshKeys found

--- a/test/obsolete/shooter-sh-2019/keypair/get-test.sh
+++ b/test/obsolete/shooter-sh-2019/keypair/get-test.sh
@@ -4,19 +4,19 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        NAME=${CONNECT_NAMES[0]}
-#        curl -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done
 
-TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
 #echo $TB_SSHKEY_IDS | json_pp
 
 if [ -n "$TB_SSHKEY_IDS" ]
 then
-        #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
         do
                 echo ....Get ${TB_SSHKEY_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | json_pp
         done
 else
         echo ....no sshKeys found

--- a/test/obsolete/shooter-sh-2019/keypair/list-test.sh
+++ b/test/obsolete/shooter-sh-2019/keypair/list-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	NAME=${CONNECT_NAMES[0]}
-	curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/sshKey |json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/sshKey |json_pp &
 #done
 

--- a/test/obsolete/shooter-sh-2019/keypair/spider-create-test.sh
+++ b/test/obsolete/shooter-sh-2019/keypair/spider-create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
         NAME=${CONNECT_NAMES[0]}
-        KEY=`curl -sX POST http://$RESTSERVER:1024/keypair?connection_name=$NAME -H 'Content-Type: application/json' -d '{ "Name": "mcb-keypair-powerkim" }' |json_pp | grep PrivateKey |sed 's/"PrivateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
+        KEY=`curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/keypair?connection_name=$NAME -H 'Content-Type: application/json' -d '{ "Name": "mcb-keypair-powerkim" }' |json_pp | grep PrivateKey |sed 's/"PrivateKey" : "//g' |sed 's/-----",/-----/g' |sed 's/-----"/-----/g'`
         echo -e ${KEY}
         echo -e ${KEY} > ./${NAME}.key
 

--- a/test/obsolete/shooter-sh-2019/keypair/spider-delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/keypair/spider-delete-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
         NAME=${CONNECT_NAMES[0]}
-        curl -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done

--- a/test/obsolete/shooter-sh-2019/keypair/spider-get-test.sh
+++ b/test/obsolete/shooter-sh-2019/keypair/spider-get-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
         NAME=${CONNECT_NAMES[0]}
-        curl -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair/mcb-keypair-powerkim?connection_name=${NAME} |json_pp &
 #done
 

--- a/test/obsolete/shooter-sh-2019/keypair/spider-list-test.sh
+++ b/test/obsolete/shooter-sh-2019/keypair/spider-list-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-        curl -sX GET http://$RESTSERVER:1024/keypair?connection_name=${NAME} #|json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/keypair?connection_name=${NAME} #|json_pp &
 #done
 

--- a/test/obsolete/shooter-sh-2019/publicip/create-test.sh
+++ b/test/obsolete/shooter-sh-2019/publicip/create-test.sh
@@ -5,8 +5,8 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-#        curl -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt'${num}'-powerkim" }' |json_pp &
-	curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspPublicIpName":"jhseo-test'${num}'"}' | json_pp
+#        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt'${num}'-powerkim" }' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspPublicIpName":"jhseo-test'${num}'"}' | json_pp
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/shooter-sh-2019/publicip/delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/publicip/delete-test.sh
@@ -4,23 +4,23 @@ source ../setup.env
 #num=0
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#        #ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#        #ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 #	ID=publicipt${num}-powerkim
-#        curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} &
+#        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} &
 #
 #	num=`expr $num + 1`
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Delete ${TB_PUBLICIP_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
         done
 else
         echo ....no publicIps found

--- a/test/obsolete/shooter-sh-2019/publicip/get-test.sh
+++ b/test/obsolete/shooter-sh-2019/publicip/get-test.sh
@@ -5,23 +5,23 @@ source ../setup.env
 #num=0
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#        #ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#        #ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 #	ID=publicipt${num}-powerkim
-#        curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #
 #	num=`expr $num + 1`
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | json_pp
         done
 else
         echo ....no publicIps found

--- a/test/obsolete/shooter-sh-2019/publicip/list-test.sh
+++ b/test/obsolete/shooter-sh-2019/publicip/list-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-	curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/publicIp | json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/publicIp | json_pp &
 #done
 

--- a/test/obsolete/shooter-sh-2019/publicip/spider-create-test.sh
+++ b/test/obsolete/shooter-sh-2019/publicip/spider-create-test.sh
@@ -5,7 +5,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt'${num}'-powerkim" }' |json_pp &
+        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/publicip?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "publicipt'${num}'-powerkim" }' |json_pp &
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/shooter-sh-2019/publicip/spider-delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/publicip/spider-delete-test.sh
@@ -4,9 +4,9 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        #ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+        #ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 	ID=publicipt${num}-powerkim
-        curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} &
+        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} &
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/shooter-sh-2019/publicip/spider-get-test.sh
+++ b/test/obsolete/shooter-sh-2019/publicip/spider-get-test.sh
@@ -5,9 +5,9 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        #ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+        #ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 	ID=publicipt${num}-powerkim
-        curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 
 	num=`expr $num + 1`
 done

--- a/test/obsolete/shooter-sh-2019/publicip/spider-list-test.sh
+++ b/test/obsolete/shooter-sh-2019/publicip/spider-list-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} #|json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} #|json_pp &
 done
 

--- a/test/obsolete/shooter-sh-2019/security/create-test.sh
+++ b/test/obsolete/shooter-sh-2019/security/create-test.sh
@@ -5,8 +5,8 @@ num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	#NAME=${CONNECT_NAMES[0]}
-#        curl -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
-	curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'",  "cspSecurityGroupName": "jhseo-test'$num'", "firewallRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' | json_pp &
+#        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'",  "cspSecurityGroupName": "jhseo-test'$num'", "firewallRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' | json_pp &
 
 	num=`expr $num + 1`
 

--- a/test/obsolete/shooter-sh-2019/security/delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/security/delete-test.sh
@@ -6,19 +6,19 @@ source ../setup.env
 #	NAME=${CONNECT_NAMES[0]}
 
 #        ID=security01-powerkim
-#        curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} &
+#        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} &
 #done
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 #echo $TB_SECURITYGROUP_IDS | json_pp
 
 if [ -n "$TB_SECURITYGROUP_IDS" ]
 then
-        #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
         do
                 echo ....Delete ${TB_SECURITYGROUP_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
         done
 else
         echo ....no securityGroups found

--- a/test/obsolete/shooter-sh-2019/security/get-test.sh
+++ b/test/obsolete/shooter-sh-2019/security/get-test.sh
@@ -6,19 +6,19 @@ source ../setup.env
 #	NAME=${CONNECT_NAMES[0]}
 
 #        ID=security01-powerkim
-#        curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
 #echo $TB_SECURITYGROUP_IDS | json_pp
 
 if [ -n "$TB_SECURITYGROUP_IDS" ]
 then
-        #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+        #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
         do
                 echo ....Get ${TB_SECURITYGROUP_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | json_pp
         done
 else
         echo ....no securityGroups found

--- a/test/obsolete/shooter-sh-2019/security/list-test.sh
+++ b/test/obsolete/shooter-sh-2019/security/list-test.sh
@@ -5,7 +5,7 @@ source ../setup.env
 #do
 	#NAME=${CONNECT_NAMES[0]}
 
-        #curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
-	curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/securityGroup | json_pp &
+        #curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
+	curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/securityGroup | json_pp &
 #done
 

--- a/test/obsolete/shooter-sh-2019/security/spider-create-test.sh
+++ b/test/obsolete/shooter-sh-2019/security/spider-create-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 	NAME=${CONNECT_NAMES[0]}
-        curl -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
+        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} -H 'Content-Type: application/json' -d '{ "Name": "security01-powerkim", "SecurityRules": [ {"FromPort": "1", "ToPort" : "65535", "IPProtocol" : "tcp", "Direction" : "inbound"} ] }' |json_pp &
 
 #done

--- a/test/obsolete/shooter-sh-2019/security/spider-delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/security/spider-delete-test.sh
@@ -6,6 +6,6 @@ source ../setup.env
 	NAME=${CONNECT_NAMES[0]}
 
         ID=security01-powerkim
-        curl -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} &
+        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} &
 #done
 

--- a/test/obsolete/shooter-sh-2019/security/spider-get-test.sh
+++ b/test/obsolete/shooter-sh-2019/security/spider-get-test.sh
@@ -6,6 +6,6 @@ source ../setup.env
 	NAME=${CONNECT_NAMES[0]}
 
         ID=security01-powerkim
-        curl -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup/${ID}?connection_name=${NAME} |json_pp &
 #done
 

--- a/test/obsolete/shooter-sh-2019/security/spider-list-test.sh
+++ b/test/obsolete/shooter-sh-2019/security/spider-list-test.sh
@@ -5,6 +5,6 @@ source ../setup.env
 #do
 	NAME=${CONNECT_NAMES[0]}
 
-        curl -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/securitygroup?connection_name=${NAME} |json_pp &
 #done
 

--- a/test/obsolete/shooter-sh-2019/spec/create-test.sh
+++ b/test/obsolete/shooter-sh-2019/spec/create-test.sh
@@ -4,7 +4,7 @@ source ../setup.env
 num=0
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
+        curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", 
         "name": "'${SPEC_IDS[num]}'",
     "os_type": "",
     "num_vCPU": "",

--- a/test/obsolete/shooter-sh-2019/spec/delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/spec/delete-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} 
 #done
 
-TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 #echo $TB_SPEC_IDS | json_pp
 
 if [ -n "$TB_SPEC_IDS" ]
 then
-        #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         for TB_SPEC_ID in ${TB_SPEC_IDS}
         do
                 echo ....Delete ${TB_SPEC_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
         done
 else
         echo ....no specs found

--- a/test/obsolete/shooter-sh-2019/spec/get-test.sh
+++ b/test/obsolete/shooter-sh-2019/spec/get-test.sh
@@ -3,20 +3,20 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-#       ID=`curl -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
-#       curl -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
+#       ID=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip?connection_name=${NAME} |json_pp |grep "\"Name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+#       curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
 #echo $TB_SPEC_IDS | json_pp
 
 if [ -n "$TB_SPEC_IDS" ]
 then
-        #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         for TB_SPEC_ID in ${TB_SPEC_IDS}
         do
                 echo ....Get ${TB_SPEC_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | json_pp
         done
 else
         echo ....no specs found

--- a/test/obsolete/shooter-sh-2019/spec/list-test.sh
+++ b/test/obsolete/shooter-sh-2019/spec/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-        curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/spec | json_pp &
+        curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/spec | json_pp &
 #done

--- a/test/obsolete/shooter-sh-2019/vm/1.service_cp_run.sh
+++ b/test/obsolete/shooter-sh-2019/vm/1.service_cp_run.sh
@@ -7,7 +7,7 @@ CONNECT_NAME=${CONNECT_NAMES[0]}
 #num=0
 
 #echo ========================== $CONNECT_NAME
-#PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/publicip/publicipt${num}-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/publicipt${num}-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 ## 137.135.167.9
 #for PUBLIC_IP in ${PUBLIC_IPS}
 #do
@@ -17,19 +17,19 @@ CONNECT_NAME=${CONNECT_NAMES[0]}
 #        scp -i ../keypair/${CONNECT_NAME}.key -o "StrictHostKeyChecking no" -r ./testsvc/conf cb-user@$PUBLIC_IP:/tmp
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+                PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                 if [ "$PIPS_CONN_NAME" == "$CONNECT_NAME" ]
                 then
-                        PUBLIC_IP=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
+                        PUBLIC_IP=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
                         echo $CONNECT_NAME : copy testsvc into ${PUBLIC_IP} ...
                         ssh-keygen -f "/root/.ssh/known_hosts" -R ${PUBLIC_IP}
                         scp -i ../keypair/${CONNECT_NAME}.key -o "StrictHostKeyChecking no" ./testsvc/TESTSvc ./testsvc/setup.env ubuntu@$PUBLIC_IP:/tmp

--- a/test/obsolete/shooter-sh-2019/vm/2.shooter_cp_run.sh
+++ b/test/obsolete/shooter-sh-2019/vm/2.shooter_cp_run.sh
@@ -10,7 +10,7 @@ source ../setup.env
 #		echo .... first vm skipped!!
 #	else
 #		echo ========================== $NAME
-#		PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+#		PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 #		for PUBLIC_IP in ${PUBLIC_IPS}
 #		do
 #			echo $NAME: copy shooter into ${PUBLIC_IP} ...
@@ -23,22 +23,22 @@ source ../setup.env
 #	num=`expr $num + 1`
 #done
 
-TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
 #echo $TB_PUBLICIP_IDS | json_pp
 
 if [ -n "$TB_PUBLICIP_IDS" ]
 then
-        #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
         do
                 echo ....Get ${TB_PUBLICIP_ID} ...
-                PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+                PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                 if [ "$PIPS_CONN_NAME" == "${CONNECT_NAMES[0]}" ]
                 then
                         echo Skipping first VM
                         continue
                 else
-                        PUBLIC_IP=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
+                        PUBLIC_IP=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.publicIp'`
                         echo $PIPS_CONN_NAME: copy shooter into ${PUBLIC_IP} ...
                         ssh-keygen -f "/root/.ssh/known_hosts" -R ${PUBLIC_IP}
                         scp -i ../keypair/$PIPS_CONN_NAME.key -o "StrictHostKeyChecking no" ./shooter/shooter.sh ubuntu@$PUBLIC_IP:/tmp

--- a/test/obsolete/shooter-sh-2019/vm/delete-mcis-info.sh
+++ b/test/obsolete/shooter-sh-2019/vm/delete-mcis-info.sh
@@ -7,8 +7,8 @@ source ../setup.env
 #
 #	VM_ID=vm-powerkim01
 #	echo ....terminate ${VM_ID} ...
-#	curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID

--- a/test/obsolete/shooter-sh-2019/vm/get-test_all.sh
+++ b/test/obsolete/shooter-sh-2019/vm/get-test_all.sh
@@ -4,8 +4,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	curl -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID | json_pp
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID | json_pp

--- a/test/obsolete/shooter-sh-2019/vm/list-status_all-test.sh
+++ b/test/obsolete/shooter-sh-2019/vm/list-status_all-test.sh
@@ -4,8 +4,8 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #	echo ========================== $NAME
-#	curl -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
+#	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME |json_pp &
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID?action=status | json_pp
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID?action=status | json_pp

--- a/test/obsolete/shooter-sh-2019/vm/shooter/shooter.sh
+++ b/test/obsolete/shooter-sh-2019/vm/shooter/shooter.sh
@@ -4,13 +4,13 @@ SERVER=18.140.152.159
 
 HN=`hostname`
 IP=`curl -s ifconfig.so`
-COUNTRY=`curl -sX GET https://api.ipgeolocationapi.com/geolocate/$IP | json_pp |grep "\"name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
+COUNTRY=`curl -H "${AUTH}" -sX GET https://api.ipgeolocationapi.com/geolocate/$IP | json_pp |grep "\"name\" :" |awk '{print $3}' | head -n 1 |sed 's/"//g' |sed 's/,//g'`
 
 while : 
 do
 	DT=`date`
 	DT=`echo $DT |sed 's/ /%20/g'`
-	curl -sX GET http://$SERVER:119/test -H 'Content-Type: application/json' -d '{
+	curl -H "${AUTH}" -sX GET http://$SERVER:119/test -H 'Content-Type: application/json' -d '{
 		"Date": "'${DT}'", 
 		"HostName": "'${HN}'", 
 		"IP": "'$IP'",

--- a/test/obsolete/shooter-sh-2019/vm/spider-1.service_cp_run.sh
+++ b/test/obsolete/shooter-sh-2019/vm/spider-1.service_cp_run.sh
@@ -7,7 +7,7 @@ CONNECT_NAME=${CONNECT_NAMES[0]}
 num=0
 
 echo ========================== $CONNECT_NAME
-PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/publicip/publicipt${num}-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/publicip/publicipt${num}-powerkim?connection_name=$CONNECT_NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 # 137.135.167.9
 for PUBLIC_IP in ${PUBLIC_IPS}
 do

--- a/test/obsolete/shooter-sh-2019/vm/spider-2.shooter_cp_run.sh
+++ b/test/obsolete/shooter-sh-2019/vm/spider-2.shooter_cp_run.sh
@@ -10,7 +10,7 @@ do
 		echo .... first vm skipped!!
 	else
 		echo ========================== $NAME
-		PUBLIC_IPS=`curl -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
+		PUBLIC_IPS=`curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm?connection_name=$NAME |json_pp |grep "\"PublicIP\"" |awk '{print $3}' |sed 's/"//g' |sed 's/,//g'`
 		for PUBLIC_IP in ${PUBLIC_IPS}
 		do
 			echo $NAME: copy shooter into ${PUBLIC_IP} ...

--- a/test/obsolete/shooter-sh-2019/vm/spider-get-test_all.sh
+++ b/test/obsolete/shooter-sh-2019/vm/spider-get-test_all.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	curl -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vm/vm-powerkim01?connection_name=$NAME |json_pp
 done

--- a/test/obsolete/shooter-sh-2019/vm/spider-list-status_all-test.sh
+++ b/test/obsolete/shooter-sh-2019/vm/spider-list-status_all-test.sh
@@ -4,5 +4,5 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
 	echo ========================== $NAME
-	curl -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME #|json_pp &
+	curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vmstatus?connection_name=$NAME #|json_pp &
 done

--- a/test/obsolete/shooter-sh-2019/vm/spider-start_all-test.sh
+++ b/test/obsolete/shooter-sh-2019/vm/spider-start_all-test.sh
@@ -13,7 +13,7 @@ do
         SG_ID1=security01-powerkim
         #echo ${VNET_ID}, ${PIP_ID}, ${SG_ID}, ${VNIC_ID}
 
-        curl -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
+        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
             "VMName": "vm-powerkim01",
                 "ImageId": "'${IMG_ID}'",
                 "VirtualNetworkId": "'${VNET_ID}'",

--- a/test/obsolete/shooter-sh-2019/vm/spider-terminate_all-test.sh
+++ b/test/obsolete/shooter-sh-2019/vm/spider-terminate_all-test.sh
@@ -7,6 +7,6 @@ do
 
 	VM_ID=jhseo-vm0
 	echo ....terminate ${VM_ID} ...
-	curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
+	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
 done
 

--- a/test/obsolete/shooter-sh-2019/vm/start_all-test.sh
+++ b/test/obsolete/shooter-sh-2019/vm/start_all-test.sh
@@ -15,16 +15,16 @@ do
 
 #############################################################################################################################################
 
-        TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         #echo $TB_NETWORK_IDS | json_pp
 
         if [ -n "$TB_NETWORK_IDS" ]
         then
-                #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+                #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
                 for TB_NETWORK_ID in ${TB_NETWORK_IDS}
                 do
 #                        echo ....Get ${TB_NETWORK_ID} ...
-                        NETWORKS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | jq -r '.connectionName'`
+                        NETWORKS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | jq -r '.connectionName'`
                         if [ "$NETWORKS_CONN_NAME" == "$NAME" ]
                         then
                                 VNET_ID=$TB_NETWORK_ID
@@ -39,16 +39,16 @@ do
 
 #############################################################################################################################################
 
-        TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+        TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
         #echo $TB_PUBLICIP_IDS | json_pp
 
         if [ -n "$TB_PUBLICIP_IDS" ]
         then
-                #TB_PUBLICIP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
+                #TB_PUBLICIP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp | jq -r '.publicIp[].id'`
                 for TB_PUBLICIP_ID in ${TB_PUBLICIP_IDS}
                 do
 #                        echo ....Get ${TB_PUBLICIP_ID} ...
-                        PIPS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
+                        PIPS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/publicIp/${TB_PUBLICIP_ID} | jq -r '.connectionName'`
                         if [ "$PIPS_CONN_NAME" == "$NAME" ]
                         then
                                 PIP_ID=$TB_PUBLICIP_ID
@@ -63,16 +63,16 @@ do
 
 #############################################################################################################################################
 
-TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
         #echo $TB_SECURITYGROUP_IDS | json_pp
 
         if [ -n "$TB_SECURITYGROUP_IDS" ]
         then
-                #TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
+                #TB_SECURITYGROUP_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup | jq -r '.securityGroup[].id'`
                 for TB_SECURITYGROUP_ID in ${TB_SECURITYGROUP_IDS}
                 do
 #                        echo ....Get ${TB_SECURITYGROUP_ID} ...
-                        SGS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | jq -r '.connectionName'`
+                        SGS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/securityGroup/${TB_SECURITYGROUP_ID} | jq -r '.connectionName'`
                         if [ "$SGS_CONN_NAME" == "$NAME" ]
                         then
                                 SG_ID=$TB_SECURITYGROUP_ID
@@ -87,16 +87,16 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID
 
 #############################################################################################################################################
 
-        TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+        TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
         #echo $TB_SSHKEY_IDS | json_pp
 
         if [ -n "$TB_SSHKEY_IDS" ]
         then
-                #TB_SSHKEY_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
+                #TB_SSHKEY_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey | jq -r '.sshKey[].id'`
                 for TB_SSHKEY_ID in ${TB_SSHKEY_IDS}
                 do
 #                        echo ....Get ${TB_SSHKEY_ID} ...
-                        SSHKEYS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | jq -r '.connectionName'`
+                        SSHKEYS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/sshKey/${TB_SSHKEY_ID} | jq -r '.connectionName'`
                         if [ "$SSHKEYS_CONN_NAME" == "$NAME" ]
                         then
                                 SSHKEY_ID=$TB_SSHKEY_ID
@@ -111,16 +111,16 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID
 
 #############################################################################################################################################
 
-        TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+        TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
         #echo $TB_SPEC_IDS | json_pp
 
         if [ -n "$TB_SPEC_IDS" ]
         then
-                #TB_SPEC_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
+                #TB_SPEC_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec | jq -r '.spec[].id'`
                 for TB_SPEC_ID in ${TB_SPEC_IDS}
                 do
 #                        echo ....Get ${TB_SPEC_ID} ...
-                        SPECS_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | jq -r '.connectionName'`
+                        SPECS_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/spec/${TB_SPEC_ID} | jq -r '.connectionName'`
                         if [ "$SPECS_CONN_NAME" == "$NAME" ]
                         then
                                 SPEC_ID=$TB_SPEC_ID
@@ -135,16 +135,16 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID
 
 #############################################################################################################################################
 
-        TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+        TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
         #echo $TB_IMAGE_IDS | json_pp
 
         if [ -n "$TB_IMAGE_IDS" ]
         then
-                #TB_IMAGE_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
+                #TB_IMAGE_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image | jq -r '.image[].id'`
                 for TB_IMAGE_ID in ${TB_IMAGE_IDS}
                 do
 #                        echo ....Get ${TB_IMAGE_ID} ...
-                        IMAGES_CONN_NAME=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | jq -r '.connectionName'`
+                        IMAGES_CONN_NAME=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/image/${TB_IMAGE_ID} | jq -r '.connectionName'`
                         if [ "$IMAGES_CONN_NAME" == "$NAME" ]
                         then
                                 IMAGE_ID=$TB_IMAGE_ID
@@ -159,7 +159,7 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID
 
 #############################################################################################################################################
 
-#        curl -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
+#        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vm?connection_name=${NAME} -H 'Content-Type: application/json' -d '{
 #            "VMName": "vm-powerkim01",
 #                "ImageId": "'${IMG_ID}'",
 #                "VirtualNetworkId": "'${VNET_ID}'",
@@ -174,7 +174,7 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID
         if [ $num == 0 ]
         then
 #                echo '{
-                curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d '{
+                curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d '{
             "name": "mcis-t01",
             "description": "Test description",
             "vm_req": [
@@ -198,9 +198,9 @@ TB_SECURITYGROUP_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID
         }' | json_pp
 
         else
-                MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+                MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
 #                echo '{
-                curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
+                curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID/vm -H 'Content-Type: application/json' -d '{
                 "name": "jhseo-vm-'$num'",
                     "connectionName": "'$NAME'",
                     "specId": "'$SPEC_ID'",

--- a/test/obsolete/shooter-sh-2019/vm/terminate_all-test.sh
+++ b/test/obsolete/shooter-sh-2019/vm/terminate_all-test.sh
@@ -7,8 +7,8 @@ source ../setup.env
 #
 #	VM_ID=vm-powerkim01
 #	echo ....terminate ${VM_ID} ...
-#	curl -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
+#	curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vm/${VM_ID}?connection_name=${NAME} &
 #done
 
-MCIS_ID=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
-curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID?action=terminate
+MCIS_ID=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis | jq -r '.mcis[].id'`
+curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/mcis/$MCIS_ID?action=terminate

--- a/test/obsolete/shooter-sh-2019/vnetwork/create-test.sh
+++ b/test/obsolete/shooter-sh-2019/vnetwork/create-test.sh
@@ -3,8 +3,8 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-#        curl -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"cb-vnet"}' |json_pp &
-	curl -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspNetworkName":"jhseo-test"}' | json_pp 
+#        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"cb-vnet"}' |json_pp &
+	curl -H "${AUTH}" -sX POST http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d '{"connectionName":"'$NAME'", "cspNetworkName":"jhseo-test"}' | json_pp 
 #	sleep 10
 done
 

--- a/test/obsolete/shooter-sh-2019/vnetwork/delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/vnetwork/delete-test.sh
@@ -4,18 +4,18 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        ID=cb-vnet
-#        curl -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 
 if [ -n "$TB_NETWORK_IDS" ]
 then
-        #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         for TB_NETWORK_ID in ${TB_NETWORK_IDS}
         do
                 echo ....Delete ${TB_NETWORK_ID} ...
-                curl -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID}
+                curl -H "${AUTH}" -sX DELETE http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID}
         done
 else
         echo ....no vNets found

--- a/test/obsolete/shooter-sh-2019/vnetwork/get-test.sh
+++ b/test/obsolete/shooter-sh-2019/vnetwork/get-test.sh
@@ -4,19 +4,19 @@ source ../setup.env
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
 #        ID=cb-vnet
-#        curl -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+#        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 #done
 
-TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
 #echo $TB_NETWORK_IDS | json_pp
 
 if [ -n "$TB_NETWORK_IDS" ]
 then
-        #TB_NETWORK_IDS=`curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
+        #TB_NETWORK_IDS=`curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet | jq -r '.vNet[].id'`
         for TB_NETWORK_ID in ${TB_NETWORK_IDS}
         do
                 echo ....Get ${TB_NETWORK_ID} ...
-                curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | json_pp
+                curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/$NS_ID/resources/vNet/${TB_NETWORK_ID} | json_pp
         done
 else
         echo ....no vNets found

--- a/test/obsolete/shooter-sh-2019/vnetwork/list-test.sh
+++ b/test/obsolete/shooter-sh-2019/vnetwork/list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 #for NAME in "${CONNECT_NAMES[@]}"
 #do
-        curl -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/vNet | json_pp &
+        curl -H "${AUTH}" -sX GET http://$TUMBLEBUG_IP:1323/tumblebug/ns/${NS_ID}/resources/vNet | json_pp &
 #done

--- a/test/obsolete/shooter-sh-2019/vnetwork/spider-create-test.sh
+++ b/test/obsolete/shooter-sh-2019/vnetwork/spider-create-test.sh
@@ -3,6 +3,6 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"cb-vnet"}' |json_pp &
+        curl -H "${AUTH}" -sX POST http://$RESTSERVER:1024/vpc?connection_name=${NAME} -H 'Content-Type: application/json' -d '{"Name":"cb-vnet"}' |json_pp &
 done
 

--- a/test/obsolete/shooter-sh-2019/vnetwork/spider-delete-test.sh
+++ b/test/obsolete/shooter-sh-2019/vnetwork/spider-delete-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
         ID=cb-vnet
-        curl -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX DELETE http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 done
 

--- a/test/obsolete/shooter-sh-2019/vnetwork/spider-get-test.sh
+++ b/test/obsolete/shooter-sh-2019/vnetwork/spider-get-test.sh
@@ -4,6 +4,6 @@ source ../setup.env
 for NAME in "${CONNECT_NAMES[@]}"
 do
         ID=cb-vnet
-        curl -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc/${ID}?connection_name=${NAME} |json_pp &
 done
 

--- a/test/obsolete/shooter-sh-2019/vnetwork/spider-list-test.sh
+++ b/test/obsolete/shooter-sh-2019/vnetwork/spider-list-test.sh
@@ -3,5 +3,5 @@ source ../setup.env
 
 for NAME in "${CONNECT_NAMES[@]}"
 do
-        curl -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp &
+        curl -H "${AUTH}" -sX GET http://$RESTSERVER:1024/vpc?connection_name=${NAME} |json_pp &
 done

--- a/test/official/0.settingSpider/get-cloud.sh
+++ b/test/official/0.settingSpider/get-cloud.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source ../conf.env
 source ../credentials.conf
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 0. Get Cloud Connction Config"
@@ -30,17 +31,17 @@ fi
 RESTSERVER=localhost
 
 # for Cloud Connection Config Info
-curl -sX GET http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | json_pp
 
 
 # for Cloud Region Info
-curl -sX GET http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]} | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]} | json_pp
 
 
 # for Cloud Credential Info
-curl -sX GET http://$SpiderServer/spider/credential/${CredentialName[INDEX]} | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/credential/${CredentialName[INDEX]} | json_pp
 
  
 # for Cloud Driver Info
-curl -sX GET http://$SpiderServer/spider/driver/${DriverName[INDEX]} | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/driver/${DriverName[INDEX]} | json_pp
 

--- a/test/official/0.settingSpider/list-cloud.sh
+++ b/test/official/0.settingSpider/list-cloud.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source ../conf.env
 source ../credentials.conf
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 0. List Cloud Connction Config(s)"
@@ -12,16 +13,16 @@ echo "####################################################################"
 RESTSERVER=localhost
 
 # for Cloud Connection Config Info
-curl -sX GET http://$SpiderServer/spider/connectionconfig | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/connectionconfig | json_pp
 
 
 # for Cloud Region Info
-curl -sX GET http://$SpiderServer/spider/region | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/region | json_pp
 
 
 # for Cloud Credential Info
-curl -sX GET http://$SpiderServer/spider/credential | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/credential | json_pp
 
  
 # for Cloud Driver Info
-curl -sX GET http://$SpiderServer/spider/driver | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/driver | json_pp

--- a/test/official/0.settingSpider/register-cloud.sh
+++ b/test/official/0.settingSpider/register-cloud.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source ../conf.env
 source ../credentials.conf
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 0. Create Cloud Connction Config"
@@ -30,7 +31,7 @@ fi
 RESTSERVER=localhost
 
  # for Cloud Driver Info
-curl -sX POST http://$SpiderServer/spider/driver -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/driver -H 'Content-Type: application/json' -d \
 	'{
         "ProviderName" : "'${ProviderName[INDEX]}'",
         "DriverLibFileName" : "'${DriverLibFileName[INDEX]}'",
@@ -38,7 +39,7 @@ curl -sX POST http://$SpiderServer/spider/driver -H 'Content-Type: application/j
 	}' | json_pp
 
  # for Cloud Credential Info
-curl -sX POST http://$SpiderServer/spider/credential -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/credential -H 'Content-Type: application/json' -d \
     "{
         \"ProviderName\" : \"${ProviderName[INDEX]}\",
         \"CredentialName\" : \"${CredentialName[INDEX]}\",
@@ -66,7 +67,7 @@ curl -sX POST http://$SpiderServer/spider/credential -H 'Content-Type: applicati
 
 if [ "${CSP}" == "azure" ]; then
     # Differenciate Cloud Region Value for Resource Group Name
-	curl -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d \
     '{
         "ProviderName" : "'${ProviderName[INDEX]}'",
         "KeyValueInfoList" : [
@@ -82,7 +83,7 @@ if [ "${CSP}" == "azure" ]; then
         "RegionName" : "'${RegionName[$INDEX,$REGION]}'"
     }' | json_pp
 else
-curl -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d \
     '{
         "ProviderName" : "'${ProviderName[INDEX]}'",
         "KeyValueInfoList" : [
@@ -101,7 +102,7 @@ fi
 
 
  # for Cloud Connection Config Info
-curl -sX POST http://$SpiderServer/spider/connectionconfig -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/connectionconfig -H 'Content-Type: application/json' -d \
     '{
         "CredentialName" : "'${CredentialName[INDEX]}'",
         "ConfigName" : "'${CONN_CONFIG[$INDEX,$REGION]}'",

--- a/test/official/0.settingSpider/unregister-cloud.sh
+++ b/test/official/0.settingSpider/unregister-cloud.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 source ../conf.env
 source ../credentials.conf
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 0. Remove All Cloud Connction Config(s)"
@@ -32,10 +33,10 @@ OPTION=${4:-none}
 RESTSERVER=localhost
 
 # for Cloud Connection Config Info
-curl -sX DELETE http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]}
+curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]}
 
 # for Cloud Region Info
-curl -sX DELETE http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]}
+curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]}
 
 if [ "${OPTION}" == "leave" ]; then
 	echo "[Leave Cloud Credential and Cloud Driver for other Regions]"
@@ -43,7 +44,7 @@ if [ "${OPTION}" == "leave" ]; then
 fi
 
 # for Cloud Credential Info
-curl -sX DELETE http://$SpiderServer/spider/credential/${CredentialName[INDEX]}
+curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/credential/${CredentialName[INDEX]}
  
 # for Cloud Driver Info
-curl -sX DELETE http://$SpiderServer/spider/driver/${DriverName[INDEX]}
+curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/driver/${DriverName[INDEX]}

--- a/test/official/0.settingTB/create-ns.sh
+++ b/test/official/0.settingTB/create-ns.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 0. Namespace: Create"
@@ -8,7 +9,7 @@ echo "####################################################################"
 
 INDEX=${1}
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns -H 'Content-Type: application/json' -d \
 	'{
 		"name": "'$NS_ID'",
 		"description": "NameSpace for General Testing"

--- a/test/official/0.settingTB/delete-ns.sh
+++ b/test/official/0.settingTB/delete-ns.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 0. Namespace: Delete"
@@ -8,4 +9,4 @@ echo "####################################################################"
 
 INDEX=${1}
 
-curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID | json_pp #|| return 1
+curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID | json_pp #|| return 1

--- a/test/official/0.settingTB/get-ns.sh
+++ b/test/official/0.settingTB/get-ns.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 0. Namespace: Get"
@@ -8,4 +9,4 @@ echo "####################################################################"
 
 INDEX=${1}
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID | json_pp #|| return 1
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID | json_pp #|| return 1

--- a/test/official/0.settingTB/list-ns.sh
+++ b/test/official/0.settingTB/list-ns.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 0. Namespace: List"
@@ -8,4 +9,4 @@ echo "####################################################################"
 
 INDEX=${1}
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns | json_pp #|| return 1
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns | json_pp #|| return 1

--- a/test/official/1.vNet/create-vNet.sh
+++ b/test/official/1.vNet/create-vNet.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 1. vpc: Create"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
 	'{
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",

--- a/test/official/1.vNet/delete-vNet.sh
+++ b/test/official/1.vNet/delete-vNet.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 1. vpc: Delete"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/1.vNet/get-vNet.sh
+++ b/test/official/1.vNet/get-vNet.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 1. vpc: Get"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/1.vNet/list-vNet.sh
+++ b/test/official/1.vNet/list-vNet.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 1. VPC: Get"
 echo "####################################################################"
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet | json_pp #|| return 1
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet | json_pp #|| return 1
 

--- a/test/official/1.vNet/spider-get-vNet.sh
+++ b/test/official/1.vNet/spider-get-vNet.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 CSP=${1}
 REGION=${2:-1}
@@ -23,4 +24,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp

--- a/test/official/2.securityGroup/create-securityGroup.sh
+++ b/test/official/2.securityGroup/create-securityGroup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 2. SecurityGroup: Create"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
 	'{
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",

--- a/test/official/2.securityGroup/delete-securityGroup.sh
+++ b/test/official/2.securityGroup/delete-securityGroup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 2. SecurityGroup: Delete"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/2.securityGroup/get-securityGroup.sh
+++ b/test/official/2.securityGroup/get-securityGroup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 2. SecurityGroup: Get"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/2.securityGroup/list-securityGroup.sh
+++ b/test/official/2.securityGroup/list-securityGroup.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 2. SecurityGroup: List"
 echo "####################################################################"
 
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup | json_pp #|| return 1
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup | json_pp #|| return 1
 

--- a/test/official/2.securityGroup/spider-get-securityGroup.sh
+++ b/test/official/2.securityGroup/spider-get-securityGroup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 CSP=${1}
 REGION=${2:-1}
@@ -24,4 +25,4 @@ else
 fi
 
 
-curl -sX GET http://$SpiderServer/spider/securitygroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/securitygroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp

--- a/test/official/3.sshKey/create-sshKey.sh
+++ b/test/official/3.sshKey/create-sshKey.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 3. sshKey: Create"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'", 

--- a/test/official/3.sshKey/delete-sshKey.sh
+++ b/test/official/3.sshKey/delete-sshKey.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 3. sshKey: Delete"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/3.sshKey/get-sshKey.sh
+++ b/test/official/3.sshKey/get-sshKey.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 3. sshKey: Get"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/3.sshKey/list-sshKey.sh
+++ b/test/official/3.sshKey/list-sshKey.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 3. sshKey: List"
 echo "####################################################################"
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/3.sshKey/spider-delete-sshKey.sh
+++ b/test/official/3.sshKey/spider-delete-sshKey.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 CSP=${1}
 REGION=${2:-1}
@@ -24,7 +25,7 @@ else
 fi
 
 
-curl -sX DELETE http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/3.sshKey/spider-get-sshKey.sh
+++ b/test/official/3.sshKey/spider-get-sshKey.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 CSP=${1}
 REGION=${2:-1}
@@ -24,7 +25,7 @@ else
 fi
 
 
-curl -sX GET http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/4.image/(notWorking)registerImageWithId.sh
+++ b/test/official/4.image/(notWorking)registerImageWithId.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 4. image: Register"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithId -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithId -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/4.image/get-image.sh
+++ b/test/official/4.image/get-image.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 4. image: Get"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/4.image/list-image.sh
+++ b/test/official/4.image/list-image.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 4. image: List"
 echo "####################################################################"
 
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image | json_pp #|| return 1
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image | json_pp #|| return 1

--- a/test/official/4.image/registerImageWithInfo.sh
+++ b/test/official/4.image/registerImageWithInfo.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 4. image: Register"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/4.image/unregister-image.sh
+++ b/test/official/4.image/unregister-image.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 4. image: Unregister"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/5.spec/fetch-specs.sh
+++ b/test/official/5.spec/fetch-specs.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: Fetch"
 echo "####################################################################"
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/fetchSpecs | json_pp #|| return 1
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/fetchSpecs | json_pp #|| return 1

--- a/test/official/5.spec/get-spec.sh
+++ b/test/official/5.spec/get-spec.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: Get"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/5.spec/list-spec.sh
+++ b/test/official/5.spec/list-spec.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: List"
 echo "####################################################################"
 
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec | json_pp #|| return 1
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec | json_pp #|| return 1

--- a/test/official/5.spec/lookupSpec.sh
+++ b/test/official/5.spec/lookupSpec.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: Lookup Spec"
@@ -28,7 +29,7 @@ else
 fi
 
 
-curl -sX GET http://$TumblebugServer/tumblebug/lookupSpec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
 	}' | json_pp #|| return 1

--- a/test/official/5.spec/lookupSpecList.sh
+++ b/test/official/5.spec/lookupSpecList.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: Lookup Spec List"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
 	}' | json_pp #|| return 1

--- a/test/official/5.spec/register-spec.sh
+++ b/test/official/5.spec/register-spec.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: Register"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d \
 	'{ 
 		"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/5.spec/spider-get-spec.sh
+++ b/test/official/5.spec/spider-get-spec.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: Fetch"
@@ -27,5 +28,5 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$SpiderServer/spider/vmspec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmspec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
 

--- a/test/official/5.spec/spider-get-speclist.sh
+++ b/test/official/5.spec/spider-get-speclist.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: Fetch"
@@ -27,5 +28,5 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$SpiderServer/spider/vmspec -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmspec -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
 

--- a/test/official/5.spec/unregister-spec.sh
+++ b/test/official/5.spec/unregister-spec.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 5. spec: Unregister"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp #|| return 1

--- a/test/official/6.mcis/create-mcis.sh
+++ b/test/official/6.mcis/create-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. vm: Create MCIS"
@@ -27,7 +28,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis -H 'Content-Type: application/json' -d \
 	'{
 		"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 		"description": "Tumblebug Demo",

--- a/test/official/6.mcis/get-mcis.sh
+++ b/test/official/6.mcis/get-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. VM: Get MCIS"
@@ -27,4 +28,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp

--- a/test/official/6.mcis/just-terminate-mcis.sh
+++ b/test/official/6.mcis/just-terminate-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. VM: Just Terminate MCIS"
@@ -27,4 +28,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=terminate | json_pp
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=terminate | json_pp

--- a/test/official/6.mcis/list-mcis.sh
+++ b/test/official/6.mcis/list-mcis.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. VM: List MCIS"
 echo "####################################################################"
 
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis | json_pp
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis | json_pp

--- a/test/official/6.mcis/reboot-mcis.sh
+++ b/test/official/6.mcis/reboot-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. VM: Reboot MCIS"
@@ -27,4 +28,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=reboot | json_pp
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=reboot | json_pp

--- a/test/official/6.mcis/resume-mcis.sh
+++ b/test/official/6.mcis/resume-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. VM: Resume from suspended MCIS"
@@ -28,4 +29,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=resume | json_pp
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=resume | json_pp

--- a/test/official/6.mcis/spider-create-vm.sh
+++ b/test/official/6.mcis/spider-create-vm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 CSP=${1}
 REGION=${2:-1}
@@ -23,7 +24,7 @@ else
 	INDEX=1
 fi
 
-curl -sX POST http://$SpiderServer/spider/vm -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/vm -H 'Content-Type: application/json' -d \
 	'{ 
 		"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 		"ReqInfo": { 

--- a/test/official/6.mcis/spider-delete-vm.sh
+++ b/test/official/6.mcis/spider-delete-vm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 CSP=${1}
 REGION=${2:-1}
@@ -22,8 +23,8 @@ else
 	CSP="aws"
 	INDEX=1
 fi
-#curl -sX DELETE http://$SpiderServer/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H
-curl -sX DELETE http://$SpiderServer/spider/vm/alibaba-ap-northeast-1-shson-01 -H 'Content-Type: application/json' -d \
+#curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H
+curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vm/alibaba-ap-northeast-1-shson-01 -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/6.mcis/spider-get-vm.sh
+++ b/test/official/6.mcis/spider-get-vm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 CSP=${1}
 REGION=${2:-1}
@@ -23,7 +24,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$SpiderServer/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01 -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01 -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/6.mcis/spider-get-vmstatus.sh
+++ b/test/official/6.mcis/spider-get-vmstatus.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 CSP=${1}
 REGION=${2:-1}
@@ -23,7 +24,7 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$SpiderServer/spider/vmstatus/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01 -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmstatus/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01 -H 'Content-Type: application/json' -d \
     '{ 
         "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
     }' | json_pp

--- a/test/official/6.mcis/status-mcis.sh
+++ b/test/official/6.mcis/status-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. VM: Status MCIS"
@@ -28,4 +29,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=status | json_pp
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=status | json_pp

--- a/test/official/6.mcis/suspend-mcis.sh
+++ b/test/official/6.mcis/suspend-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. VM: Suspend MCIS"
@@ -28,4 +29,4 @@ else
 	INDEX=1
 fi
 
-curl -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=suspend | json_pp
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=suspend | json_pp

--- a/test/official/6.mcis/terminate-and-delete-mcis.sh
+++ b/test/official/6.mcis/terminate-and-delete-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. VM: Terminate and Delete MCIS"
@@ -27,5 +28,5 @@ else
 	INDEX=1
 fi
 
-curl -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp || return 1
+curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp || return 1
 

--- a/test/official/conf.env
+++ b/test/official/conf.env
@@ -3,7 +3,9 @@
 SpiderServer=localhost:1024
 # CB-Tumblebug API Server
 TumblebugServer=localhost:1323
-
+# API BasicAuth Header
+ApiUsername=default-api-username
+ApiPassword=default-api-password
 
 ## NS_ID for Tumblebug
 NS_ID=NS-01

--- a/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
@@ -13,6 +13,7 @@ function dozing()
 }
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 source ../credentials.conf
 
 echo "####################################################################"

--- a/test/official/sequentialFullTest/command-mcis.sh
+++ b/test/official/sequentialFullTest/command-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS "
@@ -28,7 +29,7 @@ else
 fi
 
 MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 	'{
 		"command": "echo -n [CMD] Works! [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname ; echo -n ]"
 	}' | json_pp #|| return 1

--- a/test/official/sequentialFullTest/deploy-nginx-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-nginx-mcis.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS "
@@ -29,7 +30,7 @@ fi
 
 MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
 
-curl -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 	'{
 		"command": "wget https://gist.githubusercontent.com/seokho-son/92f757bd4caf50127803833787b5a77d/raw/4f6ced2d04c05910f444af4f202bcef475db73ce/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
 	}' | json_pp #|| return 1

--- a/test/official/sequentialFullTest/test-cloud.sh
+++ b/test/official/sequentialFullTest/test-cloud.sh
@@ -13,6 +13,7 @@ function dozing()
 }
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 source ../credentials.conf
 
 echo "####################################################################"

--- a/test/official/sequentialFullTest/test-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/test-mcir-ns-cloud.sh
@@ -13,6 +13,7 @@ function dozing()
 }
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 source ../credentials.conf
 
 echo "####################################################################"

--- a/test/official/sequentialFullTest/test-ns-cloud.sh
+++ b/test/official/sequentialFullTest/test-ns-cloud.sh
@@ -13,6 +13,7 @@ function dozing()
 }
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 source ../credentials.conf
 
 echo "####################################################################"

--- a/test/official/sequentialFullTest/testAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/testAll-mcis-mcir-ns-cloud.sh
@@ -13,6 +13,7 @@ function dozing()
 }
 
 source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 source ../credentials.conf
 
 echo "####################################################################"


### PR DESCRIPTION
This PR adds and applies BasicAuth for all REST API resources.

With this PR, rest api client needs to include "username" and "password" to each API header to be authorized.

The header "KEY: VAL" is "Authorization: Basic {base64 encoded $USERNAME:$PASSWORD}".
( "Authorization: Basic $(echo -n $USERNAME:$PASSWORD| base64)" )

The default values for username and password are given in the configuration file (conf/setup.env).

All test scripts also includes "Authorization" header. 
The value for Authorization is generated by test/official/conf.env (ApiUsername, ApiPassword).


**Values for "API_USERNAME" and "API_PASSWORD" in conf/setup.en would better to identical with
Values for "ApiUsername" and "ApiPassword" in test/official/conf.env.**
