### PR TITLE
Add feature for general TB object retrieve

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"encoding/json"
 
 	"github.com/beego/beego/v2/core/validation"
 	"github.com/labstack/echo/v4"
@@ -103,4 +104,62 @@ func RestGetRegionList(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, &content)
 
+}
+
+// ObjectList struct consists of object IDs
+type ObjectList struct { 
+	Object []string `json:"object"`
+}
+
+// func RestGetObjectList is a rest api wrapper for GetObjectList.
+// RestGetObjectList godoc
+// @Summary List all objects for a given key
+// @Description List all objects for a given key
+// @Tags Admin
+// @Accept  json
+// @Produce  json
+// @Param key query string true "retrieve objects by key"
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /objectList [get]
+func RestGetObjectList(c echo.Context) error {
+	parentKey := c.QueryParam("key")
+	fmt.Printf("[Get Tumblebug Object List] with Key: %s \n", parentKey)
+
+	content := common.GetObjectList(parentKey)
+
+	objectList := ObjectList{}
+	for i, v := range content {
+		fmt.Printf("[Obj: %d] %s \n", i, v)
+		objectList.Object = append(objectList.Object, v)
+	}
+	return c.JSON(http.StatusOK, &objectList)
+}
+
+// func RestGetObjectValue is a rest api wrapper for GetObjectValue.
+// RestGetObjectValue godoc
+// @Summary Get value of an object
+// @Description Get value of an object
+// @Tags Admin
+// @Accept  json
+// @Produce  json
+// @Param key query string true "get object value by key"
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /objectValue [get]
+func RestGetObjectValue(c echo.Context) error {
+	parentKey := c.QueryParam("key")
+	fmt.Printf("[Get Tumblebug Object Value] with Key: %s \n", parentKey)
+
+	content, err := common.GetObjectValue(parentKey)
+	if err != nil || content == "" {
+		return SendMessage(c, http.StatusOK, "Cannot find [" + parentKey+ "] object")
+	}
+	
+	var contentJSON map[string]interface{}
+	json.Unmarshal([]byte(content), &contentJSON)
+
+	return c.JSON(http.StatusOK, &contentJSON)
 }

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -128,6 +128,9 @@ func ApiServer() {
 	e.GET("/tumblebug/config", rest_common.RestGetAllConfig)
 	e.DELETE("/tumblebug/config", rest_common.RestDelAllConfig)
 
+	e.GET("/tumblebug/objectList", rest_common.RestGetObjectList)
+	e.GET("/tumblebug/objectValue", rest_common.RestGetObjectValue)
+
 	g := e.Group("/tumblebug/ns", common.NsValidation())
 
 	g.POST("", rest_common.RestPostNs)

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -696,3 +696,32 @@ func GetChildIdList(key string) []string {
 	return childIdList
 
 }
+
+// func GetObjectList returns IDs of each child objects that has the same key.
+func GetObjectList(key string) []string {
+
+	keyValue, _ := CBStore.GetList(key, true)
+
+	var childIdList []string
+	for _, v := range keyValue {
+		childIdList = append(childIdList, v.Key)
+	}
+
+	fmt.Println("===============================================")
+	return childIdList
+
+}
+
+// func GetObjectValue returns the object value.
+func GetObjectValue(key string) (string, error) {
+
+	keyValue, err := CBStore.Get(key)
+	if err != nil {
+		CBLog.Error(err)
+		return "", err
+	}
+	if keyValue == nil{
+		return "", nil
+	}
+	return keyValue.Value, nil
+}

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3097,6 +3097,94 @@ var doc = `{
                     }
                 }
             }
+        },
+        "/objectList": {
+            "get": {
+                "description": "List all objects for a given key",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "List all objects for a given key",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "retrieve objects by key",
+                        "name": "key",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/objectValue": {
+            "get": {
+                "description": "Get value of an object",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get value of an object",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "get object value by key",
+                        "name": "key",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3082,6 +3082,94 @@
                     }
                 }
             }
+        },
+        "/objectList": {
+            "get": {
+                "description": "List all objects for a given key",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "List all objects for a given key",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "retrieve objects by key",
+                        "name": "key",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/objectValue": {
+            "get": {
+                "description": "Get value of an object",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get value of an object",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "get object value by key",
+                        "name": "key",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -3113,6 +3113,64 @@ paths:
       summary: Get VNet
       tags:
       - VNet
+  /objectList:
+    get:
+      consumes:
+      - application/json
+      description: List all objects for a given key
+      parameters:
+      - description: retrieve objects by key
+        in: query
+        name: key
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all objects for a given key
+      tags:
+      - Admin
+  /objectValue:
+    get:
+      consumes:
+      - application/json
+      description: Get value of an object
+      parameters:
+      - description: get object value by key
+        in: query
+        name: key
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get value of an object
+      tags:
+      - Admin
 securityDefinitions:
   BasicAuth:
     type: basic

--- a/test/official/sequentialFullTest/get-object.sh
+++ b/test/official/sequentialFullTest/get-object.sh
@@ -1,0 +1,17 @@
+
+    FILE=../conf.env
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+    source ../conf.env
+    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+    echo "####################################################################"
+    echo "## 0. Object: Get value"
+    echo "####################################################################"
+
+    KEY=${1}
+
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/objectValue?key=$KEY | json_pp 

--- a/test/official/sequentialFullTest/list-object.sh
+++ b/test/official/sequentialFullTest/list-object.sh
@@ -1,0 +1,17 @@
+
+    FILE=../conf.env
+    if [ ! -f "$FILE" ]; then
+        echo "$FILE does not exist."
+        exit
+    fi
+
+    source ../conf.env
+    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+    echo "####################################################################"
+    echo "## 0. Object: List"
+    echo "####################################################################"
+
+    KEY=${1}
+
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/objectList?key=$KEY | json_pp 


### PR DESCRIPTION
기존 텀블벅은 
텀블벅에 등록된 오브젝트(특히 문제가 있는 오브젝트)를 개발자가 확인하는 데 어려움이 있었음.

본 PR은 텀블벅의 오브젝트 리스트를 조회하고,
값을 조회할 수 있는 기능 제공. (관리자 및 개발자를 위한 기능)
1) objectList
2) objectValue

예를 들어,
1) `http://localhost:1323/tumblebug/`**objectList**?key=`/ns/ns-01/` 는 
`/ns/ns-01/` 가 포함된 모든 TB 오브젝트의 ID 리스트를 반환함.

2) `http://localhost:1323/tumblebug/`**objectValue**?key=`/ns/ns-01/mcis/aws-ap-southeast-1-shson/vmgroup/aws-ap-southeast-1-shson`  는 
`/ns/ns-01/mcis/aws-ap-southeast-1-shson/vmgroup/aws-ap-southeast-1-shson` 오브젝트의 값을 반환함.

테스트 스크립트:
1) list-object.sh

```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./list-object.sh /ns/ns-01/mcis/
####################################################################
## 0. Object: List
####################################################################
{
   "object" : [
      "/ns/ns-01/mcis/aws-ap-southeast-1-shson",
      "/ns/ns-01/mcis/aws-ap-southeast-1-shson/vm/aws-ap-southeast-1-shson-0",
      "/ns/ns-01/mcis/aws-ap-southeast-1-shson/vm/aws-ap-southeast-1-shson-1",
      "/ns/ns-01/mcis/aws-ap-southeast-1-shson/vm/aws-ap-southeast-1-shson-2",
      "/ns/ns-01/mcis/aws-ap-southeast-1-shson/vmgroup/aws-ap-southeast-1-shson"
   ]
}

son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./list-object.sh /ns/ns-01/mcis/
####################################################################
## 0. Object: List
####################################################################
{
   "object" : null
}

```

2) get-object.sh

```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./get-object.sh /ns/ns-01/mcis/aws-ap-southeast-1-shson/vmgroup/aws-ap-southeast-1-shson
####################################################################
## 0. Object: Get value
####################################################################
{
   "id" : "aws-ap-southeast-1-shson",
   "name" : "aws-ap-southeast-1-shson",
   "vmId" : [
      "aws-ap-southeast-1-shson-0",
      "aws-ap-southeast-1-shson-1",
      "aws-ap-southeast-1-shson-2"
   ],
   "vmGroupSize" : "3"
}

son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./get-object.sh /ns/ns-01/mcis/aws-ap-southeast-1-shson/vmgroup/aws-ap-southeast-1-shson
####################################################################
## 0. Object: Get value
####################################################################
{
   "message" : "Failed to find /ns/ns-01/mcis/aws-ap-southeast-1-shson/vmgroup/aws-ap-southeast-1-shsonobject"
}

```
