### PR TITLE
Change way to handle credentials.conf

### DIFF
--- a/test/official/README.md
+++ b/test/official/README.md
@@ -18,8 +18,11 @@
 ## [실행 방법]
 
 ### (0) 클라우드 인증 정보, 테스트 기본 정보 입력
-- credentials.conf  # Cloud 정보 등록을 위한 CSP별 인증정보 (사용자에 맞게 수정 필요)
+- credentials.conf 파일 생성 # Cloud 정보 등록을 위한 CSP별 인증정보 파일 생성 (사용자에 맞게 수정 필요)
   - 기본적인 클라우드 타입 (AWS, GCP, AZURE, ALIBABA)에 대해 템플릿 제공
+    - credentials.conf.tmp 템플릿 파일을 참고하여 실재 정보가 포함된 credentials.conf 생성 또는 수정
+  - 주의: credentials.conf 에는 개인의 중요 정보가 포함되므로 Github에 업로드되지 않도록 주의 필요    
+    - credentials.conf가 gitignore에 등록되어 있으므로 git의 추적 대상에서는 제외되어 있음
 - conf.env  # CB-Spider 및 Tumblebug 서버 위치, 클라우드 리젼, 테스트용 이미지명, 테스트용 스팩명 등 테스트 기본 정보 제공
   - 특별한 상황이 아니면 수정이 불필요함. (CB-Spider와 CB-TB의 위치가 localhost가 아닌 경우 수정 필요)
   - 클라우드 타입(CSP)별 약 1~3개의 기본 리전이 입력되어 있음

--- a/test/official/credentials.conf.tmp
+++ b/test/official/credentials.conf.tmp
@@ -1,6 +1,8 @@
 ### Cloud credentials for auto testing
 ### This file should not uploaded to online if this includes actual credentials.
 
+
+
 ## AWS
 CredentialName[1]=aws-credential01
 


### PR DESCRIPTION
Change way to handle credentials.conf

실제 역할을 하는 credentials.conf 를 소스트리에서 삭제하고,

해당 파일은 credentials.conf.tmp 로 변경함. (이를 통해 credentials.conf 는 gitignore 적용.)

사용자가 credentials.conf.tmp 를 활용하여 credentials.conf를 생성하도록 가이드함.