### PR TITLE
Add Azure & GCP regions

### DIFF
--- a/test/official/conf.env
+++ b/test/official/conf.env
@@ -155,7 +155,7 @@ ProviderName[3]=GCP
 DriverLibFileName[3]=gcp-driver-v1.0.so
 DriverName[3]=gcp-driver01
 
-# region01
+# region01 - Changhua County  Taiwan
 RegionName[3,1]=gcp-asia-east1
 RegionKey01[3,1]=Region
 RegionVal01[3,1]=asia-east1
@@ -165,7 +165,7 @@ CONN_CONFIG[3,1]=gcp-asia-east1
 IMAGE_NAME[3,1]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[3,1]=f1-micro
 
-# region02
+# region02 - Frankfurt  Germany
 RegionName[3,2]=gcp-europe-west3
 RegionKey01[3,2]=Region
 RegionVal01[3,2]=europe-west3
@@ -175,7 +175,7 @@ CONN_CONFIG[3,2]=gcp-europe-west3
 IMAGE_NAME[3,2]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[3,2]=f1-micro
 
-# region03
+# region03 - Hong Kong
 RegionName[3,3]=gcp-asia-east2
 RegionKey01[3,3]=Region
 RegionVal01[3,3]=asia-east2
@@ -185,6 +185,206 @@ CONN_CONFIG[3,3]=gcp-asia-east2
 IMAGE_NAME[3,3]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[3,3]=f1-micro
 
+# region04 - Tokyo  Japan
+RegionName[3,4]=gcp-asia-northeast1
+RegionKey01[3,4]=Region
+RegionVal01[3,4]=asia-northeast1
+RegionKey02[3,4]=Zone
+RegionVal02[3,4]=asia-northeast1-a
+CONN_CONFIG[3,4]=gcp-asia-northeast1
+IMAGE_NAME[3,4]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,4]=f1-micro
+
+# region05 - Osaka  Japan
+RegionName[3,5]=gcp-asia-northeast2
+RegionKey01[3,5]=Region
+RegionVal01[3,5]=asia-northeast2
+RegionKey02[3,5]=Zone
+RegionVal02[3,5]=asia-northeast2-a
+CONN_CONFIG[3,5]=gcp-asia-northeast2
+IMAGE_NAME[3,5]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,5]=f1-micro
+
+# region06 - Seoul  South Korea
+RegionName[3,6]=gcp-asia-northeast3
+RegionKey01[3,6]=Region
+RegionVal01[3,6]=asia-northeast3
+RegionKey02[3,6]=Zone
+RegionVal02[3,6]=asia-northeast3-a
+CONN_CONFIG[3,6]=gcp-asia-northeast3
+IMAGE_NAME[3,6]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,6]=f1-micro
+
+# region07 - Mumbai  India
+RegionName[3,7]=gcp-asia-south1
+RegionKey01[3,7]=Region
+RegionVal01[3,7]=asia-south1
+RegionKey02[3,7]=Zone
+RegionVal02[3,7]=asia-south1-a
+CONN_CONFIG[3,7]=gcp-asia-south1
+IMAGE_NAME[3,7]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,7]=f1-micro
+
+# region08 - Jurong West  Singapore
+RegionName[3,8]=gcp-asia-southeast1
+RegionKey01[3,8]=Region
+RegionVal01[3,8]=asia-southeast1
+RegionKey02[3,8]=Zone
+RegionVal02[3,8]=asia-southeast1-a
+CONN_CONFIG[3,8]=gcp-asia-southeast1
+IMAGE_NAME[3,8]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,8]=f1-micro
+
+# region09 - Sydney  Australia
+RegionName[3,9]=gcp-australia-southeast1
+RegionKey01[3,9]=Region
+RegionVal01[3,9]=australia-southeast1
+RegionKey02[3,9]=Zone
+RegionVal02[3,9]=australia-southeast1-a
+CONN_CONFIG[3,9]=gcp-australia-southeast1
+IMAGE_NAME[3,9]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,9]=f1-micro
+
+# region10 - Hamina  Finland
+RegionName[3,10]=gcp-europe-north1
+RegionKey01[3,10]=Region
+RegionVal01[3,10]=europe-north1
+RegionKey02[3,10]=Zone
+RegionVal02[3,10]=europe-north1-a
+CONN_CONFIG[3,10]=gcp-europe-north1
+IMAGE_NAME[3,10]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,10]=f1-micro
+
+# region11 - St. Ghislain  Belgium
+RegionName[3,11]=gcp-europe-west1
+RegionKey01[3,11]=Region
+RegionVal01[3,11]=europe-west1
+RegionKey02[3,11]=Zone
+RegionVal02[3,11]=europe-west1-a
+CONN_CONFIG[3,11]=gcp-europe-west1
+IMAGE_NAME[3,11]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,11]=f1-micro
+
+# region12 - London  England  UK
+RegionName[3,12]=gcp-europe-west2
+RegionKey01[3,12]=Region
+RegionVal01[3,12]=europe-west2
+RegionKey02[3,12]=Zone
+RegionVal02[3,12]=europe-west2-a
+CONN_CONFIG[3,12]=gcp-europe-west2
+IMAGE_NAME[3,12]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,12]=f1-micro
+
+# region13 - Eemshaven  Netherlands
+RegionName[3,13]=gcp-europe-west4
+RegionKey01[3,13]=Region
+RegionVal01[3,13]=europe-west4
+RegionKey02[3,13]=Zone
+RegionVal02[3,13]=europe-west4-a
+CONN_CONFIG[3,13]=gcp-europe-west4
+IMAGE_NAME[3,13]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,13]=f1-micro
+
+# region14 - Zurich  Switzerland
+RegionName[3,14]=gcp-europe-west6
+RegionKey01[3,14]=Region
+RegionVal01[3,14]=europe-west6
+RegionKey02[3,14]=Zone
+RegionVal02[3,14]=europe-west6-a
+CONN_CONFIG[3,14]=gcp-europe-west6
+IMAGE_NAME[3,14]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,14]=f1-micro
+
+# region15 - Montreal  Quebec  Canada
+RegionName[3,15]=gcp-northamerica-northeast1
+RegionKey01[3,15]=Region
+RegionVal01[3,15]=northamerica-northeast1
+RegionKey02[3,15]=Zone
+RegionVal02[3,15]=northamerica-northeast1-a
+CONN_CONFIG[3,15]=gcp-northamerica-northeast1
+IMAGE_NAME[3,15]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,15]=f1-micro
+
+# region16 - Osasco (Sao Paulo)  Brazil
+RegionName[3,16]=gcp-southamerica-east1
+RegionKey01[3,16]=Region
+RegionVal01[3,16]=southamerica-east1
+RegionKey02[3,16]=Zone
+RegionVal02[3,16]=southamerica-east1-a
+CONN_CONFIG[3,16]=gcp-southamerica-east1
+IMAGE_NAME[3,16]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,16]=f1-micro
+
+# region17 - Council Bluffs  Iowa  USA
+RegionName[3,17]=gcp-us-central1
+RegionKey01[3,17]=Region
+RegionVal01[3,17]=us-central1
+RegionKey02[3,17]=Zone
+RegionVal02[3,17]=us-central1-a
+CONN_CONFIG[3,17]=gcp-us-central1
+IMAGE_NAME[3,17]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,17]=f1-micro
+
+# region18 - Moncks Corner  South Carolina  USA
+RegionName[3,18]=gcp-us-east1
+RegionKey01[3,18]=Region
+RegionVal01[3,18]=us-east1
+RegionKey02[3,18]=Zone
+RegionVal02[3,18]=us-east1-a
+CONN_CONFIG[3,18]=gcp-us-east1
+IMAGE_NAME[3,18]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,18]=f1-micro
+
+# region19 - Ashburn  Northern Virginia  USA
+RegionName[3,19]=gcp-us-east4
+RegionKey01[3,19]=Region
+RegionVal01[3,19]=us-east4
+RegionKey02[3,19]=Zone
+RegionVal02[3,19]=us-east4-a
+CONN_CONFIG[3,19]=gcp-us-east4
+IMAGE_NAME[3,19]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,19]=f1-micro
+
+# region20 - The Dalles  Oregon  USA
+RegionName[3,20]=gcp-us-west1
+RegionKey01[3,20]=Region
+RegionVal01[3,20]=us-west1
+RegionKey02[3,20]=Zone
+RegionVal02[3,20]=us-west1-a
+CONN_CONFIG[3,20]=gcp-us-west1
+IMAGE_NAME[3,20]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,20]=f1-micro
+
+# region21 - Los Angeles  California  USA
+RegionName[3,21]=gcp-us-west2
+RegionKey01[3,21]=Region
+RegionVal01[3,21]=us-west2
+RegionKey02[3,21]=Zone
+RegionVal02[3,21]=us-west2-a
+CONN_CONFIG[3,21]=gcp-us-west2
+IMAGE_NAME[3,21]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,21]=f1-micro
+
+# region22 - Salt Lake City  Utah  USA
+RegionName[3,22]=gcp-us-west3
+RegionKey01[3,22]=Region
+RegionVal01[3,22]=us-west3
+RegionKey02[3,22]=Zone
+RegionVal02[3,22]=us-west3-a
+CONN_CONFIG[3,22]=gcp-us-west3
+IMAGE_NAME[3,22]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,22]=f1-micro
+
+# region23 - Las Vegas  Nevada  USA
+RegionName[3,23]=gcp-us-west4
+RegionKey01[3,23]=Region
+RegionVal01[3,23]=us-west4
+RegionKey02[3,23]=Zone
+RegionVal02[3,23]=us-west4-a
+CONN_CONFIG[3,23]=gcp-us-west4
+IMAGE_NAME[3,23]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[3,23]=f1-micro
+
 
 
 ## Azure
@@ -192,7 +392,7 @@ ProviderName[4]=AZURE
 DriverLibFileName[4]=azure-driver-v1.0.so
 DriverName[4]=azure-driver01
 
-# region01
+# region01 - Korea Central
 RegionName[4,1]=azure-koreacentral
 RegionKey01[4,1]=location
 RegionVal01[4,1]=koreacentral
@@ -202,7 +402,7 @@ CONN_CONFIG[4,1]=azure-koreacentral
 IMAGE_NAME[4,1]=Canonical:UbuntuServer:18.04-LTS:latest
 SPEC_NAME[4,1]=Standard_B2s
 
-# region02
+# region02 - North Central US
 RegionName[4,2]=azure-northcentralus
 RegionKey01[4,2]=location
 RegionVal01[4,2]=northcentralus
@@ -212,7 +412,7 @@ CONN_CONFIG[4,2]=azure-northcentralus
 IMAGE_NAME[4,2]=Canonical:UbuntuServer:18.04-LTS:latest
 SPEC_NAME[4,2]=Standard_B2s
 
-# region03
+# region03 - Canada East
 RegionName[4,3]=azure-canadaeast
 RegionKey01[4,3]=location
 RegionVal01[4,3]=canadaeast
@@ -221,6 +421,378 @@ RegionVal02[4,3]=cb-tumblebug
 CONN_CONFIG[4,3]=azure-canadaeast
 IMAGE_NAME[4,3]=Canonical:UbuntuServer:18.04-LTS:latest
 SPEC_NAME[4,3]=Standard_B2s
+
+# region04 - East Asia
+RegionName[4,4]=azure-eastasia
+RegionKey01[4,4]=location
+RegionVal01[4,4]=eastasia
+RegionKey02[4,4]=ResourceGroup
+RegionVal02[4,4]=cb-tumblebug
+CONN_CONFIG[4,4]=azure-eastasia
+IMAGE_NAME[4,4]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,4]=Standard_B2s
+
+# region05 - Southeast Asia
+RegionName[4,5]=azure-southeastasia
+RegionKey01[4,5]=location
+RegionVal01[4,5]=southeastasia
+RegionKey02[4,5]=ResourceGroup
+RegionVal02[4,5]=cb-tumblebug
+CONN_CONFIG[4,5]=azure-southeastasia
+IMAGE_NAME[4,5]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,5]=Standard_B2s
+
+# region06 - Central US
+RegionName[4,6]=azure-centralus
+RegionKey01[4,6]=location
+RegionVal01[4,6]=centralus
+RegionKey02[4,6]=ResourceGroup
+RegionVal02[4,6]=cb-tumblebug
+CONN_CONFIG[4,6]=azure-centralus
+IMAGE_NAME[4,6]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,6]=Standard_B2s
+
+# region07 - East US
+RegionName[4,7]=azure-eastus
+RegionKey01[4,7]=location
+RegionVal01[4,7]=eastus
+RegionKey02[4,7]=ResourceGroup
+RegionVal02[4,7]=cb-tumblebug
+CONN_CONFIG[4,7]=azure-eastus
+IMAGE_NAME[4,7]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,7]=Standard_B2s
+
+# region08 - East US 2
+RegionName[4,8]=azure-eastus2
+RegionKey01[4,8]=location
+RegionVal01[4,8]=eastus2
+RegionKey02[4,8]=ResourceGroup
+RegionVal02[4,8]=cb-tumblebug
+CONN_CONFIG[4,8]=azure-eastus2
+IMAGE_NAME[4,8]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,8]=Standard_B2s
+
+# region09 - West US
+RegionName[4,9]=azure-westus
+RegionKey01[4,9]=location
+RegionVal01[4,9]=westus
+RegionKey02[4,9]=ResourceGroup
+RegionVal02[4,9]=cb-tumblebug
+CONN_CONFIG[4,9]=azure-westus
+IMAGE_NAME[4,9]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,9]=Standard_B2s
+
+# region10 - South Central US
+RegionName[4,10]=azure-southcentralus
+RegionKey01[4,10]=location
+RegionVal01[4,10]=southcentralus
+RegionKey02[4,10]=ResourceGroup
+RegionVal02[4,10]=cb-tumblebug
+CONN_CONFIG[4,10]=azure-southcentralus
+IMAGE_NAME[4,10]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,10]=Standard_B2s
+
+# region11 - North Europe
+RegionName[4,11]=azure-northeurope
+RegionKey01[4,11]=location
+RegionVal01[4,11]=northeurope
+RegionKey02[4,11]=ResourceGroup
+RegionVal02[4,11]=cb-tumblebug
+CONN_CONFIG[4,11]=azure-northeurope
+IMAGE_NAME[4,11]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,11]=Standard_B2s
+
+# region12 - West Europe
+RegionName[4,12]=azure-westeurope
+RegionKey01[4,12]=location
+RegionVal01[4,12]=westeurope
+RegionKey02[4,12]=ResourceGroup
+RegionVal02[4,12]=cb-tumblebug
+CONN_CONFIG[4,12]=azure-westeurope
+IMAGE_NAME[4,12]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,12]=Standard_B2s
+
+# region13 - Japan West
+RegionName[4,13]=azure-japanwest
+RegionKey01[4,13]=location
+RegionVal01[4,13]=japanwest
+RegionKey02[4,13]=ResourceGroup
+RegionVal02[4,13]=cb-tumblebug
+CONN_CONFIG[4,13]=azure-japanwest
+IMAGE_NAME[4,13]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,13]=Standard_B2s
+
+# region14 - Japan East
+RegionName[4,14]=azure-japaneast
+RegionKey01[4,14]=location
+RegionVal01[4,14]=japaneast
+RegionKey02[4,14]=ResourceGroup
+RegionVal02[4,14]=cb-tumblebug
+CONN_CONFIG[4,14]=azure-japaneast
+IMAGE_NAME[4,14]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,14]=Standard_B2s
+
+# region15 - Brazil South
+RegionName[4,15]=azure-brazilsouth
+RegionKey01[4,15]=location
+RegionVal01[4,15]=brazilsouth
+RegionKey02[4,15]=ResourceGroup
+RegionVal02[4,15]=cb-tumblebug
+CONN_CONFIG[4,15]=azure-brazilsouth
+IMAGE_NAME[4,15]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,15]=Standard_B2s
+
+# region16 - Australia East
+RegionName[4,16]=azure-australiaeast
+RegionKey01[4,16]=location
+RegionVal01[4,16]=australiaeast
+RegionKey02[4,16]=ResourceGroup
+RegionVal02[4,16]=cb-tumblebug
+CONN_CONFIG[4,16]=azure-australiaeast
+IMAGE_NAME[4,16]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,16]=Standard_B2s
+
+# region17 - Australia Southeast
+RegionName[4,17]=azure-australiasoutheast
+RegionKey01[4,17]=location
+RegionVal01[4,17]=australiasoutheast
+RegionKey02[4,17]=ResourceGroup
+RegionVal02[4,17]=cb-tumblebug
+CONN_CONFIG[4,17]=azure-australiasoutheast
+IMAGE_NAME[4,17]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,17]=Standard_B2s
+
+# region18 - South India
+RegionName[4,18]=azure-southindia
+RegionKey01[4,18]=location
+RegionVal01[4,18]=southindia
+RegionKey02[4,18]=ResourceGroup
+RegionVal02[4,18]=cb-tumblebug
+CONN_CONFIG[4,18]=azure-southindia
+IMAGE_NAME[4,18]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,18]=Standard_B2s
+
+# region19 - Central India
+RegionName[4,19]=azure-centralindia
+RegionKey01[4,19]=location
+RegionVal01[4,19]=centralindia
+RegionKey02[4,19]=ResourceGroup
+RegionVal02[4,19]=cb-tumblebug
+CONN_CONFIG[4,19]=azure-centralindia
+IMAGE_NAME[4,19]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,19]=Standard_B2s
+
+# region20 - West India
+RegionName[4,20]=azure-westindia
+RegionKey01[4,20]=location
+RegionVal01[4,20]=westindia
+RegionKey02[4,20]=ResourceGroup
+RegionVal02[4,20]=cb-tumblebug
+CONN_CONFIG[4,20]=azure-westindia
+IMAGE_NAME[4,20]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,20]=Standard_B2s
+
+# region21 - Canada Central
+RegionName[4,21]=azure-canadacentral
+RegionKey01[4,21]=location
+RegionVal01[4,21]=canadacentral
+RegionKey02[4,21]=ResourceGroup
+RegionVal02[4,21]=cb-tumblebug
+CONN_CONFIG[4,21]=azure-canadacentral
+IMAGE_NAME[4,21]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,21]=Standard_B2s
+
+# region22 - UK South
+RegionName[4,22]=azure-uksouth
+RegionKey01[4,22]=location
+RegionVal01[4,22]=uksouth
+RegionKey02[4,22]=ResourceGroup
+RegionVal02[4,22]=cb-tumblebug
+CONN_CONFIG[4,22]=azure-uksouth
+IMAGE_NAME[4,22]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,22]=Standard_B2s
+
+# region23 - UK West
+RegionName[4,23]=azure-ukwest
+RegionKey01[4,23]=location
+RegionVal01[4,23]=ukwest
+RegionKey02[4,23]=ResourceGroup
+RegionVal02[4,23]=cb-tumblebug
+CONN_CONFIG[4,23]=azure-ukwest
+IMAGE_NAME[4,23]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,23]=Standard_B2s
+
+# region24 - West Central US
+RegionName[4,24]=azure-westcentralus
+RegionKey01[4,24]=location
+RegionVal01[4,24]=westcentralus
+RegionKey02[4,24]=ResourceGroup
+RegionVal02[4,24]=cb-tumblebug
+CONN_CONFIG[4,24]=azure-westcentralus
+IMAGE_NAME[4,24]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,24]=Standard_B2s
+
+# region25 - West US 2
+RegionName[4,25]=azure-westus2
+RegionKey01[4,25]=location
+RegionVal01[4,25]=westus2
+RegionKey02[4,25]=ResourceGroup
+RegionVal02[4,25]=cb-tumblebug
+CONN_CONFIG[4,25]=azure-westus2
+IMAGE_NAME[4,25]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,25]=Standard_B2s
+
+# region26 - Korea South
+RegionName[4,26]=azure-koreasouth
+RegionKey01[4,26]=location
+RegionVal01[4,26]=koreasouth
+RegionKey02[4,26]=ResourceGroup
+RegionVal02[4,26]=cb-tumblebug
+CONN_CONFIG[4,26]=azure-koreasouth
+IMAGE_NAME[4,26]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,26]=Standard_B2s
+
+# region27 - France Central
+RegionName[4,27]=azure-francecentral
+RegionKey01[4,27]=location
+RegionVal01[4,27]=francecentral
+RegionKey02[4,27]=ResourceGroup
+RegionVal02[4,27]=cb-tumblebug
+CONN_CONFIG[4,27]=azure-francecentral
+IMAGE_NAME[4,27]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,27]=Standard_B2s
+
+# region28 - France South
+RegionName[4,28]=azure-francesouth
+RegionKey01[4,28]=location
+RegionVal01[4,28]=francesouth
+RegionKey02[4,28]=ResourceGroup
+RegionVal02[4,28]=cb-tumblebug
+CONN_CONFIG[4,28]=azure-francesouth
+IMAGE_NAME[4,28]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,28]=Standard_B2s
+
+# region29 - Australia Central
+RegionName[4,29]=azure-australiacentral
+RegionKey01[4,29]=location
+RegionVal01[4,29]=australiacentral
+RegionKey02[4,29]=ResourceGroup
+RegionVal02[4,29]=cb-tumblebug
+CONN_CONFIG[4,29]=azure-australiacentral
+IMAGE_NAME[4,29]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,29]=Standard_B2s
+
+# region30 - Australia Central 2
+RegionName[4,30]=azure-australiacentral2
+RegionKey01[4,30]=location
+RegionVal01[4,30]=australiacentral2
+RegionKey02[4,30]=ResourceGroup
+RegionVal02[4,30]=cb-tumblebug
+CONN_CONFIG[4,30]=azure-australiacentral2
+IMAGE_NAME[4,30]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,30]=Standard_B2s
+
+# region31 - UAE Central
+RegionName[4,31]=azure-uaecentral
+RegionKey01[4,31]=location
+RegionVal01[4,31]=uaecentral
+RegionKey02[4,31]=ResourceGroup
+RegionVal02[4,31]=cb-tumblebug
+CONN_CONFIG[4,31]=azure-uaecentral
+IMAGE_NAME[4,31]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,31]=Standard_B2s
+
+# region32 - UAE North
+RegionName[4,32]=azure-uaenorth
+RegionKey01[4,32]=location
+RegionVal01[4,32]=uaenorth
+RegionKey02[4,32]=ResourceGroup
+RegionVal02[4,32]=cb-tumblebug
+CONN_CONFIG[4,32]=azure-uaenorth
+IMAGE_NAME[4,32]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,32]=Standard_B2s
+
+# region33 - South Africa North
+RegionName[4,33]=azure-southafricanorth
+RegionKey01[4,33]=location
+RegionVal01[4,33]=southafricanorth
+RegionKey02[4,33]=ResourceGroup
+RegionVal02[4,33]=cb-tumblebug
+CONN_CONFIG[4,33]=azure-southafricanorth
+IMAGE_NAME[4,33]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,33]=Standard_B2s
+
+# region34 - South Africa West
+RegionName[4,34]=azure-southafricawest
+RegionKey01[4,34]=location
+RegionVal01[4,34]=southafricawest
+RegionKey02[4,34]=ResourceGroup
+RegionVal02[4,34]=cb-tumblebug
+CONN_CONFIG[4,34]=azure-southafricawest
+IMAGE_NAME[4,34]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,34]=Standard_B2s
+
+# region35 - Switzerland North
+RegionName[4,35]=azure-switzerlandnorth
+RegionKey01[4,35]=location
+RegionVal01[4,35]=switzerlandnorth
+RegionKey02[4,35]=ResourceGroup
+RegionVal02[4,35]=cb-tumblebug
+CONN_CONFIG[4,35]=azure-switzerlandnorth
+IMAGE_NAME[4,35]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,35]=Standard_B2s
+
+# region36 - Switzerland West
+RegionName[4,36]=azure-switzerlandwest
+RegionKey01[4,36]=location
+RegionVal01[4,36]=switzerlandwest
+RegionKey02[4,36]=ResourceGroup
+RegionVal02[4,36]=cb-tumblebug
+CONN_CONFIG[4,36]=azure-switzerlandwest
+IMAGE_NAME[4,36]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,36]=Standard_B2s
+
+# region37 - Germany North
+RegionName[4,37]=azure-germanynorth
+RegionKey01[4,37]=location
+RegionVal01[4,37]=germanynorth
+RegionKey02[4,37]=ResourceGroup
+RegionVal02[4,37]=cb-tumblebug
+CONN_CONFIG[4,37]=azure-germanynorth
+IMAGE_NAME[4,37]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,37]=Standard_B2s
+
+# region38 - Germany West Central
+RegionName[4,38]=azure-germanywestcentral
+RegionKey01[4,38]=location
+RegionVal01[4,38]=germanywestcentral
+RegionKey02[4,38]=ResourceGroup
+RegionVal02[4,38]=cb-tumblebug
+CONN_CONFIG[4,38]=azure-germanywestcentral
+IMAGE_NAME[4,38]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,38]=Standard_B2s
+
+# region39 - Norway West
+RegionName[4,39]=azure-norwaywest
+RegionKey01[4,39]=location
+RegionVal01[4,39]=norwaywest
+RegionKey02[4,39]=ResourceGroup
+RegionVal02[4,39]=cb-tumblebug
+CONN_CONFIG[4,39]=azure-norwaywest
+IMAGE_NAME[4,39]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,39]=Standard_B2s
+
+# region40 - Norway East
+RegionName[4,40]=azure-norwayeast
+RegionKey01[4,40]=location
+RegionVal01[4,40]=norwayeast
+RegionKey02[4,40]=ResourceGroup
+RegionVal02[4,40]=cb-tumblebug
+CONN_CONFIG[4,40]=azure-norwayeast
+IMAGE_NAME[4,40]=Canonical:UbuntuServer:18.04-LTS:latest
+SPEC_NAME[4,40]=Standard_B2s
+
+
 
 
 ## Mock


### PR DESCRIPTION
- `conf.env` 에 등록되어 있는 region 수
  - Azure: 3개 => 40개
  - GCP: 3개 => 23개
- 주의사항
  - Tumblebug 테스트 스크립트를 CSP=all 로 실행할 때
  `conf.env` 에 등록되어 있는 region 들을 실제로 활용하려면
  `conf.env` 에서 다음 부분을 수정해야 할 것으로 보입니다.

```
## Number of CSP types and corresponding regions
NumCSP=4

CSPType[1]=aws
NumRegion[1]=8

CSPType[2]=alibaba
NumRegion[2]=1

CSPType[3]=gcp
NumRegion[3]=3

CSPType[4]=azure
NumRegion[4]=1

CSPType[5]=mock
NumRegion[5]=1
```
