### PR TITLE
Change the env var name SPIDER_URL to SPIDER_REST_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,14 +38,20 @@ COPY --from=builder /go/src/github.com/cloud-barista/cb-tumblebug/src/cb-tumbleb
 #RUN /bin/bash -c "source /app/conf/setup.env"
 ENV CBSTORE_ROOT /app
 ENV CBLOG_ROOT /app
-ENV SPIDER_URL http://cb-spider:1024/spider
+ENV CBTUMBLEBUG_ROOT /app
+ENV SPIDER_CALL_METHOD REST
+ENV SPIDER_REST_URL http://cb-spider:1024/spider
+ENV DRAGONFLY_REST_URL http://cb-dragonfly:9090/dragonfly
+
 ENV DB_URL localhost:3306
 ENV DB_DATABASE cb_tumblebug
 ENV DB_USER cb_tumblebug
 ENV DB_PASSWORD cb_tumblebug
+
 ENV API_USERNAME default
 ENV API_PASSWORD default
 
 ENTRYPOINT [ "/app/src/cb-tumblebug" ]
 
 EXPOSE 1323
+EXPOSE 50252

--- a/conf/grpc_conf.yaml
+++ b/conf/grpc_conf.yaml
@@ -1,7 +1,7 @@
 version: 1
 grpc:
   tumblebugsrv:
-    addr: 127.0.0.1:50252
+    addr: :50252
     #reflection: enable
     #tls:
     #  tls_cert: $CBTUMBLEBUG_ROOT/certs/server.crt

--- a/conf/setup.env
+++ b/conf/setup.env
@@ -2,8 +2,8 @@ export CBSTORE_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
 export CBLOG_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
 export CBTUMBLEBUG_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
 export SPIDER_CALL_METHOD=REST
-export SPIDER_URL=http://localhost:1024/spider
-export DRAGONFLY_URL=http://localhost:9090/dragonfly
+export SPIDER_REST_URL=http://localhost:1024/spider
+export DRAGONFLY_REST_URL=http://localhost:9090/dragonfly
 
 export DB_URL=localhost:3306
 export DB_DATABASE=cb_tumblebug

--- a/src/core/common/common.go
+++ b/src/core/common/common.go
@@ -19,8 +19,8 @@ type KeyValue struct {
 var CBLog *logrus.Logger
 var CBStore icbs.Store
 
-var SPIDER_URL string
-var DRAGONFLY_URL string
+var SPIDER_REST_URL string
+var DRAGONFLY_REST_URL string
 var DB_URL string
 var DB_DATABASE string
 var DB_USER string

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -129,7 +129,7 @@ func GetResourcesCspType(nsId string, resourceType string, resourceId string) st
 	content := mcirIds{}
 	json.Unmarshal([]byte(keyValue.Value), &content)
 
-	url := SPIDER_URL + "/connectionconfig/" + content.ConnectionName
+	url := SPIDER_REST_URL + "/connectionconfig/" + content.ConnectionName
 
 	method := "GET"
 
@@ -257,7 +257,7 @@ func GetConnConfig(ConnConfigName string) (ConnConfig, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := SPIDER_URL + "/connectionconfig/" + ConnConfigName
+		url := SPIDER_REST_URL + "/connectionconfig/" + ConnConfigName
 
 		method := "GET"
 
@@ -345,7 +345,7 @@ func GetConnConfigList() (ConnConfigList, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := SPIDER_URL + "/connectionconfig"
+		url := SPIDER_REST_URL + "/connectionconfig"
 
 		method := "GET"
 
@@ -436,7 +436,7 @@ func GetRegion(RegionName string) (Region, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := SPIDER_URL + "/region/" + RegionName
+		url := SPIDER_REST_URL + "/region/" + RegionName
 
 		method := "GET"
 
@@ -525,7 +525,7 @@ func GetRegionList() (RegionList, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := SPIDER_URL + "/region"
+		url := SPIDER_REST_URL + "/region"
 
 		method := "GET"
 

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -20,12 +20,12 @@ import (
 //var cblog *logrus.Logger
 //var store icbs.Store
 
-//var SPIDER_URL string
+//var SPIDER_REST_URL string
 
 func init() {
 	//cblog = config.Cblogger
 	//store = cbstore.GetStore()
-	//SPIDER_URL = os.Getenv("SPIDER_URL")
+	//SPIDER_REST_URL = os.Getenv("SPIDER_REST_URL")
 }
 
 func DelAllResources(nsId string, resourceType string, forceFlag string) error {
@@ -173,17 +173,17 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 			temp := TbSshKeyInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 			tempReq.ConnectionName = temp.ConnectionName
-			url = common.SPIDER_URL + "/keypair/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
+			url = common.SPIDER_REST_URL + "/keypair/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
 		case "vNet":
 			temp := TbVNetInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 			tempReq.ConnectionName = temp.ConnectionName
-			url = common.SPIDER_URL + "/vpc/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
+			url = common.SPIDER_REST_URL + "/vpc/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
 		case "securityGroup":
 			temp := TbSecurityGroupInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 			tempReq.ConnectionName = temp.ConnectionName
-			url = common.SPIDER_URL + "/securitygroup/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
+			url = common.SPIDER_REST_URL + "/securitygroup/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
 		/*
 			case "subnet":
 				temp := subnetInfo{}
@@ -193,12 +193,12 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 				temp := publicIpInfo{}
 				json.Unmarshal([]byte(keyValue.Value), &temp)
 				tempReq.ConnectionName = temp.ConnectionName
-				url = common.SPIDER_URL + "/publicip/" + temp.CspPublicIpName //+ "?connection_name=" + temp.ConnectionName
+				url = common.SPIDER_REST_URL + "/publicip/" + temp.CspPublicIpName //+ "?connection_name=" + temp.ConnectionName
 			case "vNic":
 				temp := vNicInfo{}
 				json.Unmarshal([]byte(keyValue.Value), &temp)
 				tempReq.ConnectionName = temp.ConnectionName
-				url = common.SPIDER_URL + "/vnic/" + temp.CspVNicName //+ "?connection_name=" + temp.ConnectionName
+				url = common.SPIDER_REST_URL + "/vnic/" + temp.CspVNicName //+ "?connection_name=" + temp.ConnectionName
 		*/
 		default:
 			err := fmt.Errorf("invalid resourceType")

--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -95,7 +95,7 @@ func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 		*/
 
 		// Step 2. Send a req to Spider and save the response.
-		url := common.SPIDER_URL + "/vmimage/" + u.CspImageId + "?connection_name=" + u.ConnectionName
+		url := common.SPIDER_REST_URL + "/vmimage/" + u.CspImageId + "?connection_name=" + u.ConnectionName
 
 		method := "GET"
 

--- a/src/core/mcir/obsolete/publicip.go
+++ b/src/core/mcir/obsolete/publicip.go
@@ -234,8 +234,8 @@ func createPublicIp(nsId string, u *publicIpReq) (publicIpInfo, int, []byte, err
 	}
 	*/
 
-	//url := common.SPIDER_URL + "/publicip?connection_name=" + u.ConnectionName
-	url := common.SPIDER_URL + "/publicip"
+	//url := common.SPIDER_REST_URL + "/publicip?connection_name=" + u.ConnectionName
+	url := common.SPIDER_REST_URL + "/publicip"
 
 	method := "POST"
 
@@ -392,8 +392,8 @@ func delPublicIp(nsId string, Id string, forceFlag string) (int, []byte, error) 
 	}
 	fmt.Println("temp.CspPublicIpName: " + temp.CspPublicIpName) // Identifier is subject to change.
 
-	//url := common.SPIDER_URL + "/publicip?connection_name=" + temp.ConnectionName // for testapi.io
-	url := common.SPIDER_URL + "/publicip/" + temp.CspPublicIpId + "?connection_name=" + temp.ConnectionName // for CB-Spider
+	//url := common.SPIDER_REST_URL + "/publicip?connection_name=" + temp.ConnectionName // for testapi.io
+	url := common.SPIDER_REST_URL + "/publicip/" + temp.CspPublicIpId + "?connection_name=" + temp.ConnectionName // for CB-Spider
 	fmt.Println("url: " + url)
 
 	method := "DELETE"

--- a/src/core/mcir/obsolete/subnet.go
+++ b/src/core/mcir/obsolete/subnet.go
@@ -214,7 +214,7 @@ func createSubnet(nsId string, u *subnetReq) (subnetInfo, error) {
 	}
 	*/
 
-	//url := common.SPIDER_URL + "/subnet"
+	//url := common.SPIDER_REST_URL + "/subnet"
 
 	// TODO: To be implemented
 

--- a/src/core/mcir/obsolete/vnic.go
+++ b/src/core/mcir/obsolete/vnic.go
@@ -243,7 +243,7 @@ func createVNic(nsId string, u *vNicReq) (vNicInfo, int, []byte, error) {
 	}
 	*/
 
-	url := common.SPIDER_URL + "/vnic?connection_name=" + u.ConnectionName
+	url := common.SPIDER_REST_URL + "/vnic?connection_name=" + u.ConnectionName
 
 	method := "POST"
 
@@ -448,8 +448,8 @@ func delVNic(nsId string, Id string, forceFlag string) (int, []byte, error) {
 	}
 	fmt.Println("temp.CspVNicId: " + temp.CspVNicId)
 
-	//url := common.SPIDER_URL + "/vnic?connection_name=" + temp.ConnectionName // for testapi.io
-	url := common.SPIDER_URL + "/vnic/" + temp.CspVNicId + "?connection_name=" + temp.ConnectionName // for CB-Spider
+	//url := common.SPIDER_REST_URL + "/vnic?connection_name=" + temp.ConnectionName // for testapi.io
+	url := common.SPIDER_REST_URL + "/vnic/" + temp.CspVNicId + "?connection_name=" + temp.ConnectionName // for CB-Spider
 	fmt.Println("url: " + url)
 
 	method := "DELETE"

--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -88,8 +88,8 @@ func CreateSecurityGroup(nsId string, u *TbSecurityGroupReq) (TbSecurityGroupInf
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		//url := common.SPIDER_URL + "/securitygroup?connection_name=" + u.ConnectionName
-		url := common.SPIDER_URL + "/securitygroup"
+		//url := common.SPIDER_REST_URL + "/securitygroup?connection_name=" + u.ConnectionName
+		url := common.SPIDER_REST_URL + "/securitygroup"
 
 		method := "POST"
 

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -102,7 +102,7 @@ func LookupSpecList(connConfig string) (SpiderSpecList, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := common.SPIDER_URL + "/vmspec"
+		url := common.SPIDER_REST_URL + "/vmspec"
 
 		method := "GET"
 
@@ -195,8 +195,8 @@ func LookupSpec(connConfig string, specName string) (SpiderSpecInfo, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		//url := common.SPIDER_URL + "/vmspec/" + u.CspSpecName
-		url := common.SPIDER_URL + "/vmspec/" + specName
+		//url := common.SPIDER_REST_URL + "/vmspec/" + u.CspSpecName
+		url := common.SPIDER_REST_URL + "/vmspec/" + specName
 
 		method := "GET"
 

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -72,8 +72,8 @@ func CreateSshKey(nsId string, u *TbSshKeyReq) (TbSshKeyInfo, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		//url := common.SPIDER_URL + "/keypair?connection_name=" + u.ConnectionName
-		url := common.SPIDER_URL + "/keypair"
+		//url := common.SPIDER_REST_URL + "/keypair?connection_name=" + u.ConnectionName
+		url := common.SPIDER_REST_URL + "/keypair"
 
 		method := "POST"
 

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -84,8 +84,8 @@ func CreateVNet(nsId string, u *TbVNetReq) (TbVNetInfo, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		//url := common.SPIDER_URL + "/vpc?connection_name=" + u.ConnectionName
-		url := common.SPIDER_URL + "/vpc"
+		//url := common.SPIDER_REST_URL + "/vpc?connection_name=" + u.ConnectionName
+		url := common.SPIDER_REST_URL + "/vpc"
 
 		method := "POST"
 

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -1917,7 +1917,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := common.SPIDER_URL + "/vm"
+		url := common.SPIDER_REST_URL + "/vm"
 
 		method := "POST"
 
@@ -2401,8 +2401,8 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 			temp.TargetStatus = StatusTerminated
 			temp.Status = StatusTerminating
 
-			//url = common.SPIDER_URL + "/vm/" + cspVmId + "?connection_name=" + temp.ConnectionName
-			url = common.SPIDER_URL + "/vm/" + cspVmId
+			//url = common.SPIDER_REST_URL + "/vm/" + cspVmId + "?connection_name=" + temp.ConnectionName
+			url = common.SPIDER_REST_URL + "/vm/" + cspVmId
 			method = "DELETE"
 		case ActionReboot:
 
@@ -2410,8 +2410,8 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 			temp.TargetStatus = StatusRunning
 			temp.Status = StatusRebooting
 
-			//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=reboot"
-			url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=reboot"
+			//url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=reboot"
+			url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?action=reboot"
 			method = "GET"
 		case ActionSuspend:
 
@@ -2419,8 +2419,8 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 			temp.TargetStatus = StatusSuspended
 			temp.Status = StatusSuspending
 
-			//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=suspend"
-			url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=suspend"
+			//url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=suspend"
+			url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?action=suspend"
 			method = "GET"
 		case ActionResume:
 
@@ -2428,8 +2428,8 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 			temp.TargetStatus = StatusRunning
 			temp.Status = StatusResuming
 
-			//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=resume"
-			url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=resume"
+			//url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=resume"
+			url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?action=resume"
 			method = "GET"
 		default:
 			return errors.New(action + "is invalid actionType")
@@ -2664,20 +2664,20 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 		method := ""
 		switch action {
 		case ActionTerminate:
-			//url = common.SPIDER_URL + "/vm/" + cspVmId + "?connection_name=" + temp.ConnectionName
-			url = common.SPIDER_URL + "/vm/" + cspVmId
+			//url = common.SPIDER_REST_URL + "/vm/" + cspVmId + "?connection_name=" + temp.ConnectionName
+			url = common.SPIDER_REST_URL + "/vm/" + cspVmId
 			method = "DELETE"
 		case ActionReboot:
-			//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=reboot"
-			url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=reboot"
+			//url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=reboot"
+			url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?action=reboot"
 			method = "GET"
 		case ActionSuspend:
-			//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=suspend"
-			url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=suspend"
+			//url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=suspend"
+			url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?action=suspend"
 			method = "GET"
 		case ActionResume:
-			//url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=resume"
-			url = common.SPIDER_URL + "/controlvm/" + cspVmId + "?action=resume"
+			//url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?connection_name=" + temp.ConnectionName + "&action=resume"
+			url = common.SPIDER_REST_URL + "/controlvm/" + cspVmId + "?action=resume"
 			method = "GET"
 		default:
 			return errors.New(action + "is invalid actionType")
@@ -2966,7 +2966,7 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := common.SPIDER_URL + "/vmstatus/" + cspVmId // + "?connection_name=" + temp.ConnectionName
+		url := common.SPIDER_REST_URL + "/vmstatus/" + cspVmId // + "?connection_name=" + temp.ConnectionName
 		method := "GET"
 
 		//fmt.Println("url: " + url)
@@ -3173,7 +3173,7 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := common.SPIDER_URL + "/vm/" + cspVmId // + "?connection_name=" + temp.ConnectionName
+		url := common.SPIDER_REST_URL + "/vm/" + cspVmId // + "?connection_name=" + temp.ConnectionName
 		method := "GET"
 
 		type VMStatusReqInfo struct {

--- a/src/core/mcis/monitor.go
+++ b/src/core/mcis/monitor.go
@@ -37,7 +37,7 @@ func CallMonitoringAsync(wg *sync.WaitGroup, mcisID string, vmID string, vmIP st
 
 	defer wg.Done() //goroutin sync done
 
-	url := common.DRAGONFLY_URL + cmd
+	url := common.DRAGONFLY_REST_URL + cmd
 	fmt.Println("\n\n[Calling DRAGONFLY] START")
 	fmt.Println("url: " + url + " method: " + method)
 
@@ -238,7 +238,7 @@ func CallGetMonitoringAsync(wg *sync.WaitGroup, mcisID string, vmID string, meth
 
 	defer wg.Done() //goroutin sync done
 
-	url := common.DRAGONFLY_URL + cmd
+	url := common.DRAGONFLY_REST_URL + cmd
 	fmt.Println("\n\n[Calling DRAGONFLY] START")
 	fmt.Println("url: " + url + " method: " + method)
 

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -23,12 +23,12 @@ import (
 //var cblog *logrus.Logger
 //var store icbs.Store
 
-//var SPIDER_URL string
+//var SPIDER_REST_URL string
 
 func init() {
 	//cblog = config.Cblogger
 	//store = cbstore.GetStore()
-	//SPIDER_URL = os.Getenv("SPIDER_URL")
+	//SPIDER_REST_URL = os.Getenv("SPIDER_REST_URL")
 }
 
 /*

--- a/src/main.go
+++ b/src/main.go
@@ -37,8 +37,8 @@ import (
 // @securityDefinitions.basic BasicAuth
 
 func main() {
-	common.SPIDER_URL = os.Getenv("SPIDER_URL")
-	common.DRAGONFLY_URL = os.Getenv("DRAGONFLY_URL")
+	common.SPIDER_REST_URL = os.Getenv("SPIDER_REST_URL")
+	common.DRAGONFLY_REST_URL = os.Getenv("DRAGONFLY_REST_URL")
 	common.DB_URL = os.Getenv("DB_URL")
 	common.DB_DATABASE = os.Getenv("DB_DATABASE")
 	common.DB_USER = os.Getenv("DB_USER")

--- a/test/obsolete/tester-go/cloud-info-mgmt.go
+++ b/test/obsolete/tester-go/cloud-info-mgmt.go
@@ -47,7 +47,7 @@ func registerCloudInfo(resourceType string, param interface{}) error {
 		resourceType == "credential" ||
 		resourceType == "region" ||
 		resourceType == "connectionconfig" {
-		url = SPIDER_URL + "/" + resourceType
+		url = SPIDER_REST_URL + "/" + resourceType
 	} else {
 		err := fmt.Errorf("resourceType must be one of these: driver, credential, region, connectionconfig")
 		return err

--- a/test/obsolete/tester-go/tester.go
+++ b/test/obsolete/tester-go/tester.go
@@ -28,11 +28,11 @@ func init() {
 	//store = cbstore.GetStore()
 }
 
-var SPIDER_URL string
+var SPIDER_REST_URL string
 
 func main() {
-	//SPIDER_URL = os.Getenv("SPIDER_URL")
-	SPIDER_URL = "http://localhost:1024"
+	//SPIDER_REST_URL = os.Getenv("SPIDER_REST_URL")
+	SPIDER_REST_URL = "http://localhost:1024"
 
 	/*
 		// Step 1. Register Cloud Driver info


### PR DESCRIPTION
Since there exist 2 methods (REST / gRPC) for calling CB-Spider,
`SPIDER_REST_URL` seems clear than `SPIDER_URL`.

---

Note: You can set CB-Spider's gRPC endpoint URL at `cb-tumblebug/conf/grpc_conf.yaml`.
```YAML
  spidersrv:
    addr: 127.0.0.1:50251
```

---

And..
- `DRAGONFLY_URL` → `DRAGONFLY_REST_URL`
- Change TB gRPC listen address from `127.0.0.1:50252` to `:50252` (Same issue with https://github.com/cloud-barista/cb-spider/pull/278)
- Add some lines in `Dockerfile`
  - `ENV CBTUMBLEBUG_ROOT /app`
  - `ENV SPIDER_CALL_METHOD REST`
  - `ENV DRAGONFLY_REST_URL http://cb-dragonfly:9090/dragonfly`
  - `EXPOSE 50252`