### PR TITLE
Renew client code for latest CB-DF API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/cloud-barista/cb-tumblebug
 go 1.13
 
 replace (
-	github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/coreos/bbolt => go.etcd.io/bbolt v1.3.3
+	github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0
 	google.golang.org/grpc => google.golang.org/grpc v1.26.0
 )
 
@@ -50,7 +50,6 @@ require (
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	go.etcd.io/etcd v3.3.21+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
-	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f // indirect
 	google.golang.org/grpc v1.33.0
 	gopkg.in/yaml.v2 v2.3.0


### PR DESCRIPTION

Renew client code for latest CB-DF API

최신 CB-Dragonfly와의 연동을 위해, 내부 소스코드 수정

[TB를 통항 DF 호스팅용 MCIS-VM 생성]
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./testAll-mcis-mcir-ns-cloud.sh aws 1 shson
####################################################################
## Create MCIS from Zero Base
####################################################################
[Test for AWS]
[Single excution for a CSP region]
####################################################################
## 1. Create Cloud Connction Config
####################################################################
[Test for AWS]
{
   "DriverName" : "aws-driver01",
   "ProviderName" : "AWS",
   "DriverLibFileName" : "aws-driver-v1.0.so"
}
...
...
...
## 8. VM: Status MCIS
####################################################################
[Test for AWS]
{
   "status" : {
      "id" : "aws-us-east-1-shson",
      "vm" : [
         {
            "id" : "aws-us-east-1-shson-01",
            "name" : "aws-us-east-1-shson-01",
            "targetAction" : "None",
            "native_status" : "Running",
            "public_ip" : "107.23.249.73",
            "status" : "Running",
            "targetStatus" : "None",
            "csp_vm_id" : "aws-us-east-1-shson-01"
         }
      ],
      "status" : "Running-(1/1)",
      "name" : "aws-us-east-1-shson",
      "targetStatus" : "None",
      "targetAction" : "None"
   }
}

[Logging to notify latest command history]

[Executed Command List]
[CMD] testAll-mcis-mcir-ns-cloud.sh aws 1 shson
```

[TB를 통한 DF 자동 배포]
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./deploy-dragonfly-docker.sh aws 1 shson
####################################################################
## Command (SSH) to MCIS 
####################################################################
[Test for AWS]
{
   "result_array" : [
      {
         "vm_id" : "aws-us-east-1-shson-01",
         "vm_ip" : "107.23.249.73",
         "result" : "go build -o operator\ncb-operator is ready. Access to it with ssh 107.23.249.73 cb-dragonfly is ready. Access to it with ssh 107.23.249.73 ",
         "mcis_id" : "aws-us-east-1-shson"
      }
   ]
}
[You can update Tumblebug Environment for Dragonfly with following command]
 ../2.configureTumblebug/update-config.sh DRAGONFLY_REST_URL http://{{IPAddress}}:9090/dragonfly

[You can test Dragonfly with following command]
 ../9.monitoring/install-agent.sh aws 1 shson
 ../9.monitoring/get-monitoring-data.sh aws 1 shson
```

[TB의 DF엔드포인트 환경 설정(동작 중인 TB에 동적 설정)]
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ../2.configureTumblebug/update-config.sh DRAGONFLY_REST_URL http://107.23.249.73:9090/dragonfly
####################################################################
## 2. Config: Create or Update (Param1: Key, Param2, Value)
####################################################################
{
   "value" : "http://107.23.249.73:9090/dragonfly",
   "id" : "dragonfly-rest-url",
   "name" : "dragonfly-rest-url"
}
```

[TB를 통한 agent 설치 요청]
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ../9.monitoring/install-agent.sh aws 1 shson
####################################################################
## Install monitoring agent to MCIS 
####################################################################
[Test for AWS]
{
   "result_array" : [
      {
         "vm_ip" : "107.23.249.73",
         "mcis_id" : "aws-us-east-1-shson",
         "result" : "{\"message\":\"agent installation is finished\"}\n",
         "vm_id" : "aws-us-east-1-shson-01"
      }
   ]
}
```

[TB를 통한 온디멘드 CPU 사용률 조회 요청]
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ../9.monitoring/get-monitoring-data.sh aws 1 shson cpu
####################################################################
## Get monitoring data for MCIS (cpu/memory/disk/network)
####################################################################
[Test for AWS]
{
   "result_array" : [
      {
         "vm_id" : "aws-us-east-1-shson-01",
         "mcis_id" : "aws-us-east-1-shson",
         "result" : "{\"cpu\":{\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu-total\",\"cspType\":\"test\",\"host\":\"ip-192-168-1-155\",\"mcisId\":\"aws-us-east-1-shson\",\"nsId\":\"ns-01\",\"osType\":\"linux\",\"vmId\":\"aws-us-east-1-shson-01\"},\"fields\":{\"usage_guest\":0,\"usage_guest_nice\":0,\"usage_idle\":95.99999999999795,\"usage_iowait\":0,\"usage_irq\":0,\"usage_nice\":0,\"usage_softirq\":0,\"usage_steal\":0,\"usage_system\":1.999999999999602,\"usage_user\":1.999999999998181,\"usage_utilization\":4.000000000002046},\"timestamp\":1603288173,\"tagInfo\":null}}\n",
         "vm_ip" : ""
      }
   ]
}
```