### PR TITLE
Separate LowerizeAndCheckNs function

### DIFF
--- a/src/api/grpc/server/common/namespace.go
+++ b/src/api/grpc/server/common/namespace.go
@@ -125,7 +125,9 @@ func (s *NSService) CheckNS(ctx context.Context, req *pb.NSQryRequest) (*pb.Exis
 
 	logger.Debug("calling NSService.CheckNS()")
 
-	exists, _, err := common.LowerizeAndCheckNs(req.NsId)
+	//exists, _, err := common.LowerizeAndCheckNs(req.NsId)
+	lowerizedNsId := common.ToLower(req.NsId)
+	exists, err := common.CheckNs(lowerizedNsId)
 	if err != nil {
 		logger.Debug(err)
 	}

--- a/src/api/rest/server/common/namespace.go
+++ b/src/api/rest/server/common/namespace.go
@@ -37,7 +37,9 @@ func RestCheckNs(c echo.Context) error {
 		return SendMessage(c, http.StatusBadRequest, err.Error())
 	}
 
-	exists, _, err := common.LowerizeAndCheckNs(c.Param("nsId"))
+	//exists, _, err := common.LowerizeAndCheckNs(c.Param("nsId"))
+	lowerizedNsId := common.ToLower(c.Param("nsId"))
+	exists, err := common.CheckNs(lowerizedNsId)
 	if err != nil {
 		common.CBLog.Error(err)
 		return SendMessage(c, http.StatusBadRequest, err.Error())

--- a/src/core/common/namespace.go
+++ b/src/core/common/namespace.go
@@ -34,7 +34,9 @@ func NsValidation() echo.MiddlewareFunc {
 			if nsId == "" {
 				return next(c)
 			}
-			check, _, err := LowerizeAndCheckNs(nsId)
+			//check, _, err := LowerizeAndCheckNs(nsId)
+			nsId = ToLower(nsId)
+			check, err := CheckNs(nsId)
 
 			if check == false || err != nil {
 				return echo.NewHTTPError(http.StatusNotFound, "Not valid namespace")
@@ -45,7 +47,9 @@ func NsValidation() echo.MiddlewareFunc {
 }
 
 func CreateNs(u *NsReq) (NsInfo, error) {
-	check, lowerizedName, err := LowerizeAndCheckNs(u.Name)
+	//check, lowerizedName, err := LowerizeAndCheckNs(u.Name)
+	lowerizedName := ToLower(u.Name)
+	check, err := CheckNs(lowerizedName)
 
 	if check {
 		temp := NsInfo{}
@@ -87,7 +91,9 @@ func GetNs(id string) (NsInfo, error) {
 
 	res := NsInfo{}
 
-	check, lowerizedId, err := LowerizeAndCheckNs(id)
+	//check, lowerizedId, err := LowerizeAndCheckNs(id)
+	lowerizedId := ToLower(id)
+	check, err := CheckNs(lowerizedId)
 
 	if check == false {
 		errString := "The namespace " + lowerizedId + " does not exist."
@@ -173,7 +179,9 @@ func ListNsId() []string {
 
 func DelNs(Id string) error {
 
-	check, lowerizedId, err := LowerizeAndCheckNs(Id)
+	//check, lowerizedId, err := LowerizeAndCheckNs(Id)
+	lowerizedId := ToLower(Id)
+	check, err := CheckNs(lowerizedId)
 
 	if check == false {
 		errString := "The namespace " + lowerizedId + " does not exist."
@@ -251,6 +259,7 @@ func DelAllNs() error {
 	return nil
 }
 
+/*
 func LowerizeAndCheckNs(Id string) (bool, string, error) {
 
 	if Id == "" {
@@ -266,14 +275,30 @@ func LowerizeAndCheckNs(Id string) (bool, string, error) {
 	//fmt.Println(key)
 
 	keyValue, _ := CBStore.Get(key)
-	/*
-		if err != nil {
-			CBLog.Error(err)
-			return false, err
-		}
-	*/
 	if keyValue != nil {
 		return true, lowerizedId, nil
 	}
 	return false, lowerizedId, nil
+}
+*/
+
+func CheckNs(Id string) (bool, error) {
+
+	if Id == "" {
+		err := fmt.Errorf("CheckNs failed; nsId given is null.")
+		return false, err
+	}
+
+	lowerizedId := ToLower(Id)
+
+	fmt.Println("[Check ns] " + lowerizedId)
+
+	key := "/ns/" + lowerizedId
+	//fmt.Println(key)
+
+	keyValue, _ := CBStore.Get(key)
+	if keyValue != nil {
+		return true, nil
+	}
+	return false, nil
 }

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -48,6 +48,13 @@ func GenId(name string) string {
 	return out
 }
 
+func ToLower(name string) string {
+	r, _ := regexp.Compile("_")
+	out := r.ReplaceAllString(name, "-")
+	out = strings.ToLower(out)
+	return out
+}
+
 func GenMcisKey(nsId string, mcisId string, vmId string) string {
 
 	if vmId != "" {

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -56,7 +56,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
 	//nsId = lowerizedNsId
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedResourceId, err := LowerizeAndCheckResource(nsId, resourceType, resourceId)
 	resourceId = lowerizedResourceId
@@ -562,7 +562,7 @@ func GetResource(nsId string, resourceType string, resourceId string) (interface
 
 	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
 	//nsId = lowerizedNsId
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedResourceId, err := LowerizeAndCheckResource(nsId, resourceType, resourceId)
 	resourceId = lowerizedResourceId

--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -258,8 +258,9 @@ func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 
 func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 
-	_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
-	nsId = lowerizedNsId
+	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
+	//nsId = lowerizedNsId
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedName, err := LowerizeAndCheckResource(nsId, "image", u.Name)
 
@@ -353,7 +354,7 @@ func RegisterImageWithInfo(nsId string, content *TbImageInfo) (TbImageInfo, erro
 
 	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
 	//nsId = lowerizedNsId
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedName, err := LowerizeAndCheckResource(nsId, "image", content.Name)
 

--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -76,7 +76,7 @@ func CreateSecurityGroup(nsId string, u *TbSecurityGroupReq) (TbSecurityGroupInf
 
 	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
 	//nsId = lowerizedNsId
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedName, err := LowerizeAndCheckResource(nsId, "securityGroup", u.Name)
 	u.Name = lowerizedName

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -320,8 +320,9 @@ func RegisterSpecWithCspSpecName(nsId string, u *TbSpecReq) (TbSpecInfo, error) 
 
 	nsId = common.GenId(nsId)
 
-	_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
-	nsId = lowerizedNsId
+	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
+	//nsId = lowerizedNsId
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedName, err := LowerizeAndCheckResource(nsId, "spec", u.Name)
 	u.Name = lowerizedName
@@ -476,7 +477,7 @@ func RegisterSpecWithInfo(nsId string, content *TbSpecInfo) (TbSpecInfo, error) 
 
 	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
 	//nsId = lowerizedNsId
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedName, err := LowerizeAndCheckResource(nsId, "spec", content.Name)
 	content.Name = lowerizedName

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -60,7 +60,7 @@ func CreateSshKey(nsId string, u *TbSshKeyReq) (TbSshKeyInfo, error) {
 
 	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
 	//nsId = lowerizedNsId
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedName, err := LowerizeAndCheckResource(nsId, "sshKey", u.Name)
 	u.Name = lowerizedName

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -73,7 +73,7 @@ func CreateVNet(nsId string, u *TbVNetReq) (TbVNetInfo, error) {
 
 	//_, lowerizedNsId, _ := common.LowerizeAndCheckNs(nsId)
 	//nsId = lowerizedNsId
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	check, lowerizedName, _ := LowerizeAndCheckResource(nsId, "vNet", u.Name)
 	//fmt.Println("CreateVNet() called; nsId: " + nsId + ", u.Name: " + u.Name + ", lowerizedName: " + lowerizedName) // for debug


### PR DESCRIPTION
- Related issue: #313 
- 기존에는 underscore-to-hyphen + ToLower 로직을 `GenId` 함수에 넣어서 사용했었는데,
똑같은 내용의 `ToLower` 라는 함수를 추가했습니다.
- `LowerizeAndCheckNs` 함수는 주석처리했고,
`CheckNs` 함수를 되살렸습니다.
- `LowerizeAndCheckNs` 함수 호출 부분들을
`ToLower` 호출 + `CheckNs` 호출 로 분리했습니다.
- 이 PR에서는 `LowerizeAndCheckNs` 함수에 대해서만 다루고,
다른 `LowerizeAndCheck*` 함수들은 별도의 PR로 다룰 예정입니다.
- 테스트 스크립트로 테스트 했습니다.
  - `./testAll-mcis-mcir-ns-cloud.sh aws 1 jhseo`
  - `./cleanAll-mcis-mcir-ns-cloud.sh aws 1 jhseo`