### PR TITLE
Add paths-ignore to workflow

### DIFF
--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -9,6 +9,13 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
+      - '.all-contributorsrc'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'assets/**'
+      - 'test/**'
 
   # "Build and publish" on push event (It considers on merge PR event)
   push:
@@ -16,6 +23,13 @@ on:
     # [To be tested]
     tags:
       - "v*.*.*"
+    paths-ignore:
+      - '**.md'
+      - '.all-contributorsrc'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'assets/**'
+      - 'test/**'
 
 jobs:
   # The job key is "build-and-publish"


### PR DESCRIPTION
[#356 관련 PR]

The `build-and-publish-container-image.yaml` workflow will ignore files and directories as follows:
- Ignore files: '\*\*md', '.all-contributorsrc', '.gitignore', 'LICENSE'
- Igrnoe directories: 'assets/\*\*', 'test/\*\*"

It has passed a test on the forked repository. :heavy_check_mark:

For double-check, I will make another PR to add `.idea/` to the `.gitignore`.  :smiley: