### PR TITLE
Add private IP in mcis status to enhance weavescope deployment

### DIFF
--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -42,6 +42,16 @@ func RestPostMcis(c echo.Context) error {
 	return c.JSON(http.StatusCreated, result)
 }
 
+// JSONResult's data field will be overridden by the specific type
+type JSONResult struct {
+    //Code    int          `json:"code" `
+    //Message string       `json:"message"`
+    //Data    interface{}  `json:"data"`
+}
+
+// TODO: swag does not support multiple response types (success 200) in an API. 
+// Annotation for API documention Need to be revised.
+
 // RestGetMcis godoc
 // @Summary Get MCIS
 // @Description Get MCIS
@@ -50,7 +60,8 @@ func RestPostMcis(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
 // @Param mcisId path string true "MCIS ID"
-// @Success 200 {object} TbMcisInfo
+// @Param action query string false "Action to MCIS" Enums(status, suspend, resume, reboot, terminate)
+// @success 200 {object} JSONResult{[DEFAULT]=mcis.TbMcisInfo,[STATUS]=mcis.McisStatusInfo,[CONTROL]=common.SimpleMsg} "Different return structures by the given action param"
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis/{mcisId} [get]
@@ -438,6 +449,9 @@ func RestPostMcisVm(c echo.Context) error {
 	return c.JSON(http.StatusCreated, result)
 }
 
+// TODO: swag does not support multiple response types (success 200) in an API. 
+// Annotation for API documention Need to be revised.
+
 // RestGetMcisVm godoc
 // @Summary Get MCIS
 // @Description Get MCIS
@@ -447,7 +461,8 @@ func RestPostMcisVm(c echo.Context) error {
 // @Param nsId path string true "Namespace ID"
 // @Param mcisId path string true "MCIS ID"
 // @Param vmId path string true "VM ID"
-// @Success 200 {object} mcis.TbVmInfo
+// @Param action query string false "Action to MCIS" Enums(status, suspend, resume, reboot, terminate)
+// @success 200 {object} JSONResult{[DEFAULT]=mcis.TbVmInfo,[STATUS]=mcis.TbVmStatusInfo,[CONTROL]=common.SimpleMsg} "Different return structures by the given action param"
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis/{mcisId}/vm/{vmId} [get]

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -53,7 +53,7 @@ const milkywayPort string = ":1324/milkyway/"
 
 const SshDefaultUserName01 string = "cb-user"
 const SshDefaultUserName02 string = "ubuntu"
-const SshDefaultUserName03 string = "others"
+const SshDefaultUserName03 string = "root"
 const SshDefaultUserName04 string = "ec2-user"
 
 const LabelAutoGen string = "AutoGen"
@@ -209,6 +209,7 @@ type GeoLocation struct {
 	NativeRegion string `json:"nativeRegion"`
 }
 
+// struct McisStatusInfo is to define simple information of MCIS with updated status of all VMs
 type McisStatusInfo struct {
 	Id   string `json:"id"`
 	Name string `json:"name"`
@@ -223,6 +224,7 @@ type McisStatusInfo struct {
 	InstallMonAgent string `json:"installMonAgent" example:"[yes, no]"` // yes or no
 }
 
+// struct TbVmStatusInfo is to define simple information of VM with updated status
 type TbVmStatusInfo struct {
 	Id            string      `json:"id"`
 	Csp_vm_id     string      `json:"csp_vm_id"`
@@ -232,6 +234,7 @@ type TbVmStatusInfo struct {
 	TargetAction  string      `json:"targetAction"`
 	Native_status string      `json:"native_status"`
 	Public_ip     string      `json:"public_ip"`
+	Private_ip     string      `json:"private_ip"`
 	Location      GeoLocation `json:"location"`
 	// Montoring agent status
 	MonAgentStatus string `json:"monAgentStatus" example:"[installed, notInstalled, failed]"` // yes or no// installed, notInstalled, failed
@@ -3422,6 +3425,7 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 	vmStatusTmp.Name = temp.Name
 	vmStatusTmp.Csp_vm_id = temp.CspViewVmDetail.IId.NameId
 	vmStatusTmp.Public_ip = temp.PublicIP
+	vmStatusTmp.Private_ip = temp.PrivateIP
 	vmStatusTmp.Native_status = statusResponseTmp.Status
 
 	vmStatusTmp.TargetAction = temp.TargetAction

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1085,13 +1085,44 @@ var doc = `{
                         "name": "mcisId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "status",
+                            "suspend",
+                            "resume",
+                            "reboot",
+                            "terminate"
+                        ],
+                        "type": "string",
+                        "description": "Action to MCIS",
+                        "name": "action",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Different return structures by the given action param",
                         "schema": {
-                            "$ref": "#/definitions/mcis.TbMcisInfo"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/mcis.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "[CONTROL]": {
+                                            "$ref": "#/definitions/common.SimpleMsg"
+                                        },
+                                        "[DEFAULT]": {
+                                            "$ref": "#/definitions/mcis.TbMcisInfo"
+                                        },
+                                        "[STATUS]": {
+                                            "$ref": "#/definitions/mcis.McisStatusInfo"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "404": {
@@ -1246,13 +1277,44 @@ var doc = `{
                         "name": "vmId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "status",
+                            "suspend",
+                            "resume",
+                            "reboot",
+                            "terminate"
+                        ],
+                        "type": "string",
+                        "description": "Action to MCIS",
+                        "name": "action",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Different return structures by the given action param",
                         "schema": {
-                            "$ref": "#/definitions/mcis.TbVmInfo"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/mcis.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "[CONTROL]": {
+                                            "$ref": "#/definitions/common.SimpleMsg"
+                                        },
+                                        "[DEFAULT]": {
+                                            "$ref": "#/definitions/mcis.TbVmInfo"
+                                        },
+                                        "[STATUS]": {
+                                            "$ref": "#/definitions/mcis.TbVmStatusInfo"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "404": {
@@ -4261,6 +4323,9 @@ var doc = `{
                 }
             }
         },
+        "mcis.JSONResult": {
+            "type": "object"
+        },
         "mcis.McisCmdReq": {
             "type": "object",
             "properties": {
@@ -4328,6 +4393,46 @@ var doc = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcis.TbVmRecommendReq"
+                    }
+                }
+            }
+        },
+        "mcis.McisStatusInfo": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "installMonAgent": {
+                    "description": "InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)",
+                    "type": "string",
+                    "example": "[yes, no]"
+                },
+                "masterIp": {
+                    "type": "string",
+                    "example": "32.201.134.113"
+                },
+                "masterVmId": {
+                    "type": "string",
+                    "example": "vm-asiaeast1-cb-01"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Vm_num string         ` + "`" + `json:\"vm_num\"` + "`" + `",
+                    "type": "string"
+                },
+                "targetAction": {
+                    "type": "string"
+                },
+                "targetStatus": {
+                    "type": "string"
+                },
+                "vm": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.TbVmStatusInfo"
                     }
                 }
             }
@@ -4847,6 +4952,47 @@ var doc = `{
                     "type": "string"
                 },
                 "vmUserPassword": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.TbVmStatusInfo": {
+            "type": "object",
+            "properties": {
+                "csp_vm_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "object",
+                    "$ref": "#/definitions/mcis.GeoLocation"
+                },
+                "monAgentStatus": {
+                    "description": "Montoring agent status",
+                    "type": "string",
+                    "example": "[installed, notInstalled, failed]"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "native_status": {
+                    "type": "string"
+                },
+                "private_ip": {
+                    "type": "string"
+                },
+                "public_ip": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetAction": {
+                    "type": "string"
+                },
+                "targetStatus": {
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1070,13 +1070,44 @@
                         "name": "mcisId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "status",
+                            "suspend",
+                            "resume",
+                            "reboot",
+                            "terminate"
+                        ],
+                        "type": "string",
+                        "description": "Action to MCIS",
+                        "name": "action",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Different return structures by the given action param",
                         "schema": {
-                            "$ref": "#/definitions/mcis.TbMcisInfo"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/mcis.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "[CONTROL]": {
+                                            "$ref": "#/definitions/common.SimpleMsg"
+                                        },
+                                        "[DEFAULT]": {
+                                            "$ref": "#/definitions/mcis.TbMcisInfo"
+                                        },
+                                        "[STATUS]": {
+                                            "$ref": "#/definitions/mcis.McisStatusInfo"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "404": {
@@ -1231,13 +1262,44 @@
                         "name": "vmId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "status",
+                            "suspend",
+                            "resume",
+                            "reboot",
+                            "terminate"
+                        ],
+                        "type": "string",
+                        "description": "Action to MCIS",
+                        "name": "action",
+                        "in": "query"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Different return structures by the given action param",
                         "schema": {
-                            "$ref": "#/definitions/mcis.TbVmInfo"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/mcis.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "[CONTROL]": {
+                                            "$ref": "#/definitions/common.SimpleMsg"
+                                        },
+                                        "[DEFAULT]": {
+                                            "$ref": "#/definitions/mcis.TbVmInfo"
+                                        },
+                                        "[STATUS]": {
+                                            "$ref": "#/definitions/mcis.TbVmStatusInfo"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "404": {
@@ -4246,6 +4308,9 @@
                 }
             }
         },
+        "mcis.JSONResult": {
+            "type": "object"
+        },
         "mcis.McisCmdReq": {
             "type": "object",
             "properties": {
@@ -4313,6 +4378,46 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcis.TbVmRecommendReq"
+                    }
+                }
+            }
+        },
+        "mcis.McisStatusInfo": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "installMonAgent": {
+                    "description": "InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)",
+                    "type": "string",
+                    "example": "[yes, no]"
+                },
+                "masterIp": {
+                    "type": "string",
+                    "example": "32.201.134.113"
+                },
+                "masterVmId": {
+                    "type": "string",
+                    "example": "vm-asiaeast1-cb-01"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "status": {
+                    "description": "Vm_num string         `json:\"vm_num\"`",
+                    "type": "string"
+                },
+                "targetAction": {
+                    "type": "string"
+                },
+                "targetStatus": {
+                    "type": "string"
+                },
+                "vm": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.TbVmStatusInfo"
                     }
                 }
             }
@@ -4832,6 +4937,47 @@
                     "type": "string"
                 },
                 "vmUserPassword": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.TbVmStatusInfo": {
+            "type": "object",
+            "properties": {
+                "csp_vm_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "object",
+                    "$ref": "#/definitions/mcis.GeoLocation"
+                },
+                "monAgentStatus": {
+                    "description": "Montoring agent status",
+                    "type": "string",
+                    "example": "[installed, notInstalled, failed]"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "native_status": {
+                    "type": "string"
+                },
+                "private_ip": {
+                    "type": "string"
+                },
+                "public_ip": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "targetAction": {
+                    "type": "string"
+                },
+                "targetStatus": {
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -661,6 +661,8 @@ definitions:
       nativeRegion:
         type: string
     type: object
+  mcis.JSONResult:
+    type: object
   mcis.McisCmdReq:
     properties:
       command:
@@ -706,6 +708,34 @@ definitions:
       vm_req:
         items:
           $ref: '#/definitions/mcis.TbVmRecommendReq'
+        type: array
+    type: object
+  mcis.McisStatusInfo:
+    properties:
+      id:
+        type: string
+      installMonAgent:
+        description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
+        example: '[yes, no]'
+        type: string
+      masterIp:
+        example: 32.201.134.113
+        type: string
+      masterVmId:
+        example: vm-asiaeast1-cb-01
+        type: string
+      name:
+        type: string
+      status:
+        description: Vm_num string         `json:"vm_num"`
+        type: string
+      targetAction:
+        type: string
+      targetStatus:
+        type: string
+      vm:
+        items:
+          $ref: '#/definitions/mcis.TbVmStatusInfo'
         type: array
     type: object
   mcis.Policy:
@@ -1060,6 +1090,34 @@ definitions:
       vmUserAccount:
         type: string
       vmUserPassword:
+        type: string
+    type: object
+  mcis.TbVmStatusInfo:
+    properties:
+      csp_vm_id:
+        type: string
+      id:
+        type: string
+      location:
+        $ref: '#/definitions/mcis.GeoLocation'
+        type: object
+      monAgentStatus:
+        description: Montoring agent status
+        example: '[installed, notInstalled, failed]'
+        type: string
+      name:
+        type: string
+      native_status:
+        type: string
+      private_ip:
+        type: string
+      public_ip:
+        type: string
+      status:
+        type: string
+      targetAction:
+        type: string
+      targetStatus:
         type: string
     type: object
 host: localhost:1323
@@ -1765,13 +1823,32 @@ paths:
         name: mcisId
         required: true
         type: string
+      - description: Action to MCIS
+        enum:
+        - status
+        - suspend
+        - resume
+        - reboot
+        - terminate
+        in: query
+        name: action
+        type: string
       produces:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Different return structures by the given action param
           schema:
-            $ref: '#/definitions/mcis.TbMcisInfo'
+            allOf:
+            - $ref: '#/definitions/mcis.JSONResult'
+            - properties:
+                '[CONTROL]':
+                  $ref: '#/definitions/common.SimpleMsg'
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcis.TbMcisInfo'
+                '[STATUS]':
+                  $ref: '#/definitions/mcis.McisStatusInfo'
+              type: object
         "404":
           description: Not Found
           schema:
@@ -1878,13 +1955,32 @@ paths:
         name: vmId
         required: true
         type: string
+      - description: Action to MCIS
+        enum:
+        - status
+        - suspend
+        - resume
+        - reboot
+        - terminate
+        in: query
+        name: action
+        type: string
       produces:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Different return structures by the given action param
           schema:
-            $ref: '#/definitions/mcis.TbVmInfo'
+            allOf:
+            - $ref: '#/definitions/mcis.JSONResult'
+            - properties:
+                '[CONTROL]':
+                  $ref: '#/definitions/common.SimpleMsg'
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcis.TbVmInfo'
+                '[STATUS]':
+                  $ref: '#/definitions/mcis.TbVmStatusInfo'
+              type: object
         "404":
           description: Not Found
           schema:

--- a/test/official/conf.env
+++ b/test/official/conf.env
@@ -21,10 +21,10 @@ declare -A IMAGE_NAME
 declare -A SPEC_NAME
 
 ## Number of CSP types and corresponding regions
-NumCSP=1
+NumCSP=4
 
 CSPType[1]=aws
-NumRegion[1]=8
+NumRegion[1]=3
 
 CSPType[2]=azure
 NumRegion[2]=3
@@ -33,7 +33,7 @@ CSPType[3]=gcp
 NumRegion[3]=3
 
 CSPType[4]=alibaba
-NumRegion[3]=1
+NumRegion[4]=1
 
 
 ## AWS
@@ -120,16 +120,6 @@ RegionVal02[1,8]=eu-west-2a
 CONN_CONFIG[1,8]=aws-eu-west-2
 IMAGE_NAME[1,8]=ami-0be057a22c63962cb
 SPEC_NAME[1,8]=t2.micro
-
-# region09 - AWS Canada Central
-RegionName[1,9]=aws-ca-central-1
-RegionKey01[1,9]=Region
-RegionVal01[1,9]=ca-central-1
-RegionKey02[1,9]=Zone
-RegionVal02[1,9]=ca-central-1a
-CONN_CONFIG[1,9]=aws-ca-central-1
-IMAGE_NAME[1,9]=ami-0d0eaed20348a3389
-SPEC_NAME[1,9]=t2.micro
 
 # region09 - AWS Seoul
 RegionName[1,9]=aws-ap-northeast-2


### PR DESCRIPTION
Add private IP in mcis status to enhance weavescope deployment

- MCIS status 오브젝트에 private_ip 항목을 추가함.
- Weavescope deployment 도구를 개선함. (노드간 private IP를 인식하도록)
- API 문서화를 위한 annotation 일부 개선

[Weavescope 개선 관련]
- Private IP를 인식하는 VM간의 연결성을 보여줄 수 있음
![image](https://user-images.githubusercontent.com/5966944/112948487-15539d80-9173-11eb-881a-46d69ea0cb7d.png)

[Swag 를 활용한 API 문서화 관련]
- Get MCIS에서, 다중 쿼리 파라미터에 대한 명시 (Get MCIS는 기본 정보 조회, 상태 조회, 상태 제어 등을 쿼리 파라미터로 처리)
- Swag에서는 다중 응답에 대한 표현이 어려움으로, 임시 방편 마련
![image](https://user-images.githubusercontent.com/5966944/112948576-36b48980-9173-11eb-9f9b-ec4227cf03f5.png)
