### PR TITLE
Enhance script stability and usability

### DIFF
--- a/test/official/8.mcis/add-vmgroup-to-mcis.sh
+++ b/test/official/8.mcis/add-vmgroup-to-mcis.sh
@@ -17,7 +17,8 @@
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}
-	MCISPREFIX=${4:-avengers}
+	NUMVM=${4:-3}
+	MCISPREFIX=${5:-avengers}
 	MCISID=${MCISPREFIX}-${POSTFIX}
 
 	source ../common-functions.sh
@@ -26,7 +27,7 @@
 	
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/$MCISID/vmgroup -H 'Content-Type: application/json' -d \
 		'{
-			"vmGroupSize": "3",
+			"vmGroupSize": "'${NUMVM}'",
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"vmUserAccount": "cb-user",

--- a/test/official/8.mcis/create-mcis.sh
+++ b/test/official/8.mcis/create-mcis.sh
@@ -17,6 +17,7 @@
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}
+	NUMVM=${4:-3}
 
 	source ../common-functions.sh
 	getCloudIndex $CSP
@@ -27,7 +28,7 @@
 			"description": "Tumblebug Demo",
 			"installMonAgent": "yes",
 			"vm": [ {
-				"vmGroupSize": "3",
+				"vmGroupSize": "'${NUMVM}'",
 				"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 				"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 				"vmUserAccount": "cb-user",

--- a/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
+++ b/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
@@ -45,18 +45,52 @@
 	echo "MASTERIP: $MASTERIP"
 	echo "MASTERVM: $MASTERVM"
 
+	# Check CB-Dragonfly is healthy
+	echo ""
+	echo "[Waiting for initialization of CB-Dragonfly. (20s)]"
+	dozing 20
+
+	echo "Checking CB-Dragonfly Status. (upto 3s * 20 trials)" 
+
+	for (( try=1; try<=20; try++ ))
+	do
+		HTTP_CODE=$(curl --write-out "%{http_code}\n" "http://${MASTERIP}:9090/dragonfly/healthcheck" --silent)
+		echo "CB-Dragonfly Status: $HTTP_CODE" 
+		if [ ${HTTP_CODE} -ge 200 -a ${HTTP_CODE} -le 204 ]; then
+			break
+		else 
+			printf "[$try : NOT Healthy.].."
+			dozing 3
+		fi
+	done
+
+	HTTP_CODE=$(curl --write-out "%{http_code}\n" "http://${MASTERIP}:9090/dragonfly/healthcheck" --silent)
+	echo "CB-Dragonfly Status: $HTTP_CODE" 
+	if [ ${HTTP_CODE} -ge 200 -a ${HTTP_CODE} -le 204 ]; then
+		echo "CB-Dragonfly is healthy..!"
+	else 
+		echo "CB-Dragonfly is NOT healthy. We need to check manually. (Note: CB-DF needs 2 vCPU and 4GiB Memory at least)"
+	fi
+
+
+	echo "If CB-Dragonfly is not responding, We need to wait more."
+	echo ""
+
 	echo "[Update Tumblebug Environment for Dragonfly with following command]"
 	PARAM="DRAGONFLY_REST_URL http://${MASTERIP}:9090/dragonfly"
 	echo $PARAM
 	../2.configureTumblebug/update-config.sh $PARAM
+
 	echo ""
 	echo "[You can test Dragonfly with following command]"
 	echo " ../9.monitoring/install-agent.sh ${CSP} ${REGION} ${POSTFIX}"
 	echo " ../9.monitoring/get-monitoring-data.sh ${CSP} ${REGION} ${POSTFIX} cpu"
+
 	echo ""
 	echo "[You can check Dragonfly monitoring status with Chronograf]"
-	echo " http://${MASTERIP}:8888/sources/0/dashboards"
 	echo " (In Chronograf, you need to create a Dashboard view by selecting metrics)"
+	echo " http://${MASTERIP}:8888/sources/0/dashboards"
+
 #}
 
 #deploy_cb-df_to_mcis

--- a/test/official/sequentialFullTest/testAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/testAll-mcis-mcir-ns-cloud.sh
@@ -18,7 +18,8 @@ function test_sequence()
 	local CSP=$1
 	local REGION=$2
 	local POSTFIX=$3
-	local CMDPATH=$4
+	local NUMVM=$4
+	local CMDPATH=$5
 
 	../1.configureSpider/register-cloud.sh $CSP $REGION $POSTFIX
 	../2.configureTumblebug/create-ns.sh $CSP $REGION $POSTFIX
@@ -33,7 +34,7 @@ function test_sequence()
 	../5.sshKey/create-sshKey.sh $CSP $REGION $POSTFIX
 	../6.image/registerImageWithInfo.sh $CSP $REGION $POSTFIX
 	../7.spec/register-spec.sh $CSP $REGION $POSTFIX
-	../8.mcis/create-mcis.sh $CSP $REGION $POSTFIX
+	../8.mcis/create-mcis.sh $CSP $REGION $POSTFIX $NUMVM
 	dozing 1
 	../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX
 
@@ -41,7 +42,7 @@ function test_sequence()
 
 	echo ""
 	echo "[Logging to notify latest command history]"
-	echo "[CMD] ${_self} ${CSP} ${REGION} ${POSTFIX}" >> ./executionStatus
+	echo "[CMD] ${_self} ${CSP} ${REGION} ${POSTFIX} ${NUMVM}" >> ./executionStatus
 	echo ""
 	echo "[Executed Command List]"
 	cat  ./executionStatus
@@ -100,9 +101,10 @@ function test_sequence_allcsp_mcis_vm()
 	local CSP=$1
 	local REGION=$2
 	local POSTFIX=$3
-	local MCISPREFIX=$4
+	local NUMVM=$4
+	local MCISPREFIX=$5
 
-	../8.mcis/add-vmgroup-to-mcis.sh $CSP $REGION $POSTFIX $MCISPREFIX
+	../8.mcis/add-vmgroup-to-mcis.sh $CSP $REGION $POSTFIX $NUMVM $MCISPREFIX
 
 }
 
@@ -132,6 +134,7 @@ function test_sequence_allcsp_mcis_vm()
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}
+	NUMVM=${4:-3}
 
 	source ../common-functions.sh
 	getCloudIndex $CSP
@@ -174,7 +177,7 @@ function test_sequence_allcsp_mcis_vm()
 				echo $REGION
 				echo "[Create and Add a VM to MCIS]"
 
-				test_sequence_allcsp_mcis_vm $CSP $REGION $POSTFIX $MCISPREFIX &
+				test_sequence_allcsp_mcis_vm $CSP $REGION $POSTFIX $NUMVM $MCISPREFIX &
 
 			done
 			
@@ -186,7 +189,7 @@ function test_sequence_allcsp_mcis_vm()
 	else
 		echo "[Single excution for a CSP region]"
 
-		test_sequence $CSP $REGION $POSTFIX ${0##*/}
+		test_sequence $CSP $REGION $POSTFIX $NUMVM ${0##*/}
 
 	fi
 


### PR DESCRIPTION

This PR enhances 

### 1. deploy-dragonfly-docker.sh // add waiting session


```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./create-mcis-for-df.sh aws 1 shson
####################################################################
## Create MCIS from Zero Base
####################################################################
[For AWS]
[Single excution for a CSP region]
####################################################################
## 1. Create Cloud Connction Config
####################################################################
[For AWS]
...
...
Dozing for 1 : 1 (Back to work)
####################################################################
## 8. VM: Status MCIS
####################################################################
[For AWS]
{
   "status" : {
      "targetStatus" : "None",
      "vm" : [
         {
            "location" : {
               "longitude" : "103.8000",
               "nativeRegion" : "ap-southeast-1",
               "latitude" : "1.3700",
               "cloudType" : "aws",
               "briefAddr" : "Singapore"
            },
            "status" : "Running",
            "targetAction" : "None",
            "id" : "aws-ap-southeast-1-shson-01",
...
```
...
```
...
[Deploy CB-Dragonfly Docker]
Dozing for 30 : 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 (Back to work)
[Check jq package (if not, install)]
install ok installed
####################################################################
## Command (SSH) to MCIS 
####################################################################
[For AWS]
{
   "result_array" : [
      {
         "mcis_id" : "aws-ap-southeast-1-shson",
         "result" : "go build -o operator\ncb-operator is ready. Access to it with ssh 1xxx cb-dragonfly is ready. Access to it with ssh 1xxx ",
         "vm_id" : "aws-ap-southeast-1-shson-01",
         "vm_ip" : "18xxx"
      }
   ]
}
MASTERIP: 18.139.223.204
MASTERVM: aws-ap-southeast-1-shson-01

[Waiting for initialization of CB-Dragonfly. (20s)]
Dozing for 20 : 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 (Back to work)
Checking CB-Dragonfly Status. (upto 3s * 20 trials)
CB-Dragonfly Status: 000
[1 : NOT Healthy.]..Dozing for 3 : 1 2 3 (Back to work)
CB-Dragonfly Status: 000
...
[12 : NOT Healthy.]..Dozing for 3 : 1 2 3 (Back to work)
CB-Dragonfly Status: 000
[13 : NOT Healthy.]..Dozing for 3 : 1 2 3 (Back to work)
CB-Dragonfly Status: 204
CB-Dragonfly Status: 204
CB-Dragonfly is healthy..!
If CB-Dragonfly is not responding, We need to wait more.

[Update Tumblebug Environment for Dragonfly with following command]
DRAGONFLY_REST_URL http://18.xxx:9090/dragonfly
####################################################################
## 2. Config: Create or Update (Param1: Key, Param2: Value)
####################################################################
{
   "id" : "dragonfly-rest-url",
   "name" : "dragonfly-rest-url",
   "value" : "http://18xxx:9090/dragonfly"
}

[You can test Dragonfly with following command]
 ../9.monitoring/install-agent.sh aws 1 shson
 ../9.monitoring/get-monitoring-data.sh aws 1 shson cpu

[You can check Dragonfly monitoring status with Chronograf]
 (In Chronograf, you need to create a Dashboard view by selecting metrics)
 http://1xxxxxxxx:8888/sources/0/dashboards



```

### 2. Parameterize number of VMs for provisioning MCIS
- create-mcis.sh // 4th parameter is for number of VMs
- add-vm-to-mcis.sh // 4th parameter is for number of VMs
- testAll-mcis-mcir-ns-cloud.sh // 4th parameter is for number of VMs


son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./testAll-mcis-mcir-ns-cloud.sh all 1 etri **2**
```
####################################################################
## Create MCIS from Zero Base
####################################################################
[For all CSP regions (AWS, Azure, GCP, Alibaba,  ...)]
[Parallel excution for all CSP regions]
aws
1
alibaba
1
gcp
1
azure
1
```
...
```
[Logging to notify latest command history]

[Executed Command List]
[CMD] create-mcis-for-df.sh aws 1 shson
[CMD] testAll-mcis-mcir-ns-cloud.sh alibaba 1 etri
[CMD] testAll-mcis-mcir-ns-cloud.sh aws 1 etri
[CMD] testAll-mcis-mcir-ns-cloud.sh azure 1 etri
[CMD] testAll-mcis-mcir-ns-cloud.sh gcp 1 etri

aws
1
[Create and Add a VM to MCIS]
alibaba
1
[Create and Add a VM to MCIS]
gcp
1
[Create and Add a VM to MCIS]
azure
1
[Create and Add a VM to MCIS]
```
...

```
{
   "status" : {
      "targetAction" : "None",
      "status" : "Running-(9/9)",
      "vm" : [
         {
            "native_status" : "Running",
            "sshPort" : "22",
            "location" : {
               "latitude" : "34.6895",
               "briefAddr" : "Japan (Tokyo)",
               "cloudType" : "alibaba",
               "nativeRegion" : "ap-northeast-1",
               "longitude" : "139.9917"
            },
            "targetStatus" : "None",

```

