### PR TITLE
Add associatedObjList mgmt feature in TB sshKey object

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -105,17 +105,11 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/cloud-barista/cb-log v0.2.0-cappuccino.0.20201008023843-31002c0a088d/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJaZWV/6MOwc20c=
-github.com/cloud-barista/cb-log v0.2.9 h1:Yq05XPOKREpwBlI6uddZsq8L6wauZU9kuaHMKkP6F9Y=
-github.com/cloud-barista/cb-log v0.2.9/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJaZWV/6MOwc20c=
 github.com/cloud-barista/cb-log v0.3.0-espresso h1:q+bw/quMV2LldEgHYqbANajb330GNIfpAIIMsqYGuK0=
 github.com/cloud-barista/cb-log v0.3.0-espresso/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJaZWV/6MOwc20c=
-github.com/cloud-barista/cb-spider v0.2.9 h1:+8rTjhGKluSYXnxPOjR41BA8T7H8sqF/RhlVvcNmm/o=
-github.com/cloud-barista/cb-spider v0.2.9/go.mod h1:KUQDfzTMP/ghzTFqs0twUiCaNcR6v9KWDLP2veIaExE=
 github.com/cloud-barista/cb-spider v0.3.0-espresso h1:CJzdL0wbJt24jPby5+k6oZ5iOKCIdpaVLQ/ijBFJOfw=
 github.com/cloud-barista/cb-spider v0.3.0-espresso/go.mod h1:KUQDfzTMP/ghzTFqs0twUiCaNcR6v9KWDLP2veIaExE=
 github.com/cloud-barista/cb-store v0.2.0-cappuccino.0.20201111072717-b0bb715e2694/go.mod h1:tcMkva0951xAwoMcTqn9nXttnzk3ytHlJLs4MyH7p84=
-github.com/cloud-barista/cb-store v0.2.9 h1:/a6VDvFv9VgYyHbXYBL3fFtMqi9iG8ckFIqccHBnegY=
-github.com/cloud-barista/cb-store v0.2.9/go.mod h1:tcMkva0951xAwoMcTqn9nXttnzk3ytHlJLs4MyH7p84=
 github.com/cloud-barista/cb-store v0.3.0-espresso h1:yduf2JeyIhxPWZIevn7RMrZUUTXJzi5okJgWWqSg1x8=
 github.com/cloud-barista/cb-store v0.3.0-espresso/go.mod h1:tcMkva0951xAwoMcTqn9nXttnzk3ytHlJLs4MyH7p84=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
@@ -156,6 +150,7 @@ github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4Kfc
 github.com/docker/docker v0.0.0-20200309214505-aa6a9891b09c/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4 h1:qk/FSDDxo05wdJH28W+p5yivv7LuLYLRXPPD8KQCtZs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -303,6 +298,7 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -443,6 +439,7 @@ github.com/pelletier/go-toml v1.0.1/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
+github.com/peterh/liner v1.0.1-0.20171122030339-3681c2a91233 h1:jmJndGFBPjNWW+MAYarU/Nl8QrQVzbw4B/AYE0LzETo=
 github.com/peterh/liner v1.0.1-0.20171122030339-3681c2a91233/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/src/api/rest/server/mcir/common.go
+++ b/src/api/rest/server/mcir/common.go
@@ -66,7 +66,7 @@ func RestGetAllResources(c echo.Context) error {
 	}
 
 	switch resourceType {
-	case "image":
+	case common.StrImage:
 		var content struct {
 			Image []mcir.TbImageInfo `json:"image"`
 		}
@@ -78,7 +78,7 @@ func RestGetAllResources(c echo.Context) error {
 		// When err == nil && resourceList != nil
 		content.Image = resourceList.([]mcir.TbImageInfo) // type assertion (interface{} -> array)
 		return c.JSON(http.StatusOK, &content)
-	case "securityGroup":
+	case common.StrSecurityGroup:
 		var content struct {
 			SecurityGroup []mcir.TbSecurityGroupInfo `json:"securityGroup"`
 		}
@@ -90,7 +90,7 @@ func RestGetAllResources(c echo.Context) error {
 		// When err == nil && resourceList != nil
 		content.SecurityGroup = resourceList.([]mcir.TbSecurityGroupInfo) // type assertion (interface{} -> array)
 		return c.JSON(http.StatusOK, &content)
-	case "spec":
+	case common.StrSpec:
 		var content struct {
 			Spec []mcir.TbSpecInfo `json:"spec"`
 		}
@@ -102,7 +102,7 @@ func RestGetAllResources(c echo.Context) error {
 		// When err == nil && resourceList != nil
 		content.Spec = resourceList.([]mcir.TbSpecInfo) // type assertion (interface{} -> array)
 		return c.JSON(http.StatusOK, &content)
-	case "sshKey":
+	case common.StrSSHKey:
 		var content struct {
 			SshKey []mcir.TbSshKeyInfo `json:"sshKey"`
 		}
@@ -114,7 +114,7 @@ func RestGetAllResources(c echo.Context) error {
 		// When err == nil && resourceList != nil
 		content.SshKey = resourceList.([]mcir.TbSshKeyInfo) // type assertion (interface{} -> array)
 		return c.JSON(http.StatusOK, &content)
-	case "vNet":
+	case common.StrVNet:
 		var content struct {
 			VNet []mcir.TbVNetInfo `json:"vNet"`
 		}

--- a/src/api/rest/server/mcir/sshkey.go
+++ b/src/api/rest/server/mcir/sshkey.go
@@ -137,13 +137,14 @@ func RestDelAllSshKey(c echo.Context) error {
 	return nil
 }
 
-func RestTestAddSshKeyAsso(c echo.Context) error {
+// RestTestAddSshKeyAssociation is a REST API call handling function
+// to test "mcir.UpdateAssociatedObjList" function with "add" argument.
+func RestTestAddSshKeyAssociation(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 	sshKeyId := c.Param("sshKeyId")
 
-	//inUseCount, err := mcir.SetInUseCount(nsId, "sshKey", sshKeyId, "+1")
-	vmKeyList, err := mcir.UpdateAssoObjList(nsId, "sshKey", sshKeyId, "add", "/test/vm/key")
+	vmKeyList, err := mcir.UpdateAssociatedObjList(nsId, common.StrSSHKey, sshKeyId, common.StrAdd, "/test/vm/key")
 
 	if err != nil {
 		common.CBLog.Error(err)
@@ -161,13 +162,14 @@ func RestTestAddSshKeyAsso(c echo.Context) error {
 	return c.JSON(http.StatusOK, vmKeyList)
 }
 
-func RestTestDeleteSshKeyAsso(c echo.Context) error {
+// RestTestDeleteSshKeyAssociation is a REST API call handling function
+// to test "mcir.UpdateAssociatedObjList" function with "delete" argument.
+func RestTestDeleteSshKeyAssociation(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 	sshKeyId := c.Param("sshKeyId")
 
-	//inUseCount, err := mcir.SetInUseCount(nsId, "sshKey", sshKeyId, "+1")
-	vmKeyList, err := mcir.UpdateAssoObjList(nsId, "sshKey", sshKeyId, "delete", "/test/vm/key")
+	vmKeyList, err := mcir.UpdateAssociatedObjList(nsId, common.StrSSHKey, sshKeyId, common.StrDelete, "/test/vm/key")
 
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/api/rest/server/mcir/sshkey.go
+++ b/src/api/rest/server/mcir/sshkey.go
@@ -137,12 +137,13 @@ func RestDelAllSshKey(c echo.Context) error {
 	return nil
 }
 
-func RestTestSetSshKeyInUseCount(c echo.Context) error {
+func RestTestAddSshKeyAsso(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 	sshKeyId := c.Param("sshKeyId")
 
-	inUseCount, err := mcir.SetInUseCount(nsId, "sshKey", sshKeyId, "+1")
+	//inUseCount, err := mcir.SetInUseCount(nsId, "sshKey", sshKeyId, "+1")
+	vmKeyList, err := mcir.UpdateAssoObjList(nsId, "sshKey", sshKeyId, "add", "/test/vm/key")
 
 	if err != nil {
 		common.CBLog.Error(err)
@@ -156,6 +157,30 @@ func RestTestSetSshKeyInUseCount(c echo.Context) error {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
-	mapA := map[string]int8{"inUseCount": inUseCount}
-	return c.JSON(http.StatusOK, &mapA)
+	//mapA := map[string]int8{"inUseCount": inUseCount}
+	return c.JSON(http.StatusOK, vmKeyList)
+}
+
+func RestTestDeleteSshKeyAsso(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+	sshKeyId := c.Param("sshKeyId")
+
+	//inUseCount, err := mcir.SetInUseCount(nsId, "sshKey", sshKeyId, "+1")
+	vmKeyList, err := mcir.UpdateAssoObjList(nsId, "sshKey", sshKeyId, "delete", "/test/vm/key")
+
+	if err != nil {
+		common.CBLog.Error(err)
+		/*
+			mapA := map[string]string{
+				"message": "Failed to create a SshKey"}
+			return c.JSON(http.StatusFailedDependency, &mapA)
+		*/
+		//return c.JSON(res.StatusCode, res)
+		//body, _ := ioutil.ReadAll(res.Body)
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(http.StatusInternalServerError, &mapA)
+	}
+	//mapA := map[string]int8{"inUseCount": inUseCount}
+	return c.JSON(http.StatusOK, vmKeyList)
 }

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -182,9 +182,9 @@ func ApiServer() {
 	g.PUT("/:nsId/resources/sshKey/:sshKeyId", rest_mcir.RestPutSshKey)
 	g.DELETE("/:nsId/resources/sshKey/:resourceId", rest_mcir.RestDelResource)
 	g.DELETE("/:nsId/resources/sshKey", rest_mcir.RestDelAllResources)
-	// Temporal test API for development of SetSshKeyInUseCount
-	g.PUT("/:nsId/resources/testAddSshKeyAsso/:sshKeyId", rest_mcir.RestTestAddSshKeyAsso)
-	g.PUT("/:nsId/resources/testDeleteSshKeyAsso/:sshKeyId", rest_mcir.RestTestDeleteSshKeyAsso)
+	// Temporal test API for development of UpdateAssociatedObjList
+	g.PUT("/:nsId/resources/testAddSshKeyAssociation/:sshKeyId", rest_mcir.RestTestAddSshKeyAssociation)
+	g.PUT("/:nsId/resources/testDeleteSshKeyAssociation/:sshKeyId", rest_mcir.RestTestDeleteSshKeyAssociation)
 
 	g.POST("/:nsId/resources/spec", rest_mcir.RestPostSpec)
 	g.GET("/:nsId/resources/spec/:resourceId", rest_mcir.RestGetResource)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -183,7 +183,8 @@ func ApiServer() {
 	g.DELETE("/:nsId/resources/sshKey/:resourceId", rest_mcir.RestDelResource)
 	g.DELETE("/:nsId/resources/sshKey", rest_mcir.RestDelAllResources)
 	// Temporal test API for development of SetSshKeyInUseCount
-	g.PUT("/:nsId/resources/testSetSshKeyInUseCount/:sshKeyId", rest_mcir.RestTestSetSshKeyInUseCount)
+	g.PUT("/:nsId/resources/testAddSshKeyAsso/:sshKeyId", rest_mcir.RestTestAddSshKeyAsso)
+	g.PUT("/:nsId/resources/testDeleteSshKeyAsso/:sshKeyId", rest_mcir.RestTestDeleteSshKeyAsso)
 
 	g.POST("/:nsId/resources/spec", rest_mcir.RestPostSpec)
 	g.GET("/:nsId/resources/spec/:resourceId", rest_mcir.RestGetResource)

--- a/src/core/common/common.go
+++ b/src/core/common/common.go
@@ -20,8 +20,6 @@ type KeyValue struct {
 var CBLog *logrus.Logger
 var CBStore icbs.Store
 
-const CbStoreKeyNotFoundErrorString string = "key not found"
-
 var SPIDER_REST_URL string
 var DRAGONFLY_REST_URL string
 var DB_URL string
@@ -32,13 +30,23 @@ var AUTOCONTROL_DURATION_MS string
 var MYDB *sql.DB
 var err error
 
-const StrSPIDER_REST_URL string = "SPIDER_REST_URL"
-const StrDRAGONFLY_REST_URL string = "DRAGONFLY_REST_URL"
-const StrDB_URL string = "DB_URL"
-const StrDB_DATABASE string = "DB_DATABASE"
-const StrDB_USER string = "DB_USER"
-const StrDB_PASSWORD string = "DB_PASSWORD"
-const StrAUTOCONTROL_DURATION_MS string = "AUTOCONTROL_DURATION_MS"
+const (
+	StrSPIDER_REST_URL            string = "SPIDER_REST_URL"
+	StrDRAGONFLY_REST_URL         string = "DRAGONFLY_REST_URL"
+	StrDB_URL                     string = "DB_URL"
+	StrDB_DATABASE                string = "DB_DATABASE"
+	StrDB_USER                    string = "DB_USER"
+	StrDB_PASSWORD                string = "DB_PASSWORD"
+	StrAUTOCONTROL_DURATION_MS    string = "AUTOCONTROL_DURATION_MS"
+	CbStoreKeyNotFoundErrorString string = "key not found"
+	StrAdd                        string = "add"
+	StrDelete                     string = "delete"
+	StrSSHKey                     string = "sshKey"
+	StrImage                      string = "image"
+	StrSecurityGroup              string = "securityGroup"
+	StrSpec                       string = "spec"
+	StrVNet                       string = "vNet"
+)
 
 var StartTime string
 

--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -75,7 +75,11 @@ func UpdateEnv(id string) error {
 		return err
 	}
 	if keyValue != nil {
-		json.Unmarshal([]byte(keyValue.Value), &content)
+		err := json.Unmarshal([]byte(keyValue.Value), &content)
+		if err != nil {
+			CBLog.Error(err)
+			return err
+		}
 
 		switch id {
 		case lowStrSPIDER_REST_URL:
@@ -116,7 +120,7 @@ func GetConfig(id string) (ConfigInfo, error) {
 	lowerizedId := ToLower(id)
 	check, err := CheckConfig(lowerizedId)
 
-	if check == false {
+	if !check {
 		errString := "The config " + lowerizedId + " does not exist."
 		err := fmt.Errorf(errString)
 		return res, err
@@ -141,7 +145,11 @@ func GetConfig(id string) (ConfigInfo, error) {
 	fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
 	fmt.Println("===============================================")
 
-	json.Unmarshal([]byte(keyValue.Value), &res)
+	err = json.Unmarshal([]byte(keyValue.Value), &res)
+	if err != nil {
+		CBLog.Error(err)
+		return res, err
+	}
 	return res, nil
 }
 
@@ -161,7 +169,11 @@ func ListConfig() ([]ConfigInfo, error) {
 		res := []ConfigInfo{}
 		for _, v := range keyValue {
 			tempObj := ConfigInfo{}
-			json.Unmarshal([]byte(v.Value), &tempObj)
+			err = json.Unmarshal([]byte(v.Value), &tempObj)
+			if err != nil {
+				CBLog.Error(err)
+				return nil, err
+			}
 			res = append(res, tempObj)
 		}
 		return res, nil

--- a/src/core/common/namespace.go
+++ b/src/core/common/namespace.go
@@ -37,7 +37,7 @@ func NsValidation() echo.MiddlewareFunc {
 			nsId = ToLower(nsId)
 			check, err := CheckNs(nsId)
 
-			if check == false || err != nil {
+			if !check || err != nil {
 				return echo.NewHTTPError(http.StatusNotFound, "Not valid namespace")
 			}
 			return next(c)
@@ -92,7 +92,7 @@ func GetNs(id string) (NsInfo, error) {
 	lowerizedId := ToLower(id)
 	check, err := CheckNs(lowerizedId)
 
-	if check == false {
+	if !check {
 		errString := "The namespace " + lowerizedId + " does not exist."
 		//mapA := map[string]string{"message": errString}
 		//mapB, _ := json.Marshal(mapA)
@@ -119,7 +119,11 @@ func GetNs(id string) (NsInfo, error) {
 	fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
 	fmt.Println("===============================================")
 
-	json.Unmarshal([]byte(keyValue.Value), &res)
+	err = json.Unmarshal([]byte(keyValue.Value), &res)
+	if err != nil {
+		CBLog.Error(err)
+		return res, err
+	}
 	return res, nil
 }
 
@@ -139,7 +143,11 @@ func ListNs() ([]NsInfo, error) {
 		res := []NsInfo{}
 		for _, v := range keyValue {
 			tempObj := NsInfo{}
-			json.Unmarshal([]byte(v.Value), &tempObj)
+			err = json.Unmarshal([]byte(v.Value), &tempObj)
+			if err != nil {
+				CBLog.Error(err)
+				return nil, err
+			}
 			res = append(res, tempObj)
 		}
 		return res, nil
@@ -179,7 +187,7 @@ func DelNs(Id string) error {
 	lowerizedId := ToLower(Id)
 	check, err := CheckNs(lowerizedId)
 
-	if check == false {
+	if !check {
 		errString := "The namespace " + lowerizedId + " does not exist."
 		err := fmt.Errorf(errString)
 		return err

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -103,11 +103,11 @@ func PrintJsonPretty(v interface{}) {
 func GenResourceKey(nsId string, resourceType string, resourceId string) string {
 	//resourceType = strings.ToLower(resourceType)
 
-	if resourceType == "image" ||
-		resourceType == "sshKey" ||
-		resourceType == "spec" ||
-		resourceType == "vNet" ||
-		resourceType == "securityGroup" {
+	if resourceType == StrImage ||
+		resourceType == StrSSHKey ||
+		resourceType == StrSpec ||
+		resourceType == StrVNet ||
+		resourceType == StrSecurityGroup {
 		//resourceType == "subnet" ||
 		//resourceType == "publicIp" ||
 		//resourceType == "vNic" {
@@ -226,19 +226,19 @@ func GetCspResourceId(nsId string, resourceType string, resourceId string) (stri
 	}
 
 	switch resourceType {
-	case "image":
+	case StrImage:
 		content := mcirIds{}
 		json.Unmarshal([]byte(keyValue.Value), &content)
 		return content.CspImageId, nil
-	case "sshKey":
+	case StrSSHKey:
 		content := mcirIds{}
 		json.Unmarshal([]byte(keyValue.Value), &content)
 		return content.CspSshKeyName, nil
-	case "spec":
+	case StrSpec:
 		content := mcirIds{}
 		json.Unmarshal([]byte(keyValue.Value), &content)
 		return content.CspSpecName, nil
-	case "vNet":
+	case StrVNet:
 		content := mcirIds{}
 		json.Unmarshal([]byte(keyValue.Value), &content)
 		return content.CspVNetName, nil // contains CspSubnetId
@@ -246,7 +246,7 @@ func GetCspResourceId(nsId string, resourceType string, resourceId string) (stri
 	// 	content := subnetInfo{}
 	// 	json.Unmarshal([]byte(keyValue.Value), &content)
 	// 	return content.CspSubnetId
-	case "securityGroup":
+	case StrSecurityGroup:
 		content := mcirIds{}
 		json.Unmarshal([]byte(keyValue.Value), &content)
 		return content.CspSecurityGroupName, nil

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -62,7 +62,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	resourceId = common.ToLower(resourceId)
 	check, err := CheckResource(nsId, resourceType, resourceId)
 
-	if check == false {
+	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
 		//mapA := map[string]string{"message": errString}
 		//mapB, _ := json.Marshal(mapA)
@@ -103,7 +103,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 		tempReq := JsonTemplate{}
 
 		switch resourceType {
-		case "image":
+		case common.StrImage:
 			// delete image info
 			err := common.CBStore.Delete(key)
 			if err != nil {
@@ -133,25 +133,21 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 			//return http.StatusOK, nil, nil
 			return nil
-		case "spec":
+		case common.StrSpec:
 			// delete spec info
 
 			//get related recommend spec
 			//keyValue, err := common.CBStore.Get(key)
 			content := TbSpecInfo{}
-			json.Unmarshal([]byte(keyValue.Value), &content)
-			/*
-				if err != nil {
-					common.CBLog.Error(err)
-					return http.StatusInternalServerError, nil, err
-				}
-			*/
-			//
-
-			err := common.CBStore.Delete(key)
+			err := json.Unmarshal([]byte(keyValue.Value), &content)
 			if err != nil {
 				common.CBLog.Error(err)
-				//return http.StatusInternalServerError, nil, err
+				return err
+			}
+
+			err = common.CBStore.Delete(key)
+			if err != nil {
+				common.CBLog.Error(err)
 				return err
 			}
 
@@ -159,7 +155,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 			err = DelRecommendSpec(nsId, resourceId, content.Num_vCPU, content.Mem_GiB, content.Storage_GiB)
 			if err != nil {
 				common.CBLog.Error(err)
-				//return http.StatusInternalServerError, nil, err
 				return err
 			}
 
@@ -184,17 +179,17 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 			//return http.StatusOK, nil, nil
 			return nil
-		case "sshKey":
+		case common.StrSSHKey:
 			temp := TbSshKeyInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 			tempReq.ConnectionName = temp.ConnectionName
 			url = common.SPIDER_REST_URL + "/keypair/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
-		case "vNet":
+		case common.StrVNet:
 			temp := TbVNetInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 			tempReq.ConnectionName = temp.ConnectionName
 			url = common.SPIDER_REST_URL + "/vpc/" + temp.Name //+ "?connection_name=" + temp.ConnectionName
-		case "securityGroup":
+		case common.StrSecurityGroup:
 			temp := TbSecurityGroupInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 			tempReq.ConnectionName = temp.ConnectionName
@@ -316,7 +311,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 		defer ccm.Close()
 
 		switch resourceType {
-		case "image":
+		case common.StrImage:
 			// delete image info
 			err := common.CBStore.Delete(key)
 			if err != nil {
@@ -346,7 +341,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 			//return http.StatusOK, nil, nil
 			return nil
-		case "spec":
+		case common.StrSpec:
 			// delete spec info
 
 			//get related recommend spec
@@ -386,7 +381,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 			}
 			return nil
 
-		case "sshKey":
+		case common.StrSSHKey:
 			temp := TbSshKeyInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 
@@ -396,7 +391,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 				return err
 			}
 
-		case "vNet":
+		case common.StrVNet:
 			temp := TbVNetInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 
@@ -406,7 +401,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 				return err
 			}
 
-		case "securityGroup":
+		case common.StrSecurityGroup:
 			temp := TbSecurityGroupInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &temp)
 
@@ -435,14 +430,14 @@ func ListResourceId(nsId string, resourceType string) []string {
 
 	nsId = common.GenId(nsId)
 
-	if resourceType == "image" ||
-		resourceType == "sshKey" ||
-		resourceType == "spec" ||
-		resourceType == "vNet" ||
+	if resourceType == common.StrImage ||
+		resourceType == common.StrSSHKey ||
+		resourceType == common.StrSpec ||
+		resourceType == common.StrVNet ||
 		//resourceType == "subnet" ||
 		//resourceType == "publicIp" ||
 		//resourceType == "vNic" ||
-		resourceType == "securityGroup" {
+		resourceType == common.StrSecurityGroup {
 		// continue
 	} else {
 		return []string{"invalid resource type"}
@@ -472,14 +467,14 @@ func ListResource(nsId string, resourceType string) (interface{}, error) {
 
 	nsId = common.GenId(nsId)
 
-	if resourceType == "image" ||
-		resourceType == "sshKey" ||
-		resourceType == "spec" ||
-		resourceType == "vNet" ||
+	if resourceType == common.StrImage ||
+		resourceType == common.StrSSHKey ||
+		resourceType == common.StrSpec ||
+		resourceType == common.StrVNet ||
 		//resourceType == "subnet" ||
 		//resourceType == "publicIp" ||
 		//resourceType == "vNic" ||
-		resourceType == "securityGroup" {
+		resourceType == common.StrSecurityGroup {
 		// continue
 	} else {
 		errString := "Cannot list " + resourceType + "s."
@@ -511,7 +506,7 @@ func ListResource(nsId string, resourceType string) (interface{}, error) {
 	}
 	if keyValue != nil {
 		switch resourceType {
-		case "image":
+		case common.StrImage:
 			res := []TbImageInfo{}
 			for _, v := range keyValue {
 				tempObj := TbImageInfo{}
@@ -519,7 +514,7 @@ func ListResource(nsId string, resourceType string) (interface{}, error) {
 				res = append(res, tempObj)
 			}
 			return res, nil
-		case "securityGroup":
+		case common.StrSecurityGroup:
 			res := []TbSecurityGroupInfo{}
 			for _, v := range keyValue {
 				tempObj := TbSecurityGroupInfo{}
@@ -527,7 +522,7 @@ func ListResource(nsId string, resourceType string) (interface{}, error) {
 				res = append(res, tempObj)
 			}
 			return res, nil
-		case "spec":
+		case common.StrSpec:
 			res := []TbSpecInfo{}
 			for _, v := range keyValue {
 				tempObj := TbSpecInfo{}
@@ -535,7 +530,7 @@ func ListResource(nsId string, resourceType string) (interface{}, error) {
 				res = append(res, tempObj)
 			}
 			return res, nil
-		case "sshKey":
+		case common.StrSSHKey:
 			res := []TbSshKeyInfo{}
 			for _, v := range keyValue {
 				tempObj := TbSshKeyInfo{}
@@ -543,7 +538,7 @@ func ListResource(nsId string, resourceType string) (interface{}, error) {
 				res = append(res, tempObj)
 			}
 			return res, nil
-		case "vNet":
+		case common.StrVNet:
 			res := []TbVNetInfo{}
 			for _, v := range keyValue {
 				tempObj := TbVNetInfo{}
@@ -564,7 +559,7 @@ func GetAssoObjCount(nsId string, resourceType string, resourceId string) (int, 
 	resourceId = common.ToLower(resourceId)
 	check, err := CheckResource(nsId, resourceType, resourceId)
 
-	if check == false {
+	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
 		//mapA := map[string]string{"message": errString}
 		//mapB, _ := json.Marshal(mapA)
@@ -606,7 +601,7 @@ func GetAssoObjList(nsId string, resourceType string, resourceId string) ([]stri
 	resourceId = common.ToLower(resourceId)
 	check, err := CheckResource(nsId, resourceType, resourceId)
 
-	if check == false {
+	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
 		//mapA := map[string]string{"message": errString}
 		//mapB, _ := json.Marshal(mapA)
@@ -639,23 +634,23 @@ func GetAssoObjList(nsId string, resourceType string, resourceId string) ([]stri
 
 		/*
 			switch resourceType {
-			case "image":
+			case common.StrImage:
 				res := TbImageInfo{}
 				json.Unmarshal([]byte(keyValue.Value), &res)
 				//result = res.
-			case "securityGroup":
+			case common.StrSecurityGroup:
 				res := TbSecurityGroupInfo{}
 				json.Unmarshal([]byte(keyValue.Value), &res)
 
-			case "spec":
+			case common.StrSpec:
 				res := TbSpecInfo{}
 				json.Unmarshal([]byte(keyValue.Value), &res)
 
-			case "sshKey":
+			case common.StrSSHKey:
 				res := TbSshKeyInfo{}
 				json.Unmarshal([]byte(keyValue.Value), &res)
 				result = res.AssociatedObjectList
-			case "vNet":
+			case common.StrVNet:
 				res := TbVNetInfo{}
 				json.Unmarshal([]byte(keyValue.Value), &res)
 
@@ -676,15 +671,14 @@ func GetAssoObjList(nsId string, resourceType string, resourceId string) ([]stri
 	return nil, err
 }
 
-//func SetInUseCount(nsId string, resourceType string, resourceId string, cmd string) (int8, error) {
-func UpdateAssoObjList(nsId string, resourceType string, resourceId string, cmd string, objectKey string) ([]string, error) {
+func UpdateAssociatedObjList(nsId string, resourceType string, resourceId string, cmd string, objectKey string) ([]string, error) {
 
 	nsId = common.ToLower(nsId)
 	resourceId = common.ToLower(resourceId)
 	/*
 		check, err := CheckResource(nsId, resourceType, resourceId)
 
-		if check == false {
+		if !check {
 			errString := "The " + resourceType + " " + resourceId + " does not exist."
 			//mapA := map[string]string{"message": errString}
 			//mapB, _ := json.Marshal(mapA)
@@ -714,9 +708,7 @@ func UpdateAssoObjList(nsId string, resourceType string, resourceId string, cmd 
 	if keyValue != nil {
 		objList, _ := GetAssoObjList(nsId, resourceType, resourceId)
 		switch cmd {
-		case "add":
-			fallthrough
-		case "append":
+		case common.StrAdd:
 			for _, v := range objList {
 				if v == objectKey {
 					errString := objectKey + " is already associated with " + resourceType + " " + resourceId + "."
@@ -740,9 +732,7 @@ func UpdateAssoObjList(nsId string, resourceType string, resourceId string, cmd 
 			}
 			fmt.Println("keyValue.Value after sjson.Set: " + keyValue.Value) // for debug
 			//objList = append(objList, objectKey)
-		case "remove":
-			fallthrough
-		case "delete":
+		case common.StrDelete:
 			var foundKey int
 			var foundVal string
 			for k, v := range objList {
@@ -800,7 +790,7 @@ func GetResource(nsId string, resourceType string, resourceId string) (interface
 	resourceId = common.ToLower(resourceId)
 	check, err := CheckResource(nsId, resourceType, resourceId)
 
-	if check == false {
+	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
 		//mapA := map[string]string{"message": errString}
 		//mapB, _ := json.Marshal(mapA)
@@ -824,23 +814,23 @@ func GetResource(nsId string, resourceType string, resourceId string) (interface
 	}
 	if keyValue != nil {
 		switch resourceType {
-		case "image":
+		case common.StrImage:
 			res := TbImageInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &res)
 			return res, nil
-		case "securityGroup":
+		case common.StrSecurityGroup:
 			res := TbSecurityGroupInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &res)
 			return res, nil
-		case "spec":
+		case common.StrSpec:
 			res := TbSpecInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &res)
 			return res, nil
-		case "sshKey":
+		case common.StrSSHKey:
 			res := TbSshKeyInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &res)
 			return res, nil
-		case "vNet":
+		case common.StrVNet:
 			res := TbVNetInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &res)
 			return res, nil
@@ -852,53 +842,6 @@ func GetResource(nsId string, resourceType string, resourceId string) (interface
 	err = fmt.Errorf(errString)
 	return nil, err
 }
-
-/*
-func LowerizeAndCheckResource(nsId string, resourceType string, resourceId string) (bool, string, error) {
-
-	// Check parameters' emptiness
-	if nsId == "" {
-		err := fmt.Errorf("CheckResource failed; nsId given is null.")
-		return false, "", err
-	} else if resourceType == "" {
-		err := fmt.Errorf("CheckResource failed; resourceType given is null.")
-		return false, "", err
-	} else if resourceId == "" {
-		err := fmt.Errorf("CheckResource failed; resourceId given is null.")
-		return false, "", err
-	}
-
-	// Check resourceType's validity
-	if resourceType == "image" ||
-		resourceType == "sshKey" ||
-		resourceType == "spec" ||
-		resourceType == "vNet" ||
-		resourceType == "securityGroup" {
-		//resourceType == "subnet" ||
-		//resourceType == "publicIp" ||
-		//resourceType == "vNic" {
-		// continue
-	} else {
-		err := fmt.Errorf("invalid resource type")
-		return false, "", err
-	}
-
-	lowerizedNsId := common.GenId(nsId)
-	lowerizedResourceId := common.GenId(resourceId)
-
-	fmt.Println("[Check resource] " + resourceType + ", " + lowerizedResourceId)
-
-	key := common.GenResourceKey(lowerizedNsId, resourceType, lowerizedResourceId)
-	//fmt.Println(key)
-
-	keyValue, _ := common.CBStore.Get(key)
-	if keyValue != nil {
-		return true, lowerizedResourceId, nil
-	}
-	return false, lowerizedResourceId, nil
-
-}
-*/
 
 func CheckResource(nsId string, resourceType string, resourceId string) (bool, error) {
 
@@ -915,11 +858,11 @@ func CheckResource(nsId string, resourceType string, resourceId string) (bool, e
 	}
 
 	// Check resourceType's validity
-	if resourceType == "image" ||
-		resourceType == "sshKey" ||
-		resourceType == "spec" ||
-		resourceType == "vNet" ||
-		resourceType == "securityGroup" {
+	if resourceType == common.StrImage ||
+		resourceType == common.StrSSHKey ||
+		resourceType == common.StrSpec ||
+		resourceType == common.StrVNet ||
+		resourceType == common.StrSecurityGroup {
 		//resourceType == "subnet" ||
 		//resourceType == "publicIp" ||
 		//resourceType == "vNic" {
@@ -953,11 +896,11 @@ func convertSpiderResourceToTumblebugResource(resourceType string, i interface{}
 	}
 
 	// Check resourceType's validity
-	if resourceType == "image" ||
-		resourceType == "sshKey" ||
-		resourceType == "spec" ||
-		resourceType == "vNet" ||
-		resourceType == "securityGroup" {
+	if resourceType == common.StrImage ||
+		resourceType == common.StrSSHKey ||
+		resourceType == common.StrSpec ||
+		resourceType == common.StrVNet ||
+		resourceType == common.StrSecurityGroup {
 		//resourceType == "subnet" ||
 		//resourceType == "publicIp" ||
 		//resourceType == "vNic" {
@@ -967,55 +910,6 @@ func convertSpiderResourceToTumblebugResource(resourceType string, i interface{}
 		return nil, err
 	}
 
-}
-*/
-
-/*
-func RestDelResource(c echo.Context) error {
-
-	nsId := c.Param("nsId")
-	resourceType := c.Param("resourceType")
-	resourceId := c.Param("resourceId")
-	forceFlag := c.QueryParam("force")
-
-	fmt.Printf("RestDelResource() called; %s %s %s \n", nsId, resourceType, resourceId) // for debug
-
-	responseCode, _, err := DelResource(nsId, resourceType, resourceId, forceFlag)
-	if err != nil {
-		common.CBLog.Error(err)
-		mapA := map[string]string{"message": err.Error()}
-		return c.JSON(responseCode, &mapA)
-	}
-
-	mapA := map[string]string{"message": "The " + resourceType + " " + resourceId + " has been deleted"}
-	return c.JSON(http.StatusOK, &mapA)
-}
-
-func RestDelAllResources(c echo.Context) error {
-
-	nsId := c.Param("nsId")
-	resourceType := c.Param("resourceType")
-	forceFlag := c.QueryParam("force")
-
-	resourceList := ListResourceId(nsId, resourceType)
-
-	if len(resourceList) == 0 {
-		mapA := map[string]string{"message": "There is no " + resourceType + " element in this namespace."}
-		return c.JSON(http.StatusNotFound, &mapA)
-	} else {
-		for _, v := range resourceList {
-			responseCode, _, err := DelResource(nsId, resourceType, v, forceFlag)
-			if err != nil {
-				common.CBLog.Error(err)
-				mapA := map[string]string{"message": err.Error()}
-				return c.JSON(responseCode, &mapA)
-			}
-
-		}
-
-		mapA := map[string]string{"message": "All " + resourceType + "s has been deleted"}
-		return c.JSON(http.StatusOK, &mapA)
-	}
 }
 */
 

--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -52,11 +52,11 @@ type TbImageInfo struct {
 	ConnectionName string            `json:"connectionName"`
 	CspImageId     string            `json:"cspImageId"`
 	CspImageName   string            `json:"cspImageName"`
-	Description    string            `json:"description"`
-	CreationDate   string            `json:"creationDate"`
-	GuestOS        string            `json:"guestOS"` // Windows7, Ubuntu etc.
-	Status         string            `json:"status"`  // available, unavailable
-	KeyValueList   []common.KeyValue `json:"keyValueList"`
+	Description    string            `json:"description, omitempty"`
+	CreationDate   string            `json:"creationDate, omitempty"`
+	GuestOS        string            `json:"guestOS, omitempty"` // Windows7, Ubuntu etc.
+	Status         string            `json:"status, omitempty"`  // available, unavailable
+	KeyValueList   []common.KeyValue `json:"keyValueList, omitempty"`
 }
 
 func ConvertSpiderImageToTumblebugImage(spiderImage SpiderImageInfo) (TbImageInfo, error) {
@@ -80,192 +80,15 @@ func ConvertSpiderImageToTumblebugImage(spiderImage SpiderImageInfo) (TbImageInf
 	return tumblebugImage, nil
 }
 
-/*
-func createImage(nsId string, u *TbImageReq) (TbImageInfo, error) {
-
-}
-*/
-
-/* obsolete
-// TODO: Need to update (after CB-Spider's implementing lookupImage feature)
-func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
-	check, _ := CheckResource(nsId, "image", u.Name)
-
-	if check {
-		temp := TbImageInfo{}
-		err := fmt.Errorf("The image " + u.Name + " already exists.")
-		return temp, err
-	}
-
-	var tempSpiderImageInfo SpiderImageInfo
-
-	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
-
-		// Step 1. Create a temp `SpiderImageReqInfo (from Spider)` object.
-
-		// Step 2. Send a req to Spider and save the response.
-		url := common.SPIDER_REST_URL + "/vmimage/" + u.CspImageId + "?connection_name=" + u.ConnectionName
-
-		method := "GET"
-
-		payload := strings.NewReader("{ \"Name\": \"" + u.CspImageId + "\"}")
-
-		client := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
-		req, err := http.NewRequest(method, url, payload)
-
-		if err != nil {
-			fmt.Println(err)
-		}
-		req.Header.Add("Content-Type", "application/json")
-
-		res, err := client.Do(req)
-		if err != nil {
-			common.CBLog.Error(err)
-			content := TbImageInfo{}
-			//return content, res.StatusCode, nil, err
-			return content, err
-		}
-		defer res.Body.Close()
-
-		body, err := ioutil.ReadAll(res.Body)
-		fmt.Println(string(body))
-		if err != nil {
-			common.CBLog.Error(err)
-			content := TbImageInfo{}
-			//return content, res.StatusCode, body, err
-			return content, err
-		}
-
-		fmt.Println("HTTP Status code " + strconv.Itoa(res.StatusCode))
-		switch {
-		case res.StatusCode >= 400 || res.StatusCode < 200:
-			err := fmt.Errorf(string(body))
-			fmt.Println("body: ", string(body))
-			common.CBLog.Error(err)
-			content := TbImageInfo{}
-			//return content, res.StatusCode, body, err
-			return content, err
-		}
-
-		tempSpiderImageInfo = SpiderImageInfo{}
-		err2 := json.Unmarshal(body, &tempSpiderImageInfo)
-		if err2 != nil {
-			fmt.Println("whoops:", err2)
-		}
-
-	} else {
-
-		// CCM API 설정
-		ccm := api.NewCloudResourceHandler()
-		err := ccm.SetConfigPath(os.Getenv("CBTUMBLEBUG_ROOT") + "/conf/grpc_conf.yaml")
-		if err != nil {
-			common.CBLog.Error("ccm failed to set config : ", err)
-			return TbImageInfo{}, err
-		}
-		err = ccm.Open()
-		if err != nil {
-			common.CBLog.Error("ccm api open failed : ", err)
-			return TbImageInfo{}, err
-		}
-		defer ccm.Close()
-
-		result, err := ccm.GetImageByParam(u.ConnectionName, u.CspImageId)
-		if err != nil {
-			common.CBLog.Error(err)
-			return TbImageInfo{}, err
-		}
-
-		tempSpiderImageInfo = SpiderImageInfo{}
-		err2 := json.Unmarshal([]byte(result), &tempSpiderImageInfo)
-		if err2 != nil {
-			fmt.Println("whoops:", err2)
-		}
-	}
-
-	content := TbImageInfo{}
-	content.Id = common.GenId(u.Name)
-	content.Name = common.GenId(u.Name)
-	content.ConnectionName = u.ConnectionName
-	content.CspImageId = tempSpiderImageInfo.Name   // = u.CspImageId
-	content.CspImageName = tempSpiderImageInfo.Name // = u.CspImageName
-	content.CreationDate = common.LookupKeyValueList(tempSpiderImageInfo.KeyValueList, "CreationDate")
-	content.Description = common.LookupKeyValueList(tempSpiderImageInfo.KeyValueList, "Description")
-	content.GuestOS = tempSpiderImageInfo.GuestOS
-	content.Status = tempSpiderImageInfo.Status
-	content.KeyValueList = tempSpiderImageInfo.KeyValueList
-
-	sql := "INSERT INTO `image`(" +
-		"`id`, " +
-		"`name`, " +
-		"`connectionName`, " +
-		"`cspImageId`, " +
-		"`cspImageName`, " +
-		"`creationDate`, " +
-		"`description`, " +
-		"`guestOS`, " +
-		"`status`) " +
-		"VALUES ('" +
-		content.Id + "', '" +
-		content.Name + "', '" +
-		content.ConnectionName + "', '" +
-		content.CspImageId + "', '" +
-		content.CspImageName + "', '" +
-		content.CreationDate + "', '" +
-		content.Description + "', '" +
-		content.GuestOS + "', '" +
-		content.Status + "');"
-
-	fmt.Println("sql: " + sql)
-	// https://stackoverflow.com/questions/42486032/golang-sql-query-syntax-validator
-	_, err := sqlparser.Parse(sql)
-	if err != nil {
-		return content, err
-	}
-
-	// Step 4. Store the metadata to CB-Store.
-	fmt.Println("=========================== PUT registerImage")
-	Key := common.GenResourceKey(nsId, "image", content.Id)
-	Val, _ := json.Marshal(content)
-	err = common.CBStore.Put(string(Key), string(Val))
-	if err != nil {
-		common.CBLog.Error(err)
-		//return content, res.StatusCode, body, err
-		return content, err
-	}
-	keyValue, _ := common.CBStore.Get(string(Key))
-	fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
-	fmt.Println("===========================")
-
-	stmt, err := common.MYDB.Prepare(sql)
-	if err != nil {
-		fmt.Println(err.Error())
-	}
-	_, err = stmt.Exec()
-	if err != nil {
-		fmt.Println(err.Error())
-	} else {
-		fmt.Println("Data inserted successfully..")
-	}
-
-	//return content, res.StatusCode, body, nil
-	return content, nil
-}
-*/
-
 func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 
-	resourceType := "image"
+	resourceType := common.StrImage
 
-	//check, lowerizedName, err := LowerizeAndCheckResource(nsId, "image", u.Name)
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(u.Name)
 	check, err := CheckResource(nsId, resourceType, lowerizedName)
 
-	if check == true {
+	if check {
 		temp := TbImageInfo{}
 		err := fmt.Errorf("The image " + lowerizedName + " already exists.")
 		return temp, err
@@ -353,14 +176,13 @@ func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 
 func RegisterImageWithInfo(nsId string, content *TbImageInfo) (TbImageInfo, error) {
 
-	resourceType := "image"
+	resourceType := common.StrImage
 
-	//check, lowerizedName, err := LowerizeAndCheckResource(nsId, "image", content.Name)
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(content.Name)
 	check, err := CheckResource(nsId, resourceType, lowerizedName)
 
-	if check == true {
+	if check {
 		temp := TbImageInfo{}
 		err := fmt.Errorf("The image " + lowerizedName + " already exists.")
 		return temp, err
@@ -614,9 +436,8 @@ func FetchImages(nsId string) (connConfigCount uint, imageCount uint, err error)
 			tumblebugImageId := connConfig.ConfigName + "-" + tumblebugImage.Name
 			//fmt.Println("tumblebugImageId: " + tumblebugImageId) // for debug
 
-			//check, _, err := LowerizeAndCheckResource(nsId, "image", tumblebugImageId)
-			check, err := CheckResource(nsId, "image", tumblebugImageId)
-			if check == true {
+			check, err := CheckResource(nsId, common.StrImage, tumblebugImageId)
+			if check {
 				common.CBLog.Infoln("The image " + tumblebugImageId + " already exists in TB; continue")
 				continue
 			} else if err != nil {

--- a/src/core/mcir/image_test.go
+++ b/src/core/mcir/image_test.go
@@ -55,7 +55,7 @@ func TestImage(t *testing.T) {
 	fmt.Println("result: " + string(resultJSON))
 	assert.Equal(t, imageName, result.Name, "CreateImage 기대값과 결과값이 다릅니다.")
 
-	resultInterface, _ := GetResource(nsName, "image", imageName)
+	resultInterface, _ := GetResource(nsName, common.StrImage, imageName)
 	result = resultInterface.(TbImageInfo) // type assertion
 	assert.Equal(t, imageName, result.Name, "GetImage 기대값과 결과값이 다릅니다.")
 
@@ -63,7 +63,7 @@ func TestImage(t *testing.T) {
 
 	//result, _ := ListImageId()
 
-	resultErr := DelResource(nsName, "image", imageName, "false")
+	resultErr := DelResource(nsName, common.StrImage, imageName, "false")
 	assert.Nil(t, resultErr)
 
 	common.DelNs(nsName)

--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -74,10 +74,8 @@ type TbSecurityGroupInfo struct { // Tumblebug
 
 func CreateSecurityGroup(nsId string, u *TbSecurityGroupReq) (TbSecurityGroupInfo, error) {
 
-	resourceType := "securityGroup"
+	resourceType := common.StrSecurityGroup
 
-	//check, lowerizedName, err := LowerizeAndCheckResource(nsId, "securityGroup", u.Name)
-	//u.Name = lowerizedName
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(u.Name)
 	u.Name = lowerizedName

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -291,9 +291,8 @@ func FetchSpecs(nsId string) (connConfigCount uint, specCount uint, err error) {
 			tumblebugSpecId := connConfig.ConfigName + "-" + tumblebugSpec.Name
 			//fmt.Println("tumblebugSpecId: " + tumblebugSpecId) // for debug
 
-			//check, _, err := LowerizeAndCheckResource(nsId, "spec", tumblebugSpecId)
-			check, err := CheckResource(nsId, "spec", tumblebugSpecId)
-			if check == true {
+			check, err := CheckResource(nsId, common.StrSpec, tumblebugSpecId)
+			if check {
 				common.CBLog.Infoln("The spec " + tumblebugSpecId + " already exists in TB; continue")
 				continue
 			} else if err != nil {
@@ -319,16 +318,14 @@ func FetchSpecs(nsId string) (connConfigCount uint, specCount uint, err error) {
 
 func RegisterSpecWithCspSpecName(nsId string, u *TbSpecReq) (TbSpecInfo, error) {
 
-	resourceType := "spec"
+	resourceType := common.StrSpec
 
-	//check, lowerizedName, err := LowerizeAndCheckResource(nsId, "spec", u.Name)
-	//u.Name = lowerizedName
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(u.Name)
 	u.Name = lowerizedName
 	check, err := CheckResource(nsId, resourceType, lowerizedName)
 
-	if check == true {
+	if check {
 		temp := TbSpecInfo{}
 		err := fmt.Errorf("The spec " + u.Name + " already exists.")
 		return temp, err
@@ -474,16 +471,14 @@ func RegisterSpecWithCspSpecName(nsId string, u *TbSpecReq) (TbSpecInfo, error) 
 
 func RegisterSpecWithInfo(nsId string, content *TbSpecInfo) (TbSpecInfo, error) {
 
-	resourceType := "spec"
+	resourceType := common.StrSpec
 
-	//check, lowerizedName, err := LowerizeAndCheckResource(nsId, "spec", content.Name)
-	//content.Name = lowerizedName
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(content.Name)
 	content.Name = lowerizedName
 	check, err := CheckResource(nsId, resourceType, lowerizedName)
 
-	if check == true {
+	if check {
 		temp := TbSpecInfo{}
 		err := fmt.Errorf("The spec " + content.Name + " already exists.")
 		return temp, err
@@ -1166,16 +1161,14 @@ func SortSpecs(specList []TbSpecInfo, orderBy string, direction string) ([]TbSpe
 }
 
 func UpdateSpec(nsId string, newSpec TbSpecInfo) (TbSpecInfo, error) {
-	resourceType := "spec"
+	resourceType := common.StrSpec
 
-	//check, lowerizedName, err := LowerizeAndCheckResource(nsId, "spec", newSpec.Id)
-	//newSpec.Id = lowerizedName
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(newSpec.Id)
 	newSpec.Id = lowerizedName
 	check, err := CheckResource(nsId, resourceType, lowerizedName)
 
-	if check == false {
+	if !check {
 		temp := TbSpecInfo{}
 		err := fmt.Errorf("The spec " + newSpec.Id + " does not exist.")
 		return temp, err

--- a/src/core/mcir/spec_test.go
+++ b/src/core/mcir/spec_test.go
@@ -55,7 +55,7 @@ func TestSpec(t *testing.T) {
 	fmt.Println("result: " + string(resultJSON))
 	assert.Equal(t, specName, result.Name, "CreateSpec 기대값과 결과값이 다릅니다.")
 
-	resultInterface, _ := GetResource(nsName, "spec", specName)
+	resultInterface, _ := GetResource(nsName, common.StrSpec, specName)
 	result = resultInterface.(TbSpecInfo) // type assertion
 	assert.Equal(t, specName, result.Name, "GetSpec 기대값과 결과값이 다릅니다.")
 
@@ -63,7 +63,7 @@ func TestSpec(t *testing.T) {
 
 	//result, _ := ListSpecId()
 
-	resultErr := DelResource(nsName, "spec", specName, "false")
+	resultErr := DelResource(nsName, common.StrSpec, specName, "false")
 	assert.Nil(t, resultErr)
 
 	common.DelNs(nsName)

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -59,16 +59,14 @@ type TbSshKeyInfo struct {
 
 func CreateSshKey(nsId string, u *TbSshKeyReq) (TbSshKeyInfo, error) {
 
-	resourceType := "sshKey"
+	resourceType := common.StrSSHKey
 
-	//check, lowerizedName, err := LowerizeAndCheckResource(nsId, "sshKey", u.Name)
-	//u.Name = lowerizedName
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(u.Name)
 	u.Name = lowerizedName
 	check, err := CheckResource(nsId, resourceType, lowerizedName)
 
-	if check == true {
+	if check {
 		temp := TbSshKeyInfo{}
 		err := fmt.Errorf("The sshKey " + u.Name + " already exists.")
 		//return temp, http.StatusConflict, nil, err

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -44,17 +44,17 @@ type TbSshKeyReq struct {
 }
 
 type TbSshKeyInfo struct {
-	Id             string            `json:"id"`
-	Name           string            `json:"name"`
-	ConnectionName string            `json:"connectionName"`
-	Description    string            `json:"description"`
-	CspSshKeyName  string            `json:"cspSshKeyName"`
-	Fingerprint    string            `json:"fingerprint"`
-	Username       string            `json:"username"`
-	PublicKey      string            `json:"publicKey"`
-	PrivateKey     string            `json:"privateKey"`
-	KeyValueList   []common.KeyValue `json:"keyValueList"`
-	InUseCount     int8              `json:"inUseCount"`
+	Id                   string            `json:"id"`
+	Name                 string            `json:"name"`
+	ConnectionName       string            `json:"connectionName"`
+	Description          string            `json:"description"`
+	CspSshKeyName        string            `json:"cspSshKeyName"`
+	Fingerprint          string            `json:"fingerprint"`
+	Username             string            `json:"username"`
+	PublicKey            string            `json:"publicKey"`
+	PrivateKey           string            `json:"privateKey"`
+	KeyValueList         []common.KeyValue `json:"keyValueList"`
+	AssociatedObjectList []string          `json:"associatedObjectList"`
 }
 
 func CreateSshKey(nsId string, u *TbSshKeyReq) (TbSshKeyInfo, error) {

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -71,16 +71,14 @@ type TbVNetInfo struct { // Tumblebug
 
 func CreateVNet(nsId string, u *TbVNetReq) (TbVNetInfo, error) {
 
-	resourceType := "vNet"
+	resourceType := common.StrVNet
 
-	//check, lowerizedName, _ := LowerizeAndCheckResource(nsId, "vNet", u.Name)
-	//u.Name = lowerizedName
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(u.Name)
 	u.Name = lowerizedName
 	check, err := CheckResource(nsId, resourceType, lowerizedName)
 
-	if check == true {
+	if check {
 		temp := TbVNetInfo{}
 		err := fmt.Errorf("The vNet " + u.Name + " already exists.")
 		return temp, err
@@ -180,20 +178,7 @@ func CreateVNet(nsId string, u *TbVNetReq) (TbVNetInfo, error) {
 
 	// cb-store
 	fmt.Println("=========================== PUT CreateVNet")
-	Key := common.GenResourceKey(nsId, "vNet", content.Id)
-	/*
-		mapA := map[string]string{
-			"connectionName": content.ConnectionName,
-			"cspVNetId":   content.CspVNetId,
-			"cspVNetName": content.CspVNetName,
-			"cidrBlock":      content.CidrBlock,
-			//"region":            content.Region,
-			//"resourceGroupName": content.ResourceGroupName,
-			"description":  content.Description,
-			"status":       content.Status,
-			"keyValueList": content.KeyValueList}
-		Val, _ := json.Marshal(mapA)
-	*/
+	Key := common.GenResourceKey(nsId, common.StrVNet, content.Id)
 	Val, _ := json.Marshal(content)
 
 	//fmt.Println("Key: ", Key)

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -406,7 +406,7 @@ func InstallAgentToMcis(nsId string, mcisId string, req *McisCmdReq) (AgentInsta
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		temp := AgentInstallContentWrapper{}
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return temp, err
@@ -597,7 +597,7 @@ func CoreGetAllBenchmark(nsId string, mcisId string, host string) (*BenchmarkInf
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		temp := &BenchmarkInfoArray{}
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return temp, err
@@ -746,7 +746,7 @@ func CoreGetBenchmark(nsId string, mcisId string, action string, host string) (*
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		temp := &BenchmarkInfoArray{}
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return temp, err
@@ -1025,7 +1025,7 @@ func DelMcis(nsId string, mcisId string) error {
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return err
 	}
@@ -1066,7 +1066,7 @@ func DelMcis(nsId string, mcisId string) error {
 			return err
 		}
 
-		mcir.UpdateAssoObjList(nsId, "sshKey", vmInfo.SshKeyId, "delete", vmKey)
+		mcir.UpdateAssociatedObjList(nsId, common.StrSSHKey, vmInfo.SshKeyId, common.StrDelete, vmKey)
 	}
 	// delete mcis info
 	err = common.CBStore.Delete(key)
@@ -1087,7 +1087,7 @@ func DelMcisVm(nsId string, mcisId string, vmId string) error {
 	vmId = common.ToLower(vmId)
 	check, _ := CheckVm(nsId, mcisId, vmId)
 
-	if check == false {
+	if !check {
 		err := fmt.Errorf("The vm " + vmId + " does not exist.")
 		return err
 	}
@@ -1117,7 +1117,7 @@ func DelMcisVm(nsId string, mcisId string, vmId string) error {
 		return err
 	}
 
-	mcir.UpdateAssoObjList(nsId, "sshKey", vmInfo.SshKeyId, "delete", key)
+	mcir.UpdateAssociatedObjList(nsId, common.StrSSHKey, vmInfo.SshKeyId, common.StrDelete, key)
 
 	return nil
 }
@@ -1153,7 +1153,7 @@ func GetRecommendList(nsId string, cpuSize string, memSize string, diskSize stri
 		}
 
 		content2 := mcir.TbSpecInfo{}
-		key2 := common.GenResourceKey(nsId, "spec", content.Id)
+		key2 := common.GenResourceKey(nsId, common.StrSpec, content.Id)
 
 		keyValue2, err := common.CBStore.Get(key2)
 		if err != nil {
@@ -1186,7 +1186,7 @@ func CorePostMcis(nsId string, req *TbMcisReq) (*TbMcisInfo, error) {
 	req.Name = common.ToLower(req.Name)
 	check, _ := CheckMcis(nsId, req.Name)
 
-	if check == true {
+	if check {
 		temp := &TbMcisInfo{}
 		err := fmt.Errorf("The mcis " + req.Name + " already exists.")
 		return temp, err
@@ -1250,7 +1250,7 @@ func CoreGetMcisAction(nsId string, mcisId string, action string) (string, error
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return err.Error(), err
 	}
@@ -1342,7 +1342,7 @@ func CoreGetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		temp := &McisStatusInfo{}
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return temp, err
@@ -1378,7 +1378,7 @@ func CoreGetMcisInfo(nsId string, mcisId string) (*TbMcisInfo, error) {
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		temp := &TbMcisInfo{}
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return temp, err
@@ -1623,7 +1623,7 @@ func CorePostCmdMcisVm(nsId string, mcisId string, vmId string, req *McisCmdReq)
 	vmId = common.ToLower(vmId)
 	check, _ := CheckVm(nsId, mcisId, vmId)
 
-	if check == false {
+	if !check {
 		err := fmt.Errorf("The vm " + vmId + " does not exist.")
 		return err.Error(), err
 	}
@@ -1676,7 +1676,7 @@ func CorePostCmdMcis(nsId string, mcisId string, req *McisCmdReq) ([]SshCmdResul
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		temp := []SshCmdResult{}
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return temp, err
@@ -1753,7 +1753,7 @@ func CorePostMcisVm(nsId string, mcisId string, vmInfoData *TbVmInfo) (*TbVmInfo
 	vmInfoData.Name = common.ToLower(vmInfoData.Name)
 	check, _ := CheckVm(nsId, mcisId, vmInfoData.Name)
 
-	if check == true {
+	if check {
 		temp := &TbVmInfo{}
 		err := fmt.Errorf("The vm " + vmInfoData.Name + " already exists.")
 		return temp, err
@@ -1833,7 +1833,7 @@ func CoreGetMcisVmAction(nsId string, mcisId string, vmId string, action string)
 	vmId = common.ToLower(vmId)
 	check, _ := CheckVm(nsId, mcisId, vmId)
 
-	if check == false {
+	if !check {
 		err := fmt.Errorf("The vm " + vmId + " does not exist.")
 		return err.Error(), err
 	}
@@ -1885,7 +1885,7 @@ func CoreGetMcisVmStatus(nsId string, mcisId string, vmId string) (*TbVmStatusIn
 	vmId = common.ToLower(vmId)
 	check, _ := CheckVm(nsId, mcisId, vmId)
 
-	if check == false {
+	if !check {
 		temp := &TbVmStatusInfo{}
 		err := fmt.Errorf("The vm " + vmId + " does not exist.")
 		return temp, err
@@ -1921,7 +1921,7 @@ func CoreGetMcisVmInfo(nsId string, mcisId string, vmId string) (*TbVmInfo, erro
 	vmId = common.ToLower(vmId)
 	check, _ := CheckVm(nsId, mcisId, vmId)
 
-	if check == false {
+	if !check {
 		temp := &TbVmInfo{}
 		err := fmt.Errorf("The vm " + vmId + " does not exist.")
 		return temp, err
@@ -2236,25 +2236,25 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 
 		err := fmt.Errorf("")
 
-		tempReq.ReqInfo.ImageName, err = common.GetCspResourceId(nsId, "image", vmInfoData.ImageId)
+		tempReq.ReqInfo.ImageName, err = common.GetCspResourceId(nsId, common.StrImage, vmInfoData.ImageId)
 		if tempReq.ReqInfo.ImageName == "" || err != nil {
 			common.CBLog.Error(err)
 			return err
 		}
 
-		tempReq.ReqInfo.VMSpecName, err = common.GetCspResourceId(nsId, "spec", vmInfoData.SpecId)
+		tempReq.ReqInfo.VMSpecName, err = common.GetCspResourceId(nsId, common.StrSpec, vmInfoData.SpecId)
 		if tempReq.ReqInfo.VMSpecName == "" || err != nil {
 			common.CBLog.Error(err)
 			return err
 		}
 
-		tempReq.ReqInfo.VPCName = vmInfoData.VNetId //common.GetCspResourceId(nsId, "vNet", vmInfoData.VNetId)
+		tempReq.ReqInfo.VPCName = vmInfoData.VNetId //common.GetCspResourceId(nsId, common.StrVNet, vmInfoData.VNetId)
 		if tempReq.ReqInfo.VPCName == "" {
 			common.CBLog.Error(err)
 			return err
 		}
 
-		tempReq.ReqInfo.SubnetName = vmInfoData.SubnetId //common.GetCspResourceId(nsId, "vNet", vmInfoData.SubnetId)
+		tempReq.ReqInfo.SubnetName = vmInfoData.SubnetId //common.GetCspResourceId(nsId, common.StrVNet, vmInfoData.SubnetId)
 		if tempReq.ReqInfo.SubnetName == "" {
 			common.CBLog.Error(err)
 			return err
@@ -2262,7 +2262,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 
 		var SecurityGroupIdsTmp []string
 		for _, v := range vmInfoData.SecurityGroupIds {
-			CspSgId := v //common.GetCspResourceId(nsId, "securityGroup", v)
+			CspSgId := v //common.GetCspResourceId(nsId, common.StrSecurityGroup, v)
 			if CspSgId == "" {
 				common.CBLog.Error(err)
 				return err
@@ -2272,7 +2272,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 		}
 		tempReq.ReqInfo.SecurityGroupNames = SecurityGroupIdsTmp
 
-		tempReq.ReqInfo.KeyPairName = vmInfoData.SshKeyId //common.GetCspResourceId(nsId, "sshKey", vmInfoData.SshKeyId)
+		tempReq.ReqInfo.KeyPairName = vmInfoData.SshKeyId //common.GetCspResourceId(nsId, common.StrSSHKey, vmInfoData.SshKeyId)
 		if tempReq.ReqInfo.KeyPairName == "" {
 			common.CBLog.Error(err)
 			return err
@@ -2366,25 +2366,25 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 
 		err = fmt.Errorf("")
 
-		tempReq.ReqInfo.ImageName, err = common.GetCspResourceId(nsId, "image", vmInfoData.ImageId)
+		tempReq.ReqInfo.ImageName, err = common.GetCspResourceId(nsId, common.StrImage, vmInfoData.ImageId)
 		if tempReq.ReqInfo.ImageName == "" || err != nil {
 			common.CBLog.Error(err)
 			return err
 		}
 
-		tempReq.ReqInfo.VMSpecName, err = common.GetCspResourceId(nsId, "spec", vmInfoData.SpecId)
+		tempReq.ReqInfo.VMSpecName, err = common.GetCspResourceId(nsId, common.StrSpec, vmInfoData.SpecId)
 		if tempReq.ReqInfo.VMSpecName == "" || err != nil {
 			common.CBLog.Error(err)
 			return err
 		}
 
-		tempReq.ReqInfo.VPCName = vmInfoData.VNetId //common.GetCspResourceId(nsId, "vNet", vmInfoData.VNetId)
+		tempReq.ReqInfo.VPCName = vmInfoData.VNetId //common.GetCspResourceId(nsId, common.StrVNet, vmInfoData.VNetId)
 		if tempReq.ReqInfo.VPCName == "" {
 			common.CBLog.Error(err)
 			return err
 		}
 
-		tempReq.ReqInfo.SubnetName = vmInfoData.SubnetId //common.GetCspResourceId(nsId, "vNet", vmInfoData.SubnetId)
+		tempReq.ReqInfo.SubnetName = vmInfoData.SubnetId //common.GetCspResourceId(nsId, "subnet", vmInfoData.SubnetId)
 		if tempReq.ReqInfo.SubnetName == "" {
 			common.CBLog.Error(err)
 			return err
@@ -2392,7 +2392,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 
 		var SecurityGroupIdsTmp []string
 		for _, v := range vmInfoData.SecurityGroupIds {
-			CspSgId := v //common.GetCspResourceId(nsId, "securityGroup", v)
+			CspSgId := v //common.GetCspResourceId(nsId, common.StrSecurityGroup, v)
 			if CspSgId == "" {
 				common.CBLog.Error(err)
 				return err
@@ -2402,7 +2402,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 		}
 		tempReq.ReqInfo.SecurityGroupNames = SecurityGroupIdsTmp
 
-		tempReq.ReqInfo.KeyPairName = vmInfoData.SshKeyId //common.GetCspResourceId(nsId, "sshKey", vmInfoData.SshKeyId)
+		tempReq.ReqInfo.KeyPairName = vmInfoData.SshKeyId //common.GetCspResourceId(nsId, common.StrSSHKey, vmInfoData.SshKeyId)
 		if tempReq.ReqInfo.KeyPairName == "" {
 			common.CBLog.Error(err)
 			return err
@@ -2464,9 +2464,8 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 	configTmp, _ := common.GetConnConfig(vmInfoData.ConnectionName)
 	vmInfoData.Location = GetCloudLocation(strings.ToLower(configTmp.ProviderName), strings.ToLower(tempSpiderVMInfo.Region.Region))
 
-	//mcir.SetInUseCount(nsId, "sshKey", vmInfoData.SshKeyId, "+1")
 	vmKey := common.GenMcisKey(nsId, mcisId, vmInfoData.Id)
-	mcir.UpdateAssoObjList(nsId, "sshKey", vmInfoData.SshKeyId, "add", vmKey)
+	mcir.UpdateAssociatedObjList(nsId, common.StrSSHKey, vmInfoData.SshKeyId, common.StrAdd, vmKey)
 
 	//content.Status = temp.
 	//content.Cloud_id = temp.
@@ -3658,7 +3657,7 @@ func GetVmSshKey(nsId string, mcisId string, vmId string) (string, string) {
 
 	fmt.Printf("%+v\n", content.SshKeyId)
 
-	sshKey := common.GenResourceKey(nsId, "sshKey", content.SshKeyId)
+	sshKey := common.GenResourceKey(nsId, common.StrSSHKey, content.SshKeyId)
 	keyValue, _ = common.CBStore.Get(sshKey)
 	var keyContent struct {
 		Username   string `json:"username"`

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -1066,7 +1066,7 @@ func DelMcis(nsId string, mcisId string) error {
 			return err
 		}
 
-		mcir.SetInUseCount(nsId, "sshKey", vmInfo.SshKeyId, "-1")
+		mcir.UpdateAssoObjList(nsId, "sshKey", vmInfo.SshKeyId, "delete", vmKey)
 	}
 	// delete mcis info
 	err = common.CBStore.Delete(key)
@@ -1117,7 +1117,7 @@ func DelMcisVm(nsId string, mcisId string, vmId string) error {
 		return err
 	}
 
-	mcir.SetInUseCount(nsId, "sshKey", vmInfo.SshKeyId, "-1")
+	mcir.UpdateAssoObjList(nsId, "sshKey", vmInfo.SshKeyId, "delete", key)
 
 	return nil
 }
@@ -2464,7 +2464,9 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo) error {
 	configTmp, _ := common.GetConnConfig(vmInfoData.ConnectionName)
 	vmInfoData.Location = GetCloudLocation(strings.ToLower(configTmp.ProviderName), strings.ToLower(tempSpiderVMInfo.Region.Region))
 
-	mcir.SetInUseCount(nsId, "sshKey", vmInfoData.SshKeyId, "+1")
+	//mcir.SetInUseCount(nsId, "sshKey", vmInfoData.SshKeyId, "+1")
+	vmKey := common.GenMcisKey(nsId, mcisId, vmInfoData.Id)
+	mcir.UpdateAssoObjList(nsId, "sshKey", vmInfoData.SshKeyId, "add", vmKey)
 
 	//content.Status = temp.
 	//content.Cloud_id = temp.

--- a/src/core/mcis/monitor.go
+++ b/src/core/mcis/monitor.go
@@ -195,7 +195,7 @@ func InstallMonitorAgentToMcis(nsId string, mcisId string, req *McisCmdReq) (Age
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		temp := AgentInstallContentWrapper{}
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return temp, err
@@ -269,7 +269,7 @@ func GetMonitoringData(nsId string, mcisId string, metric string) (MonResultSimp
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcis(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		temp := MonResultSimpleResponse{}
 		err := fmt.Errorf("The mcis " + mcisId + " does not exist.")
 		return temp, err

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -376,7 +376,7 @@ func CreateMcisPolicy(nsId string, mcisId string, u *McisPolicyInfo) (McisPolicy
 	u.Id = lowerizedName
 	//u.Status = AutoStatusReady
 
-	if check == true {
+	if check {
 		temp := McisPolicyInfo{}
 		err := fmt.Errorf("The MCIS Policy Obj " + u.Name + " already exists.")
 		return temp, err
@@ -474,7 +474,7 @@ func DelMcisPolicy(nsId string, mcisId string) error {
 	mcisId = common.ToLower(mcisId)
 	check, _ := CheckMcisPolicy(nsId, mcisId)
 
-	if check == false {
+	if !check {
 		err := fmt.Errorf("The mcis Policy" + mcisId + " does not exist.")
 		return err
 	}

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3775,6 +3775,12 @@ var doc = `{
         "mcir.TbSshKeyInfo": {
             "type": "object",
             "properties": {
+                "associatedObjectList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "connectionName": {
                     "type": "string"
                 },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3760,6 +3760,12 @@
         "mcir.TbSshKeyInfo": {
             "type": "object",
             "properties": {
+                "associatedObjectList": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "connectionName": {
                     "type": "string"
                 },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -445,6 +445,10 @@ definitions:
     type: object
   mcir.TbSshKeyInfo:
     properties:
+      associatedObjectList:
+        items:
+          type: string
+        type: array
       connectionName:
         type: string
       cspSshKeyName:

--- a/test/official/5.sshKey/testAddAsso.sh
+++ b/test/official/5.sshKey/testAddAsso.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#function get_sshKey() {
+    FILE=../conf.env
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+	source ../conf.env
+	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+	echo "####################################################################"
+	echo "## 5. sshKey: Get"
+	echo "####################################################################"
+
+	CSP=${1}
+	REGION=${2:-1}
+	POSTFIX=${3:-developer}
+	if [ "${CSP}" == "aws" ]; then
+		echo "[Test for AWS]"
+		INDEX=1
+	elif [ "${CSP}" == "azure" ]; then
+		echo "[Test for Azure]"
+		INDEX=2
+	elif [ "${CSP}" == "gcp" ]; then
+		echo "[Test for GCP]"
+		INDEX=3
+	elif [ "${CSP}" == "alibaba" ]; then
+		echo "[Test for Alibaba]"
+		INDEX=4
+	else
+		echo "[No acceptable argument was provided (aws, azure, gcp, alibaba, ...). Default: Test for AWS]"
+		CSP="aws"
+		INDEX=1
+	fi
+
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testAddSshKeyAsso/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+		'{ 
+			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
+		}' #| json_pp #|| return 1
+#}
+
+#get_sshKey

--- a/test/official/5.sshKey/testAddAsso.sh
+++ b/test/official/5.sshKey/testAddAsso.sh
@@ -35,7 +35,7 @@
 		INDEX=1
 	fi
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testAddSshKeyAsso/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testAddSshKeyAssociation/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
 		'{ 
 			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
 		}' #| json_pp #|| return 1

--- a/test/official/5.sshKey/testDeleteAsso.sh
+++ b/test/official/5.sshKey/testDeleteAsso.sh
@@ -35,10 +35,10 @@
 		INDEX=1
 	fi
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testSetSshKeyInUseCount/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testDeleteSshKeyAsso/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
 		'{ 
 			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+		}' #| json_pp #|| return 1
 #}
 
 #get_sshKey

--- a/test/official/5.sshKey/testDeleteAsso.sh
+++ b/test/official/5.sshKey/testDeleteAsso.sh
@@ -35,7 +35,7 @@
 		INDEX=1
 	fi
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testDeleteSshKeyAsso/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testDeleteSshKeyAssociation/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
 		'{ 
 			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
 		}' #| json_pp #|| return 1


### PR DESCRIPTION
- Related issue: #348 

- @seokho-son 께서 https://github.com/cloud-barista/cb-tumblebug/pull/347#pullrequestreview-568827067 에서
`associatedObj` 들의 예시를 `mcis/mcis-01/vm/vm-04` 이렇게 제안해 주셨습니다.
저도 타당하다고 생각합니다.
(mcis-01, vm-04, 그리고 여기에 연결되는 obj 들은 모두 같은 ns 에 속하므로 ns 를 기재하지 않아도 됨)
그런데 이미 사용되고 있는 `GenMcisKey(nsId, mcisId, vmId)` 함수를 여기에서도 활용하니
`/ns/ns-01/mcis/avengers-jhseo/vm/aws-us-east-1-jhseo-master` 의 형식이 되었습니다.
이 형식은 변경도 가능하므로, 의견이 있으시면 알려 주시면 감사하겠습니다.

- 작성한 코드에서 제 예상과 다르게 동작하는 부분이 있었고,
이(예상과 다르게 동작하는 것)를 찾는 데에 오래 걸렸습니다.
https://play.golang.org/p/uX2UZcx4LLj
의 결과를 보시면
`result: []` 인데
`len(result): 1` 입니다.
0 이어야 할 것 같은데 말이죠..

- `sjson` 관련 참고사항
sjson 을 이용하여 json 을 조작할 때,
array 에 새로운 element 를 추가할 때에는 `-1` 이라는 index 를 사용하면 된다고 합니다.
그런데 그 json array 가 `[]` 일 때에만 정상 작동하고
`""` (`null`) 일 때에는 `{"-1":"bob"}` 이런 식으로 key-value 매핑 내지는 map 매핑 형태로 추가됩니다.
관련 issue: https://github.com/tidwall/sjson/issues/32
Go Playground 예시: https://play.golang.org/p/SVqFuZs0DXh
Go Playground 결과를 보면 알 수 있는데,
json array 가 `""` (`null`) 일 때에는 index 로 `-1` 대신 `0` 을 사용하면
의도하는 대로 동작합니다. (새로운 array 생성하면서 element 추가)

---

`cb-tumblebug/test/official/5.sshKey❯ ./create-sshKey.sh aws 1 jhseo`
```JSON
{
   "username" : "",
   "cspSshKeyName" : "aws-us-east-1-jhseo",
   "connectionName" : "aws-us-east-1",
   "privateKey" : "-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----",
   "name" : "aws-us-east-1-jhseo",
   "keyValueList" : [
      {
         "Value" : "-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----",
         "Key" : "KeyMaterial"
      }
   ],
   "id" : "aws-us-east-1-jhseo",
   "description" : "",
   "associatedObjectList" : null,
   "publicKey" : "",
   "fingerprint" : "xx:xx:xx:e5:ed:8c:2b:25:31:de:8b:57:4c:59:17:e4:7d:8a:84:30"
}
```

`cb-tumblebug/test/official/8.mcis❯ ./create-single-vm-mcis.sh aws 1 jhseo`
```JSON
...
   "targetAction" : "Create",
   "name" : "avengers-jhseo",
   "id" : "avengers-jhseo",
   "label" : "",
   "placement_algo" : "",
   "targetStatus" : "Running",
   "description" : "Tumblebug Demo"
}
```

`cb-tumblebug/test/official/5.sshKey❯ ./get-sshKey.sh aws 1 jhseo`
```JSON
{
   "keyValueList" : [
      {
         "Key" : "KeyMaterial",
         "Value" : "-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----"
      }
   ],
   "publicKey" : "",
   "id" : "aws-us-east-1-jhseo",
   "cspSshKeyName" : "aws-us-east-1-jhseo",
   "associatedObjectList" : [
      "/ns/ns-01/mcis/avengers-jhseo/vm/aws-us-east-1-jhseo-master"
   ],
   "name" : "aws-us-east-1-jhseo",
   "privateKey" : "-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----",
   "connectionName" : "aws-us-east-1",
   "fingerprint" : "xx:xx:xx:e5:ed:8c:2b:25:31:de:8b:57:4c:59:17:e4:7d:8a:84:30",
   "username" : "",
   "description" : ""
}
```

`cb-tumblebug/test/official/8.mcis❯ ./terminate-and-delete-mcis.sh aws 1 jhseo avengers`
```JSON
{
   "message" : "Deleting the MCIS info"
}
```

`cb-tumblebug/test/official/5.sshKey❯ ./get-sshKey.sh aws 1 jhseo`
```JSON
{
   "id" : "aws-us-east-1-jhseo",
   "associatedObjectList" : [],
   "cspSshKeyName" : "aws-us-east-1-jhseo",
   "fingerprint" : "xx:xx:xx:e5:ed:8c:2b:25:31:de:8b:57:4c:59:17:e4:7d:8a:84:30",
   "privateKey" : "-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----",
   "connectionName" : "aws-us-east-1",
   "description" : "",
   "username" : "",
   "publicKey" : "",
   "keyValueList" : [
      {
         "Key" : "KeyMaterial",
         "Value" : "-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----"
      }
   ],
   "name" : "aws-us-east-1-jhseo"
}
```


