### PR TITLE
Add script for automatic dragonfly deployment

### DIFF
--- a/assets/scripts/setcbdf.sh
+++ b/assets/scripts/setcbdf.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+sudo apt-get update > /dev/null
+
+# Install GIT
+sudo apt-get -y install git > /dev/null
+
+# Install Go
+wget https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.13.4.linux-amd64.tar.gz
+
+# Set Go env (for next interactive shell)
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc 
+echo  'export GOPATH=$HOME/go' >> ~/.bashrc 
+# Set Go env (for current shell)
+export PATH=$PATH:/usr/local/go/bin
+export GOPATH=$HOME/go
+
+# Install some dependencies
+sudo apt-get -y install make > /dev/null
+sudo apt-get -y install gcc > /dev/null
+sudo apt-get -y install docker-compose > /dev/null
+
+# Download cb-operator repo with dependencies
+export GO111MODULE=off
+go get -v github.com/cloud-barista/cb-operator 
+
+# Set cb-operator configuration
+printf DockerCompose > $GOPATH/src/github.com/cloud-barista/cb-operator/src/CB_OPERATOR_MODE
+
+# Set cb-tumblebug environment for go module
+export GO111MODULE=on
+
+# Build tumblebug
+cd ~/go/src/github.com/cloud-barista/cb-operator/src/
+make
+
+# Print a message (IP address)
+str=$(curl https://api.ipify.org)
+printf "cb-operator is ready. Access to it with ssh %s " $str
+
+nohup $GOPATH/src/github.com/cloud-barista/cb-operator/src/operator run -f $GOPATH/src/github.com/cloud-barista/cb-operator/docker-compose-mode-files/docker-compose-df-only.yaml 1>/dev/null 2>&1 &
+# $GOPATH/src/github.com/cloud-barista/cb-operator/src/operator info -f $GOPATH/src/github.com/cloud-barista/cb-operator/docker-compose-mode-files/docker-compose-df-only.yaml
+printf "cb-dragonfly is ready. Access to it with ssh %s " $str

--- a/test/official/8.mcis/create-mcis.sh
+++ b/test/official/8.mcis/create-mcis.sh
@@ -53,37 +53,8 @@
 				"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 				"description": "description",
 				"vmUserPassword": ""
-			},
-			{
-				"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-02",
-				"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"vmUserAccount": "cb-user",
-				"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-				"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"securityGroupIds": [
-					"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
-				],
-				"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"description": "description",
-				"vmUserPassword": ""
-			},
-			{
-				"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-03",
-				"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"vmUserAccount": "cb-user",
-				"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-				"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"securityGroupIds": [
-					"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
-				],
-				"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"description": "description",
-				"vmUserPassword": ""
-			} ]
+			}
+			]
 		}' | json_pp || return 1
 #}
 

--- a/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
+++ b/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
@@ -49,7 +49,7 @@
 
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
-			"command": "wget https://gist.githubusercontent.com/seokho-son/6c88a79dda2d711ba7f40b09a4a9d453/raw/3ba2dcf2d2348545d686c6111b41499b1486bdd3/setcbdf.sh -O ~/setcbdf.sh; chmod +x ~/setcbdf.sh; ~/setcbdf.sh"
+			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setcbdf.sh -O ~/setcbdf.sh; chmod +x ~/setcbdf.sh; ~/setcbdf.sh"
 		}' | json_pp #|| return 1
 #}
 

--- a/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
+++ b/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
@@ -49,8 +49,8 @@
 
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
-			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
+			"command": "wget https://gist.githubusercontent.com/seokho-son/6c88a79dda2d711ba7f40b09a4a9d453/raw/3ba2dcf2d2348545d686c6111b41499b1486bdd3/setcbdf.sh -O ~/setcbdf.sh; chmod +x ~/setcbdf.sh; ~/setcbdf.sh"
 		}' | json_pp #|| return 1
 #}
 
-#deploy_nginx_to_mcis
+#deploy_cb-df_to_mcis

--- a/test/official/sequentialFullTest/deploy-spider-docker.sh
+++ b/test/official/sequentialFullTest/deploy-spider-docker.sh
@@ -49,7 +49,7 @@
 
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
-			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/asset/script/setcbsp.sh -O ~/setcbtb.sh; chmod +x ~/setcbtb.sh; ~/setcbtb.sh"
+			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setcbsp.sh -O ~/setcbtb.sh; chmod +x ~/setcbtb.sh; ~/setcbtb.sh"
 		}' | json_pp #|| return 1
 #}
 

--- a/test/official/sequentialFullTest/deploy-tumblebug.sh
+++ b/test/official/sequentialFullTest/deploy-tumblebug.sh
@@ -49,7 +49,7 @@
 
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
-			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/asset/script/setcbtb.sh -O ~/setcbtb.sh; chmod +x ~/setcbtb.sh; ~/setcbtb.sh"
+			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setcbtb.sh -O ~/setcbtb.sh; chmod +x ~/setcbtb.sh; ~/setcbtb.sh"
 		}' | json_pp #|| return 1
 #}
 


### PR DESCRIPTION
Add a CB-TB script for automatic dragonfly deployment.

- Test output
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ 

./deploy-dragonfly-docker.sh aws 1 df1
####################################################################
## Command (SSH) to MCIS 
####################################################################
[Test for AWS]
{
   "result_array" : [
      {
         "result" : "go build -o operator\ncb-operator is ready. Access to it with ssh 3.84.229.190 CB_OPERATOR_MODE: DockerCompose\n\n[Get info for Cloud-Barista runtimes]\n\n[Config path] /home/ubuntu/go/src/github.com/cloud-barista/cb-operator/docker-compose-mode-files/docker-compose-df-only.yaml\n\n\n[v]Status of Cloud-Barista runtimes\nName   Command   State   Ports\n------------------------------\n\n[v]Status of Cloud-Barista runtime images\nContainer   Repository   Tag   Image Id   Size\n----------------------------------------------\ncb-dragonfly is ready. Access to it with ssh 3.84.229.190 ",
         "vm_id" : "aws-us-east-1-df1-01",
         "mcis_id" : "aws-us-east-1-df1",
         "vm_ip" : "3.84.229.190"
      }
   ]
}

son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ 

curl http://3.84.229.190:9090/dragonfly/config
{"agent_TTL":10,"agent_interval":2,"collector_interval":10,"schedule_interval":10,"max_host_count":10}

```