### PR TITLE
 Add auto control ScaleOut and ScaleIn actions

### DIFF
--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -407,59 +407,6 @@ func RestPostMcisVm(c echo.Context) error {
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
 
-	/*
-		req := &mcis.TbVmReq{}
-		if err := c.Bind(req); err != nil {
-			return err
-		}
-
-		vmInfoData := mcis.TbVmInfo{}
-		//vmInfoData.Id = common.GenUuid()
-		vmInfoData.Id = common.GenId(req.Name)
-		//req.Id = vmInfoData.Id
-		//vmInfoData.CspVmName = req.CspVmName // will be deprecated
-
-		//vmInfoData.Placement_algo = req.Placement_algo
-
-		//vmInfoData.Location = req.Location
-		//vmInfoData.Cloud_id = req.
-		vmInfoData.Description = req.Description
-
-		//vmInfoData.CspSpecId = req.CspSpecId
-
-		//vmInfoData.Vcpu_size = req.Vcpu_size
-		//vmInfoData.Memory_size = req.Memory_size
-		//vmInfoData.Disk_size = req.Disk_size
-		//vmInfoData.Disk_type = req.Disk_type
-
-		//vmInfoData.CspImageName = req.CspImageName
-
-		//vmInfoData.CspSecurityGroupIds = req.CspSecurityGroupIds
-		//vmInfoData.CspVirtualNetworkId = "TBD"
-		//vmInfoData.Subnet = "TBD"
-		//vmInfoData.CspImageName = "TBD"
-		//vmInfoData.CspSpecId = "TBD"
-
-		//vmInfoData.PublicIP = "Not assigned yet"
-		//vmInfoData.CspVmId = "Not assigned yet"
-		//vmInfoData.PublicDNS = "Not assigned yet"
-		vmInfoData.Status = "Creating"
-
-		vmInfoData.Name = req.Name
-		vmInfoData.ConnectionName = req.ConnectionName
-		vmInfoData.SpecId = req.SpecId
-		vmInfoData.ImageId = req.ImageId
-		vmInfoData.VNetId = req.VNetId
-		vmInfoData.SubnetId = req.SubnetId
-		//vmInfoData.Vnic_id = req.Vnic_id
-		//vmInfoData.Public_ip_id = req.Public_ip_id
-		vmInfoData.SecurityGroupIds = req.SecurityGroupIds
-		vmInfoData.SshKeyId = req.SshKeyId
-		vmInfoData.Description = req.Description
-
-		vmInfoData.ConnectionName = req.ConnectionName
-	*/
-
 	vmInfoData := &mcis.TbVmInfo{}
 	if err := c.Bind(vmInfoData); err != nil {
 		return err

--- a/src/core/mcir/obsolete/publicip.go
+++ b/src/core/mcir/obsolete/publicip.go
@@ -339,9 +339,9 @@ func createPublicIp(nsId string, u *publicIpReq) (publicIpInfo, int, []byte, err
 	fmt.Println("=========================== PUT createPublicIp")
 	Key := common.GenResourceKey(nsId, "publicIp", content.Id)
 	Val, _ := json.Marshal(content)
-	fmt.Println("Key: ", Key)
-	fmt.Println("Val: ", Val)
-	err := common.CBStore.Put(string(Key), string(Val))
+	//fmt.Println("Key: ", Key)
+	//fmt.Println("Val: ", Val)
+	err = common.CBStore.Put(string(Key), string(Val))
 	if err != nil {
 		common.CBLog.Error(err)
 		return content, res.StatusCode, body, err

--- a/src/core/mcir/obsolete/subnet.go
+++ b/src/core/mcir/obsolete/subnet.go
@@ -245,8 +245,8 @@ func createSubnet(nsId string, u *subnetReq) (subnetInfo, error) {
 		"resourceGroupName":  content.ResourceGroupName,
 		"description":        content.Description}
 	Val, _ := json.Marshal(mapA)
-	fmt.Println("Key: ", Key)
-	fmt.Println("Val: ", Val)
+	//fmt.Println("Key: ", Key)
+	//fmt.Println("Val: ", Val)
 	err := common.CBStore.Put(string(Key), string(Val))
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/core/mcir/obsolete/vnic.go
+++ b/src/core/mcir/obsolete/vnic.go
@@ -395,8 +395,8 @@ func createVNic(nsId string, u *vNicReq) (vNicInfo, int, []byte, error) {
 		Val, _ := json.Marshal(mapA)
 	*/
 	Val, _ := json.Marshal(content)
-	fmt.Println("Key: ", Key)
-	fmt.Println("Val: ", Val)
+	//fmt.Println("Key: ", Key)
+	//fmt.Println("Val: ", Val)
 	err := common.CBStore.Put(string(Key), string(Val))
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -197,8 +197,8 @@ func CreateVNet(nsId string, u *TbVNetReq) (TbVNetInfo, error) {
 	*/
 	Val, _ := json.Marshal(content)
 
-	fmt.Println("Key: ", Key)
-	fmt.Println("Val: ", Val)
+	//fmt.Println("Key: ", Key)
+	//fmt.Println("Val: ", Val)
 	err3 := common.CBStore.Put(string(Key), string(Val))
 	if err3 != nil {
 		common.CBLog.Error(err3)

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -57,6 +57,8 @@ const SshDefaultUserName02 string = "ubuntu"
 const SshDefaultUserName03 string = "others"
 const SshDefaultUserName04 string = "ec2-user"
 
+const LabelAutoGen string = "AutoGen"
+
 // Structs for REST API
 
 // 2020-04-13 https://github.com/cloud-barista/cb-spider/blob/master/cloud-control-manager/cloud-driver/interfaces/resources/VMHandler.go
@@ -3192,7 +3194,7 @@ func GetMcisStatus(nsId string, mcisId string) (McisStatusInfo, error) {
 }
 
 func GetVmObject(nsId string, mcisId string, vmId string) (TbVmInfo, error) {
-	fmt.Println("[GetVmObject]" + mcisId + "VM:" + vmId)
+	fmt.Println("[GetVmObject]" + mcisId + ", VM:" + vmId)
 	key := common.GenMcisKey(nsId, mcisId, vmId)
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -3626,6 +3628,41 @@ func GetVmSpecId(nsId string, mcisId string, vmId string) string {
 
 	return content.SpecId
 }
+
+func GetVmListByLabel(nsId string, mcisId string, label string) ([]string, error) {
+
+	fmt.Println("[GetVmListByLabel]" + mcisId + " by " + label)
+
+	var vmListByLabel []string
+
+	vmList, err := ListVmId(nsId, mcisId)
+	fmt.Println(vmList)
+	if err != nil {
+		common.CBLog.Error(err)
+		return nil, err
+	}
+	if len(vmList) == 0 {
+		return nil, nil
+	}
+
+	// delete vms info
+	for _, v := range vmList {
+		vmObj, vmErr:= GetVmObject(nsId, mcisId, v)
+		if vmErr != nil {
+			common.CBLog.Error(err)
+			return nil, vmErr
+		}
+		//fmt.Println("vmObj.Label: "+ vmObj.Label)
+		if vmObj.Label == label {
+			fmt.Println("Found VM with " + vmObj.Label +", VM ID: " +vmObj.Id)
+			vmListByLabel = append(vmListByLabel, vmObj.Id)
+		}
+	}
+	return vmListByLabel, nil
+
+
+}
+
 
 func GetCloudLocation(cloudType string, nativeRegion string) GeoLocation {
 

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -155,6 +155,7 @@ type TbMcisReq struct {
 	InstallMonAgent   string    `json:"installMonAgent" example:"[yes, no]"` // yes or no
 
 	Description    string    `json:"description"`
+	Label		     string   `json:"label"`
 }
 
 type TbMcisInfo struct {
@@ -163,6 +164,7 @@ type TbMcisInfo struct {
 	Vm             []TbVmInfo `json:"vm"`
 	Placement_algo string     `json:"placement_algo"`
 	Description    string     `json:"description"`
+	Label		     string   `json:"label"`
 	Status         string     `json:"status"`
 	TargetStatus   string     `json:"targetStatus"`
 	TargetAction   string     `json:"targetAction"`
@@ -184,6 +186,7 @@ type TbVmReq struct {
 	VmUserAccount    string   `json:"vmUserAccount"`
 	VmUserPassword   string   `json:"vmUserPassword"`
 	Description      string   `json:"description"`
+	Label		     string   `json:"label"`
 
 	/*
 		//Id             string `json:"id"`
@@ -240,6 +243,7 @@ type TbVmInfo struct {
 	VmUserAccount    string   `json:"vmUserAccount"`
 	VmUserPassword   string   `json:"vmUserPassword"`
 	Description      string   `json:"description"`
+	Label		     string   `json:"label"`
 	//Vnic_id            string   `json:"vnic_id"`
 	//Public_ip_id       string   `json:"public_ip_id"`
 

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -243,8 +243,18 @@ func OrchestrationController() {
 
 					switch {
 						case autoAction.ActionType == AutoActionScaleOut:
+							autoAction.Vm.Label = "AUTOGEN"
 							common.PrintJsonPretty(autoAction.Vm)
 							fmt.Println("[Action] "+ autoAction.ActionType)
+
+							// Expand MCIS according to the VM requirement.
+							result, vmCreateErr := CorePostMcisVm(nsId, mcisPolicyTmp.Id, &autoAction.Vm)
+							if vmCreateErr != nil {
+								mcisPolicyTmp.Status = AutoStatusError
+								UpdateMcisPolicyInfo(nsId, mcisPolicyTmp)
+							}
+							common.PrintJsonPretty(*result)
+
 						case autoAction.ActionType == AutoActionScaleIn:
 							fmt.Println("[Action] "+ autoAction.ActionType)
 						default:

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -243,7 +243,7 @@ func OrchestrationController() {
 
 					switch {
 						case autoAction.ActionType == AutoActionScaleOut:
-							autoAction.Vm.Label = "AUTOGEN"
+							autoAction.Vm.Label = LabelAutoGen
 							common.PrintJsonPretty(autoAction.Vm)
 							fmt.Println("[Action] "+ autoAction.ActionType)
 
@@ -261,7 +261,7 @@ func OrchestrationController() {
 
 							// ScaleIn MCIS.
 							fmt.Println("[Removing VM]")
-							vmList, vmListErr := GetVmListByLabel(nsId, mcisPolicyTmp.Id, "AUTOGEN")
+							vmList, vmListErr := GetVmListByLabel(nsId, mcisPolicyTmp.Id, LabelAutoGen)
 							if vmListErr != nil {
 								mcisPolicyTmp.Status = AutoStatusError
 								UpdateMcisPolicyInfo(nsId, mcisPolicyTmp)

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -4353,6 +4353,9 @@ var doc = `{
                     "type": "string",
                     "example": "[yes, no]"
                 },
+                "label": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4387,6 +4390,9 @@ var doc = `{
                     "type": "string",
                     "example": "[yes, no]"
                 },
+                "label": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4418,6 +4424,9 @@ var doc = `{
                     "type": "string"
                 },
                 "imageId": {
+                    "type": "string"
+                },
+                "label": {
                     "type": "string"
                 },
                 "location": {
@@ -4567,6 +4576,9 @@ var doc = `{
                     "type": "string"
                 },
                 "imageId": {
+                    "type": "string"
+                },
+                "label": {
                     "type": "string"
                 },
                 "name": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -4338,6 +4338,9 @@
                     "type": "string",
                     "example": "[yes, no]"
                 },
+                "label": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4372,6 +4375,9 @@
                     "type": "string",
                     "example": "[yes, no]"
                 },
+                "label": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4403,6 +4409,9 @@
                     "type": "string"
                 },
                 "imageId": {
+                    "type": "string"
+                },
+                "label": {
                     "type": "string"
                 },
                 "location": {
@@ -4552,6 +4561,9 @@
                     "type": "string"
                 },
                 "imageId": {
+                    "type": "string"
+                },
+                "label": {
                     "type": "string"
                 },
                 "name": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -840,6 +840,8 @@ definitions:
         description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
         example: '[yes, no]'
         type: string
+      label:
+        type: string
       name:
         type: string
       placement_algo:
@@ -863,6 +865,8 @@ definitions:
         description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
         example: '[yes, no]'
         type: string
+      label:
+        type: string
       name:
         type: string
       placement_algo:
@@ -884,6 +888,8 @@ definitions:
       id:
         type: string
       imageId:
+        type: string
+      label:
         type: string
       location:
         $ref: '#/definitions/mcis.GeoLocation'
@@ -985,6 +991,8 @@ definitions:
       description:
         type: string
       imageId:
+        type: string
+      label:
         type: string
       name:
         type: string

--- a/test/official/8.mcis/create-mcis-policy.sh
+++ b/test/official/8.mcis/create-mcis-policy.sh
@@ -37,36 +37,35 @@
 
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
 		'{
-			"description": "Tumblebug Demo",
+			"description": "Tumblebug Auto Control Demo",
 			"policy": [{
-				"autoCondition": {
-					"metric": "cpu",
-					"operator": ">=",
-					"operand": "7",
-					"evaluationPeriod": "5"
-				},
-				"autoAction": {
-					"actionType": "ScaleOut",
-					"placement_algo": "tbd",
-					"vm": {
-						"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-Autogen",
-						"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-						"vmUserAccount": "cb-user",
-						"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-						"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-						"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-						"securityGroupIds": [
-							"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
-						],
-						"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-						"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-						"description": "description",
-						"vmUserPassword": ""
+					"autoCondition": {
+						"metric": "cpu",
+						"operator": ">=",
+						"operand": "7",
+						"evaluationPeriod": "5"
+					},
+					"autoAction": {
+						"actionType": "ScaleOut",
+						"placement_algo": "tbd",
+						"vm": {
+							"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-Autogen",
+							"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+							"vmUserAccount": "cb-user",
+							"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
+							"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+							"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+							"securityGroupIds": [
+								"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
+							],
+							"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+							"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+							"description": "description",
+							"vmUserPassword": ""
+						}
 					}
 				}
-			}]
-			
-
+			]
 		}' | json_pp || return 1
 #}
 


### PR DESCRIPTION

MCIS 자동 제어에,

- ScaleOut (MCIS에 지정된 요구사항 형태의 VM 추가)
- ScaleIn (MCIS의 VM 중, label=="Autogen" 인 VM 1개 종료 및 삭제)

- ScaleOut 자동 제어 정책 등록 예시
8.mcis/create-mcis-policy.sh aws 3 shson
```
	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
		'{
			"description": "Tumblebug Auto Control Demo",
			"policy": [{
					"autoCondition": {
						"metric": "cpu",
						"operator": ">=",
						"operand": "7",
						"evaluationPeriod": "5"
					},
					"autoAction": {
						"actionType": "ScaleOut",
						"placement_algo": "tbd",
						"vm": {
							"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-Autogen",
							"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"vmUserAccount": "cb-user",
							"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
							"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"securityGroupIds": [
								"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
							],
							"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"description": "description",
							"vmUserPassword": ""
						}
					}
				}
			]
		}' | json_pp || return 1
```