### PR TITLE
Apply default agentInstall for mcis expand module

### DIFF
--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -432,7 +432,7 @@ func InstallAgentToMcis(nsId string, mcisId string, req *McisCmdReq) (AgentInsta
 
 		// find vaild username
 		userName, sshKey := GetVmSshKey(nsId, mcisId, vmId)
-		userNames := []string{SshDefaultUserName01, SshDefaultUserName02, SshDefaultUserName03, SshDefaultUserName04, userName, req.User_name}
+		userNames := []string{userName, req.User_name, SshDefaultUserName01, SshDefaultUserName02, SshDefaultUserName03, SshDefaultUserName04}
 		userName = VerifySshUserName(vmIp, userNames, sshKey)
 
 		fmt.Println("[SSH] " + mcisId + "/" + vmId + "(" + vmIp + ")" + "with userName:" + userName)
@@ -1603,12 +1603,12 @@ func CorePostCmdMcisVm(nsId string, mcisId string, vmId string, req *McisCmdReq)
 	// find vaild username
 	userName, sshKey := GetVmSshKey(nsId, mcisId, vmId)
 	userNames := []string{
+		userName,
+		req.User_name,
 		SshDefaultUserName01,
 		SshDefaultUserName02,
 		SshDefaultUserName03,
 		SshDefaultUserName04,
-		userName,
-		req.User_name,
 	}
 	userName = VerifySshUserName(vmIp, userNames, sshKey)
 	if userName == "" {
@@ -1687,12 +1687,12 @@ func CorePostCmdMcis(nsId string, mcisId string, req *McisCmdReq) ([]SshCmdResul
 		// find vaild username
 		userName, sshKey := GetVmSshKey(nsId, mcisId, vmId)
 		userNames := []string{
+			userName,
+			req.User_name,
 			SshDefaultUserName01,
 			SshDefaultUserName02,
 			SshDefaultUserName03,
 			SshDefaultUserName04,
-			userName,
-			req.User_name,
 		}
 		userName = VerifySshUserName(vmIp, userNames, sshKey)
 
@@ -1752,33 +1752,31 @@ func CorePostMcisVm(nsId string, mcisId string, vmInfoData *TbVmInfo) (*TbVmInfo
 	vmInfoData.TargetStatus = vmStatus.TargetStatus
 	vmInfoData.TargetAction = vmStatus.TargetAction
 
-		// Install CB-Dragonfly monitoring agent
+	// Install CB-Dragonfly monitoring agent
 
-		mcisTmp, _ := GetMcisObject(nsId, mcisId)
+	mcisTmp, _ := GetMcisObject(nsId, mcisId)
 
-		fmt.Printf("\n[Init monitoring agent] for %+v\n - req.InstallMonAgent: %+v\n\n", mcisId, mcisTmp.InstallMonAgent)
+	fmt.Printf("\n[Init monitoring agent] for %+v\n - req.InstallMonAgent: %+v\n\n", mcisId, mcisTmp.InstallMonAgent)
 	
-		if mcisTmp.InstallMonAgent != "no" {
+	if mcisTmp.InstallMonAgent != "no" {
 			
-			check := CheckDragonflyEndpoint()
-			if (check != nil){
-				fmt.Printf("\n\n[Warring] CB-Dragonfly is not available\n\n")
-			}
+		check := CheckDragonflyEndpoint()
+		if (check != nil){
+			fmt.Printf("\n\n[Warring] CB-Dragonfly is not available\n\n")
+		} else {
+			reqToMon := &McisCmdReq{}
+			reqToMon.User_name = "ubuntu" // this MCIS user name is temporal code. Need to improve.
 			
-			if (check == nil){
-				reqToMon := &McisCmdReq{}
-				reqToMon.User_name = "ubuntu" // this MCIS user name is temporal code. Need to improve.
-				
-				fmt.Printf("\n[InstallMonitorAgentToMcis]\n\n")
-				content, err := InstallMonitorAgentToMcis(nsId, mcisId, reqToMon)
-				if err != nil {
-					common.CBLog.Error(err)
-					//mcisTmp.InstallMonAgent = "no"
-				}
-				common.PrintJsonPretty(content)
-				//mcisTmp.InstallMonAgent = "yes"
+			fmt.Printf("\n[InstallMonitorAgentToMcis]\n\n")
+			content, err := InstallMonitorAgentToMcis(nsId, mcisId, reqToMon)
+			if err != nil {
+				common.CBLog.Error(err)
+				//mcisTmp.InstallMonAgent = "no"
 			}
+			common.PrintJsonPretty(content)
+			//mcisTmp.InstallMonAgent = "yes"
 		}
+	}
 
 
 	return vmInfoData, nil
@@ -2056,9 +2054,7 @@ func CreateMcis(nsId string, req *TbMcisReq) string {
 		check := CheckDragonflyEndpoint()
 		if (check != nil){
 			fmt.Printf("\n\n[Warring] CB-Dragonfly is not available\n\n")
-		}
-		
-		if (check == nil){
+		} else {
 			reqToMon := &McisCmdReq{}
 			reqToMon.User_name = "ubuntu" // this MCIS user name is temporal code. Need to improve.
 			
@@ -2073,8 +2069,6 @@ func CreateMcis(nsId string, req *TbMcisReq) string {
 		}
 	}
 	
-	
-
 	return key
 }
 

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -54,7 +54,7 @@ const milkywayPort string = ":1324/milkyway/"
 
 const SshDefaultUserName01 string = "cb-user"
 const SshDefaultUserName02 string = "ubuntu"
-const SshDefaultUserName03 string = "root"
+const SshDefaultUserName03 string = "others"
 const SshDefaultUserName04 string = "ec2-user"
 
 // Structs for REST API
@@ -151,11 +151,11 @@ type TbMcisReq struct {
 	Vm             []TbVmReq `json:"vm"`
 	Placement_algo string    `json:"placement_algo"`
 
-	// AgentEnabled Option for CB-Dragonfly agent installation ([yes/no] default:yes)
+	// EnableAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
     //
     // in: body
     // required: false
-	AgentEnabled   string    `json:"agentEnabled"` // yes or no
+	InstallMonAgent   string    `json:"installMonAgent"` // yes or no
 
 	Description    string    `json:"description"`
 }
@@ -169,7 +169,7 @@ type TbMcisInfo struct {
 	Status         string     `json:"status"`
 	TargetStatus   string     `json:"targetStatus"`
 	TargetAction   string     `json:"targetAction"`
-	AgentEnabled   string     `json:"agentEnabled"` // yes or no
+	InstallMonAgent   string  `json:"installMonAgent"` // yes or no
 
 	// Disabled for now
 	//Vm             []vmOverview `json:"vm"`
@@ -262,6 +262,9 @@ type TbVmInfo struct {
 	TargetStatus string `json:"targetStatus"`
 	TargetAction string `json:"targetAction"`
 
+	// Montoring agent status
+	MonAgentStatus   string  `json:"monAgentStatus"` // installed, notInstalled, failed
+
 	CspViewVmDetail SpiderVMInfo `json:"cspViewVmDetail"`
 }
 
@@ -337,17 +340,31 @@ type TbVmRecommendInfo struct {
 func VerifySshUserName(vmIp string, userNames []string, privateKey string) string {
 	theUserName := ""
 	cmd := "ls"
-	for _, v := range userNames {
-		fmt.Println("[SSH] " + "(" + vmIp + ")" + "with userName:" + v)
-		fmt.Println("[CMD] " + cmd)
-		if v != "" {
-			if result, err := RunSSH(vmIp, v, privateKey, cmd); err == nil {
-				theUserName = v
-				fmt.Println("[RST] " + *result + "[Username] " + v)
-				break
+
+	for i := 0; i < 100; i++ {
+		for _, v := range userNames {
+			fmt.Println("[SSH] " + "(" + vmIp + ")" + "with userName:" + v)
+			fmt.Println("[CMD] " + cmd)
+			if v != "" {
+				result, err := RunSSH(vmIp, v, privateKey, cmd)
+				if err != nil {
+					fmt.Println("[ERR: result] " + "[ERR: err] " + err.Error() )
+				}
+				if err == nil {
+					theUserName = v
+					fmt.Println("[RST] " + *result + "[Username] " + v)
+					break
+				}
 			}
+			time.Sleep(2 * time.Second)
+		}					
+		if theUserName != ""{
+			break
 		}
+		fmt.Println("[Trying a SSH] trial:"+ strconv.Itoa(i))
+		time.Sleep(1 * time.Second)
 	}
+
 	return theUserName
 }
 
@@ -1735,6 +1752,35 @@ func CorePostMcisVm(nsId string, mcisId string, vmInfoData *TbVmInfo) (*TbVmInfo
 	vmInfoData.TargetStatus = vmStatus.TargetStatus
 	vmInfoData.TargetAction = vmStatus.TargetAction
 
+		// Install CB-Dragonfly monitoring agent
+
+		mcisTmp, _ := GetMcisObject(nsId, mcisId)
+
+		fmt.Printf("\n[Init monitoring agent] for %+v\n - req.InstallMonAgent: %+v\n\n", mcisId, mcisTmp.InstallMonAgent)
+	
+		if mcisTmp.InstallMonAgent != "no" {
+			
+			check := CheckDragonflyEndpoint()
+			if (check != nil){
+				fmt.Printf("\n\n[Warring] CB-Dragonfly is not available\n\n")
+			}
+			
+			if (check == nil){
+				reqToMon := &McisCmdReq{}
+				reqToMon.User_name = "ubuntu" // this MCIS user name is temporal code. Need to improve.
+				
+				fmt.Printf("\n[InstallMonitorAgentToMcis]\n\n")
+				content, err := InstallMonitorAgentToMcis(nsId, mcisId, reqToMon)
+				if err != nil {
+					common.CBLog.Error(err)
+					//mcisTmp.InstallMonAgent = "no"
+				}
+				common.PrintJsonPretty(content)
+				//mcisTmp.InstallMonAgent = "yes"
+			}
+		}
+
+
 	return vmInfoData, nil
 }
 
@@ -2000,26 +2046,33 @@ func CreateMcis(nsId string, req *TbMcisReq) string {
 
 	// Install CB-Dragonfly monitoring agent
 
-	fmt.Printf("\n[Init monitoring agent] for %+v\n - req.AgentEnabled: %+v\n\n", mcisTmp.Id, req.AgentEnabled)
+	fmt.Printf("\n[Init monitoring agent] for %+v\n - req.InstallMonAgent: %+v\n\n", mcisTmp.Id, req.InstallMonAgent)
 
-	mcisTmp.AgentEnabled = "no"
-
-	if req.AgentEnabled != "no" {
-		
-		reqToMon := &McisCmdReq{}
-		reqToMon.User_name = "ubuntu" // this MCIS user name is temporal code. Need to improve.
-		
-		fmt.Printf("\n[InstallMonitorAgentToMcis]\n\n")
-		content, err := InstallMonitorAgentToMcis(nsId, mcisId, reqToMon)
-		if err != nil {
-			common.CBLog.Error(err)
-			mcisTmp.AgentEnabled = "no"
-		}
-		common.PrintJsonPretty(content)
-	
-		mcisTmp.AgentEnabled = "yes"
-	}
+	mcisTmp.InstallMonAgent = req.InstallMonAgent
 	UpdateMcisInfo(nsId, mcisTmp)
+
+	if req.InstallMonAgent != "no" {
+		
+		check := CheckDragonflyEndpoint()
+		if (check != nil){
+			fmt.Printf("\n\n[Warring] CB-Dragonfly is not available\n\n")
+		}
+		
+		if (check == nil){
+			reqToMon := &McisCmdReq{}
+			reqToMon.User_name = "ubuntu" // this MCIS user name is temporal code. Need to improve.
+			
+			fmt.Printf("\n[InstallMonitorAgentToMcis]\n\n")
+			content, err := InstallMonitorAgentToMcis(nsId, mcisId, reqToMon)
+			if err != nil {
+				common.CBLog.Error(err)
+				//mcisTmp.InstallMonAgent = "no"
+			}
+			common.PrintJsonPretty(content)
+			//mcisTmp.InstallMonAgent = "yes"
+		}
+	}
+	
 	
 
 	return key
@@ -2058,7 +2111,10 @@ func AddVmToMcis(wg *sync.WaitGroup, nsId string, mcisId string, vmInfoData *TbV
 	//vmInfoData.CspVmId = string(*instanceIds[0])
 	vmInfoData.Status = StatusRunning
 	vmInfoData.TargetAction = ActionComplete
-	vmInfoData.TargetStatus = StatusComplete
+	vmInfoData.TargetStatus = StatusComplete		
+	// Monitoring Agent Installation Status (init: notInstalled)
+	vmInfoData.MonAgentStatus = "notInstalled"
+	
 	UpdateVmInfo(nsId, mcisId, *vmInfoData)
 
 	return nil
@@ -2361,6 +2417,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 
 	configTmp, _ := common.GetConnConfig(vmInfoData.ConnectionName)
 	vmInfoData.Location = GetCloudLocation(strings.ToLower(configTmp.ProviderName), strings.ToLower(tempSpiderVMInfo.Region.Region))
+
 
 	//content.Status = temp.
 	//content.Cloud_id = temp.
@@ -2995,6 +3052,21 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 	}
 }
 
+
+func GetMcisObject(nsId string, mcisId string) (TbMcisInfo, error) {
+	fmt.Println("[GetMcisObject]" + mcisId)
+	key := common.GenMcisKey(nsId, mcisId, "")
+	keyValue, err := common.CBStore.Get(key)
+	if err != nil {
+		common.CBLog.Error(err)
+		return TbMcisInfo{}, err
+	}
+	mcisTmp := TbMcisInfo{}
+	json.Unmarshal([]byte(keyValue.Value), &mcisTmp)
+	return mcisTmp, nil
+}
+
+
 func GetMcisStatus(nsId string, mcisId string) (McisStatusInfo, error) {
 
 	fmt.Println("[GetMcisStatus]" + mcisId)
@@ -3110,6 +3182,19 @@ func GetMcisStatus(nsId string, mcisId string) (McisStatusInfo, error) {
 
 	//need to change status
 
+}
+
+func GetVmObject(nsId string, mcisId string, vmId string) (TbVmInfo, error) {
+	fmt.Println("[GetVmObject]" + mcisId + "VM:" + vmId)
+	key := common.GenMcisKey(nsId, mcisId, vmId)
+	keyValue, err := common.CBStore.Get(key)
+	if err != nil {
+		common.CBLog.Error(err)
+		return TbVmInfo{}, err
+	}
+	vmTmp := TbVmInfo{}
+	json.Unmarshal([]byte(keyValue.Value), &vmTmp)
+	return vmTmp, nil
 }
 
 func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error) {
@@ -3332,6 +3417,7 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 	return vmStatusTmp, nil
 
 }
+
 
 func UpdateVmPublicIp(nsId string, mcisId string, vmInfoData TbVmInfo) error {
 

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3664,14 +3664,14 @@ var doc = `{
         "mcis.TbMcisInfo": {
             "type": "object",
             "properties": {
-                "agentEnabled": {
-                    "description": "yes or no",
-                    "type": "string"
-                },
                 "description": {
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "installMonAgent": {
+                    "description": "yes or no",
                     "type": "string"
                 },
                 "name": {
@@ -3700,11 +3700,11 @@ var doc = `{
         "mcis.TbMcisReq": {
             "type": "object",
             "properties": {
-                "agentEnabled": {
-                    "description": "AgentEnabled Option for CB-Dragonfly agent installation ([yes/no] default:yes)\n\nin: body\nrequired: false",
+                "description": {
                     "type": "string"
                 },
-                "description": {
+                "installMonAgent": {
+                    "description": "EnableAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)\n\nin: body\nrequired: false",
                     "type": "string"
                 },
                 "name": {
@@ -3743,6 +3743,10 @@ var doc = `{
                 "location": {
                     "type": "object",
                     "$ref": "#/definitions/mcis.GeoLocation"
+                },
+                "monAgentStatus": {
+                    "description": "Montoring agent status",
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3649,14 +3649,14 @@
         "mcis.TbMcisInfo": {
             "type": "object",
             "properties": {
-                "agentEnabled": {
-                    "description": "yes or no",
-                    "type": "string"
-                },
                 "description": {
                     "type": "string"
                 },
                 "id": {
+                    "type": "string"
+                },
+                "installMonAgent": {
+                    "description": "yes or no",
                     "type": "string"
                 },
                 "name": {
@@ -3685,11 +3685,11 @@
         "mcis.TbMcisReq": {
             "type": "object",
             "properties": {
-                "agentEnabled": {
-                    "description": "AgentEnabled Option for CB-Dragonfly agent installation ([yes/no] default:yes)\n\nin: body\nrequired: false",
+                "description": {
                     "type": "string"
                 },
-                "description": {
+                "installMonAgent": {
+                    "description": "EnableAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)\n\nin: body\nrequired: false",
                     "type": "string"
                 },
                 "name": {
@@ -3728,6 +3728,10 @@
                 "location": {
                     "type": "object",
                     "$ref": "#/definitions/mcis.GeoLocation"
+                },
+                "monAgentStatus": {
+                    "description": "Montoring agent status",
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -657,12 +657,12 @@ definitions:
     type: object
   mcis.TbMcisInfo:
     properties:
-      agentEnabled:
-        description: yes or no
-        type: string
       description:
         type: string
       id:
+        type: string
+      installMonAgent:
+        description: yes or no
         type: string
       name:
         type: string
@@ -681,14 +681,14 @@ definitions:
     type: object
   mcis.TbMcisReq:
     properties:
-      agentEnabled:
+      description:
+        type: string
+      installMonAgent:
         description: |-
-          AgentEnabled Option for CB-Dragonfly agent installation ([yes/no] default:yes)
+          EnableAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
 
           in: body
           required: false
-        type: string
-      description:
         type: string
       name:
         type: string
@@ -715,6 +715,9 @@ definitions:
       location:
         $ref: '#/definitions/mcis.GeoLocation'
         type: object
+      monAgentStatus:
+        description: Montoring agent status
+        type: string
       name:
         type: string
       privateDNS:

--- a/test/official/8.mcis/create-mcis-no-agent.sh
+++ b/test/official/8.mcis/create-mcis-no-agent.sh
@@ -39,7 +39,7 @@
 		'{
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "Tumblebug Demo",
-			"agentEnabled": "no",
+			"installMonAgent": "no",
 			"vm": [ {
 				"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-01",
 				"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/8.mcis/create-mcis.sh
+++ b/test/official/8.mcis/create-mcis.sh
@@ -39,7 +39,7 @@
 		'{
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "Tumblebug Demo",
-			"agentEnabled": "yes",
+			"installMonAgent": "yes",
 			"vm": [ {
 				"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-01",
 				"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",

--- a/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
+++ b/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
@@ -57,7 +57,7 @@
 	echo ""
 	echo "[You can test Dragonfly with following command]"
 	echo " ../9.monitoring/install-agent.sh ${CSP} ${REGION} ${POSTFIX}"
-	echo " ../9.monitoring/get-monitoring-data.sh ${CSP} ${REGION} ${POSTFIX}"
+	echo " ../9.monitoring/get-monitoring-data.sh ${CSP} ${REGION} ${POSTFIX} cpu"
 #}
 
 #deploy_cb-df_to_mcis


### PR DESCRIPTION
(related issue: #274)
(related PR: #283)

The PR #283 provide a feature for installing monitoring agent of CB-Dragonfly to all VMs in a MCIS.
However, it was applicable for an initial creation of MCIS.

CB-Tumblebug has a module for "expand MCIS" to add more VMs in a MCIS.
This PR enable the default agent installation option for the "expand MCIS" module.

Note that,
API and object parameters of MCIS will be changed.

(for MCIS creation request, MCIS info)
`InstallMonAgent   string    json:"installMonAgent" // yes or no`

(in VM info)
`MonAgentStatus   string  json:"monAgentStatus" // installed, notInstalled, failed`

# [How to test]
- Create a MCIS(single VM) for CB-Draonfly hosting
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./gen-mcis-for-df.sh aws 1 df
####################################################################
## Create MCIS from Zero Base
####################################################################
[Test for AWS]
[Single excution for a CSP region]
####################################################################
## 1. Create Cloud Connction Config
####################################################################
[Test for AWS]
{
   "ProviderName" : "AWS",
   "DriverName" : "aws-driver01",
...
...
####################################################################
## 8. VM: Status MCIS
####################################################################
[Test for AWS]
{
   "status" : {
      "vm" : [
         {
            "targetAction" : "None",
            "name" : "aws-us-east-1-df-01",
            "public_ip" : "54.91.119.23",
            "targetStatus" : "None",
            "csp_vm_id" : "aws-us-east-1-df-01",
            "status" : "Running",
            "native_status" : "Running",
            "id" : "aws-us-east-1-df-01"
         }
      ],
      "targetStatus" : "None",
      "id" : "aws-us-east-1-df",
      "status" : "Running-(1/1)",
      "targetAction" : "None",
      "name" : "aws-us-east-1-df"
   }
}

[Logging to notify latest command history]

[Executed Command List]
[CMD] gen-mcis-for-df.sh aws 1 df
```

- Deploy CB-Dragonfly docker in the MCIS
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./deploy-dragonfly-docker.sh aws 1 df
####################################################################
## Command (SSH) to MCIS 
####################################################################
[Test for AWS]
{
   "result_array" : [
      {
         "mcis_id" : "aws-us-east-1-df",
         "vm_ip" : "54.91.119.23",
         "result" : "go build -o operator\ncb-operator is ready. Access to it with ssh 54.91.119.23 cb-dragonfly is ready. Access to it with ssh 54.91.119.23 ",
         "vm_id" : "aws-us-east-1-df-01"
      }
   ]
}
[You can update Tumblebug Environment for Dragonfly with following command]
 ../2.configureTumblebug/update-config.sh DRAGONFLY_REST_URL http://{{IPAddress}}:9090/dragonfly

[You can test Dragonfly with following command]
 ../9.monitoring/install-agent.sh aws 1 df
 ../9.monitoring/get-monitoring-data.sh aws 1 df cpu
```

- Update DRAGONFLY_REST_URL config (Endpoint)
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ../2.configureTumblebug/update-config.sh DRAGONFLY_REST_URL http://54.91.119.23:9090/dragonfly
####################################################################
## 2. Config: Create or Update (Param1: Key, Param2, Value)
####################################################################
{
   "name" : "dragonfly-rest-url",
   "id" : "dragonfly-rest-url",
   "value" : "http://54.91.119.23:9090/dragonfly"
}
```

- Create a MCIS for monitoring test
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./testAll-mcis-mcir-ns-cloud.sh aws 2 shson1
####################################################################
## Create MCIS from Zero Base
####################################################################
[Test for AWS]
[Single excution for a CSP region]
####################################################################
## 1. Create Cloud Connction Config
####################################################################
[Test for AWS]
{
   "DriverLibFileName" : "aws-driver-v1.0.so",
   "DriverName" : "aws-driver01",
...
...
####################################################################
## 8. VM: Status MCIS
####################################################################
[Test for AWS]
{
   "status" : {
      "name" : "aws-ap-northeast-2-shson1",
      "vm" : [
         {
            "targetStatus" : "None",
            "public_ip" : "13.124.191.77",
            "native_status" : "Running",
            "status" : "Running",
            "name" : "aws-ap-northeast-2-shson1-01",
            "csp_vm_id" : "aws-ap-northeast-2-shson1-01",
            "id" : "aws-ap-northeast-2-shson1-01",
            "targetAction" : "None"
         }
      ],
      "targetStatus" : "None",
      "id" : "aws-ap-northeast-2-shson1",
      "targetAction" : "None",
      "status" : "Running-(1/1)"
   }
}

[Logging to notify latest command history]

[Executed Command List]
[CMD] gen-mcis-for-df.sh aws 1 df
[CMD] testAll-mcis-mcir-ns-cloud.sh aws 2 shson1
```

- Get monitoring info from the MCIS (agent enabled)
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ../9.monitoring/get-monitoring-data.sh aws 2 shson1 cpu
####################################################################
## Get monitoring data for MCIS (cpu/memory/disk/network)
####################################################################
[Test for AWS]
{
   "result_array" : [
      {
         "result" : "{\"cpu\":{\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu-total\",\"cspType\":\"test\",\"host\":\"ip-192-168-1-93\",\"mcisId\":\"aws-ap-northeast-2-shson1\",\"nsId\":\"ns-01\",\"osType\":\"linux\",\"vmId\":\"aws-ap-northeast-2-shson1-01\"},\"fields\":{\"usage_guest\":0,\"usage_guest_nice\":0,\"usage_idle\":97.99999999999898,\"usage_iowait\":0,\"usage_irq\":0,\"usage_nice\":0,\"usage_softirq\":0,\"usage_steal\":0,\"usage_system\":0,\"usage_user\":2.000000000001023,\"usage_utilization\":2.000000000001023},\"timestamp\":1603767685,\"tagInfo\":null}}\n",
         "mcis_id" : "aws-ap-northeast-2-shson1",
         "vm_ip" : "",
         "vm_id" : "aws-ap-northeast-2-shson1-01"
      }
   ]
}
```

- Expand MCIS (1VM to 3VM with agent)
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./expand-mcis.sh aws 2 shson1 2
####################################################################
## 8. vm: Create MCIS
####################################################################
[Test for AWS]
aws-ap-northeast-2-shson1
aws-ap-northeast-2-shson1-04
{
   "targetAction" : "None",
   "id" : "aws-ap-northeast-2-shson1-04",
   "targetStatus" : "None",
   "name" : "aws-ap-northeast-2-shson1-04",
...
...
      "nativeRegion" : "ap-northeast-2",
      "latitude" : "37.3600",
      "briefAddr" : "Seoul"
   },
   "vNetId" : "aws-ap-northeast-2-shson1",
   "specId" : "aws-ap-northeast-2-shson1",
   "targetAction" : "None",
   "vmUserPassword" : "",
   "description" : "description",
   "sshKeyId" : "aws-ap-northeast-2-shson1",
   "status" : "Running",
   "securityGroupIds" : [
      "aws-ap-northeast-2-shson1"
   ],
   "vmBlockDisk" : "/dev/sda1",
   "privateIP" : "192.168.1.164",
   "imageId" : "aws-ap-northeast-2-shson1",
   "targetStatus" : "None"
}
```

- Get monitoring info from the expanded MCIS (3VM with agent)
```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ../9.monitoring/get-monitoring-data.sh aws 2 shson1 cpu
####################################################################
## Get monitoring data for MCIS (cpu/memory/disk/network)
####################################################################
[Test for AWS]
{
   "result_array" : [
      {
         "mcis_id" : "aws-ap-northeast-2-shson1",
         "vm_id" : "aws-ap-northeast-2-shson1-01",
         "vm_ip" : "",
         "result" : "{\"cpu\":{\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu-total\",\"cspType\":\"test\",\"host\":\"ip-192-168-1-93\",\"mcisId\":\"aws-ap-northeast-2-shson1\",\"nsId\":\"ns-01\",\"osType\":\"linux\",\"vmId\":\"aws-ap-northeast-2-shson1-01\"},\"fields\":{\"usage_guest\":0,\"usage_guest_nice\":0,\"usage_idle\":97.95918367347105,\"usage_iowait\":0,\"usage_irq\":0,\"usage_nice\":0,\"usage_softirq\":0,\"usage_steal\":0,\"usage_system\":0,\"usage_user\":2.0408163265318553,\"usage_utilization\":2.0408163265289545},\"timestamp\":1603768043,\"tagInfo\":null}}\n"
      },
      {
         "mcis_id" : "aws-ap-northeast-2-shson1",
         "result" : "{\"cpu\":{\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu-total\",\"cspType\":\"test\",\"host\":\"ip-192-168-1-164\",\"mcisId\":\"aws-ap-northeast-2-shson1\",\"nsId\":\"ns-01\",\"osType\":\"linux\",\"vmId\":\"aws-ap-northeast-2-shson1-05\"},\"fields\":{\"usage_guest\":0,\"usage_guest_nice\":0,\"usage_idle\":95.99999999999534,\"usage_iowait\":0,\"usage_irq\":0,\"usage_nice\":0,\"usage_softirq\":0,\"usage_steal\":0,\"usage_system\":0,\"usage_user\":4.000000000000398,\"usage_utilization\":4.000000000004661},\"timestamp\":1603768043,\"tagInfo\":null}}\n",
         "vm_id" : "aws-ap-northeast-2-shson1-05",
         "vm_ip" : ""
      },
      {
         "result" : "{\"cpu\":{\"name\":\"cpu\",\"tags\":{\"cpu\":\"cpu-total\",\"cspType\":\"test\",\"host\":\"ip-192-168-1-54\",\"mcisId\":\"aws-ap-northeast-2-shson1\",\"nsId\":\"ns-01\",\"osType\":\"linux\",\"vmId\":\"aws-ap-northeast-2-shson1-04\"},\"fields\":{\"usage_guest\":0,\"usage_guest_nice\":0,\"usage_idle\":96.00000000000887,\"usage_iowait\":0,\"usage_irq\":0,\"usage_nice\":0,\"usage_softirq\":0,\"usage_steal\":0,\"usage_system\":2.0000000000001847,\"usage_user\":1.9999999999998295,\"usage_utilization\":3.9999999999911324},\"timestamp\":1603768044,\"tagInfo\":null}}\n",
         "vm_ip" : "",
         "vm_id" : "aws-ap-northeast-2-shson1-04",
         "mcis_id" : "aws-ap-northeast-2-shson1"
      }
   ]
}
```