### PR TITLE
Fix JSON unmarshaling error

### DIFF
--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -770,22 +770,30 @@ func UpdateAssociatedObjectList(nsId string, resourceType string, resourceId str
 					return nil, err
 				}
 			}
-			fmt.Println("keyValue.Value before sjson.Set: " + keyValue.Value) // for debug
-			fmt.Println("len(objList): " + strconv.Itoa(len(objList)))        // for debug
-			fmt.Print("objList: ")                                            // for debug
-			fmt.Println(objList)                                              // for debug
-			if len(objList) == 0 {
-				keyValue.Value, err = sjson.Set(keyValue.Value, "associatedObjectList.0", objectKey) // Create a new array by using the 0 key in a path
-			} else {
-				keyValue.Value, err = sjson.Set(keyValue.Value, "associatedObjectList.-1", objectKey) // Append an array value by using the -1 key in a path
-			}
+			// fmt.Println("len(objList): " + strconv.Itoa(len(objList))) // for debug
+			// fmt.Print("objList: ")                                     // for debug
+			// fmt.Println(objList)                                       // for debug
 
-			if err != nil {
-				common.CBLog.Error(err)
-				return nil, err
+			var anyJson map[string]interface{}
+			json.Unmarshal([]byte(keyValue.Value), &anyJson)
+			if anyJson["associatedObjectList"] == nil {
+				array_to_be := []string{objectKey}
+				// fmt.Println("array_to_be: ", array_to_be) // for debug
+
+				anyJson["associatedObjectList"] = array_to_be
+			} else { // anyJson["associatedObjectList"] != nil
+				array_as_is := anyJson["associatedObjectList"].([]interface{})
+				// fmt.Println("array_as_is: ", array_as_is) // for debug
+
+				array_to_be := append(array_as_is, objectKey)
+				// fmt.Println("array_to_be: ", array_to_be) // for debug
+
+				anyJson["associatedObjectList"] = array_to_be
 			}
-			fmt.Println("keyValue.Value after sjson.Set: " + keyValue.Value) // for debug
-			//objList = append(objList, objectKey)
+			updatedJson, _ := json.Marshal(anyJson)
+			// fmt.Println(string(updatedJson)) // for debug
+
+			keyValue.Value = string(updatedJson)
 		case common.StrDelete:
 			var foundKey int
 			var foundVal string


### PR DESCRIPTION
- Resolves #426
  - `UpdateAssociatedObjectList` 함수의 "delete" 파트에는 여전히 SJSON 을 사용하도록 두었습니다. 
  `UpdateAssociatedObjectList` 함수의 "delete" 파트는 문제 없이 동작하고 있습니다.
- **하지만, 다른 문제가 있습니다.**
  이 PR로 업데이트되는 `UpdateAssociatedObjectList` 함수의 "add" 파트와 관련이 있습니다.

[문제에 대한 설명]
현재 `test/official/sequentialFullTest/testAll-mcis-mcir-ns-cloud.sh` 스크립트는 
3개의 VM으로 구성되는 1개의 MCIS를 생성합니다.

`❯ ./testAll-mcis-mcir-ns-cloud.sh mock 1 jhseo`
```JSON
...
      "targetStatus" : "None",
      "installMonAgent" : "no",
      "masterVmId" : "mock-seoul-jhseo-0",
      "masterIp" : "4.3.2.1",
      "status" : "Running-(3/3)",
      "name" : "mock-seoul-jhseo",
      "targetAction" : "None",
      "id" : "mock-seoul-jhseo"
   }
}
```

---

이 스크립트를 실행하면, 먼저
- vNet
- securityGroup
- sshKey
- image
- spec

5종류의 CB-Tumblebug MCIR object 를 1개씩 생성하고,
이후 3개의 VM으로 구성되는 1개의 MCIS를 생성하면서
위에서 생성한 MCIR 들의 `associatedObjectList` 필드를 업데이트 합니다.

그러므로, `associatedObjectList` 필드에는 VM 3개의 key가 기록되어 있어야 정상입니다.


`❯ ./list-image.sh`
```JSON
{
         "id" : "mock-seoul-jhseo",
         "name" : "mock-seoul-jhseo",
         "cspImageId" : "mock-vmimage-01",
         "associatedObjectList" : [
            "/ns/ns-01/mcis/mock-seoul-jhseo/vm/mock-seoul-jhseo-1",
            "/ns/ns-01/mcis/mock-seoul-jhseo/vm/mock-seoul-jhseo-2",
            "/ns/ns-01/mcis/mock-seoul-jhseo/vm/mock-seoul-jhseo-0"
         ],
         "guestOS" : "Ubuntu",
         "connectionName" : "mock-seoul",
         "keyValueList" : [
            {
               "Key" : "",
               "Value" : ""
            },
            {
               "Key" : "",
               "Value" : ""
            }
         ],
         "isAutoGenerated" : false,
         "description" : "Canonical, Ubuntu, 18.04 LTS, amd64 bionic"
      }
   ]
}
```

문제는, key가 3개 기록되는 경우도 있고, 간헐적으로 key가 2개 기록되는 경우도 있다는 것입니다.

`❯ ./list-image.sh`
```JSON
{
   "image" : [
      {
         "guestOS" : "Ubuntu",
         "description" : "Canonical, Ubuntu, 18.04 LTS, amd64 bionic",
         "cspImageName" : "",
         "name" : "mock-seoul-jhseo",
         "connectionName" : "mock-seoul",
         "id" : "mock-seoul-jhseo",
         "cspImageId" : "mock-vmimage-01",
         "keyValueList" : [
            {
               "Value" : "",
               "Key" : ""
            },
            {
               "Value" : "",
               "Key" : ""
            }
         ],
         "associatedObjectList" : [
            "/ns/ns-01/mcis/mock-seoul-jhseo/vm/mock-seoul-jhseo-0",
            "/ns/ns-01/mcis/mock-seoul-jhseo/vm/mock-seoul-jhseo-2"
         ],
         "isAutoGenerated" : false
      }
   ]
}
```

[다른 회차]
`❯ ./list-image.sh`
```JSON
{
   "image" : [
      {
         "cspImageName" : "",
         "cspImageId" : "mock-vmimage-01",
         "name" : "mock-seoul-jhseo",
         "associatedObjectList" : [
            "/ns/ns-01/mcis/mock-seoul-jhseo/vm/mock-seoul-jhseo-1",
            "/ns/ns-01/mcis/mock-seoul-jhseo/vm/mock-seoul-jhseo-2"
         ],
         "guestOS" : "Ubuntu",
         "keyValueList" : [
            {
               "Value" : "",
               "Key" : ""
            },
            {
               "Key" : "",
               "Value" : ""
            }
         ],
         "description" : "Canonical, Ubuntu, 18.04 LTS, amd64 bionic",
         "isAutoGenerated" : false,
         "connectionName" : "mock-seoul",
         "id" : "mock-seoul-jhseo"
      }
   ]
}
```

[추정]
- `CreateMcis` 함수는 goroutine 을 사용하여 `AddVmToMcis` 함수를 실행합니다.
- `AddVmToMcis` => `CreateVm` => `UpdateAssociatedObjectList` 의 콜체인이 있습니다.
- `UpdateAssociatedObjectList` 의 "add" 부분 안에, `associatedObjectList` 리스트를 읽고 쓰는 동작이 있습니다.
- 이 때, `associatedObjectList` 리스트에 대한 락이 없기 때문에, 이런 현상이 생기는 것으로 추정합니다.
  - 예: 거의 동시에 `jhseo-0` 과 `jhseo-1` 을 기록하려고 하면, 
  거의 동시에 `UpdateAssociatedObjectList` 함수가 실행되고, 
  이 함수 인스턴스에서 `associatedObjectList` 리스트를 Key-Value store 에서 읽으면 
  두 함수 인스턴스 모두에서 `associatedObjectList` 리스트가 비어 있는 것으로 나옴.
  두 함수 인스턴스가 각각 `jhseo-0` 과 `jhseo-1` 을 기록하고 Key-Value store 에 저장하면,
  둘 중 빨리 수행된 쪽의 결과만 남게 됨

