### PR TITLE
Enable auto-push on new tag, to Docker Hub and GHCR

### DIFF
--- a/.github/workflows/publish-multi-arch-container-images.yaml
+++ b/.github/workflows/publish-multi-arch-container-images.yaml
@@ -12,6 +12,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v*.*.*"
     paths-ignore:
       - '**.md'
       - '.all-contributorsrc'


### PR DESCRIPTION
- Resolves #409 

> **What would you like to be added**
> :
> 얼마 전에 CB-TB repo 에 v0.3.1 tag 가 추가되었는데, Docker Hub 과 GHCR 에는 container image 가 push 되지 않았습니다.
> 
> * https://github.com/cloud-barista/cb-tumblebug/releases
> * https://hub.docker.com/r/cloudbaristaorg/cb-tumblebug/tags?page=1&ordering=last_updated
> * https://github.com/orgs/cloud-barista/packages/container/cb-tumblebug/versions
> 
> **Why is this needed**
> :
> CB-TB repo 에 tag 가 추가될 때 Docker Hub 과 GHCR 에 자동으로 container image 가 push 되면 편리할 것으로 보입니다.
> 
> **Suggested solution**
> :
> [publish-multi-arch-container-images.yaml](https://github.com/cloud-barista/cb-tumblebug/blob/master/.github/workflows/publish-multi-arch-container-images.yaml) 에 다음을 추가
> 
> ```yaml
> on:
>   push:
>     tags:
>       - "v*.*.*"
> ```

