### PR TITLE
Add path-ignore in build-publish-container-image

### DIFF
--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -14,6 +14,7 @@ on:
       - '.all-contributorsrc'
       - '.gitignore'
       - 'LICENSE'
+      - 'CODEOWNERS'
       - 'assets/**'
       - 'test/**'
 
@@ -28,6 +29,7 @@ on:
       - '.all-contributorsrc'
       - '.gitignore'
       - 'LICENSE'
+      - 'CODEOWNERS'
       - 'assets/**'
       - 'test/**'
 


### PR DESCRIPTION
Add 'CODEOWNERS' file path to
paths-ignore in build-and-publish-container-image.yaml

(we don't need to build and publish image according to codeowners files changes)