### PR TITLE
Update Swagger annotations for MCIS/VM REST functions

### DIFF
--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -345,13 +345,22 @@ var doc = `{
                         "name": "mcisId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Host IP address to benchmark",
+                        "name": "hostIP",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/mcis.RestGetBenchmarkRequest"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.BenchmarkInfoArray"
                         }
                     },
                     "404": {
@@ -451,12 +460,19 @@ var doc = `{
                         "required": true
                     },
                     {
-                        "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCIS Command Request",
+                        "name": "mcisCmdReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.McisCmdReq"
                         }
                     }
                 ],
@@ -464,7 +480,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.RestPostCmdMcisResponseWrapper"
                         }
                     },
                     "404": {
@@ -504,12 +520,26 @@ var doc = `{
                         "required": true
                     },
                     {
-                        "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCIS Command Request",
+                        "name": "mcisCmdReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.McisCmdReq"
                         }
                     }
                 ],
@@ -517,7 +547,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.RestPostCmdMcisVmResponse"
                         }
                     },
                     "404": {
@@ -557,12 +587,19 @@ var doc = `{
                         "required": true
                     },
                     {
-                        "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCIS Command Request",
+                        "name": "mcisCmdReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.McisCmdReq"
                         }
                     }
                 ],
@@ -570,7 +607,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.AgentInstallContentWrapper"
                         }
                     },
                     "404": {
@@ -742,11 +779,11 @@ var doc = `{
                     },
                     {
                         "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "name": "mcisRecommendReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.McisRecommendReq"
                         }
                     }
                 ],
@@ -754,7 +791,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.RestPostMcisRecommandResponse"
                         }
                     },
                     "404": {
@@ -888,6 +925,13 @@ var doc = `{
                         "required": true
                     },
                     {
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
                         "description": "Details for an VM object",
                         "name": "vmReq",
                         "in": "body",
@@ -901,7 +945,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.TbVmInfo"
                         }
                     },
                     "404": {
@@ -946,13 +990,20 @@ var doc = `{
                         "name": "mcisId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.TbVmInfo"
                         }
                     },
                     "404": {
@@ -993,6 +1044,13 @@ var doc = `{
                         "type": "string",
                         "description": "MCIS ID",
                         "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VM ID",
+                        "name": "vmId",
                         "in": "path",
                         "required": true
                     }
@@ -2407,7 +2465,6 @@ var doc = `{
                     "type": "string"
                 },
                 "vcpu": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.SpiderVCpuInfo"
                 }
             }
@@ -2428,7 +2485,6 @@ var doc = `{
             "properties": {
                 "iid": {
                     "description": "{NameId, SystemId}",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "ipv4_CIDR": {
@@ -2790,6 +2846,34 @@ var doc = `{
                 }
             }
         },
+        "mcis.AgentInstallContent": {
+            "type": "object",
+            "properties": {
+                "mcis_id": {
+                    "type": "string"
+                },
+                "result": {
+                    "type": "string"
+                },
+                "vm_id": {
+                    "type": "string"
+                },
+                "vm_ip": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.AgentInstallContentWrapper": {
+            "type": "object",
+            "properties": {
+                "result_array": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.AgentInstallContent"
+                    }
+                }
+            }
+        },
         "mcis.BenchmarkInfo": {
             "type": "object",
             "properties": {
@@ -2848,6 +2932,52 @@ var doc = `{
                 }
             }
         },
+        "mcis.McisCmdReq": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "ip": {
+                    "type": "string"
+                },
+                "mcis_id": {
+                    "type": "string"
+                },
+                "ssh_key": {
+                    "type": "string"
+                },
+                "user_name": {
+                    "type": "string"
+                },
+                "vm_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.McisRecommendReq": {
+            "type": "object",
+            "properties": {
+                "max_result_num": {
+                    "type": "string"
+                },
+                "placement_algo": {
+                    "type": "string"
+                },
+                "placement_param": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "vm_req": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.TbVmRecommendReq"
+                    }
+                }
+            }
+        },
         "mcis.RegionInfo": {
             "type": "object",
             "properties": {
@@ -2878,23 +3008,85 @@ var doc = `{
                 }
             }
         },
+        "mcis.RestGetBenchmarkRequest": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.RestPostCmdMcisResponse": {
+            "type": "object",
+            "properties": {
+                "mcis_id": {
+                    "type": "string"
+                },
+                "result": {
+                    "type": "string"
+                },
+                "vm_id": {
+                    "type": "string"
+                },
+                "vm_ip": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.RestPostCmdMcisResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "result_array": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.RestPostCmdMcisResponse"
+                    }
+                }
+            }
+        },
+        "mcis.RestPostCmdMcisVmResponse": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.RestPostMcisRecommandResponse": {
+            "type": "object",
+            "properties": {
+                "placement_algo": {
+                    "type": "string"
+                },
+                "placement_param": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "vm_recommend": {
+                    "description": "Vm_req          []TbVmRecommendReq    ` + "`" + `json:\"vm_req\"` + "`" + `",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.TbVmRecommendInfo"
+                    }
+                }
+            }
+        },
         "mcis.SpiderVMInfo": {
             "type": "object",
             "properties": {
                 "iid": {
                     "description": "Fields for response",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "imageIId": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "imageName": {
                     "type": "string"
                 },
                 "keyPairIId": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "keyPairName": {
@@ -2928,7 +3120,6 @@ var doc = `{
                 },
                 "region": {
                     "description": "ex) {us-east1, us-east1-c} or {ap-northeast-2}",
-                    "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
                 "securityGroupIIds": {
@@ -2950,7 +3141,6 @@ var doc = `{
                 },
                 "subnetIID": {
                     "description": "AWS, ex) subnet-8c4a53e4",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "subnetName": {
@@ -2976,7 +3166,6 @@ var doc = `{
                     "type": "string"
                 },
                 "vpcIID": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "vpcname": {
@@ -3043,7 +3232,6 @@ var doc = `{
                     "type": "string"
                 },
                 "cspViewVmDetail": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.SpiderVMInfo"
                 },
                 "description": {
@@ -3056,7 +3244,6 @@ var doc = `{
                     "type": "string"
                 },
                 "location": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.GeoLocation"
                 },
                 "name": {
@@ -3076,7 +3263,6 @@ var doc = `{
                 },
                 "region": {
                     "description": "2. Provided by CB-Spider",
-                    "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
                 "securityGroupIds": {
@@ -3118,6 +3304,69 @@ var doc = `{
                     "type": "string"
                 },
                 "vmUserPassword": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.TbVmPriority": {
+            "type": "object",
+            "properties": {
+                "priority": {
+                    "type": "string"
+                },
+                "vm_spec": {
+                    "$ref": "#/definitions/mcir.TbSpecInfo"
+                }
+            }
+        },
+        "mcis.TbVmRecommendInfo": {
+            "type": "object",
+            "properties": {
+                "placement_algo": {
+                    "type": "string"
+                },
+                "placement_param": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "vm_priority": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.TbVmPriority"
+                    }
+                },
+                "vm_req": {
+                    "$ref": "#/definitions/mcis.TbVmRecommendReq"
+                }
+            }
+        },
+        "mcis.TbVmRecommendReq": {
+            "type": "object",
+            "properties": {
+                "disk_size": {
+                    "type": "string"
+                },
+                "max_result_num": {
+                    "type": "string"
+                },
+                "memory_size": {
+                    "type": "string"
+                },
+                "placement_algo": {
+                    "type": "string"
+                },
+                "placement_param": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "request_name": {
+                    "type": "string"
+                },
+                "vcpu_size": {
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -330,13 +330,22 @@
                         "name": "mcisId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "description": "Host IP address to benchmark",
+                        "name": "hostIP",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/mcis.RestGetBenchmarkRequest"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.BenchmarkInfoArray"
                         }
                     },
                     "404": {
@@ -436,12 +445,19 @@
                         "required": true
                     },
                     {
-                        "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCIS Command Request",
+                        "name": "mcisCmdReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.McisCmdReq"
                         }
                     }
                 ],
@@ -449,7 +465,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.RestPostCmdMcisResponseWrapper"
                         }
                     },
                     "404": {
@@ -489,12 +505,26 @@
                         "required": true
                     },
                     {
-                        "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCIS Command Request",
+                        "name": "mcisCmdReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.McisCmdReq"
                         }
                     }
                 ],
@@ -502,7 +532,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.RestPostCmdMcisVmResponse"
                         }
                     },
                     "404": {
@@ -542,12 +572,19 @@
                         "required": true
                     },
                     {
-                        "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCIS Command Request",
+                        "name": "mcisCmdReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.McisCmdReq"
                         }
                     }
                 ],
@@ -555,7 +592,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.AgentInstallContentWrapper"
                         }
                     },
                     "404": {
@@ -727,11 +764,11 @@
                     },
                     {
                         "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "name": "mcisRecommendReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.McisRecommendReq"
                         }
                     }
                 ],
@@ -739,7 +776,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.RestPostMcisRecommandResponse"
                         }
                     },
                     "404": {
@@ -873,6 +910,13 @@
                         "required": true
                     },
                     {
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
                         "description": "Details for an VM object",
                         "name": "vmReq",
                         "in": "body",
@@ -886,7 +930,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.TbVmInfo"
                         }
                     },
                     "404": {
@@ -931,13 +975,20 @@
                         "name": "mcisId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.TbVmInfo"
                         }
                     },
                     "404": {
@@ -978,6 +1029,13 @@
                         "type": "string",
                         "description": "MCIS ID",
                         "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VM ID",
+                        "name": "vmId",
                         "in": "path",
                         "required": true
                     }
@@ -2392,7 +2450,6 @@
                     "type": "string"
                 },
                 "vcpu": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.SpiderVCpuInfo"
                 }
             }
@@ -2413,7 +2470,6 @@
             "properties": {
                 "iid": {
                     "description": "{NameId, SystemId}",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "ipv4_CIDR": {
@@ -2775,6 +2831,34 @@
                 }
             }
         },
+        "mcis.AgentInstallContent": {
+            "type": "object",
+            "properties": {
+                "mcis_id": {
+                    "type": "string"
+                },
+                "result": {
+                    "type": "string"
+                },
+                "vm_id": {
+                    "type": "string"
+                },
+                "vm_ip": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.AgentInstallContentWrapper": {
+            "type": "object",
+            "properties": {
+                "result_array": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.AgentInstallContent"
+                    }
+                }
+            }
+        },
         "mcis.BenchmarkInfo": {
             "type": "object",
             "properties": {
@@ -2833,6 +2917,52 @@
                 }
             }
         },
+        "mcis.McisCmdReq": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "ip": {
+                    "type": "string"
+                },
+                "mcis_id": {
+                    "type": "string"
+                },
+                "ssh_key": {
+                    "type": "string"
+                },
+                "user_name": {
+                    "type": "string"
+                },
+                "vm_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.McisRecommendReq": {
+            "type": "object",
+            "properties": {
+                "max_result_num": {
+                    "type": "string"
+                },
+                "placement_algo": {
+                    "type": "string"
+                },
+                "placement_param": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "vm_req": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.TbVmRecommendReq"
+                    }
+                }
+            }
+        },
         "mcis.RegionInfo": {
             "type": "object",
             "properties": {
@@ -2863,23 +2993,85 @@
                 }
             }
         },
+        "mcis.RestGetBenchmarkRequest": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.RestPostCmdMcisResponse": {
+            "type": "object",
+            "properties": {
+                "mcis_id": {
+                    "type": "string"
+                },
+                "result": {
+                    "type": "string"
+                },
+                "vm_id": {
+                    "type": "string"
+                },
+                "vm_ip": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.RestPostCmdMcisResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "result_array": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.RestPostCmdMcisResponse"
+                    }
+                }
+            }
+        },
+        "mcis.RestPostCmdMcisVmResponse": {
+            "type": "object",
+            "properties": {
+                "result": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.RestPostMcisRecommandResponse": {
+            "type": "object",
+            "properties": {
+                "placement_algo": {
+                    "type": "string"
+                },
+                "placement_param": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "vm_recommend": {
+                    "description": "Vm_req          []TbVmRecommendReq    `json:\"vm_req\"`",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.TbVmRecommendInfo"
+                    }
+                }
+            }
+        },
         "mcis.SpiderVMInfo": {
             "type": "object",
             "properties": {
                 "iid": {
                     "description": "Fields for response",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "imageIId": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "imageName": {
                     "type": "string"
                 },
                 "keyPairIId": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "keyPairName": {
@@ -2913,7 +3105,6 @@
                 },
                 "region": {
                     "description": "ex) {us-east1, us-east1-c} or {ap-northeast-2}",
-                    "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
                 "securityGroupIIds": {
@@ -2935,7 +3126,6 @@
                 },
                 "subnetIID": {
                     "description": "AWS, ex) subnet-8c4a53e4",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "subnetName": {
@@ -2961,7 +3151,6 @@
                     "type": "string"
                 },
                 "vpcIID": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "vpcname": {
@@ -3028,7 +3217,6 @@
                     "type": "string"
                 },
                 "cspViewVmDetail": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.SpiderVMInfo"
                 },
                 "description": {
@@ -3041,7 +3229,6 @@
                     "type": "string"
                 },
                 "location": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.GeoLocation"
                 },
                 "name": {
@@ -3061,7 +3248,6 @@
                 },
                 "region": {
                     "description": "2. Provided by CB-Spider",
-                    "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
                 "securityGroupIds": {
@@ -3103,6 +3289,69 @@
                     "type": "string"
                 },
                 "vmUserPassword": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.TbVmPriority": {
+            "type": "object",
+            "properties": {
+                "priority": {
+                    "type": "string"
+                },
+                "vm_spec": {
+                    "$ref": "#/definitions/mcir.TbSpecInfo"
+                }
+            }
+        },
+        "mcis.TbVmRecommendInfo": {
+            "type": "object",
+            "properties": {
+                "placement_algo": {
+                    "type": "string"
+                },
+                "placement_param": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "vm_priority": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.TbVmPriority"
+                    }
+                },
+                "vm_req": {
+                    "$ref": "#/definitions/mcis.TbVmRecommendReq"
+                }
+            }
+        },
+        "mcis.TbVmRecommendReq": {
+            "type": "object",
+            "properties": {
+                "disk_size": {
+                    "type": "string"
+                },
+                "max_result_num": {
+                    "type": "string"
+                },
+                "memory_size": {
+                    "type": "string"
+                },
+                "placement_algo": {
+                    "type": "string"
+                },
+                "placement_param": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "request_name": {
+                    "type": "string"
+                },
+                "vcpu_size": {
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -129,7 +129,6 @@ definitions:
         type: string
       vcpu:
         $ref: '#/definitions/mcir.SpiderVCpuInfo'
-        type: object
     type: object
   mcir.SpiderSpecList:
     properties:
@@ -143,7 +142,6 @@ definitions:
       iid:
         $ref: '#/definitions/common.IID'
         description: '{NameId, SystemId}'
-        type: object
       ipv4_CIDR:
         type: string
       keyValueList:
@@ -380,6 +378,24 @@ definitions:
           $ref: '#/definitions/mcir.SpiderSubnetReqInfo'
         type: array
     type: object
+  mcis.AgentInstallContent:
+    properties:
+      mcis_id:
+        type: string
+      result:
+        type: string
+      vm_id:
+        type: string
+      vm_ip:
+        type: string
+    type: object
+  mcis.AgentInstallContentWrapper:
+    properties:
+      result_array:
+        items:
+          $ref: '#/definitions/mcis.AgentInstallContent'
+        type: array
+    type: object
   mcis.BenchmarkInfo:
     properties:
       desc:
@@ -418,6 +434,36 @@ definitions:
       nativeRegion:
         type: string
     type: object
+  mcis.McisCmdReq:
+    properties:
+      command:
+        type: string
+      ip:
+        type: string
+      mcis_id:
+        type: string
+      ssh_key:
+        type: string
+      user_name:
+        type: string
+      vm_id:
+        type: string
+    type: object
+  mcis.McisRecommendReq:
+    properties:
+      max_result_num:
+        type: string
+      placement_algo:
+        type: string
+      placement_param:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      vm_req:
+        items:
+          $ref: '#/definitions/mcis.TbVmRecommendReq'
+        type: array
+    type: object
   mcis.RegionInfo:
     properties:
       region:
@@ -437,20 +483,59 @@ definitions:
           $ref: '#/definitions/mcis.TbMcisInfo'
         type: array
     type: object
+  mcis.RestGetBenchmarkRequest:
+    properties:
+      host:
+        type: string
+    type: object
+  mcis.RestPostCmdMcisResponse:
+    properties:
+      mcis_id:
+        type: string
+      result:
+        type: string
+      vm_id:
+        type: string
+      vm_ip:
+        type: string
+    type: object
+  mcis.RestPostCmdMcisResponseWrapper:
+    properties:
+      result_array:
+        items:
+          $ref: '#/definitions/mcis.RestPostCmdMcisResponse'
+        type: array
+    type: object
+  mcis.RestPostCmdMcisVmResponse:
+    properties:
+      result:
+        type: string
+    type: object
+  mcis.RestPostMcisRecommandResponse:
+    properties:
+      placement_algo:
+        type: string
+      placement_param:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      vm_recommend:
+        description: Vm_req          []TbVmRecommendReq    `json:"vm_req"`
+        items:
+          $ref: '#/definitions/mcis.TbVmRecommendInfo'
+        type: array
+    type: object
   mcis.SpiderVMInfo:
     properties:
       iid:
         $ref: '#/definitions/common.IID'
         description: Fields for response
-        type: object
       imageIId:
         $ref: '#/definitions/common.IID'
-        type: object
       imageName:
         type: string
       keyPairIId:
         $ref: '#/definitions/common.IID'
-        type: object
       keyPairName:
         type: string
       keyValueList:
@@ -474,7 +559,6 @@ definitions:
       region:
         $ref: '#/definitions/mcis.RegionInfo'
         description: ex) {us-east1, us-east1-c} or {ap-northeast-2}
-        type: object
       securityGroupIIds:
         description: AWS, ex) sg-0b7452563e1121bb6
         items:
@@ -490,7 +574,6 @@ definitions:
       subnetIID:
         $ref: '#/definitions/common.IID'
         description: AWS, ex) subnet-8c4a53e4
-        type: object
       subnetName:
         type: string
       vmblockDisk:
@@ -509,7 +592,6 @@ definitions:
         type: string
       vpcIID:
         $ref: '#/definitions/common.IID'
-        type: object
       vpcname:
         type: string
     type: object
@@ -553,7 +635,6 @@ definitions:
         type: string
       cspViewVmDetail:
         $ref: '#/definitions/mcis.SpiderVMInfo'
-        type: object
       description:
         type: string
       id:
@@ -562,7 +643,6 @@ definitions:
         type: string
       location:
         $ref: '#/definitions/mcis.GeoLocation'
-        type: object
       name:
         type: string
       privateDNS:
@@ -576,7 +656,6 @@ definitions:
       region:
         $ref: '#/definitions/mcis.RegionInfo'
         description: 2. Provided by CB-Spider
-        type: object
       securityGroupIds:
         items:
           type: string
@@ -604,6 +683,47 @@ definitions:
       vmUserAccount:
         type: string
       vmUserPassword:
+        type: string
+    type: object
+  mcis.TbVmPriority:
+    properties:
+      priority:
+        type: string
+      vm_spec:
+        $ref: '#/definitions/mcir.TbSpecInfo'
+    type: object
+  mcis.TbVmRecommendInfo:
+    properties:
+      placement_algo:
+        type: string
+      placement_param:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      vm_priority:
+        items:
+          $ref: '#/definitions/mcis.TbVmPriority'
+        type: array
+      vm_req:
+        $ref: '#/definitions/mcis.TbVmRecommendReq'
+    type: object
+  mcis.TbVmRecommendReq:
+    properties:
+      disk_size:
+        type: string
+      max_result_num:
+        type: string
+      memory_size:
+        type: string
+      placement_algo:
+        type: string
+      placement_param:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      request_name:
+        type: string
+      vcpu_size:
         type: string
     type: object
   mcis.TbVmReq:
@@ -851,13 +971,19 @@ paths:
         name: mcisId
         required: true
         type: string
+      - description: Host IP address to benchmark
+        in: body
+        name: hostIP
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.RestGetBenchmarkRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.BenchmarkInfoArray'
         "404":
           description: Not Found
           schema:
@@ -920,19 +1046,24 @@ paths:
         name: nsId
         required: true
         type: string
-      - description: Details for an MCIS object
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: MCIS Command Request
         in: body
-        name: mcisInfo
+        name: mcisCmdReq
         required: true
         schema:
-          $ref: '#/definitions/mcir.TbSshKeyInfo'
+          $ref: '#/definitions/mcis.McisCmdReq'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.RestPostCmdMcisResponseWrapper'
         "404":
           description: Not Found
           schema:
@@ -955,19 +1086,29 @@ paths:
         name: nsId
         required: true
         type: string
-      - description: Details for an MCIS object
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
+      - description: MCIS Command Request
         in: body
-        name: mcisInfo
+        name: mcisCmdReq
         required: true
         schema:
-          $ref: '#/definitions/mcir.TbSshKeyInfo'
+          $ref: '#/definitions/mcis.McisCmdReq'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.RestPostCmdMcisVmResponse'
         "404":
           description: Not Found
           schema:
@@ -990,19 +1131,24 @@ paths:
         name: nsId
         required: true
         type: string
-      - description: Details for an MCIS object
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: MCIS Command Request
         in: body
-        name: mcisInfo
+        name: mcisCmdReq
         required: true
         schema:
-          $ref: '#/definitions/mcir.TbSshKeyInfo'
+          $ref: '#/definitions/mcis.McisCmdReq'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.AgentInstallContentWrapper'
         "404":
           description: Not Found
           schema:
@@ -1175,6 +1321,11 @@ paths:
         name: nsId
         required: true
         type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
       - description: Details for an VM object
         in: body
         name: vmReq
@@ -1187,7 +1338,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.TbVmInfo'
         "404":
           description: Not Found
           schema:
@@ -1213,6 +1364,11 @@ paths:
       - description: MCIS ID
         in: path
         name: mcisId
+        required: true
+        type: string
+      - description: VM ID
+        in: path
+        name: vmId
         required: true
         type: string
       produces:
@@ -1244,13 +1400,18 @@ paths:
         name: mcisId
         required: true
         type: string
+      - description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.TbVmInfo'
         "404":
           description: Not Found
           schema:
@@ -1275,17 +1436,17 @@ paths:
         type: string
       - description: Details for an MCIS object
         in: body
-        name: mcisInfo
+        name: mcisRecommendReq
         required: true
         schema:
-          $ref: '#/definitions/mcir.TbSshKeyInfo'
+          $ref: '#/definitions/mcis.McisRecommendReq'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.RestPostMcisRecommandResponse'
         "404":
           description: Not Found
           schema:


### PR DESCRIPTION
BTW,
in PR #199 by @seokho-son,
`"type": "object"` field is added for some structs.
But in this PR,
`"type": "object"` field will be removed from those structs.
I guess that this phenomenon may occur from using different version of `swag`.

- `swag` version in my dev env:
```
❯ swag -v
swag version v1.6.7
```

---

