### PR TITLE
Add default agent install for MCIS

### DIFF
--- a/src/core/mcis/monitor.go
+++ b/src/core/mcis/monitor.go
@@ -139,6 +139,8 @@ func InstallMonitorAgentToMcis(nsId string, mcisId string, req *McisCmdReq) (Age
 		return content, err
 	}
 
+	fmt.Println("[Install agent for each VM]")
+
 	//goroutin sync wg
 	var wg sync.WaitGroup
 

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3664,6 +3664,10 @@ var doc = `{
         "mcis.TbMcisInfo": {
             "type": "object",
             "properties": {
+                "agentEnabled": {
+                    "description": "yes or no",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -3696,6 +3700,10 @@ var doc = `{
         "mcis.TbMcisReq": {
             "type": "object",
             "properties": {
+                "agentEnabled": {
+                    "description": "AgentEnabled Option for CB-Dragonfly agent installation ([yes/no] default:yes)\n\nin: body\nrequired: false",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3649,6 +3649,10 @@
         "mcis.TbMcisInfo": {
             "type": "object",
             "properties": {
+                "agentEnabled": {
+                    "description": "yes or no",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -3681,6 +3685,10 @@
         "mcis.TbMcisReq": {
             "type": "object",
             "properties": {
+                "agentEnabled": {
+                    "description": "AgentEnabled Option for CB-Dragonfly agent installation ([yes/no] default:yes)\n\nin: body\nrequired: false",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -657,6 +657,9 @@ definitions:
     type: object
   mcis.TbMcisInfo:
     properties:
+      agentEnabled:
+        description: yes or no
+        type: string
       description:
         type: string
       id:
@@ -678,6 +681,13 @@ definitions:
     type: object
   mcis.TbMcisReq:
     properties:
+      agentEnabled:
+        description: |-
+          AgentEnabled Option for CB-Dragonfly agent installation ([yes/no] default:yes)
+
+          in: body
+          required: false
+        type: string
       description:
         type: string
       name:

--- a/test/official/1.configureSpider/unregister-cloud.sh
+++ b/test/official/1.configureSpider/unregister-cloud.sh
@@ -46,16 +46,17 @@
 
 	RESTSERVER=localhost
 
-	# for Cloud Connection Config Info
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]}
-
-	# for Cloud Region Info
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]}
 
 	if [ "${OPTION}" == "leave" ]; then
 		echo "[Leave Cloud Credential and Cloud Driver for other Regions]"
 		exit
 	fi
+	
+	# for Cloud Connection Config Info
+	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]}
+
+	# for Cloud Region Info
+	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]}
 
 	# for Cloud Credential Info
 	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/credential/${CredentialName[INDEX]}

--- a/test/official/8.mcis/create-mcis-no-agent.sh
+++ b/test/official/8.mcis/create-mcis-no-agent.sh
@@ -39,7 +39,7 @@
 		'{
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "Tumblebug Demo",
-			"agentEnabled": "yes",
+			"agentEnabled": "no",
 			"vm": [ {
 				"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-01",
 				"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/sequentialFullTest/gen-mcis-for-df.sh
+++ b/test/official/sequentialFullTest/gen-mcis-for-df.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+
+function dozing()
+{
+	duration=$1
+	printf "Dozing for %s : " $duration
+	for (( i=1; i<=$duration; i++ ))
+	do
+		printf "%s " $i
+		sleep 1
+	done
+	echo "(Back to work)"
+}
+
+# Function for individual CSP test
+function test_sequence()
+{
+	local CSP=$1
+	local REGION=$2
+	local POSTFIX=$3
+	local CMDPATH=$4
+
+	../1.configureSpider/register-cloud.sh $CSP $REGION $POSTFIX
+	../2.configureTumblebug/create-ns.sh $CSP $REGION $POSTFIX
+	../3.vNet/create-vNet.sh $CSP $REGION $POSTFIX
+	dozing 10
+	if [ "${CSP}" == "gcp" ]; then
+		echo "[Test for GCP needs more preparation time]"
+		dozing 20
+	fi
+	../4.securityGroup/create-securityGroup.sh $CSP $REGION $POSTFIX
+	dozing 10
+	../5.sshKey/create-sshKey.sh $CSP $REGION $POSTFIX
+	../6.image/registerImageWithInfo.sh $CSP $REGION $POSTFIX
+	../7.spec/register-spec.sh $CSP $REGION $POSTFIX
+	../8.mcis/create-mcis-no-agent.sh $CSP $REGION $POSTFIX
+	dozing 1
+	../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX
+
+	_self=$CMDPATH
+
+	echo ""
+	echo "[Logging to notify latest command history]"
+	echo "[CMD] ${_self} ${CSP} ${REGION} ${POSTFIX}" >> ./executionStatus
+	echo ""
+	echo "[Executed Command List]"
+	cat  ./executionStatus
+	echo ""
+}
+
+# Functions for all CSP test
+function test_sequence_allcsp_mcir()
+{
+	local CSP=$1
+	local REGION=$2
+	local POSTFIX=$3
+	local CMDPATH=$4
+
+	../1.configureSpider/register-cloud.sh $CSP $REGION $POSTFIX
+	../2.configureTumblebug/create-ns.sh $CSP $REGION $POSTFIX
+	../3.vNet/create-vNet.sh $CSP $REGION $POSTFIX
+	dozing 10
+	if [ "${CSP}" == "gcp" ]; then
+		echo "[Test for GCP needs more preparation time]"
+		dozing 20
+	fi
+	../4.securityGroup/create-securityGroup.sh $CSP $REGION $POSTFIX
+	dozing 10
+	../5.sshKey/create-sshKey.sh $CSP $REGION $POSTFIX
+	../6.image/registerImageWithInfo.sh $CSP $REGION $POSTFIX
+	../7.spec/register-spec.sh $CSP $REGION $POSTFIX
+
+	_self=$CMDPATH
+
+	echo ""
+	echo "[Logging to notify latest command history]"
+	echo "[CMD] ${_self} ${CSP} ${REGION} ${POSTFIX}" >> ./executionStatus
+	echo ""
+	echo "[Executed Command List]"
+	cat  ./executionStatus
+	echo ""
+
+}
+
+function test_sequence_allcsp_mcis()
+{
+	local CSP=$1
+	local REGION=$2
+	local POSTFIX=$3
+	local MCISPREFIX=$4
+
+	../8.mcis/create-single-vm-mcis.sh $CSP $REGION $POSTFIX $MCISPREFIX
+	dozing 1
+	../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX $MCISPREFIX
+
+}
+
+function test_sequence_allcsp_mcis_vm()
+{
+	local CSP=$1
+	local REGION=$2
+	local POSTFIX=$3
+	local MCISPREFIX=$4
+
+	../8.mcis/add-vm-to-mcis.sh $CSP $REGION $POSTFIX $MCISPREFIX
+
+}
+
+
+#function testAll() {
+    FILE=../conf.env
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+	FILE=../credentials.conf
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+	source ../conf.env
+	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+	source ../credentials.conf
+
+	echo "####################################################################"
+	echo "## Create MCIS from Zero Base"
+	echo "####################################################################"
+
+
+	CSP=${1}
+	REGION=${2:-1}
+	POSTFIX=${3:-developer}
+	if [ "${CSP}" == "all" ]; then
+		echo "[Test for all CSP regions (AWS, Azure, GCP, Alibaba, ...)]"
+		CSP="aws"
+		INDEX=0
+	elif [ "${CSP}" == "aws" ]; then
+		echo "[Test for AWS]"
+		INDEX=1
+	elif [ "${CSP}" == "azure" ]; then
+		echo "[Test for Azure]"
+		INDEX=2
+	elif [ "${CSP}" == "gcp" ]; then
+		echo "[Test for GCP]"
+		INDEX=3
+	elif [ "${CSP}" == "alibaba" ]; then
+		echo "[Test for Alibaba]"
+		INDEX=4
+	else
+		echo "[No acceptable argument was provided (all, aws, azure, gcp, alibaba, ...). Default: Test for AWS]"
+		CSP="aws"
+		INDEX=1
+	fi
+
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
+
+		INDEXX=${NumCSP}
+		for ((cspi=1;cspi<=INDEXX;cspi++)); do
+			#echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj=1;cspj<=INDEXY;cspj++)); do
+				#echo $j
+				REGION=$cspj
+
+				echo $CSP
+				echo $REGION
+
+				test_sequence_allcsp_mcir $CSP $REGION $POSTFIX ${0##*/}
+
+			done
+		done
+
+		MCISPREFIX=avengers
+
+		test_sequence_allcsp_mcis ${CSPType[1]} 1 $POSTFIX $MCISPREFIX
+
+		for ((cspi=1;cspi<=INDEXX;cspi++)); do
+			#echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj=1;cspj<=INDEXY;cspj++)); do
+				#echo $j
+				REGION=$cspj
+
+				echo $CSP
+				echo $REGION
+				echo "[Create and Add a VM to MCIS]"
+
+				test_sequence_allcsp_mcis_vm $CSP $REGION $POSTFIX $MCISPREFIX
+
+			done
+		done
+
+		../8.mcis/status-mcis.sh ${CSPType[1]} 1 $POSTFIX $MCISPREFIX
+		
+	else
+		echo "[Single excution for a CSP region]"
+
+		test_sequence $CSP $REGION $POSTFIX ${0##*/}
+
+	fi
+
+#}
+
+#testAll


### PR DESCRIPTION
resolves : #274

```
type TbMcisReq struct {
	Name           string    `json:"name"`
	Vm             []TbVmReq `json:"vm"`
	Placement_algo string    `json:"placement_algo"`

	// AgentEnabled Option for CB-Dragonfly agent installation ([yes/no] default:yes)
    //
    // in: body
    // required: false
	AgentEnabled   string    `json:"agentEnabled"` // yes or no

	Description    string    `json:"description"`
}
```