### PR TITLE
Add URL encoding for Spider image lookup API call

### DIFF
--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -3,6 +3,7 @@ package mcir
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -348,7 +349,7 @@ func LookupImage(connConfig string, imageId string) (SpiderImageInfo, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-		url := common.SPIDER_REST_URL + "/vmimage/" + imageId
+		url := common.SPIDER_REST_URL + "/vmimage/" + url.QueryEscape(imageId)
 
 		// Create Req body
 		type JsonTemplate struct {

--- a/test/official/6.image/registerImageWithId.sh
+++ b/test/official/6.image/registerImageWithId.sh
@@ -21,7 +21,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d \
+	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithId -H 'Content-Type: application/json' -d \
 		'{ 
 			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",


### PR DESCRIPTION
- Related issue comment: https://github.com/cloud-barista/cb-spider/issues/339#issuecomment-813383531
- Resolves https://github.com/cloud-barista/cb-spider/issues/339
- 필요 시, PR #444 를 롤백 할 수도 있습니다.

[테스트 결과]

`❯ ./lookupImage.sh gcp 1 jhseo`

```JSON
{
   "Name" : "",
   "Status" : "READY",
   "KeyValueList" : [
      {
         "Key" : "Name",
         "Value" : "ubuntu-minimal-1804-bionic-v20191024"
      },
      {
         "Value" : "",
         "Key" : "SourceImage"
      },
      {
         "Key" : "SourceType",
         "Value" : "RAW"
      },
      {
         "Value" : "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024",
         "Key" : "SelfLink"
      },
      {
         "Key" : "Family",
         "Value" : "ubuntu-minimal-1804-lts"
      },
      {
         "Key" : "DiskSizeGb",
         "Value" : "10"
      }
   ],
   "IId" : {
      "SystemId" : "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024",
      "NameId" : "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
   },
   "GuestOS" : "ubuntu-minimal-1804-lts"
}
```