### PR TITLE
Add spider grpc call to core logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ test/official/sequentialFullTests/executionStatus
 test/official/credentials.conf
 
 # Config file for mcism
-conf/
+# conf/
 
 # Runtime files
 src/benchmarking.csv

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ test/official/sequentialFullTests/executionStatus
 test/official/credentials.conf
 
 # Config file for mcism
-# conf/
+conf/
 
 # Runtime files
 src/benchmarking.csv

--- a/conf/grpc_conf.yaml
+++ b/conf/grpc_conf.yaml
@@ -1,0 +1,32 @@
+version: 1
+grpc:
+  tumblebugsrv:
+    addr: 127.0.0.1:50252
+    #reflection: enable
+    #tls:
+    #  tls_cert: $CBTUMBLEBUG_ROOT/certs/server.crt
+    #  tls_key: $CBTUMBLEBUG_ROOT/certs/server.key
+    interceptors:
+      #auth_jwt:
+      #  jwt_key: your_secret_key
+      prometheus_metrics:
+        listen_port: 9093
+      opentracing:
+        jaeger:
+          endpoint: localhost:6832
+          service_name: tumblebug grpc server
+          sample_rate: 1  
+  spidersrv:
+    addr: 127.0.0.1:50251
+  spidercli:
+    timeout: 90s
+    #tls:
+    #  tls_ca: $CBTUMBLEBUG_ROOT/certs/ca.crt
+    interceptors:
+      #auth_jwt:
+      #  jwt_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRJUCI6IjEyNy4wLjAuMSIsImV4cGlyZSI6MTkwODMyNTY1OCwib3JnTmFtZSI6IkVUUkkiLCJ1c2VyTmFtZSI6IkhvbmdHaWxEb25nIn0.4lkjYduo8iwv4AcKH96MpTnk8d7HRhi_p1xlnvZts8A
+      opentracing:
+        jaeger:
+          endpoint: localhost:6832
+          service_name: spider grpc client for tumblebug
+          sample_rate: 1

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
 	//uuid "github.com/google/uuid"
+	"github.com/cloud-barista/cb-spider/interface/api"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/xwb1989/sqlparser"
 	// CB-Store
@@ -75,231 +77,364 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 	//cspType := common.GetResourcesCspType(nsId, resourceType, resourceId)
 
-	var url string
+	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-	// Create Req body
-	type JsonTemplate struct {
-		ConnectionName string
-	}
-	tempReq := JsonTemplate{}
+		var url string
 
-	switch resourceType {
-	case "image":
-		// delete image info
-		err := common.CBStore.Delete(key)
-		if err != nil {
-			common.CBLog.Error(err)
-			//return http.StatusInternalServerError, nil, err
-			return err
+		// Create Req body
+		type JsonTemplate struct {
+			ConnectionName string
 		}
+		tempReq := JsonTemplate{}
 
-		sql := "DELETE FROM `image` WHERE `id` = '" + resourceId + "';"
-		fmt.Println("sql: " + sql)
-		// https://stackoverflow.com/questions/42486032/golang-sql-query-syntax-validator
-		_, err = sqlparser.Parse(sql)
-		if err != nil {
-			//return
-		}
-
-		stmt, err := common.MYDB.Prepare(sql)
-		if err != nil {
-			fmt.Println(err.Error())
-		}
-		_, err = stmt.Exec()
-		if err != nil {
-			fmt.Println(err.Error())
-		} else {
-			fmt.Println("Data deleted successfully..")
-		}
-
-		//return http.StatusOK, nil, nil
-		return nil
-	case "spec":
-		// delete spec info
-
-		//get related recommend spec
-		//keyValue, err := common.CBStore.Get(key)
-		content := TbSpecInfo{}
-		json.Unmarshal([]byte(keyValue.Value), &content)
-		/*
+		switch resourceType {
+		case "image":
+			// delete image info
+			err := common.CBStore.Delete(key)
 			if err != nil {
 				common.CBLog.Error(err)
-				return http.StatusInternalServerError, nil, err
+				//return http.StatusInternalServerError, nil, err
+				return err
 			}
-		*/
-		//
 
-		err := common.CBStore.Delete(key)
-		if err != nil {
-			common.CBLog.Error(err)
-			//return http.StatusInternalServerError, nil, err
-			return err
-		}
+			sql := "DELETE FROM `image` WHERE `id` = '" + resourceId + "';"
+			fmt.Println("sql: " + sql)
+			// https://stackoverflow.com/questions/42486032/golang-sql-query-syntax-validator
+			_, err = sqlparser.Parse(sql)
+			if err != nil {
+				//return
+			}
 
-		//delete related recommend spec
-		err = DelRecommendSpec(nsId, resourceId, content.Num_vCPU, content.Mem_GiB, content.Storage_GiB)
-		if err != nil {
-			common.CBLog.Error(err)
-			//return http.StatusInternalServerError, nil, err
-			return err
-		}
+			stmt, err := common.MYDB.Prepare(sql)
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+			_, err = stmt.Exec()
+			if err != nil {
+				fmt.Println(err.Error())
+			} else {
+				fmt.Println("Data deleted successfully..")
+			}
 
-		sql := "DELETE FROM `spec` WHERE `id` = '" + resourceId + "';"
-		fmt.Println("sql: " + sql)
-		// https://stackoverflow.com/questions/42486032/golang-sql-query-syntax-validator
-		_, err = sqlparser.Parse(sql)
-		if err != nil {
-			//return
-		}
+			//return http.StatusOK, nil, nil
+			return nil
+		case "spec":
+			// delete spec info
 
-		stmt, err := common.MYDB.Prepare(sql)
-		if err != nil {
-			fmt.Println(err.Error())
-		}
-		_, err = stmt.Exec()
-		if err != nil {
-			fmt.Println(err.Error())
-		} else {
-			fmt.Println("Data deleted successfully..")
-		}
-
-		//return http.StatusOK, nil, nil
-		return nil
-	case "sshKey":
-		temp := TbSshKeyInfo{}
-		json.Unmarshal([]byte(keyValue.Value), &temp)
-		tempReq.ConnectionName = temp.ConnectionName
-		url = common.SPIDER_URL + "/keypair/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
-	case "vNet":
-		temp := TbVNetInfo{}
-		json.Unmarshal([]byte(keyValue.Value), &temp)
-		tempReq.ConnectionName = temp.ConnectionName
-		url = common.SPIDER_URL + "/vpc/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
-	case "securityGroup":
-		temp := TbSecurityGroupInfo{}
-		json.Unmarshal([]byte(keyValue.Value), &temp)
-		tempReq.ConnectionName = temp.ConnectionName
-		url = common.SPIDER_URL + "/securitygroup/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
-	/*
-		case "subnet":
-			temp := subnetInfo{}
+			//get related recommend spec
+			//keyValue, err := common.CBStore.Get(key)
+			content := TbSpecInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &content)
-			return content.CspSubnetId
-		case "publicIp":
-			temp := publicIpInfo{}
+			/*
+				if err != nil {
+					common.CBLog.Error(err)
+					return http.StatusInternalServerError, nil, err
+				}
+			*/
+			//
+
+			err := common.CBStore.Delete(key)
+			if err != nil {
+				common.CBLog.Error(err)
+				//return http.StatusInternalServerError, nil, err
+				return err
+			}
+
+			//delete related recommend spec
+			err = DelRecommendSpec(nsId, resourceId, content.Num_vCPU, content.Mem_GiB, content.Storage_GiB)
+			if err != nil {
+				common.CBLog.Error(err)
+				//return http.StatusInternalServerError, nil, err
+				return err
+			}
+
+			sql := "DELETE FROM `spec` WHERE `id` = '" + resourceId + "';"
+			fmt.Println("sql: " + sql)
+			// https://stackoverflow.com/questions/42486032/golang-sql-query-syntax-validator
+			_, err = sqlparser.Parse(sql)
+			if err != nil {
+				//return
+			}
+
+			stmt, err := common.MYDB.Prepare(sql)
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+			_, err = stmt.Exec()
+			if err != nil {
+				fmt.Println(err.Error())
+			} else {
+				fmt.Println("Data deleted successfully..")
+			}
+
+			//return http.StatusOK, nil, nil
+			return nil
+		case "sshKey":
+			temp := TbSshKeyInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 			tempReq.ConnectionName = temp.ConnectionName
-			url = common.SPIDER_URL + "/publicip/" + temp.CspPublicIpName //+ "?connection_name=" + temp.ConnectionName
-		case "vNic":
-			temp := vNicInfo{}
+			url = common.SPIDER_URL + "/keypair/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
+		case "vNet":
+			temp := TbVNetInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 			tempReq.ConnectionName = temp.ConnectionName
-			url = common.SPIDER_URL + "/vnic/" + temp.CspVNicName //+ "?connection_name=" + temp.ConnectionName
-	*/
-	default:
-		err := fmt.Errorf("invalid resourceType")
-		//return http.StatusBadRequest, nil, err
-		return err
-	}
-
-	fmt.Println("url: " + url)
-
-	method := "DELETE"
-
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	//req, err := http.NewRequest(method, url, nil)
-	payload, _ := json.MarshalIndent(tempReq, "", "  ")
-	//fmt.Println("payload: " + string(payload))
-	req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
-
-	if err != nil {
-		common.CBLog.Error(err)
-		return err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	res, err := client.Do(req)
-	if err != nil {
-		common.CBLog.Error(err)
-		return err
-	}
-	defer res.Body.Close()
-
-	body, err := ioutil.ReadAll(res.Body)
-	fmt.Println(string(body))
-	if err != nil {
-		common.CBLog.Error(err)
-		return err
-	}
-
-	/*
-		if res.StatusCode == 400 || res.StatusCode == 401 {
-			fmt.Println("HTTP Status code 400 Bad Request or 401 Unauthorized.")
-			err := fmt.Errorf("HTTP Status code 400 Bad Request or 401 Unauthorized")
-			common.CBLog.Error(err)
-			return res, err
+			url = common.SPIDER_URL + "/vpc/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
+		case "securityGroup":
+			temp := TbSecurityGroupInfo{}
+			json.Unmarshal([]byte(keyValue.Value), &temp)
+			tempReq.ConnectionName = temp.ConnectionName
+			url = common.SPIDER_URL + "/securitygroup/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
+		/*
+			case "subnet":
+				temp := subnetInfo{}
+				json.Unmarshal([]byte(keyValue.Value), &content)
+				return content.CspSubnetId
+			case "publicIp":
+				temp := publicIpInfo{}
+				json.Unmarshal([]byte(keyValue.Value), &temp)
+				tempReq.ConnectionName = temp.ConnectionName
+				url = common.SPIDER_URL + "/publicip/" + temp.CspPublicIpName //+ "?connection_name=" + temp.ConnectionName
+			case "vNic":
+				temp := vNicInfo{}
+				json.Unmarshal([]byte(keyValue.Value), &temp)
+				tempReq.ConnectionName = temp.ConnectionName
+				url = common.SPIDER_URL + "/vnic/" + temp.CspVNicName //+ "?connection_name=" + temp.ConnectionName
+		*/
+		default:
+			err := fmt.Errorf("invalid resourceType")
+			//return http.StatusBadRequest, nil, err
+			return err
 		}
 
-		// delete vNet info
-		err := common.CBStore.Delete(key)
-		if err != nil {
-			common.CBLog.Error(err)
-			return res, err
+		fmt.Println("url: " + url)
+
+		method := "DELETE"
+
+		client := &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		}
-
-		return res, nil
-	*/
-
-	fmt.Println("HTTP Status code " + strconv.Itoa(res.StatusCode))
-	switch {
-	case forceFlag == "true":
-		url += "?force=true"
-		fmt.Println("forceFlag == true; url: " + url)
+		//req, err := http.NewRequest(method, url, nil)
+		payload, _ := json.MarshalIndent(tempReq, "", "  ")
+		//fmt.Println("payload: " + string(payload))
 		req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
+
 		if err != nil {
 			common.CBLog.Error(err)
-			//return err
+			return err
 		}
+
 		req.Header.Add("Content-Type", "application/json")
 		res, err := client.Do(req)
 		if err != nil {
 			common.CBLog.Error(err)
-			//return err
+			return err
 		}
 		defer res.Body.Close()
+
 		body, err := ioutil.ReadAll(res.Body)
 		fmt.Println(string(body))
 		if err != nil {
 			common.CBLog.Error(err)
-			//return err
+			return err
+		}
+
+		/*
+			if res.StatusCode == 400 || res.StatusCode == 401 {
+				fmt.Println("HTTP Status code 400 Bad Request or 401 Unauthorized.")
+				err := fmt.Errorf("HTTP Status code 400 Bad Request or 401 Unauthorized")
+				common.CBLog.Error(err)
+				return res, err
+			}
+
+			// delete vNet info
+			err := common.CBStore.Delete(key)
+			if err != nil {
+				common.CBLog.Error(err)
+				return res, err
+			}
+
+			return res, nil
+		*/
+
+		fmt.Println("HTTP Status code " + strconv.Itoa(res.StatusCode))
+		switch {
+		case forceFlag == "true":
+			url += "?force=true"
+			fmt.Println("forceFlag == true; url: " + url)
+			req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
+			if err != nil {
+				common.CBLog.Error(err)
+				//return err
+			}
+			req.Header.Add("Content-Type", "application/json")
+			res, err := client.Do(req)
+			if err != nil {
+				common.CBLog.Error(err)
+				//return err
+			}
+			defer res.Body.Close()
+			body, err := ioutil.ReadAll(res.Body)
+			fmt.Println(string(body))
+			if err != nil {
+				common.CBLog.Error(err)
+				//return err
+			}
+
+			err = common.CBStore.Delete(key)
+			if err != nil {
+				common.CBLog.Error(err)
+				//return res.StatusCode, body, err
+				return err
+			}
+			//return res.StatusCode, body, nil
+			return nil
+		case res.StatusCode >= 400 || res.StatusCode < 200:
+			err := fmt.Errorf(string(body))
+			common.CBLog.Error(err)
+			//return res.StatusCode, body, err
+			return err
+		default:
+			err := common.CBStore.Delete(key)
+			if err != nil {
+				common.CBLog.Error(err)
+				//return res.StatusCode, body, err
+				return err
+			}
+			//return res.StatusCode, body, nil
+			return nil
+		}
+
+	} else {
+
+		// CCM API 설정
+		ccm := api.NewCloudInfoResourceHandler()
+		err := ccm.SetConfigPath(os.Getenv("CBTUMBLEBUG_ROOT") + "/conf/grpc_conf.yaml")
+		if err != nil {
+			common.CBLog.Error("ccm failed to set config : ", err)
+			return err
+		}
+		err = ccm.Open()
+		if err != nil {
+			common.CBLog.Error("ccm api open failed : ", err)
+			return err
+		}
+		defer ccm.Close()
+
+		switch resourceType {
+		case "image":
+			// delete image info
+			err := common.CBStore.Delete(key)
+			if err != nil {
+				common.CBLog.Error(err)
+				//return http.StatusInternalServerError, nil, err
+				return err
+			}
+
+			sql := "DELETE FROM `image` WHERE `id` = '" + resourceId + "';"
+			fmt.Println("sql: " + sql)
+			// https://stackoverflow.com/questions/42486032/golang-sql-query-syntax-validator
+			_, err = sqlparser.Parse(sql)
+			if err != nil {
+				//return
+			}
+
+			stmt, err := common.MYDB.Prepare(sql)
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+			_, err = stmt.Exec()
+			if err != nil {
+				fmt.Println(err.Error())
+			} else {
+				fmt.Println("Data deleted successfully..")
+			}
+
+			//return http.StatusOK, nil, nil
+			return nil
+		case "spec":
+			// delete spec info
+
+			//get related recommend spec
+			content := TbSpecInfo{}
+			json.Unmarshal([]byte(keyValue.Value), &content)
+
+			err := common.CBStore.Delete(key)
+			if err != nil {
+				common.CBLog.Error(err)
+				return err
+			}
+
+			//delete related recommend spec
+			err = DelRecommendSpec(nsId, resourceId, content.Num_vCPU, content.Mem_GiB, content.Storage_GiB)
+			if err != nil {
+				common.CBLog.Error(err)
+				return err
+			}
+
+			sql := "DELETE FROM `spec` WHERE `id` = '" + resourceId + "';"
+			fmt.Println("sql: " + sql)
+			// https://stackoverflow.com/questions/42486032/golang-sql-query-syntax-validator
+			_, err = sqlparser.Parse(sql)
+			if err != nil {
+				//return
+			}
+
+			stmt, err := common.MYDB.Prepare(sql)
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+			_, err = stmt.Exec()
+			if err != nil {
+				fmt.Println(err.Error())
+			} else {
+				fmt.Println("Data deleted successfully..")
+			}
+			return nil
+
+		case "sshKey":
+			temp := TbSshKeyInfo{}
+			json.Unmarshal([]byte(keyValue.Value), &temp)
+
+			_, err := ccm.DeleteKeyByParam(temp.ConnectionName, temp.Name, forceFlag)
+			if err != nil {
+				common.CBLog.Error(err)
+				return err
+			}
+
+		case "vNet":
+			temp := TbVNetInfo{}
+			json.Unmarshal([]byte(keyValue.Value), &temp)
+
+			_, err := ccm.DeleteVPCByParam(temp.ConnectionName, temp.Name, forceFlag)
+			if err != nil {
+				common.CBLog.Error(err)
+				return err
+			}
+
+		case "securityGroup":
+			temp := TbSecurityGroupInfo{}
+			json.Unmarshal([]byte(keyValue.Value), &temp)
+
+			_, err := ccm.DeleteSecurityByParam(temp.ConnectionName, temp.Name, forceFlag)
+			if err != nil {
+				common.CBLog.Error(err)
+				return err
+			}
+
+		default:
+			err := fmt.Errorf("invalid resourceType")
+			return err
 		}
 
 		err = common.CBStore.Delete(key)
 		if err != nil {
 			common.CBLog.Error(err)
-			//return res.StatusCode, body, err
 			return err
 		}
-		//return res.StatusCode, body, nil
 		return nil
-	case res.StatusCode >= 400 || res.StatusCode < 200:
-		err := fmt.Errorf(string(body))
-		common.CBLog.Error(err)
-		//return res.StatusCode, body, err
-		return err
-	default:
-		err := common.CBStore.Delete(key)
-		if err != nil {
-			common.CBLog.Error(err)
-			//return res.StatusCode, body, err
-			return err
-		}
-		//return res.StatusCode, body, nil
-		return nil
+
 	}
 }
 

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
+	"github.com/cloud-barista/cb-spider/interface/api"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 )
 
@@ -66,63 +68,103 @@ func CreateSshKey(nsId string, u *TbSshKeyReq) (TbSshKeyInfo, error) {
 		return temp, err
 	}
 
-	//url := common.SPIDER_URL + "/keypair?connection_name=" + u.ConnectionName
-	url := common.SPIDER_URL + "/keypair"
+	var tempSpiderKeyPairInfo SpiderKeyPairInfo
 
-	method := "POST"
+	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-	//payload := strings.NewReader("{ \"Name\": \"" + u.CspSshKeyName + "\"}")
-	tempReq := SpiderKeyPairReqInfoWrapper{}
-	tempReq.ConnectionName = u.ConnectionName
-	tempReq.ReqInfo.Name = u.Name
-	payload, _ := json.MarshalIndent(tempReq, "", "  ")
-	//fmt.Println("payload: " + string(payload)) // for debug
+		//url := common.SPIDER_URL + "/keypair?connection_name=" + u.ConnectionName
+		url := common.SPIDER_URL + "/keypair"
 
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-	req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
+		method := "POST"
 
-	if err != nil {
-		fmt.Println(err)
-	}
-	req.Header.Add("Content-Type", "application/json")
+		//payload := strings.NewReader("{ \"Name\": \"" + u.CspSshKeyName + "\"}")
+		tempReq := SpiderKeyPairReqInfoWrapper{}
+		tempReq.ConnectionName = u.ConnectionName
+		tempReq.ReqInfo.Name = u.Name
+		payload, _ := json.MarshalIndent(tempReq, "", "  ")
+		//fmt.Println("payload: " + string(payload)) // for debug
 
-	res, err := client.Do(req)
-	if err != nil {
-		common.CBLog.Error(err)
-		content := TbSshKeyInfo{}
-		//return content, res.StatusCode, nil, err
-		return content, err
-	}
-	defer res.Body.Close()
+		client := &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
 
-	body, err := ioutil.ReadAll(res.Body)
-	fmt.Println(string(body))
-	if err != nil {
-		common.CBLog.Error(err)
-		content := TbSshKeyInfo{}
-		//return content, res.StatusCode, body, err
-		return content, err
-	}
+		if err != nil {
+			fmt.Println(err)
+		}
+		req.Header.Add("Content-Type", "application/json")
 
-	fmt.Println("HTTP Status code " + strconv.Itoa(res.StatusCode))
-	switch {
-	case res.StatusCode >= 400 || res.StatusCode < 200:
-		err := fmt.Errorf(string(body))
-		fmt.Println("body: ", string(body))
-		common.CBLog.Error(err)
-		content := TbSshKeyInfo{}
-		//return content, res.StatusCode, body, err
-		return content, err
-	}
+		res, err := client.Do(req)
+		if err != nil {
+			common.CBLog.Error(err)
+			content := TbSshKeyInfo{}
+			//return content, res.StatusCode, nil, err
+			return content, err
+		}
+		defer res.Body.Close()
 
-	temp := SpiderKeyPairInfo{}
-	err2 := json.Unmarshal(body, &temp)
-	if err2 != nil {
-		fmt.Println("whoops:", err2)
+		body, err := ioutil.ReadAll(res.Body)
+		fmt.Println(string(body))
+		if err != nil {
+			common.CBLog.Error(err)
+			content := TbSshKeyInfo{}
+			//return content, res.StatusCode, body, err
+			return content, err
+		}
+
+		fmt.Println("HTTP Status code " + strconv.Itoa(res.StatusCode))
+		switch {
+		case res.StatusCode >= 400 || res.StatusCode < 200:
+			err := fmt.Errorf(string(body))
+			fmt.Println("body: ", string(body))
+			common.CBLog.Error(err)
+			content := TbSshKeyInfo{}
+			//return content, res.StatusCode, body, err
+			return content, err
+		}
+
+		tempSpiderKeyPairInfo = SpiderKeyPairInfo{}
+		err2 := json.Unmarshal(body, &tempSpiderKeyPairInfo)
+		if err2 != nil {
+			fmt.Println("whoops:", err2)
+		}
+
+	} else {
+
+		// CCM API 설정
+		ccm := api.NewCloudInfoResourceHandler()
+		err := ccm.SetConfigPath(os.Getenv("CBTUMBLEBUG_ROOT") + "/conf/grpc_conf.yaml")
+		if err != nil {
+			common.CBLog.Error("ccm failed to set config : ", err)
+			return TbSshKeyInfo{}, err
+		}
+		err = ccm.Open()
+		if err != nil {
+			common.CBLog.Error("ccm api open failed : ", err)
+			return TbSshKeyInfo{}, err
+		}
+		defer ccm.Close()
+
+		tempReq := SpiderKeyPairReqInfoWrapper{}
+		tempReq.ConnectionName = u.ConnectionName
+		tempReq.ReqInfo.Name = u.Name
+		payload, _ := json.MarshalIndent(tempReq, "", "  ")
+		//fmt.Println("payload: " + string(payload)) // for debug
+
+		result, err := ccm.CreateKey(string(payload))
+		if err != nil {
+			common.CBLog.Error(err)
+			return TbSshKeyInfo{}, err
+		}
+
+		tempSpiderKeyPairInfo = SpiderKeyPairInfo{}
+		err2 := json.Unmarshal([]byte(result), &tempSpiderKeyPairInfo)
+		if err2 != nil {
+			fmt.Println("whoops:", err2)
+		}
+
 	}
 
 	content := TbSshKeyInfo{}
@@ -130,19 +172,19 @@ func CreateSshKey(nsId string, u *TbSshKeyReq) (TbSshKeyInfo, error) {
 	content.Id = common.GenId(u.Name)
 	content.Name = u.Name
 	content.ConnectionName = u.ConnectionName
-	content.CspSshKeyName = temp.IId.NameId
-	content.Fingerprint = temp.Fingerprint
-	content.Username = temp.VMUserID
-	content.PublicKey = temp.PublicKey
-	content.PrivateKey = temp.PrivateKey
+	content.CspSshKeyName = tempSpiderKeyPairInfo.IId.NameId
+	content.Fingerprint = tempSpiderKeyPairInfo.Fingerprint
+	content.Username = tempSpiderKeyPairInfo.VMUserID
+	content.PublicKey = tempSpiderKeyPairInfo.PublicKey
+	content.PrivateKey = tempSpiderKeyPairInfo.PrivateKey
 	content.Description = u.Description
-	content.KeyValueList = temp.KeyValueList
+	content.KeyValueList = tempSpiderKeyPairInfo.KeyValueList
 
 	// cb-store
 	fmt.Println("=========================== PUT CreateSshKey")
 	Key := common.GenResourceKey(nsId, "sshKey", content.Id)
 	Val, _ := json.Marshal(content)
-	err = common.CBStore.Put(string(Key), string(Val))
+	err := common.CBStore.Put(string(Key), string(Val))
 	if err != nil {
 		common.CBLog.Error(err)
 		//return content, res.StatusCode, body, err


### PR DESCRIPTION
- core logic 에 spider api 를 이용한 연결 추가
- setup.env 에서 SPIDER_CALL_METHOD=REST 로 설정하면 REST방식으로 spider 와 통신
- setup.env 에서 SPIDER_CALL_METHOD=GRPC 로 설정하면 GRPC방식으로 spider 와 통신