### PR TITLE
BugFix for Add 'credentials.conf' existence check logic in 'test/official/*/*.sh'

### DIFF
--- a/test/official/1.configureSpider/get-cloud.sh
+++ b/test/official/1.configureSpider/get-cloud.sh
@@ -7,8 +7,14 @@
         exit
     fi
 
+    FILE=../credentials.conf
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
     source ../conf.env
-    #source ../credentials.conf
+    source ../credentials.conf
     AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
     echo "####################################################################"

--- a/test/official/1.configureSpider/unregister-cloud.sh
+++ b/test/official/1.configureSpider/unregister-cloud.sh
@@ -7,8 +7,14 @@
         exit
     fi
 
+    FILE=../credentials.conf
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
 	source ../conf.env
-	#source ../credentials.conf
+	source ../credentials.conf
 	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 	echo "####################################################################"

--- a/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
@@ -19,9 +19,15 @@ function dozing()
         exit
     fi
 
+	FILE=../credentials.conf
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
 	source ../conf.env
 	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-	#source ../credentials.conf
+	source ../credentials.conf
 
 	echo "####################################################################"
 	echo "## Remove MCIS test to Zero Base"


### PR DESCRIPTION
Tested with:
- `test/official/sequentialFullTest/testAll-mcis-mcir-ns-cloud.sh aws 1 jhseo`
- `test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh aws 1 jhseo`
- `test/official/sequentialFullTest/1.configureSpider/get-cloud.sh aws 1 jhseo`
- `test/official/sequentialFullTest/1.configureSpider/unregister-cloud.sh aws 1 jhseo`