### PR TITLE
Update test scripts

### DIFF
--- a/test/official/1.configureSpider/get-cloud.sh
+++ b/test/official/1.configureSpider/get-cloud.sh
@@ -47,20 +47,23 @@
     RESTSERVER=localhost
 
     # for Cloud Connection Config Info
-    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | json_pp
+    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | jq
+    echo ""
 
 
     # for Cloud Region Info
-    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]} | json_pp
+    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]} | jq
+    echo ""
 
 
     # for Cloud Credential Info
-    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/credential/${CredentialName[INDEX]} | json_pp
+    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/credential/${CredentialName[INDEX]} | jq
+    echo ""
 
     
     # for Cloud Driver Info
-    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/driver/${DriverName[INDEX]} | json_pp
-
+    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/driver/${DriverName[INDEX]} | jq
+    echo ""
 #}
 
 #get_cloud

--- a/test/official/1.configureSpider/list-cloud.sh
+++ b/test/official/1.configureSpider/list-cloud.sh
@@ -29,19 +29,23 @@
     RESTSERVER=localhost
 
     # for Cloud Connection Config Info
-    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/connectionconfig | json_pp
+    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/connectionconfig | jq
+    echo ""
 
 
     # for Cloud Region Info
-    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/region | json_pp
+    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/region | jq
+    echo ""
 
 
     # for Cloud Credential Info
-    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/credential | json_pp
-
+    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/credential | jq
+    echo ""
+    
     
     # for Cloud Driver Info
-    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/driver | json_pp
+    curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/driver | jq
+    echo ""
 #}
 
 #list_cloud

--- a/test/official/1.configureSpider/register-cloud.sh
+++ b/test/official/1.configureSpider/register-cloud.sh
@@ -39,89 +39,108 @@
     RESTSERVER=localhost
 
     # for Cloud Driver Info
-    curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/driver -H 'Content-Type: application/json' -d \
-        '{
-            "ProviderName" : "'${ProviderName[INDEX]}'",
-            "DriverLibFileName" : "'${DriverLibFileName[INDEX]}'",
-            "DriverName" : "'${DriverName[INDEX]}'"
-        }' | json_pp
+    resp=$(
+        curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/driver -H 'Content-Type: application/json' -d @- <<EOF
+        {
+             "ProviderName" : "${ProviderName[INDEX]}",
+             "DriverLibFileName" : "${DriverLibFileName[INDEX]}",
+             "DriverName" : "${DriverName[INDEX]}"
+         }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 
     # for Cloud Credential Info
-    curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/credential -H 'Content-Type: application/json' -d \
-        "{
-            \"ProviderName\" : \"${ProviderName[INDEX]}\",
-            \"CredentialName\" : \"${CredentialName[INDEX]}\",
-            \"KeyValueInfoList\" : [
-                {
-                    \"Key\" : \"${CredentialKey01[INDEX]:-NULL}\",
-                    \"Value\" : \"${CredentialVal01[INDEX]:-NULL}\"
-                },
-                {
-                    \"Key\" : \"${CredentialKey02[INDEX]:-NULL}\",
-                    \"Value\" : \"${CredentialVal02[INDEX]:-NULL}\"
-                },
-                {
-                    \"Key\" : \"${CredentialKey03[INDEX]:-NULL}\",
-                    \"Value\" : \"${CredentialVal03[INDEX]:-NULL}\"
-                },
-                {
-                    \"Key\" : \"${CredentialKey04[INDEX]:-NULL}\",
-                    \"Value\" : \"${CredentialVal04[INDEX]:-NULL}\"
-                },
-                {
-                    \"Key\" : \"${CredentialKey05[INDEX]:-NULL}\",
-                    \"Value\" : \"${CredentialVal05[INDEX]:-NULL}\"
-                }
-            ]
-        }" | json_pp | head -n2
+    resp=$(
+        curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/credential -H 'Content-Type: application/json' -d @- <<EOF
+        {
+             "ProviderName" : "${ProviderName[INDEX]}",
+             "CredentialName" : "${CredentialName[INDEX]}",
+             "KeyValueInfoList" : [
+                 {
+                     "Key" : "${CredentialKey01[INDEX]:-NULL}",
+                     "Value" : "${CredentialVal01[INDEX]:-NULL}"
+                 },
+                 {
+                     "Key" : "${CredentialKey02[INDEX]:-NULL}",
+                     "Value" : "${CredentialVal02[INDEX]:-NULL}"
+                 },
+                 {
+                     "Key" : "${CredentialKey03[INDEX]:-NULL}",
+                     "Value" : "${CredentialVal03[INDEX]:-NULL}"
+                 },
+                 {
+                     "Key" : "${CredentialKey04[INDEX]:-NULL}",
+                     "Value" : "${CredentialVal04[INDEX]:-NULL}"
+                 },
+                 {
+                     "Key" : "${CredentialKey05[INDEX]:-NULL}",
+                     "Value" : "${CredentialVal05[INDEX]:-NULL}"
+                 }
+             ]
+         }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 
     # for Cloud Region Info
-
+    # Differenciate Cloud Region Value for Resource Group Name
     if [ "${CSP}" == "azure" ]; then
-        # Differenciate Cloud Region Value for Resource Group Name
-        curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d \
-        '{
-            "ProviderName" : "'${ProviderName[INDEX]}'",
+        resp=$(
+            curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d @- <<EOF
+            {
+            "ProviderName" : "${ProviderName[INDEX]}",
             "KeyValueInfoList" : [
                 {
-                    "Key" : "'${RegionKey01[$INDEX,$REGION]:-NULL}'",
-                    "Value" : "'${RegionVal01[$INDEX,$REGION]:-NULL}'"
+                    "Key" : "${RegionKey01[$INDEX,$REGION]:-NULL}",
+                    "Value" : "${RegionVal01[$INDEX,$REGION]:-NULL}"
                 },
                 {
-                    "Key" : "'${RegionKey02[$INDEX,$REGION]:-NULL}'",
-                    "Value" : "'${RegionVal02[$INDEX,$REGION]:-NULL}'-'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
+                    "Key" : "${RegionKey02[$INDEX,$REGION]:-NULL}",
+                    "Value" : "${RegionVal02[$INDEX,$REGION]:-NULL}-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}"
                 }
             ],
-            "RegionName" : "'${RegionName[$INDEX,$REGION]}'"
-        }' | json_pp #| head -n1
+            "RegionName" : "${RegionName[$INDEX,$REGION]}"
+        }
+EOF
+        ); echo ${resp} | jq
+        echo ""
     else
-        curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d \
-        '{
-            "ProviderName" : "'${ProviderName[INDEX]}'",
+        resp=$(
+            curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/region -H 'Content-Type: application/json' -d @- <<EOF
+            {
+            "ProviderName" : "${ProviderName[INDEX]}",
             "KeyValueInfoList" : [
                 {
-                    "Key" : "'${RegionKey01[$INDEX,$REGION]:-NULL}'",
-                    "Value" : "'${RegionVal01[$INDEX,$REGION]:-NULL}'"
+                    "Key" : "${RegionKey01[$INDEX,$REGION]:-NULL}",
+                    "Value" : "${RegionVal01[$INDEX,$REGION]:-NULL}"
                 },
                 {
-                    "Key" : "'${RegionKey02[$INDEX,$REGION]:-NULL}'",
-                    "Value" : "'${RegionVal02[$INDEX,$REGION]:-NULL}'"
+                    "Key" : "${RegionKey02[$INDEX,$REGION]:-NULL}",
+                    "Value" : "${RegionVal02[$INDEX,$REGION]:-NULL}"
                 }
             ],
-            "RegionName" : "'${RegionName[$INDEX,$REGION]}'"
-        }' | json_pp #| head -n1
+            "RegionName" : "${RegionName[$INDEX,$REGION]}"
+        }
+EOF
+        ); echo ${resp} | jq
+        echo ""
     fi
 
 
     # for Cloud Connection Config Info
-    curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/connectionconfig -H 'Content-Type: application/json' -d \
-        '{
-            "CredentialName" : "'${CredentialName[INDEX]}'",
-            "ConfigName" : "'${CONN_CONFIG[$INDEX,$REGION]}'",
-            "ProviderName" : "'${ProviderName[INDEX]}'",
-            "DriverName" : "'${DriverName[INDEX]}'",
-            "RegionName" : "'${RegionName[$INDEX,$REGION]}'"
-        }' | json_pp
+    resp=$(
+        curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/connectionconfig -H 'Content-Type: application/json' -d @- <<EOF
+        {
+            "CredentialName" : "${CredentialName[INDEX]}",
+            "ConfigName" : "${CONN_CONFIG[$INDEX,$REGION]}",
+            "ProviderName" : "${ProviderName[INDEX]}",
+            "DriverName" : "${DriverName[INDEX]}",
+            "RegionName" : "${RegionName[$INDEX,$REGION]}"
+        }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #register_cloud

--- a/test/official/1.configureSpider/unregister-cloud.sh
+++ b/test/official/1.configureSpider/unregister-cloud.sh
@@ -47,16 +47,25 @@
 	fi
 	
 	# for Cloud Connection Config Info
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]}
+	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | jq
+    echo ""
+
 
 	# for Cloud Region Info
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]}
+	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/region/${RegionName[$INDEX,$REGION]} | jq
+    echo ""
+
 
 	# for Cloud Credential Info
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/credential/${CredentialName[INDEX]}
-	
+	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/credential/${CredentialName[INDEX]} | jq
+    echo ""
+
+
 	# for Cloud Driver Info
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/driver/${DriverName[INDEX]}
+	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/driver/${DriverName[INDEX]} | jq
+    echo ""
+
+
 #}
 
 #unregister_cloud

--- a/test/official/2.configureTumblebug/check-ns.sh
+++ b/test/official/2.configureTumblebug/check-ns.sh
@@ -24,7 +24,8 @@
 
     INDEX=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/checkNs/$NS_ID | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/checkNs/$NS_ID | jq
+    echo ""
 #}
 
 #get_ns

--- a/test/official/2.configureTumblebug/create-ns.sh
+++ b/test/official/2.configureTumblebug/create-ns.sh
@@ -24,11 +24,15 @@
 
 	INDEX=${1}
 
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns -H 'Content-Type: application/json' -d \
-		'{
-			"name": "'$NS_ID'",
+    resp=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns -H 'Content-Type: application/json' -d @- <<EOF
+        {
+			"name": "$NS_ID",
 			"description": "NameSpace for General Testing"
-		}' | json_pp #|| return 1
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #create_ns

--- a/test/official/2.configureTumblebug/delete-all-config.sh
+++ b/test/official/2.configureTumblebug/delete-all-config.sh
@@ -23,7 +23,8 @@
     echo "####################################################################"
 
 
-    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/config | json_pp #|| return 1
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/config | jq
+    echo ""
 #}
 
 #delete_ns

--- a/test/official/2.configureTumblebug/delete-all-ns.sh
+++ b/test/official/2.configureTumblebug/delete-all-ns.sh
@@ -24,7 +24,8 @@
 
     INDEX=${1}
 
-    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns | json_pp #|| return 1
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns | jq
+    echo ""
 #}
 
 #delete_ns

--- a/test/official/2.configureTumblebug/delete-ns.sh
+++ b/test/official/2.configureTumblebug/delete-ns.sh
@@ -24,7 +24,8 @@
 
     INDEX=${1}
 
-    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID | json_pp #|| return 1
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID | jq
+    echo ""
 #}
 
 #delete_ns

--- a/test/official/2.configureTumblebug/get-config.sh
+++ b/test/official/2.configureTumblebug/get-config.sh
@@ -24,7 +24,8 @@
 
     VAR=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/config/$VAR | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/config/$VAR | jq
+    echo ""
 #}
 
 #get_config

--- a/test/official/2.configureTumblebug/get-ns.sh
+++ b/test/official/2.configureTumblebug/get-ns.sh
@@ -24,7 +24,8 @@
 
     INDEX=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID | jq
+    echo ""
 #}
 
 #get_ns

--- a/test/official/2.configureTumblebug/list-config.sh
+++ b/test/official/2.configureTumblebug/list-config.sh
@@ -24,7 +24,8 @@
 
     INDEX=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/config | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/config | jq
+    echo ""
 #}
 
 #list_ns

--- a/test/official/2.configureTumblebug/list-ns.sh
+++ b/test/official/2.configureTumblebug/list-ns.sh
@@ -24,7 +24,8 @@
 
     INDEX=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns | jq
+    echo ""
 #}
 
 #list_ns

--- a/test/official/2.configureTumblebug/update-config.sh
+++ b/test/official/2.configureTumblebug/update-config.sh
@@ -25,11 +25,15 @@
 	KEY=${1}
 	VALUE=${2}
 
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/config -H 'Content-Type: application/json' -d \
-		'{
-			"name": "'${KEY}'",
-			"value": "'${VALUE}'"
-		}' | json_pp #|| return 1
+	resp=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/config -H 'Content-Type: application/json' -d @- <<EOF
+		{
+			"name": "${KEY}",
+			"value": "${VALUE}"
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #create_ns

--- a/test/official/3.vNet/create-vNet.sh
+++ b/test/official/3.vNet/create-vNet.sh
@@ -29,16 +29,20 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d \
-		'{
-			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
+    resp=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d @- <<EOF
+        {
+			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
 			"cidrBlock": "192.168.0.0/16",
 			"subnetInfoList": [ {
-				"Name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+				"Name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
 				"IPv4_CIDR": "192.168.1.0/24"
 			} ]
-		}' | json_pp #|| return 1
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #create_vNet

--- a/test/official/3.vNet/delete-vNet.sh
+++ b/test/official/3.vNet/delete-vNet.sh
@@ -29,10 +29,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
+    echo ""
 #}
 
 #delete_vNet

--- a/test/official/3.vNet/get-vNet.sh
+++ b/test/official/3.vNet/get-vNet.sh
@@ -29,10 +29,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
+    echo ""
 #}
 
 #get_vNet

--- a/test/official/3.vNet/list-vNet.sh
+++ b/test/official/3.vNet/list-vNet.sh
@@ -22,7 +22,8 @@
     echo "## 1. VPC: Get"
     echo "####################################################################"
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet | jq
+    echo ""
 #}
 
 #list_vNet

--- a/test/official/3.vNet/spider-create-vNet.sh
+++ b/test/official/3.vNet/spider-create-vNet.sh
@@ -29,20 +29,24 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/vpc -H 'Content-Type: application/json' -d \
-		'{
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-			"ReqInfo": {
-				"Name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-				"IPv4_CIDR": "192.168.0.0/16",
-				"SubnetInfoList": [ {
-					"Name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-					"IPv4_CIDR": "192.168.1.0/24"
+        resp=$(
+            curl -H "${AUTH}" -sX POST http://$SpiderServer/spider/vpc -H 'Content-Type: application/json' -d @- <<EOF
+            {
+                "ConnectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
+                "ReqInfo": {
+                    "Name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+                    "IPv4_CIDR": "192.168.0.0/16",
+                    "SubnetInfoList": [ {
+                        "Name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+                        "IPv4_CIDR": "192.168.1.0/24"
 
-				} ]
+                    } ]
 
-			}
-		}' #| json_pp #|| return 1
+                }
+            }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #create_vNet

--- a/test/official/3.vNet/spider-delete-vNet.sh
+++ b/test/official/3.vNet/spider-delete-vNet.sh
@@ -25,7 +25,12 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' #| json_pp
+	# curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' #| jq
+
+    resp=$(
+        curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' 
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #spider_get_vNet

--- a/test/official/3.vNet/spider-get-vNet.sh
+++ b/test/official/3.vNet/spider-get-vNet.sh
@@ -25,7 +25,13 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp
+	# curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | jq
+
+
+    resp=$(
+        curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' 
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #spider_get_vNet

--- a/test/official/3.vNet/testAddAsso.sh
+++ b/test/official/3.vNet/testAddAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/3.vNet/testDeleteAsso.sh
+++ b/test/official/3.vNet/testDeleteAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/3.vNet/testGetAssoCount.sh
+++ b/test/official/3.vNet/testGetAssoCount.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/4.securityGroup/create-securityGroup.sh
+++ b/test/official/4.securityGroup/create-securityGroup.sh
@@ -29,11 +29,12 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d \
-		'{
-			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-			"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+    resp=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup -H 'Content-Type: application/json' -d @- <<EOF
+        {
+			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
+			"vNetId": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
 			"description": "test description",
 				"firewallRules": [
 					{
@@ -49,7 +50,10 @@
 						"Direction": "inbound"
 					}
 				]
-			}' | json_pp #|| return 1
+			}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #create_securityGroup

--- a/test/official/4.securityGroup/delete-securityGroup.sh
+++ b/test/official/4.securityGroup/delete-securityGroup.sh
@@ -29,10 +29,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
+    echo ""
 #}
 
 #delete_securityGroup

--- a/test/official/4.securityGroup/get-securityGroup.sh
+++ b/test/official/4.securityGroup/get-securityGroup.sh
@@ -29,10 +29,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
+    echo ""
 #}
 
 #get_securityGroup

--- a/test/official/4.securityGroup/list-securityGroup.sh
+++ b/test/official/4.securityGroup/list-securityGroup.sh
@@ -23,7 +23,7 @@
     echo "####################################################################"
 
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/securityGroup | jq
 #}
 
 #list_securityGroup

--- a/test/official/4.securityGroup/spider-get-securityGroup.sh
+++ b/test/official/4.securityGroup/spider-get-securityGroup.sh
@@ -26,7 +26,7 @@
 	getCloudIndex $CSP
 
 
-	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/securitygroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | json_pp
+	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/securitygroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | jq
 #}
 
 #spider_get_securityGroup

--- a/test/official/4.securityGroup/testAddAsso.sh
+++ b/test/official/4.securityGroup/testAddAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/4.securityGroup/testDeleteAsso.sh
+++ b/test/official/4.securityGroup/testDeleteAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/4.securityGroup/testGetAssoCount.sh
+++ b/test/official/4.securityGroup/testGetAssoCount.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/5.sshKey/delete-sshKey.sh
+++ b/test/official/5.sshKey/delete-sshKey.sh
@@ -29,10 +29,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
+    echo ""
 #}
 
 #delete_sshKey

--- a/test/official/5.sshKey/force-delete-sshKey.sh
+++ b/test/official/5.sshKey/force-delete-sshKey.sh
@@ -29,10 +29,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true | jq
+    echo ""
 #}
 
 #force_delete_sshKey

--- a/test/official/5.sshKey/get-sshKey.sh
+++ b/test/official/5.sshKey/get-sshKey.sh
@@ -29,10 +29,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
+    echo ""
 #}
 
 #get_sshKey

--- a/test/official/5.sshKey/list-sshKey.sh
+++ b/test/official/5.sshKey/list-sshKey.sh
@@ -22,10 +22,8 @@
     echo "## 5. sshKey: List"
     echo "####################################################################"
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey -H 'Content-Type: application/json' -d \
-        '{ 
-            "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-        }' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/sshKey | jq
+    echo ""
 #}
 
 #list_sshKey

--- a/test/official/5.sshKey/spider-delete-sshKey.sh
+++ b/test/official/5.sshKey/spider-delete-sshKey.sh
@@ -25,11 +25,14 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp
+    resp=$(
+        curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d @- <<EOF
+        { 
+			"ConnectionName": "${CONN_CONFIG[$INDEX,$REGION]}"
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #spider_delete_sshKey

--- a/test/official/5.sshKey/spider-get-sshKey.sh
+++ b/test/official/5.sshKey/spider-get-sshKey.sh
@@ -25,11 +25,14 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-
-	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp
+    resp=$(
+        curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d @- <<EOF
+        { 
+			"ConnectionName": "${CONN_CONFIG[$INDEX,$REGION]}"
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #spider_get_sshKey

--- a/test/official/5.sshKey/testAddAsso.sh
+++ b/test/official/5.sshKey/testAddAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/5.sshKey/testDeleteAsso.sh
+++ b/test/official/5.sshKey/testDeleteAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/5.sshKey/testGetAssoCount.sh
+++ b/test/official/5.sshKey/testGetAssoCount.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/6.image/fetch-images.sh
+++ b/test/official/6.image/fetch-images.sh
@@ -22,7 +22,8 @@
     echo "## 6. image: Fetch"
     echo "####################################################################"
 
-    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/fetchImages | json_pp #|| return 1
+    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/fetchImages | jq
+    echo ""
 #}
 
 #fetch_images

--- a/test/official/6.image/get-image.sh
+++ b/test/official/6.image/get-image.sh
@@ -29,10 +29,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
+    echo ""
 #}
 
 #get_image

--- a/test/official/6.image/list-image.sh
+++ b/test/official/6.image/list-image.sh
@@ -23,7 +23,7 @@
     echo "####################################################################"
 
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image | jq #|| return 1
 #}
 
 #list_image

--- a/test/official/6.image/lookupImage.sh
+++ b/test/official/6.image/lookupImage.sh
@@ -30,11 +30,15 @@
 	getCloudIndex $CSP
 
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupImage -H 'Content-Type: application/json' -d \
-		'{ 
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-            "cspImageId": "'${IMAGE_NAME[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+	resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupImage -H 'Content-Type: application/json' -d @- <<EOF
+		{ 
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
+            "cspImageId": "${IMAGE_NAME[$INDEX,$REGION]}"
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #lookup_image

--- a/test/official/6.image/lookupImageList.sh
+++ b/test/official/6.image/lookupImageList.sh
@@ -29,10 +29,14 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupImages -H 'Content-Type: application/json' -d \
-		'{ 
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+	resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupImages -H 'Content-Type: application/json' -d @- <<EOF
+		{ 
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}"
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #lookup_spec_list

--- a/test/official/6.image/obsolete_registerImageWithInfo.sh
+++ b/test/official/6.image/obsolete_registerImageWithInfo.sh
@@ -29,11 +29,12 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d \
-        '{ 
-            "connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
-            "name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-            "cspImageId": "'${IMAGE_NAME[$INDEX,$REGION]}'",
+    resp=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d @- <<EOF
+        { 
+            "connectionName": "${CONN_CONFIG[$INDEX,$REGION]}", 
+            "name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+            "cspImageId": "${IMAGE_NAME[$INDEX,$REGION]}",
             "cspImageName": "",
             "creationDate": "",
             "description": "Canonical, Ubuntu, 18.04 LTS, amd64 bionic",
@@ -49,7 +50,10 @@
                     "Value": ""
                 }
             ]
-        }' | json_pp #|| return 1
+        }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #registerImageWithInfo

--- a/test/official/6.image/registerImageWithId.sh
+++ b/test/official/6.image/registerImageWithId.sh
@@ -29,14 +29,18 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d \
-		'{ 
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
-			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"cspImageId": "'${IMAGE_NAME[$INDEX,$REGION]}'",
+	resp=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d @- <<EOF
+		{ 
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}", 
+			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+			"cspImageId": "${IMAGE_NAME[$INDEX,$REGION]}",
 			"description": "Canonical, Ubuntu, 18.04 LTS, amd64 bionic",
             "guestOS": "Ubuntu"
-		}' | json_pp #|| return 1
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #registerImageWithId

--- a/test/official/6.image/spider-get-image.sh
+++ b/test/official/6.image/spider-get-image.sh
@@ -29,7 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmimage/${IMAGE_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
+	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmimage/${IMAGE_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | jq
 #}
 
 #spider_get_image

--- a/test/official/6.image/spider-get-imagelist.sh
+++ b/test/official/6.image/spider-get-imagelist.sh
@@ -29,7 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmimage -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
+	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmimage -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | jq
 #}
 
 #spider_get_image_list

--- a/test/official/6.image/test-search-image.sh
+++ b/test/official/6.image/test-search-image.sh
@@ -22,13 +22,17 @@
     echo "## 6. image: Search"
     echo "####################################################################"
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/searchImage -H 'Content-Type: application/json' -d \
-        '{ 
+    resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/searchImage -H 'Content-Type: application/json' -d @- <<EOF
+        { 
             "keywords": [
                     "ubuntu",
                     "18.04"
             ]
-        }' | json_pp #|| return 1
+        }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #registerImageWithInfo

--- a/test/official/6.image/testAddAsso.sh
+++ b/test/official/6.image/testAddAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/6.image/testDeleteAsso.sh
+++ b/test/official/6.image/testDeleteAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/6.image/testGetAssoCount.sh
+++ b/test/official/6.image/testGetAssoCount.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/6.image/unregister-all-images.sh
+++ b/test/official/6.image/unregister-all-images.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image #-H 'Content-Type: application/json' -d \
-#		'{ 
-#			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-#		}' | json_pp #|| return 1
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image | jq
 
 #}
 

--- a/test/official/6.image/unregister-image.sh
+++ b/test/official/6.image/unregister-image.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} #-H 'Content-Type: application/json' -d \
-#		'{ 
-#			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-#		}' | json_pp #|| return 1
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 
 #}
 

--- a/test/official/7.spec/fetch-specs.sh
+++ b/test/official/7.spec/fetch-specs.sh
@@ -22,7 +22,7 @@
     echo "## 7. spec: Fetch"
     echo "####################################################################"
 
-    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/fetchSpecs | json_pp #|| return 1
+    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/fetchSpecs | jq #|| return 1
 #}
 
 #fetch_specs

--- a/test/official/7.spec/filter-specs.sh
+++ b/test/official/7.spec/filter-specs.sh
@@ -22,12 +22,15 @@
     echo "## 7. spec: filter"
     echo "####################################################################"
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/filterSpecs -H 'Content-Type: application/json' -d \
-	    '{ 
-		    "num_vCPU": '1', 
-		    "mem_GiB": '2'
-	    }' | json_pp #|| return 1
-
+    resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/filterSpecs -H 'Content-Type: application/json' -d @- <<EOF
+	    { 
+		    "num_vCPU": 1, 
+		    "mem_GiB": 2
+	    }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #filter_specs

--- a/test/official/7.spec/get-spec.sh
+++ b/test/official/7.spec/get-spec.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_spec

--- a/test/official/7.spec/list-spec.sh
+++ b/test/official/7.spec/list-spec.sh
@@ -23,7 +23,7 @@
     echo "####################################################################"
 
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec | jq #|| return 1
 #}
 
 #list_spec

--- a/test/official/7.spec/lookupSpec.sh
+++ b/test/official/7.spec/lookupSpec.sh
@@ -30,11 +30,15 @@
 	getCloudIndex $CSP
 
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d \
-		'{ 
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
-            "cspSpecName": "'${SPEC_NAME[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+	resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d @- <<EOF
+		{ 
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
+            "cspSpecName": "${SPEC_NAME[$INDEX,$REGION]}"
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #lookup_spec

--- a/test/official/7.spec/lookupSpecList.sh
+++ b/test/official/7.spec/lookupSpecList.sh
@@ -29,10 +29,14 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpecs -H 'Content-Type: application/json' -d \
-		'{ 
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+	resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpecs -H 'Content-Type: application/json' -d @- <<EOF
+		{ 
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}"
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #lookup_spec_list

--- a/test/official/7.spec/range-filter-specs.sh
+++ b/test/official/7.spec/range-filter-specs.sh
@@ -22,8 +22,9 @@
     echo "## 7. spec: filter"
     echo "####################################################################"
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/filterSpecsByRange -H 'Content-Type: application/json' -d \
-	    '{ 
+    resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/filterSpecsByRange -H 'Content-Type: application/json' -d @- <<EOF
+	    { 
 		    "num_vCPU": {
 			    "min": 2,
 			    "max": 4
@@ -34,8 +35,10 @@
 		    "storage_GiB": {
 			    "max": 400
 		    }
-	    }' | json_pp #|| return 1
-
+	    }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #filter_specs

--- a/test/official/7.spec/register-spec.sh
+++ b/test/official/7.spec/register-spec.sh
@@ -29,12 +29,16 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d \
-		'{ 
-			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
-			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"cspSpecName": "'${SPEC_NAME[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+	resp=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d @- <<EOF
+		{ 
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}", 
+			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+			"cspSpecName": "${SPEC_NAME[$INDEX,$REGION]}"
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #register_spec

--- a/test/official/7.spec/spider-get-spec.sh
+++ b/test/official/7.spec/spider-get-spec.sh
@@ -29,7 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmspec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
+	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmspec/${SPEC_NAME[$INDEX,$REGION]} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | jq
 #}
 
 #spider_get_spec

--- a/test/official/7.spec/spider-get-speclist.sh
+++ b/test/official/7.spec/spider-get-speclist.sh
@@ -29,7 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmspec -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | json_pp
+	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmspec -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'" }' | jq
 #}
 
 #spider_get_spec_list

--- a/test/official/7.spec/test-sort-specs.sh
+++ b/test/official/7.spec/test-sort-specs.sh
@@ -22,11 +22,14 @@
     echo "## 7. spec: filter"
     echo "####################################################################"
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testSortSpecs -H 'Content-Type: application/json' -d \
-	    '{ 
-		    "num_vCPU": '4'
-	    }' | json_pp #|| return 1
-
+    resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/testSortSpecs -H 'Content-Type: application/json' -d @- <<EOF
+	    { 
+		    "num_vCPU": 4
+	    }
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #filter_specs

--- a/test/official/7.spec/testAddAsso.sh
+++ b/test/official/7.spec/testAddAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testAddObjectAssociation/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/7.spec/testDeleteAsso.sh
+++ b/test/official/7.spec/testDeleteAsso.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/testDeleteObjectAssociation/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/7.spec/testGetAssoCount.sh
+++ b/test/official/7.spec/testGetAssoCount.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' #| json_pp #|| return 1
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/testGetAssociatedObjectCount/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 #}
 
 #get_sshKey

--- a/test/official/7.spec/unregister-all-specs.sh
+++ b/test/official/7.spec/unregister-all-specs.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec -H 'Content-Type: application/json' -d \
-		'{ 
-			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp #|| return 1
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec | jq
 #}
 
 #unregister_spec

--- a/test/official/7.spec/unregister-spec.sh
+++ b/test/official/7.spec/unregister-spec.sh
@@ -29,10 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp #-H 'Content-Type: application/json' -d \
-#		'{ 
-#			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-#		}' | json_pp #|| return 1
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq
 
 #}
 

--- a/test/official/7.spec/update-spec.sh
+++ b/test/official/7.spec/update-spec.sh
@@ -22,11 +22,15 @@
 	echo "## 7. spec: Update"
 	echo "####################################################################"
 
-	curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/aws-us-east-1-m5ad.2xlarge -H 'Content-Type: application/json' -d \
-		'{ 
+	resp=$(
+        curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/spec/aws-us-east-1-m5ad.2xlarge -H 'Content-Type: application/json' -d @- <<EOF
+		{ 
 			"id": "aws-us-east-1-m5ad.2xlarge", 
 			"description": "UpdateSpec() test"
-		}' | json_pp #|| return 1
+		}
+EOF
+    ); echo ${resp} | jq
+    echo ""
 #}
 
 #register_spec

--- a/test/official/8.mcis/add-vm-to-mcis.sh
+++ b/test/official/8.mcis/add-vm-to-mcis.sh
@@ -47,7 +47,7 @@
 			"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "description",
 			"vmUserPassword": ""
-		}' | json_pp || return 1
+		}' | jq || return 1
 #}
 
 #add-vm-to-mcis

--- a/test/official/8.mcis/add-vmgroup-to-mcis.sh
+++ b/test/official/8.mcis/add-vmgroup-to-mcis.sh
@@ -49,7 +49,7 @@
 			"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "description",
 			"vmUserPassword": ""
-		}' | json_pp || return 1
+		}' | jq || return 1
 #}
 
 #add-vm-to-mcis

--- a/test/official/8.mcis/create-mcis-no-agent.sh
+++ b/test/official/8.mcis/create-mcis-no-agent.sh
@@ -50,7 +50,7 @@
 				"vmUserPassword": ""
 			}
 			]
-		}' | json_pp || return 1
+		}' | jq || return 1
 #}
 
 #create_mcis

--- a/test/official/8.mcis/create-mcis-policy.sh
+++ b/test/official/8.mcis/create-mcis-policy.sh
@@ -77,7 +77,7 @@
 					}
 				}
 			]
-		}' | json_pp || return 1
+		}' | jq || return 1
 #}
 
 #create_mcis

--- a/test/official/8.mcis/create-mcis.sh
+++ b/test/official/8.mcis/create-mcis.sh
@@ -56,7 +56,7 @@
 				"vmUserPassword": ""
 			}
 			]
-		}' | json_pp || return 1
+		}' | jq || return 1
 #}
 
 #create_mcis

--- a/test/official/8.mcis/create-single-vm-mcis.sh
+++ b/test/official/8.mcis/create-single-vm-mcis.sh
@@ -58,7 +58,7 @@
 				"vmUserPassword": ""
 			}
 			]
-		}' | json_pp || return 1
+		}' | jq || return 1
 #}
 
 #create_mcis

--- a/test/official/8.mcis/delete-mcis-policy-all.sh
+++ b/test/official/8.mcis/delete-mcis-policy-all.sh
@@ -30,7 +30,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 	
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis | json_pp || return 1
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis | jq || return 1
 
 #}
 

--- a/test/official/8.mcis/delete-mcis-policy.sh
+++ b/test/official/8.mcis/delete-mcis-policy.sh
@@ -44,7 +44,7 @@
 	fi
 	
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis/${MCISID} | json_pp || return 1
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis/${MCISID} | jq || return 1
 
 
 #}

--- a/test/official/8.mcis/get-mcis-policy.sh
+++ b/test/official/8.mcis/get-mcis-policy.sh
@@ -43,7 +43,7 @@
 		MCISID=${MCISNAME}
 	fi
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis/${MCISID} | json_pp
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis/${MCISID} | jq
 #}
 
 #get_mcis

--- a/test/official/8.mcis/get-mcis.sh
+++ b/test/official/8.mcis/get-mcis.sh
@@ -41,7 +41,7 @@
 		MCISID=${MCISPREFIX}-${POSTFIX}
 	fi
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID} | json_pp
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID} | jq
 #}
 
 #get_mcis

--- a/test/official/8.mcis/just-terminate-mcis.sh
+++ b/test/official/8.mcis/just-terminate-mcis.sh
@@ -32,10 +32,10 @@
 
 	if [ -z "$MCISPREFIX" ]
 	then
-		curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=terminate | json_pp || return 1
+		curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=terminate | jq || return 1
 	else
 		MCISID=${MCISPREFIX}-${POSTFIX}
-		curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=terminate | json_pp || return 1
+		curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=terminate | jq || return 1
 	fi
 #}
 

--- a/test/official/8.mcis/list-mcis-policy.sh
+++ b/test/official/8.mcis/list-mcis-policy.sh
@@ -23,7 +23,7 @@
     echo "####################################################################"
 
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis | json_pp
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/policy/mcis | jq
 #}
 
 #list_mcis

--- a/test/official/8.mcis/list-mcis-status.sh
+++ b/test/official/8.mcis/list-mcis-status.sh
@@ -23,7 +23,7 @@
     echo "####################################################################"
 
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis?option=status | json_pp
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis?option=status | jq
 #}
 
 #list_mcis

--- a/test/official/8.mcis/list-mcis.sh
+++ b/test/official/8.mcis/list-mcis.sh
@@ -23,7 +23,7 @@
     echo "####################################################################"
 
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis | json_pp
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis | jq
 #}
 
 #list_mcis

--- a/test/official/8.mcis/reboot-mcis.sh
+++ b/test/official/8.mcis/reboot-mcis.sh
@@ -29,7 +29,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=reboot | json_pp
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=reboot | jq
 #}
 
 #reboot_mcis

--- a/test/official/8.mcis/resume-mcis.sh
+++ b/test/official/8.mcis/resume-mcis.sh
@@ -30,7 +30,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=resume | json_pp
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=resume | jq
 #}
 
 #resume_mcis

--- a/test/official/8.mcis/spider-create-vm.sh
+++ b/test/official/8.mcis/spider-create-vm.sh
@@ -37,7 +37,7 @@
 				"VMSpecName": "'${SPEC_NAME[$INDEX,$REGION]}'", 
 				"KeyPairName": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
 			} 
-		}' | json_pp
+		}' | jq
 #}
 
 #spider_create_mcis

--- a/test/official/8.mcis/spider-delete-vm.sh
+++ b/test/official/8.mcis/spider-delete-vm.sh
@@ -28,7 +28,7 @@
 	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vm/alibaba-ap-northeast-1-shson-01 -H 'Content-Type: application/json' -d \
 		'{ 
 			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp
+		}' | jq
 #}
 
 #spider_delete_mcis

--- a/test/official/8.mcis/spider-get-vm.sh
+++ b/test/official/8.mcis/spider-get-vm.sh
@@ -28,7 +28,7 @@
 	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vm/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01 -H 'Content-Type: application/json' -d \
 		'{ 
 			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp
+		}' | jq
 #}
 
 #spider_get_vm

--- a/test/official/8.mcis/spider-get-vmstatus.sh
+++ b/test/official/8.mcis/spider-get-vmstatus.sh
@@ -28,7 +28,7 @@
 	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vmstatus/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01 -H 'Content-Type: application/json' -d \
 		'{ 
 			"ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"
-		}' | json_pp
+		}' | jq
 #}
 
 #spider_get_vmstatus

--- a/test/official/8.mcis/status-mcis.sh
+++ b/test/official/8.mcis/status-mcis.sh
@@ -41,7 +41,7 @@
 	else
 		MCISID=${MCISPREFIX}-${POSTFIX}
 	fi
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status | json_pp 
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status | jq 
 	
 	#HTTP_CODE=$(curl -o /dev/null -w "%{http_code}\n" -H "${AUTH}" "http://${TumblebugServer}/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status" --silent)
 	#echo "Status: $HTTP_CODE" 

--- a/test/official/8.mcis/suspend-mcis.sh
+++ b/test/official/8.mcis/suspend-mcis.sh
@@ -30,7 +30,7 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=suspend | json_pp
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=suspend | jq
 #}
 
 #suspend_mcis

--- a/test/official/8.mcis/terminate-and-delete-mcis.sh
+++ b/test/official/8.mcis/terminate-and-delete-mcis.sh
@@ -34,7 +34,7 @@
 
 	if [ -z "$MCISPREFIX" ]
 	then
-		curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | json_pp || return 1
+		curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq || return 1
 	else
 		if [ ! -z "$GIVENMCISID" ]
 		then
@@ -44,7 +44,7 @@
 		fi
 		echo ""
 		echo "Terminate and Delete [MCIS: $MCISID]"
-		curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID} | json_pp 
+		curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID} | jq 
 	fi
 
 

--- a/test/official/9.monitoring/get-monitoring-data.sh
+++ b/test/official/9.monitoring/get-monitoring-data.sh
@@ -37,7 +37,7 @@
 
 	USERCMD=${4}
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/monitoring/mcis/$MCISID/metric/$USERCMD | json_pp #|| return 1
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/monitoring/mcis/$MCISID/metric/$USERCMD | jq #|| return 1
 #}
 
 #get_monitoring_data

--- a/test/official/9.monitoring/install-agent.sh
+++ b/test/official/9.monitoring/install-agent.sh
@@ -39,7 +39,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/monitoring/install/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "echo -n [CMD] Works! [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname ; echo -n ]"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 #}
 
 #install_agent

--- a/test/official/misc/get-conn-config.sh
+++ b/test/official/misc/get-conn-config.sh
@@ -39,7 +39,7 @@
     RESTSERVER=localhost
 
     # for Cloud Connection Config Info
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/connConfig/${CONN_CONFIG[$INDEX,$REGION]} | json_pp
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/connConfig/${CONN_CONFIG[$INDEX,$REGION]} | jq
 
 #}
 

--- a/test/official/misc/get-region.sh
+++ b/test/official/misc/get-region.sh
@@ -39,7 +39,7 @@
     RESTSERVER=localhost
 
     # for Cloud Region Info
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/region/${RegionName[$INDEX,$REGION]} | json_pp
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/region/${RegionName[$INDEX,$REGION]} | jq
 
 #}
 

--- a/test/official/misc/list-conn-config.sh
+++ b/test/official/misc/list-conn-config.sh
@@ -24,7 +24,7 @@
 
     INDEX=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/connConfig | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/connConfig | jq #|| return 1
 #}
 
 #get_ns

--- a/test/official/misc/list-region.sh
+++ b/test/official/misc/list-region.sh
@@ -24,7 +24,7 @@
 
     INDEX=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/region | json_pp #|| return 1
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/region | jq #|| return 1
 #}
 
 #get_ns

--- a/test/official/sequentialFullTest/command-mcis-custom.sh
+++ b/test/official/sequentialFullTest/command-mcis-custom.sh
@@ -35,7 +35,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "'${USERCMD}'"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 #}
 
 #command_mcis_custom

--- a/test/official/sequentialFullTest/command-mcis.sh
+++ b/test/official/sequentialFullTest/command-mcis.sh
@@ -40,7 +40,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "echo -n [CMD] Works! [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname ; echo -n ]"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 
 
 #}

--- a/test/official/sequentialFullTest/delete-object.sh
+++ b/test/official/sequentialFullTest/delete-object.sh
@@ -22,4 +22,4 @@
 
     KEY=${1}
 
-    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/object?key=$KEY | json_pp 
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/object?key=$KEY | jq 

--- a/test/official/sequentialFullTest/delete-objects-becareful.sh
+++ b/test/official/sequentialFullTest/delete-objects-becareful.sh
@@ -22,4 +22,4 @@
 
     KEY=${1}
 
-    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/objects?key=$KEY | json_pp 
+    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/objects?key=$KEY | jq 

--- a/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
+++ b/test/official/sequentialFullTest/deploy-dragonfly-docker.sh
@@ -44,7 +44,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setcbdf.sh -O ~/setcbdf.sh; chmod +x ~/setcbdf.sh; ~/setcbdf.sh"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 
 	MCISINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status`
 	MASTERIP=$(jq -r '.status.masterIp' <<< "$MCISINFO")

--- a/test/official/sequentialFullTest/deploy-loadMaker-to-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-loadMaker-to-mcis.sh
@@ -40,7 +40,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/runLoadMaker.sh -O ~/runLoadMaker.sh; chmod +x ~/runLoadMaker.sh; sudo ~/runLoadMaker.sh"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 #}
 
 #deploy_nginx_to_mcis

--- a/test/official/sequentialFullTest/deploy-nginx-mcis-vm-withGivenName.sh
+++ b/test/official/sequentialFullTest/deploy-nginx-mcis-vm-withGivenName.sh
@@ -33,7 +33,7 @@
 			curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d \
 			'{
 				"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
-			}' | json_pp #|| return 1
+			}' | jq #|| return 1
 
 		fi
 

--- a/test/official/sequentialFullTest/deploy-nginx-mcis-with-loadmaker.sh
+++ b/test/official/sequentialFullTest/deploy-nginx-mcis-with-loadmaker.sh
@@ -40,7 +40,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh; wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/runLoadMaker.sh -O ~/runLoadMaker.sh; chmod +x ~/runLoadMaker.sh; sudo ~/runLoadMaker.sh"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 #}
 
 #deploy_nginx_to_mcis

--- a/test/official/sequentialFullTest/deploy-nginx-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-nginx-mcis.sh
@@ -40,7 +40,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 #}
 
 #deploy_nginx_to_mcis

--- a/test/official/sequentialFullTest/deploy-spider-docker.sh
+++ b/test/official/sequentialFullTest/deploy-spider-docker.sh
@@ -40,7 +40,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setcbsp.sh -O ~/setcbtb.sh; chmod +x ~/setcbtb.sh; ~/setcbtb.sh"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 #}
 
 #deploy_nginx_to_mcis

--- a/test/official/sequentialFullTest/deploy-tumblebug.sh
+++ b/test/official/sequentialFullTest/deploy-tumblebug.sh
@@ -40,7 +40,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
 			"command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setcbtb.sh -O ~/setcbtb.sh; chmod +x ~/setcbtb.sh; ~/setcbtb.sh"
-		}' | json_pp #|| return 1
+		}' | jq #|| return 1
 #}
 
 #deploy_nginx_to_mcis

--- a/test/official/sequentialFullTest/deploy-weavescope-to-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-mcis.sh
@@ -88,7 +88,7 @@
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
 	'{
 	"command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
-	}' | json_pp 
+	}' | jq 
 	echo ""
 
 	echo "Launching Weavescope for master node..."

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
@@ -108,7 +108,7 @@
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
         '{
         "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
-        }' | json_pp 
+        }' | jq 
         echo ""
     done
 

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
@@ -109,7 +109,7 @@
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
         '{
         "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
-        }' | json_pp 
+        }' | jq 
         echo ""
     done
 

--- a/test/official/sequentialFullTest/expand-mcis.sh
+++ b/test/official/sequentialFullTest/expand-mcis.sh
@@ -65,7 +65,7 @@
 			"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "description",
 			"vmUserPassword": ""
-		}' | json_pp || return 1
+		}' | jq || return 1
 		
 
 	done

--- a/test/official/sequentialFullTest/get-object.sh
+++ b/test/official/sequentialFullTest/get-object.sh
@@ -22,4 +22,4 @@
 
     KEY=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/object?key=$KEY | json_pp 
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/object?key=$KEY | jq 

--- a/test/official/sequentialFullTest/list-object.sh
+++ b/test/official/sequentialFullTest/list-object.sh
@@ -22,4 +22,4 @@
 
     KEY=${1}
 
-    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/objects?key=$KEY | json_pp 
+    curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/objects?key=$KEY | jq 


### PR DESCRIPTION
- Shell script 에서 JSON pretty 를 위해 사용하는 유틸리티를 `json_pp` => `jq` 로 변경
- API 요청 시 JSON body 에 불필요하게 `ConnectionName` 을 적어 보내는 경우가 있었는데, 이를 삭제
- API 요청 시 JSON body 도 보내는 경우에 대해서 shell script 작성 방식을 변경
  - (출처: https://github.com/cloud-barista/cb-ladybug/blob/master/docs/test/cluster-create.sh)
  - 향후 CLI 도구를 만들 때 shell script 에서 JSON body 예시를 참고할 수 있는데, 
  이 PR로 JSON body 예시의 readability 가 향상될 것입니다.
  - `8.mcis/` 디렉토리와 `sequentialFullTest/` 디렉토리 아래의 스크립트들에 대해서는 아직 적용하지 않았습니다.