### PR TITLE
Add workflow for action by command-style comments

### DIFF
--- a/.github/workflows/prow-commands.yml
+++ b/.github/workflows/prow-commands.yml
@@ -1,0 +1,34 @@
+# Action by command-style comments (inspired by Kubernetes Prow)
+name: "action by command-style comments"
+
+# Event on a comment (in issue and PR)
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  execute:
+    # Execute when author_association of the comment is OWNER or MEMBER
+    if: ${{ github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' }}
+    runs-on: ubuntu-latest
+    # Execute action according to commands
+    steps:
+      - uses: jpmcb/prow-github-actions@v1.1.2
+        with:
+          prow-commands: '/assign 
+            /unassign
+            /approve 
+            /retitle 
+            /area 
+            /kind 
+            /priority 
+            /remove 
+            /lgtm 
+            /close 
+            /reopen 
+            /lock 
+            /milestone 
+            /hold 
+            /cc 
+            /uncc'
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION

This PR proposes a GitHub workflow for action by command-style comments (inspired by Kubernetes Prow))

Supported comments are as follows,
            /assign 
            /unassign
            /approve 
            /retitle 
            /area 
            /kind 
            /priority 
            /remove 
            /lgtm 
            /close 
            /reopen 
            /lock 
            /milestone 
            /hold 
            /cc 
            /uncc

This GitHub workflow is based on jpmcb/prow-github-actions .
https://github.com/jpmcb/prow-github-actions/blob/main/docs/commands.md

You can see a demo PR from [here](https://github.com/seokho-son/docs/pull/18) to check actions.