### PR TITLE
Divide and edit container-related workflows for efficiency

### DIFF
--- a/.github/workflows/build-amd64-container-image.yaml
+++ b/.github/workflows/build-amd64-container-image.yaml
@@ -1,13 +1,8 @@
-# This workflow will build the container image and publish it to container registries.
+# This workflow will build the container image for amd64 arch. (as a basic build test)
 name: Build amd64 container image
 
-# When its time to do a release do a full cross platform build for all supported
-# architectures and push all of them to Docker Hub and GitHub Container Registry (GHCR).
-# Only trigger on semver shaped tags.
 on:
-  # "Build and publish" on merged
-  # Actually, there's no "merged" event type.
-  # The "merged" event will be detected by the "closed" event and condition below.
+  # On pull-request event with detailed condition below.
   pull_request:
     branches:
       - master

--- a/.github/workflows/build-amd64-container-image.yaml
+++ b/.github/workflows/build-amd64-container-image.yaml
@@ -1,5 +1,5 @@
 # This workflow will build the container image and publish it to container registries.
-name: Build a container image
+name: Build amd64 container image
 
 # When its time to do a release do a full cross platform build for all supported
 # architectures and push all of them to Docker Hub and GitHub Container Registry (GHCR).
@@ -21,10 +21,10 @@ on:
       - 'test/**'
 
 jobs:
-  # The job key is build-amd64-conatiner-image"
-  build-amd64-conatiner-image:
-    # Job name is "Build amd64 container image"
-    name: Build amd64 container image
+  # The job key is "building"
+  building:
+    # Job name is "Building"
+    name: Building
 
     # This job runs on Ubuntu-latest
     runs-on: ubuntu-latest

--- a/.github/workflows/build-amd64-container-image.yaml
+++ b/.github/workflows/build-amd64-container-image.yaml
@@ -1,0 +1,41 @@
+# This workflow will build the container image and publish it to container registries.
+name: Build a container image
+
+# When its time to do a release do a full cross platform build for all supported
+# architectures and push all of them to Docker Hub and GitHub Container Registry (GHCR).
+# Only trigger on semver shaped tags.
+on:
+  # "Build and publish" on merged
+  # Actually, there's no "merged" event type.
+  # The "merged" event will be detected by the "closed" event and condition below.
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+      - '.all-contributorsrc'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'assets/**'
+      - 'test/**'
+
+jobs:
+  # The job key is build-amd64-conatiner-image"
+  build-amd64-conatiner-image:
+    # Job name is "Build amd64 container image"
+    name: Build amd64 container image
+
+    # This job runs on Ubuntu-latest
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Build image
+        env:
+          # TODO: Change variable to your repository name and image name.
+          IMAGE_NAME: cb-tumblebug
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME

--- a/.github/workflows/build-and-publish-container-image.yaml
+++ b/.github/workflows/build-and-publish-container-image.yaml
@@ -5,25 +5,13 @@ name: Build and publish container image
 # architectures and push all of them to Docker Hub and GitHub Container Registry (GHCR).
 # Only trigger on semver shaped tags.
 on:
-  # "Build" on pull request event
+  # "Build and publish" on merged
+  # Actually, there's no "merged" event type.
+  # The "merged" event will be detected by the "closed" event and condition below.
   pull_request:
+    types: [ closed ]
     branches:
       - master
-    paths-ignore:
-      - '**.md'
-      - '.all-contributorsrc'
-      - '.gitignore'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'assets/**'
-      - 'test/**'
-
-  # "Build and publish" on push event (It considers on merge PR event)
-  push:
-    branches: master
-    # [To be tested]
-    tags:
-      - "v*.*.*"
     paths-ignore:
       - '**.md'
       - '.all-contributorsrc'
@@ -41,7 +29,7 @@ jobs:
 
     # This job runs on Ubuntu-latest
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') && github.event.pull_request.merged == true }}
 
     steps:
       - name: Checkout source code
@@ -102,7 +90,6 @@ jobs:
 
       # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -118,7 +105,7 @@ jobs:
           file: ./Dockerfile
           target: prod
           platforms: linux/amd64,linux/arm/v7,linux/arm64 # linux/386,linux/ppc64le,linux/s390x,linux/arm/v6
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: |
             ${{ steps.prep.outputs.docker-tags }}
             ${{ steps.prep.outputs.ghcr-tags }}

--- a/.github/workflows/publish-multi-arch-container-images.yaml
+++ b/.github/workflows/publish-multi-arch-container-images.yaml
@@ -1,5 +1,5 @@
 # This workflow will build the container image and publish it to container registries.
-name: Build and publish container image
+name: Publish container images
 
 # When its time to do a release do a full cross platform build for all supported
 # architectures and push all of them to Docker Hub and GitHub Container Registry (GHCR).
@@ -22,10 +22,10 @@ on:
       - 'test/**'
 
 jobs:
-  # The job key is "build-and-publish"
-  build-and-publish:
-    # Job name is "Build and publish"
-    name: Build and publish
+  # The job key is publish-multi-arch-conatiner-image"
+  publish-multi-arch-conatiner-image:
+    # Job name is "Publish multi-arch container images"
+    name: Publish multi-arch container images
 
     # This job runs on Ubuntu-latest
     runs-on: ubuntu-latest
@@ -96,7 +96,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
-      - name: Build and push
+      - name: Build and publish
         id: docker_build
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/publish-multi-arch-container-images.yaml
+++ b/.github/workflows/publish-multi-arch-container-images.yaml
@@ -1,5 +1,5 @@
 # This workflow will build the container image and publish it to container registries.
-name: Publish container images
+name: Publish multi-arch container images
 
 # When its time to do a release do a full cross platform build for all supported
 # architectures and push all of them to Docker Hub and GitHub Container Registry (GHCR).
@@ -22,10 +22,10 @@ on:
       - 'test/**'
 
 jobs:
-  # The job key is publish-multi-arch-conatiner-image"
-  publish-multi-arch-conatiner-image:
-    # Job name is "Publish multi-arch container images"
-    name: Publish multi-arch container images
+  # The job key is "publishing"
+  publishing:
+    # Job name is "Publishing"
+    name: Publishing
 
     # This job runs on Ubuntu-latest
     runs-on: ubuntu-latest


### PR DESCRIPTION
For efficient continuous integration (CI), the existing workflow has been divided into the two below.
- Publish (build and publish) multi-arch container images on `merged` event.
- Build an amd64 container image on `pull request` event.

And also, the workflow name, job ID and name are renamed for readability on GitHub Actions.