### PR TITLE
Update to support Spider's force delete feature

### DIFF
--- a/src/mcir/common.go
+++ b/src/mcir/common.go
@@ -217,14 +217,14 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
 
 	if err != nil {
-		fmt.Println(err)
+		common.CBLog.Error(err)
+		return err
 	}
 
 	req.Header.Add("Content-Type", "application/json")
 	res, err := client.Do(req)
 	if err != nil {
 		common.CBLog.Error(err)
-		//return res.StatusCode, nil, err
 		return err
 	}
 	defer res.Body.Close()
@@ -233,7 +233,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	fmt.Println(string(body))
 	if err != nil {
 		common.CBLog.Error(err)
-		//return res.StatusCode, body, err
 		return err
 	}
 
@@ -246,10 +245,10 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 		}
 
 		// delete vNet info
-		cbStoreDeleteErr := common.CBStore.Delete(key)
-		if cbStoreDeleteErr != nil {
-			common.CBLog.Error(cbStoreDeleteErr)
-			return res, cbStoreDeleteErr
+		err := common.CBStore.Delete(key)
+		if err != nil {
+			common.CBLog.Error(err)
+			return res, err
 		}
 
 		return res, nil
@@ -258,11 +257,32 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	fmt.Println("HTTP Status code " + strconv.Itoa(res.StatusCode))
 	switch {
 	case forceFlag == "true":
-		cbStoreDeleteErr := common.CBStore.Delete(key)
-		if cbStoreDeleteErr != nil {
-			common.CBLog.Error(cbStoreDeleteErr)
-			//return res.StatusCode, body, cbStoreDeleteErr
-			return cbStoreDeleteErr
+		url += "?force=true"
+		fmt.Println("forceFlag == true; url: " + url)
+		req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
+		if err != nil {
+			common.CBLog.Error(err)
+			//return err
+		}
+		req.Header.Add("Content-Type", "application/json")
+		res, err := client.Do(req)
+		if err != nil {
+			common.CBLog.Error(err)
+			//return err
+		}
+		defer res.Body.Close()
+		body, err := ioutil.ReadAll(res.Body)
+		fmt.Println(string(body))
+		if err != nil {
+			common.CBLog.Error(err)
+			//return err
+		}
+
+		err = common.CBStore.Delete(key)
+		if err != nil {
+			common.CBLog.Error(err)
+			//return res.StatusCode, body, err
+			return err
 		}
 		//return res.StatusCode, body, nil
 		return nil
@@ -272,11 +292,11 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 		//return res.StatusCode, body, err
 		return err
 	default:
-		cbStoreDeleteErr := common.CBStore.Delete(key)
-		if cbStoreDeleteErr != nil {
-			common.CBLog.Error(cbStoreDeleteErr)
-			//return res.StatusCode, body, cbStoreDeleteErr
-			return cbStoreDeleteErr
+		err := common.CBStore.Delete(key)
+		if err != nil {
+			common.CBLog.Error(err)
+			//return res.StatusCode, body, err
+			return err
 		}
 		//return res.StatusCode, body, nil
 		return nil

--- a/src/mcir/obsolete/publicip.go
+++ b/src/mcir/obsolete/publicip.go
@@ -426,10 +426,10 @@ func delPublicIp(nsId string, Id string, forceFlag string) (int, []byte, error) 
 	fmt.Println("HTTP Status code " + strconv.Itoa(res.StatusCode))
 	switch {
 	case forceFlag == "true":
-		cbStoreDeleteErr := common.CBStore.Delete(key)
-		if cbStoreDeleteErr != nil {
-			common.CBLog.Error(cbStoreDeleteErr)
-			return res.StatusCode, body, cbStoreDeleteErr
+		err := common.CBStore.Delete(key)
+		if err != nil {
+			common.CBLog.Error(err)
+			return res.StatusCode, body, err
 		}
 		return res.StatusCode, body, nil
 	case res.StatusCode >= 400 || res.StatusCode < 200:
@@ -437,10 +437,10 @@ func delPublicIp(nsId string, Id string, forceFlag string) (int, []byte, error) 
 		common.CBLog.Error(err)
 		return res.StatusCode, body, err
 	default:
-		cbStoreDeleteErr := common.CBStore.Delete(key)
-		if cbStoreDeleteErr != nil {
-			common.CBLog.Error(cbStoreDeleteErr)
-			return res.StatusCode, body, cbStoreDeleteErr
+		err := common.CBStore.Delete(key)
+		if err != nil {
+			common.CBLog.Error(err)
+			return res.StatusCode, body, err
 		}
 		return res.StatusCode, body, nil
 	}

--- a/src/mcir/obsolete/vnic.go
+++ b/src/mcir/obsolete/vnic.go
@@ -482,10 +482,10 @@ func delVNic(nsId string, Id string, forceFlag string) (int, []byte, error) {
 	fmt.Println("HTTP Status code " + strconv.Itoa(res.StatusCode))
 	switch {
 	case forceFlag == "true":
-		cbStoreDeleteErr := common.CBStore.Delete(key)
-		if cbStoreDeleteErr != nil {
-			common.CBLog.Error(cbStoreDeleteErr)
-			return res.StatusCode, body, cbStoreDeleteErr
+		err := common.CBStore.Delete(key)
+		if err != nil {
+			common.CBLog.Error(err)
+			return res.StatusCode, body, err
 		}
 		return res.StatusCode, body, nil
 	case res.StatusCode >= 400 || res.StatusCode < 200:
@@ -493,10 +493,10 @@ func delVNic(nsId string, Id string, forceFlag string) (int, []byte, error) {
 		common.CBLog.Error(err)
 		return res.StatusCode, body, err
 	default:
-		cbStoreDeleteErr := common.CBStore.Delete(key)
-		if cbStoreDeleteErr != nil {
-			common.CBLog.Error(cbStoreDeleteErr)
-			return res.StatusCode, body, cbStoreDeleteErr
+		err := common.CBStore.Delete(key)
+		if err != nil {
+			common.CBLog.Error(err)
+			return res.StatusCode, body, err
 		}
 		return res.StatusCode, body, nil
 	}

--- a/test/official/5.sshKey/force-delete-sshKey.sh
+++ b/test/official/5.sshKey/force-delete-sshKey.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+echo "####################################################################"
+echo "## 5. sshKey: Delete"
+echo "####################################################################"
+
+CSP=${1}
+REGION=${2:-1}
+POSTFIX=${3:-developer}
+if [ "${CSP}" == "aws" ]; then
+	echo "[Test for AWS]"
+	INDEX=1
+elif [ "${CSP}" == "azure" ]; then
+	echo "[Test for Azure]"
+	INDEX=2
+elif [ "${CSP}" == "gcp" ]; then
+	echo "[Test for GCP]"
+	INDEX=3
+elif [ "${CSP}" == "alibaba" ]; then
+	echo "[Test for Alibaba]"
+	INDEX=4
+else
+	echo "[No acceptable argument was provided (aws, azure, gcp, alibaba, ...). Default: Test for AWS]"
+	CSP="aws"
+	INDEX=1
+fi
+
+curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d \
+    '{ 
+        "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
+    }' | json_pp #|| return 1


### PR DESCRIPTION
[Implementation details]

[Pseudo-code of `func DelResource(nsId string, resourceType string, resourceId string, forceFlag string) error {`]
```
func DelResource(nsId string, resourceType string, resourceId string, forceFlag string) error {
  call Spider's DELETE REST API;

  switch {
  case forceFlag == "true":
    call Spider's DELETE REST API again with `?force=true` query param;
    CBStore.Delete(key)
  case res.StatusCode >= 400 || res.StatusCode < 200:
    return err
  default: // forceFlag != "true" && (200 <= res.StatusCode <= 399)
    CBStore.Delete(key)
  }
}
```

You can see that
when `?force=true` query param is set in REST API call to Tumblebug,
Tumblebug calls Spider's DELETE REST API 2 times.
1. Tumblebug calls Spider's DELETE REST API without `?force=true` query param.
2. Tumblebug calls Spider's DELETE REST API with `?force=true` query param.

Cf) When `?force=true` query param is not set in REST API call to Tumblebug,
Tumblebug calls Spider's DELETE REST API 1 time.
1. Tumblebug calls Spider's DELETE REST API without `?force=true` query param.

---

[Test result with `test/official/5.sshKey/force-delete-sshKey.sh`]

[TB]
```
[API request!]
[Check ns] NS-01
DelResource() called; NS-01 sshKey aws-us-east-1-jhseo
[Check resource] sshKey, aws-us-east-1-jhseo
key: /ns/NS-01/resources/sshKey/aws-us-east-1-jhseo
url: http://localhost:1024/spider/keypair/aws-us-east-1-jhseo
{"Result":"true"}

HTTP Status code 200
forceFlag == true; url: http://localhost:1024/spider/keypair/aws-us-east-1-jhseo?force=true
{"message":"[aws-us-east-1:keypair:aws-us-east-1-jhseo] does not exist!"}

{"time":"2020-07-16T14:19:12.074615338+09:00","id":"","remote_ip":"127.0.0.1","host":"localhost:1323","method":"DELETE","uri":"/tumblebug/ns/NS-01/resources/sshKey/aws-us-east-1-jhseo?force=true","user_agent":"curl/7.58.0","status":200,"error":"","latency":1226935812,"latency_human":"1.226935812s","bytes_in":50,"bytes_out":62}
```

[Spider]
```
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 KeyPairHandler.go:181, github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/aws/resources.(*AwsKeyPairHandler).DeleteKey() - Successfully deleted "aws-us-east-1-jhseo" key pair

[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 IIDManager.go:241, github.com/cloud-barista/cb-spider/cloud-control-manager/iid-manager.(*IIDRWLOCK).DeleteIID() - call DeleteIID()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 nutsdb-driver.go:151, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.(*NUTSDBDriver).GetList() - Key:/resource-info-spaces/iids/aws-us-east-1/keypair/aws-us-east-1-jhseo
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 nutsdb-driver.go:188, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.(*NUTSDBDriver).Delete() - Key:/resource-info-spaces/iids/aws-us-east-1/keypair/aws-us-east-1-jhseo
{"time":"2020-07-16T14:19:12.072249649+09:00","id":"","remote_ip":"127.0.0.1","host":"localhost:1024","method":"DELETE","uri":"/spider/keypair/aws-us-east-1-jhseo","user_agent":"Go-http-client/1.1","status":200,"error":"","latency":1224190280,"latency_human":"1.22419028s","bytes_in":39,"bytes_out":18}
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 CCMRest.go:662, github.com/cloud-barista/cb-spider/api-runtime/rest-runtime.deleteKey() - call deleteKey()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 CCMCommon.go:1765, github.com/cloud-barista/cb-spider/api-runtime/common-runtime.DeleteResource() - call DeleteResource()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 ConnectionConfigInfoManager.go:79, github.com/cloud-barista/cb-spider/cloud-info-manager/connection-config-info-manager.GetConnectionConfig() - call GetConnectionConfig()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 nutsdb-driver.go:151, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.(*NUTSDBDriver).GetList() - Key:/cloud-info-spaces/connection-configs/aws-us-east-1
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 DriverInfoManager.go:83, github.com/cloud-barista/cb-spider/cloud-info-manager/driver-info-manager.GetCloudDriver() - call GetCloudDriver()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 nutsdb-driver.go:151, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.(*NUTSDBDriver).GetList() - Key:/cloud-info-spaces/drivers/aws-driver01
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 CloudDriverHandler.go:264, github.com/cloud-barista/cb-spider/cloud-control-manager.getStaticCloudDriver() - CloudDriverHandler: called getStaticCloudDriver() - aws-driver01
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 CredentialInfoManager.go:108, github.com/cloud-barista/cb-spider/cloud-info-manager/credential-info-manager.GetCredentialDecrypt() - call GetCredential()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 nutsdb-driver.go:151, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.(*NUTSDBDriver).GetList() - Key:/cloud-info-spaces/credentials/aws-credential01
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 RegionInfoManager.go:77, github.com/cloud-barista/cb-spider/cloud-info-manager/region-info-manager.GetRegion() - call GetRegion()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 nutsdb-driver.go:151, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.(*NUTSDBDriver).GetList() - Key:/cloud-info-spaces/regions/aws-us-east-1
AwsDriver : getVMClient() - Region : [us-east-1]
AwsDriver : getVMClient() - Zone : [us-east-1a]
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 AwsCloudConnection.go:49, github.com/cloud-barista/cb-spider/cloud-control-manager/cloud-driver/drivers/aws/connect.(*AwsCloudConnection).CreateKeyPairHandler() - Start CreateKeyPairHandler()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 IIDManager.go:151, github.com/cloud-barista/cb-spider/cloud-control-manager/iid-manager.(*IIDRWLOCK).GetIID() - call GetIID()
[CLOUD-BARISTA].[INFO]: 2020-07-16 14:19:12 nutsdb-driver.go:151, github.com/cloud-barista/cb-store/store-drivers/nutsdb-driver.(*NUTSDBDriver).GetList() - Key:/resource-info-spaces/iids/aws-us-east-1/keypair/aws-us-east-1-jhseo
[CLOUD-BARISTA].[ERROR]: 2020-07-16 14:19:12 IIDManager.go:168, github.com/cloud-barista/cb-spider/cloud-control-manager/iid-manager.(*IIDRWLOCK).GetIID() - [aws-us-east-1:keypair:aws-us-east-1-jhseo] does not exist!
[CLOUD-BARISTA].[ERROR]: 2020-07-16 14:19:12 CCMCommon.go:1821, github.com/cloud-barista/cb-spider/api-runtime/common-runtime.DeleteResource() - [aws-us-east-1:keypair:aws-us-east-1-jhseo] does not exist!
{"time":"2020-07-16T14:19:12.073064507+09:00","id":"","remote_ip":"127.0.0.1","host":"localhost:1024","method":"DELETE","uri":"/spider/keypair/aws-us-east-1-jhseo?force=true","user_agent":"Go-http-client/1.1","status":500,"error":"code=500, message=[aws-us-east-1:keypair:aws-us-east-1-jhseo] does not exist!","latency":493465,"latency_human":"493.465µs","bytes_in":39,"bytes_out":74}
```

---

FYI: There are no `forceFlag`-receiving part in
- `func DelMcis(nsId string, mcisId string) error {`
- `func DelMcisVm(nsId string, mcisId string, vmId string) error {`
