### PR TITLE
Enable scaleout with auto vm template selection

### DIFF
--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -20,6 +20,8 @@ import (
 	"encoding/csv"
 	"os"
 
+	"math/rand"
+
 	// REST API (echo)
 	"net/http"
 
@@ -3673,6 +3675,46 @@ func GetVmListByLabel(nsId string, mcisId string, label string) ([]string, error
 	}
 	return vmListByLabel, nil
 
+
+}
+
+func GetVmTemplate(nsId string, mcisId string, algo string) (TbVmInfo, error) {
+
+	fmt.Println("[GetVmTemplate]" + mcisId + " by algo: " + algo)
+
+	vmList, err := ListVmId(nsId, mcisId)
+	//fmt.Println(vmList)
+	if err != nil {
+		common.CBLog.Error(err)
+		return TbVmInfo{}, err
+	}
+	if len(vmList) == 0 {
+		return TbVmInfo{}, nil
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	index := rand.Intn(len(vmList))
+	vmObj, vmErr:= GetVmObject(nsId, mcisId, vmList[index])
+	var vmTemplate TbVmInfo
+
+	// only take template required to create VM 
+	vmTemplate.Name = vmObj.Name
+	vmTemplate.ConnectionName = vmObj.ConnectionName
+	vmTemplate.ImageId = vmObj.ImageId
+	vmTemplate.SpecId = vmObj.SpecId
+	vmTemplate.VNetId = vmObj.VNetId
+	vmTemplate.SubnetId = vmObj.SubnetId
+	vmTemplate.SecurityGroupIds = vmObj.SecurityGroupIds
+	vmTemplate.SshKeyId = vmObj.SshKeyId
+	vmTemplate.VmUserAccount = vmObj.VmUserAccount
+	vmTemplate.VmUserPassword = vmObj.VmUserPassword
+
+	if vmErr != nil {
+		common.CBLog.Error(err)
+		return TbVmInfo{}, vmErr
+	}
+
+	return vmTemplate, nil
 
 }
 

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -244,7 +244,23 @@ func OrchestrationController() {
 
 					switch {
 						case autoAction.ActionType == AutoActionScaleOut:
+							
 							autoAction.Vm.Label = LabelAutoGen
+							// append UUID to given vm name to avoid duplicated vm ID.
+							autoAction.Vm.Name = autoAction.Vm.Name +"-"+ common.GenUuid()
+							//vmReqTmp := autoAction.Vm
+
+							if autoAction.Placement_algo == "random" {
+								fmt.Println("[autoAction.Placement_algo] " + autoAction.Placement_algo)
+								var vmTmpErr error
+								autoAction.Vm, vmTmpErr = GetVmTemplate(nsId, mcisPolicyTmp.Id, autoAction.Placement_algo)
+								if vmTmpErr != nil {
+									mcisPolicyTmp.Status = AutoStatusError
+									UpdateMcisPolicyInfo(nsId, mcisPolicyTmp)
+								}
+								autoAction.Vm.Name = autoAction.Vm.Name +"-Random"
+							}
+							
 							common.PrintJsonPretty(autoAction.Vm)
 							fmt.Println("[Action] "+ autoAction.ActionType)
 

--- a/test/official/8.mcis/create-mcis-policy.sh
+++ b/test/official/8.mcis/create-mcis-policy.sh
@@ -48,9 +48,9 @@
 					},
 					"autoAction": {
 						"actionType": "ScaleOut",
-						"placement_algo": "tbd",
+						"placement_algo": "random",
 						"vm": {
-							"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-Autogen",
+							"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-AutoGen",
 							"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 							"vmUserAccount": "cb-user",
 							"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",

--- a/test/official/sequentialFullTest/create-mcis-for-df.sh
+++ b/test/official/sequentialFullTest/create-mcis-for-df.sh
@@ -204,6 +204,10 @@ function test_sequence_allcsp_mcis_vm()
 
 	fi
 
+	echo "[Deploy CB-Dragonfly Docker]"
+	dozing 30
+	./deploy-dragonfly-docker.sh $CSP $REGION $POSTFIX
+
 #}
 
 #testAll

--- a/test/official/sequentialFullTest/expand-mcis.sh
+++ b/test/official/sequentialFullTest/expand-mcis.sh
@@ -18,6 +18,7 @@
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}
 	EXPAND=${4:-1}
+	MCISNAME=${5:-noname}
 	
 	if [ "${CSP}" == "aws" ]; then
 		echo "[Test for AWS]"
@@ -38,6 +39,13 @@
 	fi
 
 	MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+
+	if [ "${MCISNAME}" != "noname" ]; then
+		echo "[MCIS name is given]"
+		MCISID=${MCISNAME}
+	else
+		MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+	fi
 
 	#echo $i
 	INDEXY=${EXPAND}

--- a/test/official/sequentialFullTest/gen-sshKey-withGivenMcisName.sh
+++ b/test/official/sequentialFullTest/gen-sshKey-withGivenMcisName.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+#function get_sshKey() {
+
+
+
+    FILE=../conf.env
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+	source ../conf.env
+	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+	echo "####################################################################"
+	echo "## Generate SSH KEY (PEM, PPK)" 
+	echo "####################################################################"
+
+	CSP=${1}
+	REGION=${2:-1}
+	POSTFIX=${3:-developer}
+	MCISNAME=${4:-noname}
+	if [ "${CSP}" == "all" ]; then
+		echo "[Test for all CSP regions (AWS, Azure, GCP, Alibaba, ...)]"
+		CSP="aws"
+		INDEX=0
+	elif [ "${CSP}" == "aws" ]; then
+		INDEX=1
+	elif [ "${CSP}" == "azure" ]; then
+		INDEX=2
+	elif [ "${CSP}" == "gcp" ]; then
+		INDEX=3
+	elif [ "${CSP}" == "alibaba" ]; then
+		INDEX=4
+	else
+		echo "[No acceptable argument was provided (all, aws, azure, gcp, alibaba, ...). Default: Test for AWS]"
+		CSP="aws"
+		INDEX=1
+	fi
+
+
+	MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+
+	if [ "${INDEX}" == "0" ]; then
+		MCISPREFIX=avengers
+		MCISID=${MCISPREFIX}-${POSTFIX}
+	fi
+
+	if [ "${MCISNAME}" != "noname" ]; then
+		echo "[MCIS name is given]"
+		MCISID=${MCISNAME}
+	fi
+
+	#install jq and puttygen
+	echo "[Check jq and putty-tools package (if not, install)]"
+	if ! dpkg-query -W -f='${Status}' jq  | grep "ok installed"; then sudo apt install -y jq; fi
+	if ! dpkg-query -W -f='${Status}' putty-tools  | grep "ok installed"; then sudo apt install -y putty-tools; fi
+
+
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/$MCISID -H 'Content-Type: application/json' | jq '.privateKey' | sed -e 's/\\n/\n/g' -e 's/\"//g' > ./sshkey-tmp/$MCISID.pem
+	chmod 600 ./sshkey-tmp/$MCISID.pem
+	puttygen ./sshkey-tmp/$MCISID.pem -o ./sshkey-tmp/$MCISID.ppk -O private
+
+	MCISINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status`
+	MCISINFO=$(jq '.status.vm' <<< "$MCISINFO")
+
+	echo "$MCISINFO" | jq
+
+
+	echo ""
+	echo "[GENERATED PRIVATE KEY (PEM, PPK)]"
+	echo -e " ./sshkey-tmp/$MCISID.pem \n ./sshkey-tmp/$MCISID.ppk"
+	echo ""
+
+	echo "[MCIS INFO: $MCISID]"
+	for k in $(jq -c '.[]' <<< "$MCISINFO"); do
+		
+		id=$(jq ".id" <<< "$k");
+		ip=$(jq ".public_ip" <<< "$k");
+		printf ' VMID: %s \t VMIP: %s\n' "$id" "$ip";
+
+	done 
+
+	echo ""
+	echo "[SSH USAGE EXAMPLE]"
+	for k in $(jq -c '.[]' <<< "$MCISINFO"); do
+		
+		id=$(jq -r ".id" <<< "$k");
+		ip=$(jq -r ".public_ip" <<< "$k");
+		user="ubuntu"
+		printf ' ssh -i ./sshkey-tmp/%s.pem %s@%s -o StrictHostKeyChecking=no\n' "$MCISID" "$user" "$ip";
+		#echo "Use [ssh -i ./sshkey-tmp/$MCISID.pem $user@$ip]"
+
+	done 
+
+	echo ""
+
+
+#}
+
+#get_sshKey


### PR DESCRIPTION

- 자동 제어의 scaleout 시, "placement_algo": "random" 으로 선택하면, MCIS 내의 기존 VM의 템플릿을 복제해서 ScaleOut용 VM의 템플릿으로 사용하도록 기능 수정

```
	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
		'{
			"description": "Tumblebug Auto Control Demo",
			"policy": [
				{
					"autoCondition": {
						"metric": "cpu",
						"operator": ">=",
						"operand": "20",
						"evaluationPeriod": "5"
					},
					"autoAction": {
						"actionType": "ScaleOut",
						"placement_algo": "random",
						"vm": {
							"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'-AutoGen",
							"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"vmUserAccount": "cb-user",
							"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
							"sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"securityGroupIds": [
								"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
							],
							"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
							"description": "description",
							"vmUserPassword": ""
						}
					}
				},				
				{
					"autoCondition": {
						"metric": "cpu",
						"operator": "<=",
						"operand": "15",
						"evaluationPeriod": "5"
					},
					"autoAction": {
						"actionType": "ScaleIn"
					}
				}

			]
		}' 
```