### PR TITLE
Update REST API of LookupImage & LookupSpec

### DIFF
--- a/src/api/rest/server/mcir/image.go
+++ b/src/api/rest/server/mcir/image.go
@@ -94,6 +94,7 @@ func RestPutImage(c echo.Context) error {
 // Request structure for RestLookupImage
 type RestLookupImageRequest struct {
 	ConnectionName string `json:"connectionName"`
+	CspImageId     string `json:"cspImageId"`
 }
 
 // RestLookupImage godoc
@@ -107,7 +108,7 @@ type RestLookupImageRequest struct {
 // @Success 200 {object} mcir.SpiderImageInfo
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
-// @Router /lookupImage/{imageId} [get]
+// @Router /lookupImage [get]
 func RestLookupImage(c echo.Context) error {
 
 	u := &RestLookupImageRequest{}
@@ -115,9 +116,8 @@ func RestLookupImage(c echo.Context) error {
 		return err
 	}
 
-	imageId := c.Param("imageId")
-	fmt.Println("[Lookup image]" + imageId)
-	content, err := mcir.LookupImage(u.ConnectionName, imageId)
+	fmt.Println("[Lookup image]" + u.CspImageId)
+	content, err := mcir.LookupImage(u.ConnectionName, u.CspImageId)
 	if err != nil {
 		common.CBLog.Error(err)
 		return c.JSONBlob(http.StatusNotFound, []byte(err.Error()))
@@ -137,7 +137,7 @@ func RestLookupImage(c echo.Context) error {
 // @Success 200 {object} mcir.SpiderImageList
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
-// @Router /lookupImage [get]
+// @Router /lookupImages [get]
 func RestLookupImageList(c echo.Context) error {
 
 	//type JsonTemplate struct {

--- a/src/api/rest/server/mcir/spec.go
+++ b/src/api/rest/server/mcir/spec.go
@@ -111,6 +111,7 @@ func RestPutSpec(c echo.Context) error {
 // Request structure for RestLookupSpec
 type RestLookupSpecRequest struct {
 	ConnectionName string `json:"connectionName"`
+	CspSpecName    string `json:"cspSpecName"`
 }
 
 // RestLookupSpec godoc
@@ -124,7 +125,7 @@ type RestLookupSpecRequest struct {
 // @Success 200 {object} mcir.SpiderSpecInfo
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
-// @Router /lookupSpec/{specName} [get]
+// @Router /lookupSpec [get]
 func RestLookupSpec(c echo.Context) error {
 
 	u := &RestLookupSpecRequest{}
@@ -132,9 +133,8 @@ func RestLookupSpec(c echo.Context) error {
 		return err
 	}
 
-	specName := c.Param("specName")
-	fmt.Println("[Lookup spec]" + specName)
-	content, err := mcir.LookupSpec(u.ConnectionName, specName)
+	fmt.Println("[Lookup spec]" + u.CspSpecName)
+	content, err := mcir.LookupSpec(u.ConnectionName, u.CspSpecName)
 	if err != nil {
 		common.CBLog.Error(err)
 		return c.JSONBlob(http.StatusNotFound, []byte(err.Error()))
@@ -154,7 +154,7 @@ func RestLookupSpec(c echo.Context) error {
 // @Success 200 {object} mcir.SpiderSpecList
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
-// @Router /lookupSpec [get]
+// @Router /lookupSpecs [get]
 func RestLookupSpecList(c echo.Context) error {
 
 	//type JsonTemplate struct {

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -112,11 +112,11 @@ func ApiServer() {
 	e.GET("/tumblebug/region", rest_common.RestGetRegionList)
 	e.GET("/tumblebug/region/:regionName", rest_common.RestGetRegion)
 
-	e.GET("/tumblebug/lookupSpec", rest_mcir.RestLookupSpecList)
-	e.GET("/tumblebug/lookupSpec/:specName", rest_mcir.RestLookupSpec)
+	e.GET("/tumblebug/lookupSpecs", rest_mcir.RestLookupSpecList)
+	e.GET("/tumblebug/lookupSpec", rest_mcir.RestLookupSpec)
 
-	e.GET("/tumblebug/lookupImage", rest_mcir.RestLookupImageList)
-	e.GET("/tumblebug/lookupImage/:imageId", rest_mcir.RestLookupImage)
+	e.GET("/tumblebug/lookupImages", rest_mcir.RestLookupImageList)
+	e.GET("/tumblebug/lookupImage", rest_mcir.RestLookupImage)
 
 	e.GET("/tumblebug/webadmin", webadmin.Mainpage)
 	e.GET("/tumblebug/webadmin/menu", webadmin.Menu)
@@ -148,7 +148,7 @@ func ApiServer() {
 	g.PUT("/:nsId/mcis/:mcisId", rest_mcis.RestPutMcis)
 	g.DELETE("/:nsId/mcis/:mcisId", rest_mcis.RestDelMcis)
 	g.DELETE("/:nsId/mcis", rest_mcis.RestDelAllMcis)
-	
+
 	g.POST("/:nsId/mcis/:mcisId/vm", rest_mcis.RestPostMcisVm)
 	g.POST("/:nsId/mcis/:mcisId/vmgroup", rest_mcis.RestPostMcisVmGroup)
 	g.GET("/:nsId/mcis/:mcisId/vm/:vmId", rest_mcis.RestGetMcisVm)

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -185,52 +185,6 @@ var doc = `{
         },
         "/lookupImage": {
             "get": {
-                "description": "Lookup image list",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Image"
-                ],
-                "summary": "Lookup image list",
-                "parameters": [
-                    {
-                        "description": "Specify connectionName",
-                        "name": "connectionName",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/mcir.RestLookupImageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/mcir.SpiderImageList"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    }
-                }
-            }
-        },
-        "/lookupImage/{imageId}": {
-            "get": {
                 "description": "Lookup image",
                 "consumes": [
                     "application/json"
@@ -282,9 +236,9 @@ var doc = `{
                 }
             }
         },
-        "/lookupSpec": {
+        "/lookupImages": {
             "get": {
-                "description": "Lookup spec list",
+                "description": "Lookup image list",
                 "consumes": [
                     "application/json"
                 ],
@@ -292,9 +246,9 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "Image"
                 ],
-                "summary": "Lookup spec list",
+                "summary": "Lookup image list",
                 "parameters": [
                     {
                         "description": "Specify connectionName",
@@ -302,7 +256,7 @@ var doc = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestLookupSpecRequest"
+                            "$ref": "#/definitions/mcir.RestLookupImageRequest"
                         }
                     }
                 ],
@@ -310,7 +264,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.SpiderSpecList"
+                            "$ref": "#/definitions/mcir.SpiderImageList"
                         }
                     },
                     "404": {
@@ -328,7 +282,7 @@ var doc = `{
                 }
             }
         },
-        "/lookupSpec/{specName}": {
+        "/lookupSpec": {
             "get": {
                 "description": "Lookup spec",
                 "consumes": [
@@ -364,6 +318,52 @@ var doc = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/mcir.SpiderSpecInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/lookupSpecs": {
+            "get": {
+                "description": "Lookup spec list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Spec"
+                ],
+                "summary": "Lookup spec list",
+                "parameters": [
+                    {
+                        "description": "Specify connectionName",
+                        "name": "connectionName",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/mcir.RestLookupSpecRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcir.SpiderSpecList"
                         }
                     },
                     "404": {
@@ -3500,91 +3500,69 @@ var doc = `{
             "type": "object",
             "properties": {
                 "cost_per_hour": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "ebs_bw_Mbps": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_01": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_02": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_03": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_04": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_05": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_06": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_07": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_08": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_09": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_10": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "gpumem_GiB": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "max_num_storage": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "max_total_storage_TiB": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "mem_GiB": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "net_bw_Gbps": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "num_core": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "num_gpu": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "num_storage": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "num_vCPU": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "storage_GiB": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 }
             }
@@ -3671,6 +3649,9 @@ var doc = `{
             "properties": {
                 "connectionName": {
                     "type": "string"
+                },
+                "cspImageId": {
+                    "type": "string"
                 }
             }
         },
@@ -3678,6 +3659,9 @@ var doc = `{
             "type": "object",
             "properties": {
                 "connectionName": {
+                    "type": "string"
+                },
+                "cspSpecName": {
                     "type": "string"
                 }
             }
@@ -3719,7 +3703,6 @@ var doc = `{
                 },
                 "iid": {
                     "description": "Fields for response",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "keyValueList": {
@@ -3791,7 +3774,6 @@ var doc = `{
                     "type": "string"
                 },
                 "vcpu": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.SpiderVCpuInfo"
                 }
             }
@@ -3812,7 +3794,6 @@ var doc = `{
             "properties": {
                 "iid": {
                     "description": "{NameId, SystemId}",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "ipv4_CIDR": {
@@ -4293,11 +4274,9 @@ var doc = `{
                     "type": "string"
                 },
                 "postCommand": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.McisCmdReq"
                 },
                 "vm": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.TbVmInfo"
                 }
             }
@@ -4507,11 +4486,9 @@ var doc = `{
             "type": "object",
             "properties": {
                 "autoAction": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.AutoAction"
                 },
                 "autoCondition": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.AutoCondition"
                 },
                 "status": {
@@ -4630,18 +4607,15 @@ var doc = `{
             "properties": {
                 "iid": {
                     "description": "Fields for response",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "imageIId": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "imageName": {
                     "type": "string"
                 },
                 "keyPairIId": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "keyPairName": {
@@ -4675,7 +4649,6 @@ var doc = `{
                 },
                 "region": {
                     "description": "ex) {us-east1, us-east1-c} or {ap-northeast-2}",
-                    "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
                 "securityGroupIIds": {
@@ -4700,7 +4673,6 @@ var doc = `{
                 },
                 "subnetIID": {
                     "description": "AWS, ex) subnet-8c4a53e4",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "subnetName": {
@@ -4726,7 +4698,6 @@ var doc = `{
                     "type": "string"
                 },
                 "vpcIID": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "vpcname": {
@@ -4819,7 +4790,6 @@ var doc = `{
                     "type": "string"
                 },
                 "cspViewVmDetail": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.SpiderVMInfo"
                 },
                 "description": {
@@ -4835,7 +4805,6 @@ var doc = `{
                     "type": "string"
                 },
                 "location": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.GeoLocation"
                 },
                 "monAgentStatus": {
@@ -4860,7 +4829,6 @@ var doc = `{
                 },
                 "region": {
                     "description": "Provided by CB-Spider",
-                    "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
                 "securityGroupIds": {
@@ -4925,7 +4893,6 @@ var doc = `{
                     "type": "string"
                 },
                 "vm_spec": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.TbSpecInfo"
                 }
             }
@@ -4949,7 +4916,6 @@ var doc = `{
                     }
                 },
                 "vm_req": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.TbVmRecommendReq"
                 }
             }
@@ -5043,7 +5009,6 @@ var doc = `{
                     "type": "string"
                 },
                 "location": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.GeoLocation"
                 },
                 "monAgentStatus": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -170,52 +170,6 @@
         },
         "/lookupImage": {
             "get": {
-                "description": "Lookup image list",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Image"
-                ],
-                "summary": "Lookup image list",
-                "parameters": [
-                    {
-                        "description": "Specify connectionName",
-                        "name": "connectionName",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/mcir.RestLookupImageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/mcir.SpiderImageList"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    }
-                }
-            }
-        },
-        "/lookupImage/{imageId}": {
-            "get": {
                 "description": "Lookup image",
                 "consumes": [
                     "application/json"
@@ -267,9 +221,9 @@
                 }
             }
         },
-        "/lookupSpec": {
+        "/lookupImages": {
             "get": {
-                "description": "Lookup spec list",
+                "description": "Lookup image list",
                 "consumes": [
                     "application/json"
                 ],
@@ -277,9 +231,9 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "Image"
                 ],
-                "summary": "Lookup spec list",
+                "summary": "Lookup image list",
                 "parameters": [
                     {
                         "description": "Specify connectionName",
@@ -287,7 +241,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestLookupSpecRequest"
+                            "$ref": "#/definitions/mcir.RestLookupImageRequest"
                         }
                     }
                 ],
@@ -295,7 +249,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.SpiderSpecList"
+                            "$ref": "#/definitions/mcir.SpiderImageList"
                         }
                     },
                     "404": {
@@ -313,7 +267,7 @@
                 }
             }
         },
-        "/lookupSpec/{specName}": {
+        "/lookupSpec": {
             "get": {
                 "description": "Lookup spec",
                 "consumes": [
@@ -349,6 +303,52 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/mcir.SpiderSpecInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/lookupSpecs": {
+            "get": {
+                "description": "Lookup spec list",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Spec"
+                ],
+                "summary": "Lookup spec list",
+                "parameters": [
+                    {
+                        "description": "Specify connectionName",
+                        "name": "connectionName",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/mcir.RestLookupSpecRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcir.SpiderSpecList"
                         }
                     },
                     "404": {
@@ -3485,91 +3485,69 @@
             "type": "object",
             "properties": {
                 "cost_per_hour": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "ebs_bw_Mbps": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_01": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_02": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_03": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_04": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_05": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_06": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_07": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_08": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_09": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "evaluationScore_10": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "gpumem_GiB": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "max_num_storage": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "max_total_storage_TiB": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "mem_GiB": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "net_bw_Gbps": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "num_core": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "num_gpu": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "num_storage": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "num_vCPU": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 },
                 "storage_GiB": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.Range"
                 }
             }
@@ -3656,6 +3634,9 @@
             "properties": {
                 "connectionName": {
                     "type": "string"
+                },
+                "cspImageId": {
+                    "type": "string"
                 }
             }
         },
@@ -3663,6 +3644,9 @@
             "type": "object",
             "properties": {
                 "connectionName": {
+                    "type": "string"
+                },
+                "cspSpecName": {
                     "type": "string"
                 }
             }
@@ -3704,7 +3688,6 @@
                 },
                 "iid": {
                     "description": "Fields for response",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "keyValueList": {
@@ -3776,7 +3759,6 @@
                     "type": "string"
                 },
                 "vcpu": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.SpiderVCpuInfo"
                 }
             }
@@ -3797,7 +3779,6 @@
             "properties": {
                 "iid": {
                     "description": "{NameId, SystemId}",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "ipv4_CIDR": {
@@ -4278,11 +4259,9 @@
                     "type": "string"
                 },
                 "postCommand": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.McisCmdReq"
                 },
                 "vm": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.TbVmInfo"
                 }
             }
@@ -4492,11 +4471,9 @@
             "type": "object",
             "properties": {
                 "autoAction": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.AutoAction"
                 },
                 "autoCondition": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.AutoCondition"
                 },
                 "status": {
@@ -4615,18 +4592,15 @@
             "properties": {
                 "iid": {
                     "description": "Fields for response",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "imageIId": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "imageName": {
                     "type": "string"
                 },
                 "keyPairIId": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "keyPairName": {
@@ -4660,7 +4634,6 @@
                 },
                 "region": {
                     "description": "ex) {us-east1, us-east1-c} or {ap-northeast-2}",
-                    "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
                 "securityGroupIIds": {
@@ -4685,7 +4658,6 @@
                 },
                 "subnetIID": {
                     "description": "AWS, ex) subnet-8c4a53e4",
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "subnetName": {
@@ -4711,7 +4683,6 @@
                     "type": "string"
                 },
                 "vpcIID": {
-                    "type": "object",
                     "$ref": "#/definitions/common.IID"
                 },
                 "vpcname": {
@@ -4804,7 +4775,6 @@
                     "type": "string"
                 },
                 "cspViewVmDetail": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.SpiderVMInfo"
                 },
                 "description": {
@@ -4820,7 +4790,6 @@
                     "type": "string"
                 },
                 "location": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.GeoLocation"
                 },
                 "monAgentStatus": {
@@ -4845,7 +4814,6 @@
                 },
                 "region": {
                     "description": "Provided by CB-Spider",
-                    "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
                 "securityGroupIds": {
@@ -4910,7 +4878,6 @@
                     "type": "string"
                 },
                 "vm_spec": {
-                    "type": "object",
                     "$ref": "#/definitions/mcir.TbSpecInfo"
                 }
             }
@@ -4934,7 +4901,6 @@
                     }
                 },
                 "vm_req": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.TbVmRecommendReq"
                 }
             }
@@ -5028,7 +4994,6 @@
                     "type": "string"
                 },
                 "location": {
-                    "type": "object",
                     "$ref": "#/definitions/mcis.GeoLocation"
                 },
                 "monAgentStatus": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -73,70 +73,48 @@ definitions:
     properties:
       cost_per_hour:
         $ref: '#/definitions/mcir.Range'
-        type: object
       ebs_bw_Mbps:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_01:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_02:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_03:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_04:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_05:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_06:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_07:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_08:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_09:
         $ref: '#/definitions/mcir.Range'
-        type: object
       evaluationScore_10:
         $ref: '#/definitions/mcir.Range'
-        type: object
       gpumem_GiB:
         $ref: '#/definitions/mcir.Range'
-        type: object
       max_num_storage:
         $ref: '#/definitions/mcir.Range'
-        type: object
       max_total_storage_TiB:
         $ref: '#/definitions/mcir.Range'
-        type: object
       mem_GiB:
         $ref: '#/definitions/mcir.Range'
-        type: object
       net_bw_Gbps:
         $ref: '#/definitions/mcir.Range'
-        type: object
       num_core:
         $ref: '#/definitions/mcir.Range'
-        type: object
       num_gpu:
         $ref: '#/definitions/mcir.Range'
-        type: object
       num_storage:
         $ref: '#/definitions/mcir.Range'
-        type: object
       num_vCPU:
         $ref: '#/definitions/mcir.Range'
-        type: object
       storage_GiB:
         $ref: '#/definitions/mcir.Range'
-        type: object
     type: object
   mcir.Range:
     properties:
@@ -191,10 +169,14 @@ definitions:
     properties:
       connectionName:
         type: string
+      cspImageId:
+        type: string
     type: object
   mcir.RestLookupSpecRequest:
     properties:
       connectionName:
+        type: string
+      cspSpecName:
         type: string
     type: object
   mcir.RestSearchImageRequest:
@@ -223,7 +205,6 @@ definitions:
       iid:
         $ref: '#/definitions/common.IID'
         description: Fields for response
-        type: object
       keyValueList:
         items:
           $ref: '#/definitions/common.KeyValue'
@@ -271,7 +252,6 @@ definitions:
         type: string
       vcpu:
         $ref: '#/definitions/mcir.SpiderVCpuInfo'
-        type: object
     type: object
   mcir.SpiderSpecList:
     properties:
@@ -285,7 +265,6 @@ definitions:
       iid:
         $ref: '#/definitions/common.IID'
         description: '{NameId, SystemId}'
-        type: object
       ipv4_CIDR:
         type: string
       keyValueList:
@@ -602,10 +581,8 @@ definitions:
         type: string
       postCommand:
         $ref: '#/definitions/mcis.McisCmdReq'
-        type: object
       vm:
         $ref: '#/definitions/mcis.TbVmInfo'
-        type: object
     type: object
   mcis.AutoCondition:
     properties:
@@ -746,10 +723,8 @@ definitions:
     properties:
       autoAction:
         $ref: '#/definitions/mcis.AutoAction'
-        type: object
       autoCondition:
         $ref: '#/definitions/mcis.AutoCondition'
-        type: object
       status:
         type: string
     type: object
@@ -826,15 +801,12 @@ definitions:
       iid:
         $ref: '#/definitions/common.IID'
         description: Fields for response
-        type: object
       imageIId:
         $ref: '#/definitions/common.IID'
-        type: object
       imageName:
         type: string
       keyPairIId:
         $ref: '#/definitions/common.IID'
-        type: object
       keyPairName:
         type: string
       keyValueList:
@@ -858,7 +830,6 @@ definitions:
       region:
         $ref: '#/definitions/mcis.RegionInfo'
         description: ex) {us-east1, us-east1-c} or {ap-northeast-2}
-        type: object
       securityGroupIIds:
         description: AWS, ex) sg-0b7452563e1121bb6
         items:
@@ -876,7 +847,6 @@ definitions:
       subnetIID:
         $ref: '#/definitions/common.IID'
         description: AWS, ex) subnet-8c4a53e4
-        type: object
       subnetName:
         type: string
       vmblockDisk:
@@ -895,7 +865,6 @@ definitions:
         type: string
       vpcIID:
         $ref: '#/definitions/common.IID'
-        type: object
       vpcname:
         type: string
     type: object
@@ -959,7 +928,6 @@ definitions:
         type: string
       cspViewVmDetail:
         $ref: '#/definitions/mcis.SpiderVMInfo'
-        type: object
       description:
         type: string
       id:
@@ -970,7 +938,6 @@ definitions:
         type: string
       location:
         $ref: '#/definitions/mcis.GeoLocation'
-        type: object
       monAgentStatus:
         description: Montoring agent status
         example: '[installed, notInstalled, failed]'
@@ -988,7 +955,6 @@ definitions:
       region:
         $ref: '#/definitions/mcis.RegionInfo'
         description: Provided by CB-Spider
-        type: object
       securityGroupIds:
         items:
           type: string
@@ -1033,7 +999,6 @@ definitions:
         type: string
       vm_spec:
         $ref: '#/definitions/mcir.TbSpecInfo'
-        type: object
     type: object
   mcis.TbVmRecommendInfo:
     properties:
@@ -1049,7 +1014,6 @@ definitions:
         type: array
       vm_req:
         $ref: '#/definitions/mcis.TbVmRecommendReq'
-        type: object
     type: object
   mcis.TbVmRecommendReq:
     properties:
@@ -1112,7 +1076,6 @@ definitions:
         type: string
       location:
         $ref: '#/definitions/mcis.GeoLocation'
-        type: object
       monAgentStatus:
         description: Montoring agent status
         example: '[installed, notInstalled, failed]'
@@ -1251,36 +1214,6 @@ paths:
     get:
       consumes:
       - application/json
-      description: Lookup image list
-      parameters:
-      - description: Specify connectionName
-        in: body
-        name: connectionName
-        required: true
-        schema:
-          $ref: '#/definitions/mcir.RestLookupImageRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/mcir.SpiderImageList'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/common.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/common.SimpleMsg'
-      summary: Lookup image list
-      tags:
-      - Image
-  /lookupImage/{imageId}:
-    get:
-      consumes:
-      - application/json
       description: Lookup image
       parameters:
       - description: Specify connectionName
@@ -1312,25 +1245,25 @@ paths:
       summary: Lookup image
       tags:
       - Image
-  /lookupSpec:
+  /lookupImages:
     get:
       consumes:
       - application/json
-      description: Lookup spec list
+      description: Lookup image list
       parameters:
       - description: Specify connectionName
         in: body
         name: connectionName
         required: true
         schema:
-          $ref: '#/definitions/mcir.RestLookupSpecRequest'
+          $ref: '#/definitions/mcir.RestLookupImageRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.SpiderSpecList'
+            $ref: '#/definitions/mcir.SpiderImageList'
         "404":
           description: Not Found
           schema:
@@ -1339,10 +1272,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/common.SimpleMsg'
-      summary: Lookup spec list
+      summary: Lookup image list
       tags:
-      - Spec
-  /lookupSpec/{specName}:
+      - Image
+  /lookupSpec:
     get:
       consumes:
       - application/json
@@ -1375,6 +1308,36 @@ paths:
           schema:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup spec
+      tags:
+      - Spec
+  /lookupSpecs:
+    get:
+      consumes:
+      - application/json
+      description: Lookup spec list
+      parameters:
+      - description: Specify connectionName
+        in: body
+        name: connectionName
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.RestLookupSpecRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.SpiderSpecList'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Lookup spec list
       tags:
       - Spec
   /ns:

--- a/test/official/6.image/lookupImage.sh
+++ b/test/official/6.image/lookupImage.sh
@@ -22,9 +22,10 @@
 	getCloudIndex $CSP
 
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupImage/${IMAGE_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupImage -H 'Content-Type: application/json' -d \
 		'{ 
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
+			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
+            "cspImageId": "'${IMAGE_NAME[$INDEX,$REGION]}'"
 		}' | json_pp #|| return 1
 #}
 

--- a/test/official/6.image/lookupImageList.sh
+++ b/test/official/6.image/lookupImageList.sh
@@ -21,7 +21,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupImages -H 'Content-Type: application/json' -d \
 		'{ 
 			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
 		}' | json_pp #|| return 1

--- a/test/official/7.spec/lookupSpec.sh
+++ b/test/official/7.spec/lookupSpec.sh
@@ -22,9 +22,10 @@
 	getCloudIndex $CSP
 
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
 		'{ 
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
+			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
+            "cspSpecName": "'${SPEC_NAME[$INDEX,$REGION]}'"
 		}' | json_pp #|| return 1
 #}
 

--- a/test/official/7.spec/lookupSpecList.sh
+++ b/test/official/7.spec/lookupSpecList.sh
@@ -21,7 +21,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpecs -H 'Content-Type: application/json' -d \
 		'{ 
 			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
 		}' | json_pp #|| return 1


### PR DESCRIPTION
- Related issue: GCP image lookup fails (#442)
- Related issue: How to lookup GCP VM image info? (https://github.com/cloud-barista/cb-spider/issues/339)

Tumblebug 에 LookupImage 함수가 있습니다. (호출되면 Spider 에 Lookup 요청 보냄)

그런데, LookupImage 에 대한 REST API 를 호출하면, Tumblebug 이 Spider 를 호출하지 않고 바로 404 Not Found 를 리턴하는 현상이 있었습니다.
(GCP 의 `cspImageId` 가 URL 형식이라서 발생하는 현상으로 추정)

[요청]
`GET http://$TumblebugServer/tumblebug/lookupImage/https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024`
```JSON
{
  "connectionName": "gcp-asia-east1"
}
```

[응답]
```JSON
{
  "message": "Not Found"
}
```

---

그래서, `cspImageId` 를 
GET 요청의 URL 이 아니라
JSON 바디에 넣는 것으로 바꾸니

[요청]
`GET http://$TumblebugServer/tumblebug/lookupImage`
```JSON
{
  "connectionName": "gcp-asia-east1",
  "cspImageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
}
```

이 현상이 사라졌습니다. (Tumblebug 이 404 에러를 리턴하지 않고, Spider 를 호출함. 하지만 이번에는 Spider 가 404 를 리턴함)

---

[REST API 변경사항]

- `func RestLookupImage`
  - GET /lookupImage/{imageId} => /lookupImage
  - 요청의 JSON 바디에 `cspImageId` 를 명시해야 함
- `func RestLookupImageList`
  - GET /lookupImage => /lookupImages
- `func RestLookupSpec`
  - GET /lookupSpec/{specId} => /lookupSpec
  - 요청의 JSON 바디에 `cspSpecName` 을 명시해야 함
- `func RestLookupSpecList`
  - GET /lookupSpec => /lookupSpecs
