### PR TITLE
Fix bug in 'FilterSpecs' function

### DIFF
--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -293,6 +293,7 @@ func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 	content.ConnectionName = u.ConnectionName
 
 	sql := "INSERT INTO `image`(" +
+		"`namespace`, " +
 		"`id`, " +
 		"`name`, " +
 		"`connectionName`, " +
@@ -303,6 +304,7 @@ func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 		"`guestOS`, " +
 		"`status`) " +
 		"VALUES ('" +
+		nsId + "', '" +
 		content.Id + "', '" +
 		content.Name + "', '" +
 		content.ConnectionName + "', '" +
@@ -372,6 +374,7 @@ func RegisterImageWithInfo(nsId string, content *TbImageInfo) (TbImageInfo, erro
 	content.Name = lowerizedName
 
 	sql := "INSERT INTO `image`(" +
+		"`namespace`, " +
 		"`id`, " +
 		"`name`, " +
 		"`connectionName`, " +
@@ -382,6 +385,7 @@ func RegisterImageWithInfo(nsId string, content *TbImageInfo) (TbImageInfo, erro
 		"`guestOS`, " +
 		"`status`) " +
 		"VALUES ('" +
+		nsId + "', '" +
 		content.Id + "', '" +
 		content.Name + "', '" +
 		content.ConnectionName + "', '" +

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -768,49 +768,31 @@ func FilterSpecs(nsId string, filter TbSpecInfo) ([]TbSpecInfo, error) {
 		return tempList, err
 	}
 
+	cols, err := rows.Columns()
+	if err != nil {
+		common.CBLog.Error(err)
+		return tempList, err
+	}
+
 	for rows.Next() {
-		temp := TbSpecInfo{}
-		var tempString string
-		err := rows.Scan(
-			&tempString,
-			&temp.Id,
-			&temp.Name,
-			&temp.ConnectionName,
-			&temp.CspSpecName,
-			&temp.Os_type,
-			&temp.Num_vCPU,
-			&temp.Num_core,
-			&temp.Mem_GiB,
-			&temp.Storage_GiB,
-			&temp.Description,
-			&temp.Cost_per_hour,
-			&temp.Num_storage,
-			&temp.Max_num_storage,
-			&temp.Max_total_storage_TiB,
-			&temp.Net_bw_Gbps,
-			&temp.Ebs_bw_Mbps,
-			&temp.Gpu_model,
-			&temp.Num_gpu,
-			&temp.Gpumem_GiB,
-			&temp.Gpu_p2p,
-			&temp.OrderInFilteredResult,
-			&temp.EvaluationStatus,
-			&temp.EvaluationScore_01,
-			&temp.EvaluationScore_02,
-			&temp.EvaluationScore_03,
-			&temp.EvaluationScore_04,
-			&temp.EvaluationScore_05,
-			&temp.EvaluationScore_06,
-			&temp.EvaluationScore_07,
-			&temp.EvaluationScore_08,
-			&temp.EvaluationScore_09,
-			&temp.EvaluationScore_10,
-		)
-		if err != nil {
-			common.CBLog.Error(err)
+		columns := make([]interface{}, len(cols))
+		columnPointers := make([]interface{}, len(cols))
+		for i, _ := range columns {
+			columnPointers[i] = &columns[i]
+		}
+
+		if err := rows.Scan(columnPointers...); err != nil {
 			return tempList, err
 		}
-		tempList = append(tempList, temp)
+		m := make(map[string]interface{})
+		for i, colName := range cols {
+			val := columnPointers[i].(*interface{})
+			m[colName] = *val
+		}
+		js, _ := json.Marshal(m)
+		tempSpec := TbSpecInfo{}
+		json.Unmarshal(js, &tempSpec)
+		tempList = append(tempList, tempSpec)
 	}
 	return tempList, nil
 }
@@ -1018,49 +1000,31 @@ func FilterSpecsByRange(nsId string, filter FilterSpecsByRangeRequest) ([]TbSpec
 		return tempList, err
 	}
 
+	cols, err := rows.Columns()
+	if err != nil {
+		common.CBLog.Error(err)
+		return tempList, err
+	}
+
 	for rows.Next() {
-		temp := TbSpecInfo{}
-		var tempString string
-		err := rows.Scan(
-			&tempString,
-			&temp.Id,
-			&temp.Name,
-			&temp.ConnectionName,
-			&temp.CspSpecName,
-			&temp.Os_type,
-			&temp.Num_vCPU,
-			&temp.Num_core,
-			&temp.Mem_GiB,
-			&temp.Storage_GiB,
-			&temp.Description,
-			&temp.Cost_per_hour,
-			&temp.Num_storage,
-			&temp.Max_num_storage,
-			&temp.Max_total_storage_TiB,
-			&temp.Net_bw_Gbps,
-			&temp.Ebs_bw_Mbps,
-			&temp.Gpu_model,
-			&temp.Num_gpu,
-			&temp.Gpumem_GiB,
-			&temp.Gpu_p2p,
-			&temp.OrderInFilteredResult,
-			&temp.EvaluationStatus,
-			&temp.EvaluationScore_01,
-			&temp.EvaluationScore_02,
-			&temp.EvaluationScore_03,
-			&temp.EvaluationScore_04,
-			&temp.EvaluationScore_05,
-			&temp.EvaluationScore_06,
-			&temp.EvaluationScore_07,
-			&temp.EvaluationScore_08,
-			&temp.EvaluationScore_09,
-			&temp.EvaluationScore_10,
-		)
-		if err != nil {
-			common.CBLog.Error(err)
+		columns := make([]interface{}, len(cols))
+		columnPointers := make([]interface{}, len(cols))
+		for i, _ := range columns {
+			columnPointers[i] = &columns[i]
+		}
+
+		if err := rows.Scan(columnPointers...); err != nil {
 			return tempList, err
 		}
-		tempList = append(tempList, temp)
+		m := make(map[string]interface{})
+		for i, colName := range cols {
+			val := columnPointers[i].(*interface{})
+			m[colName] = *val
+		}
+		js, _ := json.Marshal(m)
+		tempSpec := TbSpecInfo{}
+		json.Unmarshal(js, &tempSpec)
+		tempList = append(tempList, tempSpec)
 	}
 	return tempList, nil
 }


### PR DESCRIPTION
- Resolves #307 

---

`cb-tumblebug/test/official/7.spec# ./filter-specs.sh | less`
```
####################################################################
## 7. spec: filter
####################################################################
{
   "spec" : [
      {
         "max_num_storage" : 0,
         "name" : "aws-us-east-1-a1.medium",
         "num_core" : 0,
         "num_vCPU" : 1,
         "storage_GiB" : 0,
         "id" : "aws-us-east-1-a1.medium",
         "evaluationScore_09" : 0,
         "num_storage" : 0,
         "evaluationScore_04" : 0,
         "connectionName" : "aws-us-east-1",
         "evaluationScore_02" : 0,
         "evaluationScore_01" : 0,
         "evaluationScore_08" : 0,
         "gpu_p2p" : "",
         "ebs_bw_Mbps" : 0,
         "gpu_model" : "",
         "gpumem_GiB" : 0,
         "description" : "",
         "num_gpu" : 0,
         "max_total_storage_TiB" : 0,
         "evaluationScore_05" : 0,
         "cspSpecName" : "a1.medium",
         "orderInFilteredResult" : 0,
         "cost_per_hour" : 0,
         "evaluationScore_10" : 0,
         "os_type" : "",
         "evaluationScore_07" : 0,
         "evaluationScore_03" : 0,
         "net_bw_Gbps" : 0,
         "evaluationScore_06" : 0,
         "mem_GiB" : 2,
         "evaluationStatus" : ""
      },
...
```

---

`cb-tumblebug/test/official/7.spec# ./range-filter-specs.sh | less`
```
####################################################################
## 7. spec: filter
####################################################################
{
   "spec" : [
      {
         "evaluationScore_10" : 0,
         "evaluationScore_02" : 0,
         "evaluationScore_06" : 0,
         "max_num_storage" : 0,
         "orderInFilteredResult" : 0,
         "gpu_model" : "",
         "storage_GiB" : 0,
         "num_core" : 0,
         "evaluationScore_05" : 0,
         "max_total_storage_TiB" : 0,
         "num_gpu" : 0,
         "evaluationScore_07" : 0,
         "os_type" : "",
         "evaluationScore_01" : 0,
         "net_bw_Gbps" : 0,
         "gpu_p2p" : "",
         "evaluationScore_09" : 0,
         "evaluationScore_03" : 0,
         "cost_per_hour" : 0,
         "evaluationStatus" : "",
         "num_vCPU" : 2,
         "mem_GiB" : 4,
         "gpumem_GiB" : 0,
         "ebs_bw_Mbps" : 0,
         "evaluationScore_08" : 0,
         "id" : "aws-us-east-1-a1.large",
         "connectionName" : "aws-us-east-1",
         "name" : "aws-us-east-1-a1.large",
         "description" : "",
         "evaluationScore_04" : 0,
         "cspSpecName" : "a1.large",
         "num_storage" : 0
      },
```