### PR TITLE
Modify basic conf for testing

### DIFF
--- a/test/official/README.md
+++ b/test/official/README.md
@@ -55,6 +55,7 @@
 ```
 - 사용 예시
   - 생성 테스트
+    - ./testAll-mcis-mcir-ns-cloud.sh all 1 shson       # 등록된 CSP 및 리전들을 활용한 MCIS 생성 (conf.env의 NumCSP, NumRegion 에 따라 VM 생성) shson이라는 개발자명으로 테스트 수행
     - ./testAll-mcis-mcir-ns-cloud.sh aws 1 shson       # aws의 1번 리전에 shson이라는 개발자명으로 테스트 수행
     - ./testAll-mcis-mcir-ns-cloud.sh aws 2 shson       # aws의 2번 리전에 shson이라는 개발자명으로 테스트 수행
     - ./testAll-mcis-mcir-ns-cloud.sh aws 3 shson       # aws의 3번 리전에 shson이라는 개발자명으로 테스트 수행
@@ -63,13 +64,14 @@
     - ./testAll-mcis-mcir-ns-cloud.sh azure 1 shson     # azure의 1번 리전에 shson이라는 개발자명으로 테스트 수행
     - ./testAll-mcis-mcir-ns-cloud.sh alibaba 1 shson   # alibaba의 1번 리전에 shson이라는 개발자명으로 테스트 수행
   - 제거 테스트 (이미 수행이 진행된 클라우드타입/리전/개발자명 으로만 삭제 진행이 필요)
-    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 1 shson       # aws의 1번 리전에 shson이라는 개발자명으로 제거 테스트 수행
-    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 2 shson       # aws의 2번 리전에 shson이라는 개발자명으로 제거 테스트 수행
-    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 3 shson       # aws의 3번 리전에 shson이라는 개발자명으로 제거 테스트 수행
-    - ./cleanAll-mcis-mcir-ns-cloud.sh gcp 1 shson       # gcp의 1번 리전에 shson이라는 개발자명으로 제거 테스트 수행
-    - ./cleanAll-mcis-mcir-ns-cloud.sh gcp 2 shson       # gcp의 2번 리전에 shson이라는 개발자명으로 제거 테스트 수행
-    - ./cleanAll-mcis-mcir-ns-cloud.sh azure 1 shson     # azure의 1번 리전에 shson이라는 개발자명으로 제거 테스트 수행
-    - ./cleanAll-mcis-mcir-ns-cloud.sh alibaba 1 shson   # alibaba의 1번 리전에 shson이라는 개발자명으로 제거 테스트 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh all 1 shson       # all로 수행된 shson이라는 개발자명으로 제거 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 1 shson       # aws의 1번 리전에 shson이라는 개발자명으로 제거 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 2 shson       # aws의 2번 리전에 shson이라는 개발자명으로 제거 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh aws 3 shson       # aws의 3번 리전에 shson이라는 개발자명으로 제거 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh gcp 1 shson       # gcp의 1번 리전에 shson이라는 개발자명으로 제거 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh gcp 2 shson       # gcp의 2번 리전에 shson이라는 개발자명으로 제거 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh azure 1 shson     # azure의 1번 리전에 shson이라는 개발자명으로 제거 수행
+    - ./cleanAll-mcis-mcir-ns-cloud.sh alibaba 1 shson   # alibaba의 1번 리전에 shson이라는 개발자명으로 제거 수행
 
 ```
 ~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./testAll-mcis-mcir-ns-cloud.sh aws 1 shson

--- a/test/official/conf.env
+++ b/test/official/conf.env
@@ -21,19 +21,19 @@ declare -A IMAGE_NAME
 declare -A SPEC_NAME
 
 ## Number of CSP types and corresponding regions
-NumCSP=4
+NumCSP=1
 
 CSPType[1]=aws
-NumRegion[1]=2
+NumRegion[1]=3
 
 CSPType[2]=azure
-NumRegion[2]=1
+NumRegion[2]=3
 
 CSPType[3]=gcp
-NumRegion[3]=1
+NumRegion[3]=3
 
 CSPType[4]=alibaba
-NumRegion[4]=1
+NumRegion[3]=1
 
 
 ## AWS


### PR DESCRIPTION

AWS의 3개의 리전을 사용하는 MCIS 를 생성할 수 있도록 기본 conf.env 를 수정.

여러 클라우드 및 리전에 걸친 MCIS 테스트를 위한 가이드 일부 수정.