### PR TITLE
Move cloudlocation.csv, and so on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# vendor dir
+vendor/
+
 # Binaries
 src/src
 src/mcism

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /go/src/github.com/cloud-barista/cb-tumblebug
 
 WORKDIR src
 
-RUN go build -ldflags '-w -extldflags "-static"' -tags cb-tumblebug -o cb-tumblebug -v
+RUN go build -mod=mod -ldflags '-w -extldflags "-static"' -tags cb-tumblebug -o cb-tumblebug -v
 
 #############################################################
 ## Stage 2 - Application Setup
@@ -30,6 +30,8 @@ FROM ubuntu:latest as prod
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 WORKDIR /app/src
+
+COPY --from=builder /go/src/github.com/cloud-barista/cb-tumblebug/assets/* /app/assets/
 
 COPY --from=builder /go/src/github.com/cloud-barista/cb-tumblebug/conf/* /app/conf/
 

--- a/assets/cloudlocation.csv
+++ b/assets/cloudlocation.csv
@@ -109,4 +109,5 @@ alibaba,eu-central-1,Germany (Frankfurt),50.4000,8.7000
 alibaba,eu-west-1,UK (London),51.8000,-0.2000
 alibaba,me-east-1,UAE (Dubai),25.2770,55.2962
 cloudit,default,Seoul  South Korea,37.2665,126.7780
+mock,default,Seoul  South Korea,37.2665,126.7780
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 default:
-	go build -o cb-tumblebug
+	go build -mod=mod -o cb-tumblebug
 cc:
-	GOOS=linux GOARCH=arm go build -o cb-tumblebug-arm
+	GOOS=linux GOARCH=arm go build -mod=mod -o cb-tumblebug-arm
 run:
 	./cb-tumblebug
 clean:

--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -60,13 +60,13 @@ func UpdateEnv(id string) error {
 
 	content := ConfigInfo{}
 
-	lowStrSPIDER_REST_URL := GenId(StrSPIDER_REST_URL)
-	lowStrDRAGONFLY_REST_URL := GenId(StrDRAGONFLY_REST_URL)
-	lowStrDB_URL := GenId(StrDB_URL)
-	lowStrDB_DATABASE := GenId(StrDB_DATABASE)
-	lowStrDB_USER := GenId(StrDB_USER)
-	lowStrDB_PASSWORD := GenId(StrDB_PASSWORD)
-	lowStrAUTOCONTROL_DURATION_MS := GenId(StrAUTOCONTROL_DURATION_MS)
+	lowStrSPIDER_REST_URL := ToLower(StrSPIDER_REST_URL)
+	lowStrDRAGONFLY_REST_URL := ToLower(StrDRAGONFLY_REST_URL)
+	lowStrDB_URL := ToLower(StrDB_URL)
+	lowStrDB_DATABASE := ToLower(StrDB_DATABASE)
+	lowStrDB_USER := ToLower(StrDB_USER)
+	lowStrDB_PASSWORD := ToLower(StrDB_PASSWORD)
+	lowStrAUTOCONTROL_DURATION_MS := ToLower(StrAUTOCONTROL_DURATION_MS)
 
 	Key := "/config/" + id
 	keyValue, err := CBStore.Get(Key)
@@ -230,7 +230,7 @@ func LowerizeAndCheckConfig(Id string) (bool, string, error) {
 		return false, "", err
 	}
 
-	lowerizedId := GenId(Id)
+	lowerizedId := ToLower(Id)
 
 	fmt.Println("[Check config] " + lowerizedId)
 

--- a/src/core/common/namespace.go
+++ b/src/core/common/namespace.go
@@ -263,29 +263,6 @@ func DelAllNs() error {
 	return nil
 }
 
-/*
-func LowerizeAndCheckNs(Id string) (bool, string, error) {
-
-	if Id == "" {
-		err := fmt.Errorf("CheckNs failed; nsId given is null.")
-		return false, "", err
-	}
-
-	lowerizedId := GenId(Id)
-
-	fmt.Println("[Check ns] " + lowerizedId)
-
-	key := "/ns/" + lowerizedId
-	//fmt.Println(key)
-
-	keyValue, _ := CBStore.Get(key)
-	if keyValue != nil {
-		return true, lowerizedId, nil
-	}
-	return false, lowerizedId, nil
-}
-*/
-
 func CheckNs(Id string) (bool, error) {
 
 	if Id == "" {

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -41,13 +41,6 @@ func GenUuid() string {
 	return uuid.New().String()
 }
 
-func GenId(name string) string {
-	r, _ := regexp.Compile("_")
-	out := r.ReplaceAllString(name, "-")
-	out = strings.ToLower(out)
-	return out
-}
-
 func ToLower(name string) string {
 	r, _ := regexp.Compile("_")
 	out := r.ReplaceAllString(name, "-")

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -34,7 +34,7 @@ func init() {
 // DelAllResources deletes all TB MCIR object of given resourceType
 func DelAllResources(nsId string, resourceType string, forceFlag string) error {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	resourceIdList := ListResourceId(nsId, resourceType)
 
@@ -458,7 +458,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 // ListResourceId returns the list of TB MCIR object IDs of given resourceType
 func ListResourceId(nsId string, resourceType string) []string {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	if resourceType == common.StrImage ||
 		resourceType == common.StrSSHKey ||
@@ -496,7 +496,7 @@ func ListResourceId(nsId string, resourceType string) []string {
 // ListResource returns the list of TB MCIR objects of given resourceType
 func ListResource(nsId string, resourceType string) (interface{}, error) {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	if resourceType == common.StrImage ||
 		resourceType == common.StrSSHKey ||

--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -120,6 +120,7 @@ func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 		return emptyImageInfoObj, err
 	}
 	content.ConnectionName = u.ConnectionName
+	content.Id = common.ToLower(u.Name)
 
 	sql := "INSERT INTO `image`(" +
 		"`namespace`, " +
@@ -474,7 +475,7 @@ func FetchImages(nsId string) (connConfigCount uint, imageCount uint, err error)
 
 // SearchImage accepts arbitrary number of keywords, and returns the list of matched TB image objects
 func SearchImage(nsId string, keywords ...string) ([]TbImageInfo, error) {
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	tempList := []TbImageInfo{}
 
@@ -482,7 +483,7 @@ func SearchImage(nsId string, keywords ...string) ([]TbImageInfo, error) {
 
 	for _, keyword := range keywords {
 		//fmt.Println("in SearchImage(); keyword: " + keyword) // for debug
-		keyword = common.GenId(keyword)
+		keyword = common.ToLower(keyword)
 		sqlQuery += " AND `name` LIKE '%" + keyword + "%'"
 	}
 	sqlQuery += ";"

--- a/src/core/mcir/obsolete/publicip.go
+++ b/src/core/mcir/obsolete/publicip.go
@@ -308,8 +308,8 @@ func createPublicIp(nsId string, u *publicIpReq) (publicIpInfo, int, []byte, err
 
 	content := publicIpInfo{}
 	//content.Id = common.GenUuid()
-	content.Id = common.GenId(u.Name)
-	content.Name = common.GenId(u.Name)
+	content.Id = common.ToLower(u.Name)
+	content.Name = common.ToLower(u.Name)
 	content.ConnectionName = u.ConnectionName
 	content.CspPublicIpId = temp.Name
 	content.CspPublicIpName = temp.Name //common.LookupKeyValueList(temp.KeyValueList, "Name")

--- a/src/core/mcir/obsolete/subnet.go
+++ b/src/core/mcir/obsolete/subnet.go
@@ -219,8 +219,8 @@ func createSubnet(nsId string, u *subnetReq) (subnetInfo, error) {
 	// TODO: To be implemented
 
 	content := subnetInfo{}
-	content.Id = common.GenId(u.Name)
-	content.Name = common.GenId(u.Name)
+	content.Id = common.ToLower(u.Name)
+	content.Name = common.ToLower(u.Name)
 	content.ConnectionName = u.ConnectionName
 	content.CspSubnetId = u.CspSubnetId
 	content.CspSubnetName = u.CspSubnetName
@@ -262,7 +262,7 @@ func createSubnet(nsId string, u *subnetReq) (subnetInfo, error) {
 func registerSubnet(nsId string, u *subnetReq) (subnetInfo, error) {
 
 	content := subnetInfo{}
-	content.Id = common.GenId(u.Name)
+	content.Id = common.ToLower(u.Name)
 	content.ConnectionName = u.ConnectionName
 	content.CspSubnetId = u.CspSubnetId
 	content.CspSubnetName = u.CspSubnetName

--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -172,8 +172,8 @@ func CreateSecurityGroup(nsId string, u *TbSecurityGroupReq) (TbSecurityGroupInf
 
 	content := TbSecurityGroupInfo{}
 	//content.Id = common.GenUuid()
-	content.Id = common.GenId(u.Name)
-	content.Name = common.GenId(u.Name)
+	content.Id = common.ToLower(u.Name)
+	content.Name = common.ToLower(u.Name)
 	content.ConnectionName = u.ConnectionName
 	content.VNetId = tempSpiderSecurityInfo.VpcIID.NameId
 	content.CspSecurityGroupId = tempSpiderSecurityInfo.IId.SystemId

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -271,7 +271,7 @@ func LookupSpec(connConfig string, specName string) (SpiderSpecInfo, error) {
 // FetchSpecs gets all conn configs from Spider, lookups all specs for each region of conn config, and saves into TB spec objects
 func FetchSpecs(nsId string) (connConfigCount uint, specCount uint, err error) {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	connConfigs, err := common.GetConnConfigList()
 	if err != nil {
@@ -349,8 +349,8 @@ func RegisterSpecWithCspSpecName(nsId string, u *TbSpecReq) (TbSpecInfo, error) 
 
 	content := TbSpecInfo{}
 	//content.Id = common.GenUuid()
-	content.Id = common.GenId(u.Name)
-	content.Name = common.GenId(u.Name)
+	content.Id = common.ToLower(u.Name)
+	content.Name = common.ToLower(u.Name)
 	content.CspSpecName = res.Name
 	content.ConnectionName = u.ConnectionName
 
@@ -607,7 +607,7 @@ func RegisterSpecWithInfo(nsId string, content *TbSpecInfo) (TbSpecInfo, error) 
 // RegisterRecommendList creates the spec recommendation info
 func RegisterRecommendList(nsId string, connectionName string, cpuSize uint16, memSize uint16, diskSize uint32, specId string, price float32) error {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	//fmt.Println("[Get MCISs")
 	key := common.GenMcisKey(nsId, "", "") + "/cpuSize/" + strconv.Itoa(int(cpuSize)) + "/memSize/" + strconv.Itoa(int(memSize)) + "/diskSize/" + strconv.Itoa(int(diskSize)) + "/specId/" + specId
@@ -630,7 +630,7 @@ func RegisterRecommendList(nsId string, connectionName string, cpuSize uint16, m
 // DelRecommendSpec deletes the spec recommendation info
 func DelRecommendSpec(nsId string, specId string, cpuSize uint16, memSize uint16, diskSize uint32) error {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	fmt.Println("DelRecommendSpec()")
 
@@ -649,7 +649,7 @@ func DelRecommendSpec(nsId string, specId string, cpuSize uint16, memSize uint16
 // FilterSpecs accepts criteria for filtering, and returns the list of filtered TB spec objects
 func FilterSpecs(nsId string, filter TbSpecInfo) ([]TbSpecInfo, error) {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	tempList := []TbSpecInfo{}
 
@@ -844,7 +844,7 @@ type FilterSpecsByRangeRequest struct {
 
 // FilterSpecsByRange accepts criteria ranges for filtering, and returns the list of filtered TB spec objects
 func FilterSpecsByRange(nsId string, filter FilterSpecsByRangeRequest) ([]TbSpecInfo, error) {
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	tempList := []TbSpecInfo{}
 

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -961,7 +961,7 @@ func UpdateVmInfo(nsId string, mcisId string, vmInfoData TbVmInfo) {
 
 func ListMcisId(nsId string) []string {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	fmt.Println("[Get MCIS ID list]")
 	key := "/ns/" + nsId + "/mcis"
@@ -988,8 +988,8 @@ func ListMcisId(nsId string) []string {
 
 func ListVmId(nsId string, mcisId string) ([]string, error) {
 
-	nsId = common.GenId(nsId)
-	mcisId = common.GenId(mcisId)
+	nsId = common.ToLower(nsId)
+	mcisId = common.ToLower(mcisId)
 
 	fmt.Println("[ListVmId]")
 	key := common.GenMcisKey(nsId, mcisId, "")
@@ -1207,7 +1207,7 @@ func CorePostMcis(nsId string, req *TbMcisReq) (*TbMcisInfo, error) {
 	}
 
 	key := CreateMcis(nsId, req)
-	mcisId := common.GenId(req.Name)
+	mcisId := common.ToLower(req.Name)
 
 	keyValue, _ := common.CBStore.Get(key)
 
@@ -1473,7 +1473,7 @@ func CoreGetMcisInfo(nsId string, mcisId string) (*TbMcisInfo, error) {
 
 func CoreGetAllMcis(nsId string, option string) ([]TbMcisInfo, error) {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	/*
 		var content struct {
@@ -1561,7 +1561,7 @@ func CoreGetAllMcis(nsId string, option string) ([]TbMcisInfo, error) {
 
 func CoreDelAllMcis(nsId string) (string, error) {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	mcisList := ListMcisId(nsId)
 
@@ -1586,7 +1586,7 @@ func CoreDelAllMcis(nsId string) (string, error) {
 
 func CorePostMcisRecommand(nsId string, req *McisRecommendReq) ([]TbVmRecommendInfo, error) {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 
 	/*
 		var content struct {
@@ -1776,7 +1776,7 @@ func CorePostMcisVm(nsId string, mcisId string, vmInfoData *TbVmInfo) (*TbVmInfo
 	targetAction := ActionCreate
 	targetStatus := StatusRunning
 
-	vmInfoData.Id = common.GenId(vmInfoData.Name)
+	vmInfoData.Id = common.ToLower(vmInfoData.Name)
 	vmInfoData.PublicIP = "Not assigned yet"
 	vmInfoData.PublicDNS = "Not assigned yet"
 	vmInfoData.TargetAction = targetAction
@@ -1987,8 +1987,8 @@ func CreateMcis(nsId string, req *TbMcisReq) string {
 	targetStatus := StatusRunning
 
 	//req.Id = common.GenUuid()
-	//req.Id = common.GenId(req.Name)
-	mcisId := common.GenId(req.Name)
+	//req.Id = common.ToLower(req.Name)
+	mcisId := common.ToLower(req.Name)
 	vmRequest := req.Vm
 
 	fmt.Println("=========================== Put createSvc")
@@ -2019,7 +2019,7 @@ func CreateMcis(nsId string, req *TbMcisReq) string {
 
 		vmInfoData := TbVmInfo{}
 		//vmInfoData.Id = common.GenUuid()
-		vmInfoData.Id = common.GenId(k.Name)
+		vmInfoData.Id = common.ToLower(k.Name)
 		//vmInfoData.CspVmName = k.CspVmName
 
 		//vmInfoData.Placement_algo = k.Placement_algo
@@ -3818,7 +3818,7 @@ func GetCloudLocation(cloudType string, nativeRegion string) GeoLocation {
 	}
 
 	if keyValue == nil {
-		file, fileErr := os.Open("./resource/cloudlocation.csv")
+		file, fileErr := os.Open("../assets/cloudlocation.csv")
 		defer file.Close()
 		if fileErr != nil {
 			common.CBLog.Error(fileErr)

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -388,7 +388,7 @@ func UpdateMcisPolicyInfo(nsId string, mcisPolicyInfoData McisPolicyInfo) {
 // CreateMcisPolicy create McisPolicyInfo object in DB according to user's requirements.
 func CreateMcisPolicy(nsId string, mcisId string, u *McisPolicyInfo) (McisPolicyInfo, error) {
 
-	//nsId = common.GenId(nsId)
+	//nsId = common.ToLower(nsId)
 	//check, lowerizedName, _ := LowerizeAndCheckMcisPolicy(nsId, mcisId)
 	nsId = common.ToLower(nsId)
 	lowerizedName := common.ToLower(mcisId)
@@ -432,7 +432,7 @@ func CreateMcisPolicy(nsId string, mcisId string, u *McisPolicyInfo) (McisPolicy
 // GetMcisPolicyObject returns McisPolicyInfo object.
 func GetMcisPolicyObject(nsId string, mcisId string) (McisPolicyInfo, error) {
 	fmt.Println("[GetMcisPolicyObject]" + mcisId)
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 	key := common.GenMcisPolicyKey(nsId, mcisId, "")
 	fmt.Println("Key: ", key)
 	keyValue, err := common.CBStore.Get(key)
@@ -454,7 +454,7 @@ func GetMcisPolicyObject(nsId string, mcisId string) (McisPolicyInfo, error) {
 // GetAllMcisPolicyObject returns all McisPolicyInfo objects.
 func GetAllMcisPolicyObject(nsId string) ([]McisPolicyInfo, error) {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 	Mcis := []McisPolicyInfo{}
 	mcisList := ListMcisPolicyId(nsId)
 
@@ -476,7 +476,7 @@ func GetAllMcisPolicyObject(nsId string) ([]McisPolicyInfo, error) {
 // ListMcisPolicyId returns a list of Ids for all McisPolicyInfo objects .
 func ListMcisPolicyId(nsId string) []string {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 	//fmt.Println("[Get MCIS Policy ID list]")
 	key := "/ns/" + nsId + "/policy/mcis"
 	keyValue, _ := common.CBStore.GetList(key, true)
@@ -493,7 +493,7 @@ func ListMcisPolicyId(nsId string) []string {
 // DelMcisPolicy deletes McisPolicyInfo object by mcisId.
 func DelMcisPolicy(nsId string, mcisId string) error {
 
-	//nsId = common.GenId(nsId)
+	//nsId = common.ToLower(nsId)
 	//check, lowerizedName, _ := LowerizeAndCheckMcisPolicy(nsId, mcisId)
 	//mcisId = lowerizedName
 	nsId = common.ToLower(nsId)
@@ -523,7 +523,7 @@ func DelMcisPolicy(nsId string, mcisId string) error {
 // DelAllMcisPolicy deletes all McisPolicyInfo objects.
 func DelAllMcisPolicy(nsId string) (string, error) {
 
-	nsId = common.GenId(nsId)
+	nsId = common.ToLower(nsId)
 	mcisList := ListMcisPolicyId(nsId)
 	if len(mcisList) == 0 {
 		return "No MCIS Policy to delete", nil

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -68,10 +68,10 @@ func LowerizeAndCheckMcis(nsId string, mcisId string) (bool, string, error) {
 		return false, "", err
 	}
 
-	lowerizedNsId := common.GenId(nsId)
+	lowerizedNsId := common.ToLower(nsId)
 	nsId = lowerizedNsId
 
-	lowerizedMcisId := common.GenId(mcisId)
+	lowerizedMcisId := common.ToLower(mcisId)
 	mcisId = lowerizedMcisId
 
 	fmt.Println("[Check mcis] " + mcisId)
@@ -135,13 +135,13 @@ func LowerizeAndCheckVm(nsId string, mcisId string, vmId string) (bool, string, 
 		return false, "", err
 	}
 
-	lowerizedNsId := common.GenId(nsId)
+	lowerizedNsId := common.ToLower(nsId)
 	nsId = lowerizedNsId
 
-	lowerizedMcisId := common.GenId(mcisId)
+	lowerizedMcisId := common.ToLower(mcisId)
 	mcisId = lowerizedMcisId
 
-	lowerizedVmId := common.GenId(vmId)
+	lowerizedVmId := common.ToLower(vmId)
 	vmId = lowerizedVmId
 
 	fmt.Println("[Check vm] " + mcisId + ", " + vmId)
@@ -206,10 +206,10 @@ func LowerizeAndCheckMcisPolicy(nsId string, mcisId string) (bool, string, error
 		return false, "", err
 	}
 
-	lowerizedNsId := common.GenId(nsId)
+	lowerizedNsId := common.ToLower(nsId)
 	nsId = lowerizedNsId
 
-	lowerizedMcisId := common.GenId(mcisId)
+	lowerizedMcisId := common.ToLower(mcisId)
 	mcisId = lowerizedMcisId
 
 	fmt.Println("[Check McisPolicy] " + mcisId)

--- a/src/main.go
+++ b/src/main.go
@@ -46,11 +46,11 @@ func main() {
 	common.AUTOCONTROL_DURATION_MS = common.NVL(os.Getenv("AUTOCONTROL_DURATION_MS"), "10000")
 
 	// load the latest configuration from DB (if exist)
-	lowerizedName := common.GenId("DRAGONFLY_REST_URL")
+	lowerizedName := common.ToLower("DRAGONFLY_REST_URL")
 	common.UpdateEnv(lowerizedName)
-	lowerizedName = common.GenId("SPIDER_REST_URL")
+	lowerizedName = common.ToLower("SPIDER_REST_URL")
 	common.UpdateEnv(lowerizedName)
-	lowerizedName = common.GenId("AUTOCONTROL_DURATION_MS")
+	lowerizedName = common.ToLower("AUTOCONTROL_DURATION_MS")
 	common.UpdateEnv(lowerizedName)
 
 	// load config

--- a/test/official/3.vNet/spider-create-vNet.sh
+++ b/test/official/3.vNet/spider-create-vNet.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+#function create_vNet() {
+    FILE=../conf.env
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+	source ../conf.env
+	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+	echo "####################################################################"
+	echo "## 3. vNet: Create"
+	echo "####################################################################"
+
+	CSP=${1}
+	REGION=${2:-1}
+	POSTFIX=${3:-developer}
+	if [ "${CSP}" == "aws" ]; then
+		echo "[Test for AWS]"
+		INDEX=1
+	elif [ "${CSP}" == "azure" ]; then
+		echo "[Test for Azure]"
+		INDEX=2
+	elif [ "${CSP}" == "gcp" ]; then
+		echo "[Test for GCP]"
+		INDEX=3
+	elif [ "${CSP}" == "alibaba" ]; then
+		echo "[Test for Alibaba]"
+		INDEX=4
+	else
+		echo "[No acceptable argument was provided (aws, azure, gcp, alibaba, ...). Default: Test for AWS]"
+		CSP="aws"
+		INDEX=1
+	fi
+
+	curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/vpc -H 'Content-Type: application/json' -d \
+		'{
+			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
+			"ReqInfo": {
+				"Name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+				"IPv4_CIDR": "192.168.0.0/16",
+				"SubnetInfoList": [ {
+					"Name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+					"IPv4_CIDR": "192.168.1.0/24"
+
+				} ]
+
+			}
+		}' #| json_pp #|| return 1
+#}
+
+#create_vNet

--- a/test/official/3.vNet/spider-delete-vNet.sh
+++ b/test/official/3.vNet/spider-delete-vNet.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#function spider_get_vNet() {
+    FILE=../conf.env
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+	source ../conf.env
+	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+	CSP=${1}
+	REGION=${2:-1}
+	POSTFIX=${3:-developer}
+	if [ "${CSP}" == "aws" ]; then
+		echo "[Test for AWS]"
+		INDEX=1
+	elif [ "${CSP}" == "azure" ]; then
+		echo "[Test for Azure]"
+		INDEX=2
+	elif [ "${CSP}" == "gcp" ]; then
+		echo "[Test for GCP]"
+		INDEX=3
+	elif [ "${CSP}" == "alibaba" ]; then
+		echo "[Test for Alibaba]"
+		INDEX=4
+	else
+		echo "[No acceptable argument was provided (aws, azure, gcp, alibaba, ...). Default: Test for AWS]"
+		CSP="aws"
+		INDEX=1
+	fi
+
+	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' #| json_pp
+#}
+
+#spider_get_vNet


### PR DESCRIPTION
- Move `src/resource/cloudlocation.csv` to `assets/` (Resolves #259)
- `cloudlocation.csv` 에 Mock driver 테스트용 라인 추가
- 컨테이너 이미지 빌드 시 `cloudlocation.csv` 및 `assets/` 파일을 컨테이너로 복사하는 부분이 누락되어 있었고, 이것을 보완
- `.gitignore` 에 `vendor/` 추가
- `go build` 시 `vendor/` 디렉토리가 있어도 이를 무시하도록 `Makefile` 및 `Dockerfile` 수정 (Resolves #406)
- `GenId` 함수가 실제로는 대문자->소문자, `_`->`-` 변환만을 하고 있어서, 
`GenId` 레퍼런스들을 `ToLower` 로 일괄 변경하여 명확성/readability 강화
- Spider 테스트 스크립트 추가
  - `test/official/3.vNet/spider-create-vNet.sh`
  - `test/official/3.vNet/spider-delete-vNet.sh`