### PR TITLE
Add 'SortSpecs' function

### DIFF
--- a/src/api/rest/server/mcir/spec.go
+++ b/src/api/rest/server/mcir/spec.go
@@ -221,6 +221,34 @@ func RestFilterSpecs(c echo.Context) error {
 	return c.JSON(http.StatusOK, &result)
 }
 
+func RestTestSortSpecs(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+
+	u := &mcir.TbSpecInfo{}
+	if err := c.Bind(u); err != nil {
+		return err
+	}
+
+	fmt.Println("[Filter specs]")
+	content, err := mcir.FilterSpecs(nsId, *u)
+
+	if err != nil {
+		common.CBLog.Error(err)
+		return c.JSONBlob(http.StatusNotFound, []byte(err.Error()))
+	}
+
+	content, err = mcir.SortSpecs(content, "mem_GiB", "descending")
+	if err != nil {
+		common.CBLog.Error(err)
+		return c.JSONBlob(http.StatusNotFound, []byte(err.Error()))
+	}
+
+	result := RestFilterSpecsResponse{}
+	result.Spec = content
+	return c.JSON(http.StatusOK, &result)
+}
+
 // RestGetSpec godoc
 // @Summary Get spec
 // @Description Get spec

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -185,6 +185,7 @@ func ApiServer() {
 
 	g.POST("/:nsId/resources/fetchSpecs", rest_mcir.RestFetchSpecs)
 	g.GET("/:nsId/resources/filterSpecs", rest_mcir.RestFilterSpecs)
+	g.GET("/:nsId/resources/testSortSpecs", rest_mcir.RestTestSortSpecs)
 	g.POST("/:nsId/resources/fetchImages", rest_mcir.RestFetchImages)
 
 	g.POST("/:nsId/resources/securityGroup", rest_mcir.RestPostSecurityGroup)

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 
 	//"strings"
@@ -727,4 +728,48 @@ func FilterSpecs(nsId string, filter TbSpecInfo) ([]TbSpecInfo, error) {
 		tempList = append(tempList, temp)
 	}
 	return tempList, nil
+}
+
+func SortSpecs(specList []TbSpecInfo, orderBy string, direction string) ([]TbSpecInfo, error) {
+	var err error = nil
+
+	sort.Slice(specList, func(i, j int) bool {
+		if orderBy == "num_vCPU" {
+			if direction == "descending" {
+				return specList[i].Num_vCPU > specList[j].Num_vCPU
+			} else if direction == "ascending" {
+				return specList[i].Num_vCPU < specList[j].Num_vCPU
+			} else {
+				err = fmt.Errorf("'direction' should one of these: ascending, descending")
+				return true
+			}
+		} else if orderBy == "mem_GiB" {
+			if direction == "descending" {
+				return specList[i].Mem_GiB > specList[j].Mem_GiB
+			} else if direction == "ascending" {
+				return specList[i].Mem_GiB < specList[j].Mem_GiB
+			} else {
+				err = fmt.Errorf("'direction' should one of these: ascending, descending")
+				return true
+			}
+		} else if orderBy == "storage_GiB" {
+			if direction == "descending" {
+				return specList[i].Storage_GiB > specList[j].Storage_GiB
+			} else if direction == "ascending" {
+				return specList[i].Storage_GiB < specList[j].Storage_GiB
+			} else {
+				err = fmt.Errorf("'direction' should one of these: ascending, descending")
+				return true
+			}
+		} else {
+			err = fmt.Errorf("'orderBy' should one of these: num_vCPU, mem_GiB, storage_GiB")
+			return true
+		}
+	})
+
+	for i, _ := range specList {
+		specList[i].OrderInFilteredResult = uint16(i + 1)
+	}
+
+	return specList, err
 }

--- a/test/official/7.spec/test-sort-specs.sh
+++ b/test/official/7.spec/test-sort-specs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#function filter_specs() {
+    FILE=../conf.env
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+    source ../conf.env
+    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+    echo "####################################################################"
+    echo "## 7. spec: filter"
+    echo "####################################################################"
+
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testSortSpecs -H 'Content-Type: application/json' -d \
+	    '{ 
+		    "num_vCPU": '4'
+	    }' | json_pp #|| return 1
+
+#}
+
+#filter_specs


### PR DESCRIPTION
CB-Tumblebug Go 코드 내부에서 사용하는 방법:
`func SortSpecs(specList []TbSpecInfo, orderBy string, direction string) ([]TbSpecInfo, error)` 함수 호출

---

호출 예시:
`func RestTestSortSpecs(c echo.Context) error` 에 기재되어 있음
```Go
content, err = mcir.SortSpecs(content, "mem_GiB", "descending")
```

---

테스트를 위한 REST API 호출:
`test/official/7.spec/test-sort-specs.sh` 에 기재되어 있음
```
curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testSortSpecs -H 'Content-Type: application/json' -d \
	    '{ 
		    "num_vCPU": '4'
	    }' | json_pp
```
- JSON body 의 `"num_vCPU": 4` 는 정렬용이 아니라, 정렬에 사용할 데이터를 필터하기 위한 조건임
(`"num_vCPU": 4` 인 spec들 중에서)
- 정렬 조건은 `func RestTestSortSpecs(c echo.Context) error` 에 하드코딩 되어 있음
`content, err = mcir.SortSpecs(content, "mem_GiB", "descending")`
("mem_GiB" 내림차순으로 정렬)
- 결과

`cb-tumblebug/test/official/7.spec# ./test-sort-specs.sh | less`
```
####################################################################
## 7. spec: filter
####################################################################
{
   "spec" : [
      {
         "evaluationScore_05" : 0,
         "max_num_storage" : 0,
         "gpu_model" : "",
         "evaluationScore_08" : 0,
         "orderInFilteredResult" : 1,
         "description" : "",
         "gpumem_GiB" : 0,
         "evaluationScore_02" : 0,
         "storage_GiB" : 0,
         "net_bw_Gbps" : 0,
         "evaluationScore_04" : 0,
         "os_type" : "",
         "evaluationScore_07" : 0,
         "mem_GiB" : 122,
         "evaluationScore_09" : 0,
         "max_total_storage_TiB" : 0,
         "num_core" : 0,
         "evaluationScore_10" : 0,
         "num_storage" : 0,
         "name" : "cb-aws-config",
         "evaluationScore_01" : 0,
         "ebs_bw_Mbps" : 0,
         "id" : "cb-aws-config-x1e.xlarge",
         "cost_per_hour" : 0,
         "num_vCPU" : 4,
         "evaluationStatus" : "",
         "evaluationScore_06" : 0,
         "cspSpecName" : "cb-aws-config-x1e.xlarge",
         "connectionName" : "x1e.xlarge",
         "evaluationScore_03" : 0,
         "gpu_p2p" : "",
         "num_gpu" : 0
      },
...
      {
         "name" : "aws-us-east-1",
         "evaluationScore_01" : 0,
         "num_storage" : 0,
         "evaluationScore_10" : 0,
         "num_core" : 0,
         "gpu_p2p" : "",
         "num_gpu" : 0,
         "evaluationScore_03" : 0,
         "connectionName" : "c3.xlarge",
         "cspSpecName" : "aws-us-east-1-c3.xlarge",
         "evaluationScore_06" : 0,
         "num_vCPU" : 4,
         "evaluationStatus" : "",
         "cost_per_hour" : 0,
         "id" : "aws-us-east-1-c3.xlarge",
         "ebs_bw_Mbps" : 0,
         "evaluationScore_04" : 0,
         "net_bw_Gbps" : 0,
         "storage_GiB" : 0,
         "gpumem_GiB" : 0,
         "evaluationScore_02" : 0,
         "description" : "",
         "orderInFilteredResult" : 92,
         "evaluationScore_08" : 0,
         "gpu_model" : "",
         "max_num_storage" : 0,
         "evaluationScore_05" : 0,
         "max_total_storage_TiB" : 0,
         "evaluationScore_09" : 0,
         "mem_GiB" : 7,
         "evaluationScore_07" : 0,
         "os_type" : ""
      }
   ]
}
```

---

- 향후 `evaluationScore_01 ~ 10` 으로도 정렬 가능하도록 업데이트 예정
- `func SortSpecs(specList []TbSpecInfo, orderBy string, direction string) ([]TbSpecInfo, error)` 함수의 구현 방법에는 개선의 여지가 많이 있음
