### PR TITLE
Enhance scripts and fix some bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ src/api/grpc/cbadm/cbadm
 meta_db/
 
 # Config file for test
-test/official/sequentialFullTest/executionStatus
+test/official/sequentialFullTest/executionStatus*
 test/official/credentials.conf
 src/api/grpc/cbadm/test/official/sequentialFullTest/executionStatus
 src/api/grpc/cbadm/test/official/credentials.conf

--- a/assets/cloudlocation.csv
+++ b/assets/cloudlocation.csv
@@ -112,7 +112,7 @@ alibaba,eu-west-1,UK (London),51.8000,-0.2000
 alibaba,me-east-1,UAE (Dubai),25.2770,55.2962
 cloudit,default,South Korea (Seoul),37.2665,126.7780
 mock,default,South Korea (Seoul),37.0000,126.0000
-openstack,RegionOne,South Korea (Daejeon),36.3804,127.3650
+openstack,regionone,South Korea (Daejeon),36.3804,127.3650
 ncp,kr-1,South Korea (Seoul),37.4767,126.8841
 ncp,kr-2,South Korea (Seoul),37.3881,126.9705
 ncp,hk-1,Hong Kong,22.3964,114.1095

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -2356,7 +2356,7 @@ func AddVmToMcis(wg *sync.WaitGroup, nsId string, mcisId string, vmInfoData *TbV
 
 	nativeRegion := ""
 	for _, v := range regionTmp.KeyValueInfoList {
-		if strings.ToLower(v.Key) == "region" {
+		if strings.ToLower(v.Key) == "region" || strings.ToLower(v.Key) == "location" {
 			nativeRegion = v.Value
 			break
 		}

--- a/test/official/3.vNet/create-vNet.sh
+++ b/test/official/3.vNet/create-vNet.sh
@@ -25,6 +25,10 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
+	CIRDNum=$(($INDEX+1))
+	CIDRDiff=$(($CIRDNum*$REGION))
+	CIDRDiff=$(($CIDRDiff%254))
+
     resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/resources/vNet -H 'Content-Type: application/json' -d @- <<EOF
         {
@@ -33,7 +37,7 @@
 			"cidrBlock": "192.168.0.0/16",
 			"subnetInfoList": [ {
 				"Name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
-				"IPv4_CIDR": "192.168.1.0/24"
+				"IPv4_CIDR": "192.168.${CIDRDiff}.0/24"
 			} ]
 		}
 EOF

--- a/test/official/8.mcis/get-mcis.sh
+++ b/test/official/8.mcis/get-mcis.sh
@@ -1,43 +1,40 @@
 #!/bin/bash
 
-#function get_mcis() {
+
+TestSetFile=${4:-../testSet.env}
+
+FILE=$TestSetFile
+if [ ! -f "$FILE" ]; then
+	echo "$FILE does not exist."
+	exit
+fi
+source $TestSetFile
+source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+echo "####################################################################"
+echo "## 8. Get MCIS"
+echo "####################################################################"
+
+CSP=${1}
+REGION=${2:-1}
+POSTFIX=${3:-developer}
+
+source ../common-functions.sh
+getCloudIndex $CSP
 
 
-	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
-	echo "####################################################################"
-	echo "## 8. VM: Get MCIS"
-	echo "####################################################################"
-
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-
-	source ../common-functions.sh
-	getCloudIndex $CSP
-
-	MCISPREFIX=${4}
-	if [ -z "$MCISPREFIX" ]
-	then
-		MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
-		if [ "${INDEX}" == "0" ]; then
-			# MCISPREFIX=avengers
-			MCISID=${MCISPREFIX}-${POSTFIX}
-		fi
-	else
+if [ -z "$MCISPREFIX" ]; then
+	MCISID=${CONN_CONFIG[$INDEX, $REGION]}-${POSTFIX}
+	if [ "${INDEX}" == "0" ]; then
+		# MCISPREFIX=avengers
 		MCISID=${MCISPREFIX}-${POSTFIX}
 	fi
+else
+	MCISID=${MCISPREFIX}-${POSTFIX}
+fi
 
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID} | jq ''
-#}
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID} | jq ''
+
 
 #get_mcis

--- a/test/official/conf.env
+++ b/test/official/conf.env
@@ -1468,35 +1468,75 @@ SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 function getCloudIndex()
 {
 	local CSP=$1
+	local CSPIndex=0
 
 	if [ "${CSP}" == "all" ]; then
-		echo "[all CSP regions (AWS, Azure, GCP, Alibaba,  ...)]"
-		#CSP="aws"
-		INDEX=0
+		# echo "[all CSP regions (AWS, Azure, GCP, Alibaba,  ...)]"
+		CSPIndex=0
 	elif [ "${CSP}" == "aws" ]; then
-		echo "[AWS]"
-		INDEX=$IndexAWS
+		# echo "[AWS]"
+		CSPIndex=$IndexAWS
 	elif [ "${CSP}" == "alibaba" ]; then
-		echo "[Alibaba]"
-		INDEX=$IndexAlibaba
+		# echo "[Alibaba]"
+		CSPIndex=$IndexAlibaba
 	elif [ "${CSP}" == "gcp" ]; then
-		echo "[GCP]"
-		INDEX=$IndexGCP
+		# echo "[GCP]"
+		CSPIndex=$IndexGCP
 	elif [ "${CSP}" == "azure" ]; then
-		echo "[Azure]"
-		INDEX=$IndexAzure
+		# echo "[Azure]"
+		CSPIndex=$IndexAzure
 	elif [ "${CSP}" == "mock" ]; then
-		echo "[Mock driver]"
-		INDEX=$IndexMock
+		# echo "[Mock driver]"
+		CSPIndex=$IndexMock
 	elif [ "${CSP}" == "openstack" ]; then
-		echo "[OpenStack driver]"
-		INDEX=$IndexOpenstack
+		# echo "[OpenStack driver]"
+		CSPIndex=$IndexOpenstack
 	elif [ "${CSP}" == "ncp" ]; then
-		echo "[NCP driver]"
-		INDEX=$IndexNCP
+		# echo "[NCP driver]"
+		CSPIndex=$IndexNCP
 	else
 		echo "[No acceptable argument was provided (all, aws, azure, gcp, alibaba, mock, openstack, ...).]"
 		exit
 	fi
+
+	INDEX=$CSPIndex
+
+}
+
+function getCloudIndexGeneral()
+{
+	local CSP=$1
+	local CSPIndex=0
+
+	if [ "${CSP}" == "all" ]; then
+		# echo "[all CSP regions (AWS, Azure, GCP, Alibaba,  ...)]"
+		CSPIndex=a
+	elif [ "${CSP}" == "aws" ]; then
+		# echo "[AWS]"
+		CSPIndex=b
+	elif [ "${CSP}" == "alibaba" ]; then
+		# echo "[Alibaba]"
+		CSPIndex=c
+	elif [ "${CSP}" == "gcp" ]; then
+		# echo "[GCP]"
+		CSPIndex=d
+	elif [ "${CSP}" == "azure" ]; then
+		# echo "[Azure]"
+		CSPIndex=e
+	elif [ "${CSP}" == "mock" ]; then
+		# echo "[Mock driver]"
+		CSPIndex=f
+	elif [ "${CSP}" == "openstack" ]; then
+		# echo "[OpenStack driver]"
+		CSPIndex=g
+	elif [ "${CSP}" == "ncp" ]; then
+		# echo "[NCP driver]"
+		CSPIndex=h
+	else
+		echo "[No acceptable argument was provided (all, aws, azure, gcp, alibaba, mock, openstack, ...).]"
+		exit
+	fi
+
+	GeneralINDEX=$CSPIndex
 
 }

--- a/test/official/sequentialFullTest/change-mcis-hostname.sh
+++ b/test/official/sequentialFullTest/change-mcis-hostname.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+SECONDS=0
+
+echo "[Check jq package (if not, install)]"
+if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
+
+TestSetFile=${4:-../testSet.env}
+
+FILE=$TestSetFile
+if [ ! -f "$FILE" ]; then
+	echo "$FILE does not exist."
+	exit
+fi
+source $TestSetFile
+source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+echo "####################################################################"
+echo "## Command (SSH) to MCIS to change-mcis-hostname"
+echo "####################################################################"
+
+CSP=${1}
+REGION=${2:-1}
+POSTFIX=${3:-developer}
+
+source ../common-functions.sh
+getCloudIndex $CSP
+
+MCISID=${CONN_CONFIG[$INDEX, $REGION]}-${POSTFIX}
+
+if [ "${INDEX}" == "0" ]; then
+	# MCISPREFIX=avengers
+	MCISID=${MCISPREFIX}-${POSTFIX}
+fi
+
+MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID})
+VMARRAY=$(jq -r '.vm' <<<"$MCISINFO")
+
+for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+	_jq() {
+		echo ${row} | base64 --decode | jq -r ${1}
+	}
+
+    VMID=$(_jq '.id')
+	connectionName=$(_jq '.connectionName')
+    publicIP=$(_jq '.publicIP')
+    
+    echo "connectionName: $connectionName"
+    echo "publicIP: $publicIP"
+
+    ChangeHostCMD="sudo hostnamectl set-hostname ${connectionName}-${publicIP}; sudo hostname -f"
+    ./command-mcis-vm-custom.sh "$@" "${VMID}" "${ChangeHostCMD}"
+
+done
+
+echo "Done!"
+duration=$SECONDS
+echo "[CMD] ${_self}"
+echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+echo ""
+
+./command-mcis.sh "$@"

--- a/test/official/sequentialFullTest/change-mcis-hostname.sh
+++ b/test/official/sequentialFullTest/change-mcis-hostname.sh
@@ -46,11 +46,12 @@ for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
 	connectionName=$(_jq '.connectionName')
     publicIP=$(_jq '.publicIP')
     
+    echo "VMID: $VMID"
     echo "connectionName: $connectionName"
     echo "publicIP: $publicIP"
 
     ChangeHostCMD="sudo hostnamectl set-hostname ${connectionName}-${publicIP}; sudo hostname -f"
-    ./command-mcis-vm-custom.sh "$@" "${VMID}" "${ChangeHostCMD}"
+    ./command-mcis-vm-custom.sh "${1}" "${2}" "${3}" "${VMID}" "${ChangeHostCMD}"
 
 done
 

--- a/test/official/sequentialFullTest/change-mcis-hostname.sh
+++ b/test/official/sequentialFullTest/change-mcis-hostname.sh
@@ -45,19 +45,22 @@ for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
     VMID=$(_jq '.id')
 	connectionName=$(_jq '.connectionName')
     publicIP=$(_jq '.publicIP')
+    cloudType=$(_jq '.location.cloudType')
     
     echo "VMID: $VMID"
     echo "connectionName: $connectionName"
     echo "publicIP: $publicIP"
 
-    ChangeHostCMD="sudo hostnamectl set-hostname ${connectionName}-${publicIP}; sudo hostname -f"
-    ./command-mcis-vm-custom.sh "${1}" "${2}" "${3}" "${VMID}" "${ChangeHostCMD}"
+    getCloudIndexGeneral $cloudType
 
+    ChangeHostCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${connectionName}-${publicIP}; sudo hostname -f"
+    ./command-mcis-vm-custom.sh "${1}" "${2}" "${3}" "${4}" "${VMID}" "${ChangeHostCMD}" &
 done
+wait
 
 echo "Done!"
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 echo ""
 

--- a/test/official/sequentialFullTest/clean-mcis-only.sh
+++ b/test/official/sequentialFullTest/clean-mcis-only.sh
@@ -244,6 +244,7 @@ else
 fi
 
 duration=$SECONDS
+echo "[CMD] ${_self}"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 #}
 

--- a/test/official/sequentialFullTest/clean-mcis-only.sh
+++ b/test/official/sequentialFullTest/clean-mcis-only.sh
@@ -158,6 +158,7 @@ function clean_sequence() {
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 
 }
@@ -234,6 +235,7 @@ if [ "${INDEX}" == "0" ]; then
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 
 else

--- a/test/official/sequentialFullTest/clean-mcis-only.sh
+++ b/test/official/sequentialFullTest/clean-mcis-only.sh
@@ -246,7 +246,7 @@ else
 fi
 
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 #}
 

--- a/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
@@ -229,6 +229,7 @@ else
 fi
 
 duration=$SECONDS
+echo "[CMD] ${_self}"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 #}
 

--- a/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
@@ -152,6 +152,7 @@ function clean_sequence() {
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 
 }
@@ -219,6 +220,7 @@ if [ "${INDEX}" == "0" ]; then
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 
 else

--- a/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/cleanAll-mcis-mcir-ns-cloud.sh
@@ -231,7 +231,7 @@ else
 fi
 
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 #}
 

--- a/test/official/sequentialFullTest/command-mcis-custom.sh
+++ b/test/official/sequentialFullTest/command-mcis-custom.sh
@@ -2,45 +2,45 @@
 
 #function command_mcis_custom() {
 
+TestSetFile=${4:-../testSet.env}
 
-	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+FILE=$TestSetFile
+if [ ! -f "$FILE" ]; then
+	echo "$FILE does not exist."
+	exit
+fi
+source $TestSetFile
+source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
-	echo "####################################################################"
-	echo "## Command (SSH) to MCIS "
-	echo "####################################################################"
+echo "####################################################################"
+echo "## Command (SSH) to MCIS "
+echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+CSP=${1}
+REGION=${2:-1}
+POSTFIX=${3:-developer}
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+source ../common-functions.sh
+getCloudIndex $CSP
 
-	USERCMD=${5}
+USERCMD=${5}
 
-	MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+MCISID=${CONN_CONFIG[$INDEX, $REGION]}-${POSTFIX}
 
-	if [ "${INDEX}" == "0" ]; then
-		# MCISPREFIX=avengers
-		MCISID=${MCISPREFIX}-${POSTFIX}
-	fi
+if [ "${INDEX}" == "0" ]; then
+	# MCISPREFIX=avengers
+	MCISID=${MCISPREFIX}-${POSTFIX}
+fi
 
-	VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+VAR1=$(
+	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
 	{
 	"command"        : "${USERCMD}"
 	} 
 EOF
-	)
-	echo "${VAR1}" | jq ''
+)
+echo "${VAR1}" | jq ''
 
 #}
 

--- a/test/official/sequentialFullTest/command-mcis-vm-custom.sh
+++ b/test/official/sequentialFullTest/command-mcis-vm-custom.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#function command_mcis_custom() {
+
+TestSetFile=${4:-../testSet.env}
+
+FILE=$TestSetFile
+if [ ! -f "$FILE" ]; then
+	echo "$FILE does not exist."
+	exit
+fi
+source $TestSetFile
+source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+
+echo "####################################################################"
+echo "## Command (SSH) to MCIS "
+echo "####################################################################"
+
+CSP=${1}
+REGION=${2:-1}
+POSTFIX=${3:-developer}
+
+source ../common-functions.sh
+getCloudIndex $CSP
+
+VMID=${5}
+USERCMD=${6}
+
+MCISID=${CONN_CONFIG[$INDEX, $REGION]}-${POSTFIX}
+
+if [ "${INDEX}" == "0" ]; then
+	# MCISPREFIX=avengers
+	MCISID=${MCISPREFIX}-${POSTFIX}
+fi
+
+VAR1=$(
+	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${USERCMD}"
+	} 
+EOF
+)
+echo "${VAR1}" | jq ''
+
+#}
+
+#command_mcis_custom

--- a/test/official/sequentialFullTest/create-mcis-for-df.sh
+++ b/test/official/sequentialFullTest/create-mcis-for-df.sh
@@ -30,10 +30,11 @@ function test_sequence()
 
 	echo ""
 	echo "[Logging to notify latest command history]"
-	echo "[CMD] (MCIRS) ${_self} ${CSP} ${REGION} ${POSTFIX} ${TestSetFile}" >> ./executionStatus
+	echo "[CMD] (MCIRS) ${_self} ${CSP} ${REGION} ${POSTFIX} ${TestSetFile}" >>./executionStatus
 	echo ""
 	echo "[Executed Command List]"
 	cat  ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 }
 

--- a/test/official/sequentialFullTest/create-mcis-for-ws.sh
+++ b/test/official/sequentialFullTest/create-mcis-for-ws.sh
@@ -33,6 +33,7 @@ function test_sequence() {
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 }
 

--- a/test/official/sequentialFullTest/create-mcis-only.sh
+++ b/test/official/sequentialFullTest/create-mcis-only.sh
@@ -21,6 +21,7 @@ function test_sequence() {
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 }
 
@@ -45,6 +46,7 @@ function test_sequence_allcsp_mcis() {
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 
 }

--- a/test/official/sequentialFullTest/create-mcis-only.sh
+++ b/test/official/sequentialFullTest/create-mcis-only.sh
@@ -165,7 +165,7 @@ else
 fi
 
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 
 echo ""

--- a/test/official/sequentialFullTest/create-mcis-only.sh
+++ b/test/official/sequentialFullTest/create-mcis-only.sh
@@ -17,7 +17,7 @@ function test_sequence() {
 
 	echo ""
 	echo "[Logging to notify latest command history]"
-	echo "[CMD] (MCIS) ${_self} ${CSP} ${REGION} ${POSTFIX} ${NUMVM}" >>./executionStatus
+	echo "[MCIS:${MCISID}] ${_self} ${CSP} ${REGION} ${POSTFIX} ${NUMVM}" >>./executionStatus
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
@@ -41,7 +41,7 @@ function test_sequence_allcsp_mcis() {
 	#../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX $TestSetFile $MCISPREFIX
 	echo ""
 	echo "[Logging to notify latest command history]"
-	echo "[CMD] (MCIS) ${_self} all 1 ${POSTFIX} ${TestSetFile}" >>./executionStatus
+	echo "[MCIS:${MCISID}] ${_self} all 1 ${POSTFIX} ${TestSetFile}" >>./executionStatus
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
@@ -156,11 +156,14 @@ else
 	TOTALVM=$((1 * 1 * NUMVM))
 	echo "[Create MCIS] VMs($TOTALVM) = Cloud(1) * Region(1) * VMgroup($NUMVM)"
 
+	MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+
 	test_sequence $CSP $REGION $POSTFIX $NUMVM $TestSetFile ${0##*/}
 
 fi
 
 duration=$SECONDS
+echo "[CMD] ${_self}"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 
 echo ""

--- a/test/official/sequentialFullTest/createAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/createAll-mcis-mcir-ns-cloud.sh
@@ -6,6 +6,7 @@ SECONDS=0
 ./create-mcis-only.sh "$@"
 
 duration=$SECONDS
+echo "[CMD] ${_self}"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 
 echo ""

--- a/test/official/sequentialFullTest/createAll-mcis-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/createAll-mcis-mcir-ns-cloud.sh
@@ -6,7 +6,7 @@ SECONDS=0
 ./create-mcis-only.sh "$@"
 
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 
 echo ""

--- a/test/official/sequentialFullTest/deploy-weavescope-to-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-mcis.sh
@@ -115,7 +115,7 @@ EOF
 
 echo "Done!"
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 echo ""
 

--- a/test/official/sequentialFullTest/deploy-weavescope-to-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-mcis.sh
@@ -76,11 +76,18 @@ LAUNCHCMD="sudo scope launch $IPLIST $PRIVIPLIST"
 
 echo ""
 echo "Installing Weavescope to MCIS..."
+ScopeInstallFile="git.io/scope"
+ScopeInstallFile="https://gist.githubusercontent.com/seokho-son/bb2703ca49555f9afe0d0097894c74fa/raw/9eb65b296b85bc53f53af3e8733603d807fb9287/scope"
+INSTALLCMD="sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L $ScopeInstallFile -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
 echo ""
-curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
-	'{
-	"command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
-	}' | jq ''
+
+VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${INSTALLCMD}"
+	}
+EOF
+)
+echo "${VAR1}" | jq ''
 echo ""
 
 echo "Launching Weavescope for master node..."

--- a/test/official/sequentialFullTest/deploy-weavescope-to-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-mcis.sh
@@ -98,6 +98,8 @@ curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/
 EOF
 #LAUNCHCMD="sudo scope launch $MASTERIP"
 
+LAUNCHCMD="sudo scope launch $MASTERIP $PRIVIPLIST"
+
 echo ""
 echo "[MCIS Weavescope: master node only] Access to"
 echo " $MASTERIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update-noinstall.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update-noinstall.sh
@@ -143,7 +143,7 @@ EOF
 
 echo "Done!"
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 echo ""
 

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update-noinstall.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update-noinstall.sh
@@ -1,140 +1,134 @@
 #!/bin/bash
 
+SECONDS=0
 
-	SECONDS=0
+echo "[Check jq package (if not, install)]"
+if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
+source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
+echo "####################################################################"
+echo "## Command (SSH) to MCIS "
+echo "####################################################################"
 
-	echo "[Check jq package (if not, install)]"
-	if ! dpkg-query -W -f='${Status}' jq  | grep "ok installed"; then sudo apt install -y jq; fi
-	
+source ../common-functions.sh
 
-    source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+# CSP=${1}
+# REGION=${2:-1}
+# POSTFIX=${3:-developer}
 
-	echo "####################################################################"
-	echo "## Command (SSH) to MCIS "
-	echo "####################################################################"
+# NUM_MCIS=${1}
 
-    source ../common-functions.sh
+# if [ "${NUM_MCIS}" == "" ]; then
+#     echo "Usage: ./script.sh <NUM_MCIS> <MCIS_1> <MCIS_2> <MCIS_3> ..."
+#     exit 1
+# fi
 
-	# CSP=${1}
-	# REGION=${2:-1}
-	# POSTFIX=${3:-developer}
+# for (( i=0; i<${NUM_MCIS}; i++ ));
+# do
+#     j=$((i+2))
+#     echo ${$j};
+# done
 
-    # NUM_MCIS=${1}
-    
-    # if [ "${NUM_MCIS}" == "" ]; then
-    #     echo "Usage: ./script.sh <NUM_MCIS> <MCIS_1> <MCIS_2> <MCIS_3> ..."
-    #     exit 1
-    # fi
+NUM_MCIS=$#
 
-    # for (( i=0; i<${NUM_MCIS}; i++ ));
-    # do
-    #     j=$((i+2))
-    #     echo ${$j};
-    # done
+WHOLE_IPLIST=""
+WHOLE_PRIVIPLIST=""
+LORDIP=""
+LORDVM=""
+LORDMCIS=""
 
-    NUM_MCIS=$#
+for MCISID in "$@"; do
+    MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status)
+    VMARRAY=$(jq -r '.status.vm' <<<"$MCISINFO")
+    MASTERIP=$(jq -r '.status.masterIp' <<<"$MCISINFO")
+    MASTERVM=$(jq -r '.status.masterVmId' <<<"$MCISINFO")
 
-    WHOLE_IPLIST=""
-    WHOLE_PRIVIPLIST=""
-    LORDIP=""
-    LORDVM=""
-    LORDMCIS=""
+    echo "MASTERIP: $MASTERIP"
+    echo "MASTERVM: $MASTERVM"
+    echo "VMARRAY: $VMARRAY"
 
-    for MCISID in "$@" ; do
-        MCISINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status`
-        VMARRAY=$(jq -r '.status.vm' <<< "$MCISINFO")
-        MASTERIP=$(jq -r '.status.masterIp' <<< "$MCISINFO")
-        MASTERVM=$(jq -r '.status.masterVmId' <<< "$MCISINFO")
-        
-        echo "MASTERIP: $MASTERIP"
-        echo "MASTERVM: $MASTERVM"	
-        echo "VMARRAY: $VMARRAY"
+    IPLIST=""
 
-        IPLIST=""
-
-        for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-            _jq() {
+    for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+        _jq() {
             echo ${row} | base64 --decode | jq -r ${1}
-            }
+        }
 
-            IPLIST+=$(_jq '.public_ip')
-            IPLIST+=" "
-        done
-
-        IPLIST=`echo ${IPLIST}`
-        echo "PublicIPList: $IPLIST"
-
-        PRIVIPLIST=""
-
-        for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-            _jq() {
-            echo ${row} | base64 --decode | jq -r ${1}
-            }
-
-            PRIVIPLIST+=$(_jq '.private_ip')
-            PRIVIPLIST+=" "
-        done
-
-        PRIVIPLIST=`echo ${PRIVIPLIST}`
-        echo "PrivateIPList: $PRIVIPLIST"
-
-        WHOLE_IPLIST+=$IPLIST
-        WHOLE_IPLIST+=" "
-        WHOLE_PRIVIPLIST+=$PRIVIPLIST
-        WHOLE_PRIVIPLIST+=" "
-        # WHOLE_IPLIST=(${WHOLE_IPLIST[@]} ${IPLIST[@]})
-        # WHOLE_PRIVIPLIST=(${WHOLE_PRIVIPLIST[@]} ${PRIVIPLIST[@]})
-        LORDIP=$MASTERIP
-        LORDVM=$MASTERVM
-        LORDMCIS=$MCISID
+        IPLIST+=$(_jq '.public_ip')
+        IPLIST+=" "
     done
 
-    echo ""
-    echo "WHOLE_PublicIPList: $WHOLE_IPLIST"
-    echo "WHOLE_PrivateIPList: $WHOLE_PRIVIPLIST"
+    IPLIST=$(echo ${IPLIST})
+    echo "PublicIPList: $IPLIST"
 
+    PRIVIPLIST=""
 
-    # for MCISID in "$@" ; do
-    #     echo ""
-    #     echo "Installing Weavescope to MCIS..."	
-    #     echo ""
-    #     curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
-    #     '{
-    #     "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
-    #     }' | jq '' 
-    #     echo ""
-    # done
+    for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+        _jq() {
+            echo ${row} | base64 --decode | jq -r ${1}
+        }
 
-	LAUNCHCMD="sudo scope stop"
-    echo "Stopping Weavescope for master node if exist..."
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
+        PRIVIPLIST+=$(_jq '.private_ip')
+        PRIVIPLIST+=" "
+    done
+
+    PRIVIPLIST=$(echo ${PRIVIPLIST})
+    echo "PrivateIPList: $PRIVIPLIST"
+
+    WHOLE_IPLIST+=$IPLIST
+    WHOLE_IPLIST+=" "
+    WHOLE_PRIVIPLIST+=$PRIVIPLIST
+    WHOLE_PRIVIPLIST+=" "
+    # WHOLE_IPLIST=(${WHOLE_IPLIST[@]} ${IPLIST[@]})
+    # WHOLE_PRIVIPLIST=(${WHOLE_PRIVIPLIST[@]} ${PRIVIPLIST[@]})
+    LORDIP=$MASTERIP
+    LORDVM=$MASTERVM
+    LORDMCIS=$MCISID
+done
+
+echo ""
+echo "WHOLE_PublicIPList: $WHOLE_IPLIST"
+echo "WHOLE_PrivateIPList: $WHOLE_PRIVIPLIST"
+
+# for MCISID in "$@" ; do
+#     echo ""
+#     echo "Installing Weavescope to MCIS..."
+#     echo ""
+#     curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
+#     '{
+#     "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
+#     }' | jq ''
+#     echo ""
+# done
+
+LAUNCHCMD="sudo scope stop"
+echo "Stopping Weavescope for master node if exist..."
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
 	{
 	"command"        : "${LAUNCHCMD}"
 	}
 EOF
 
-	#LAUNCHCMD="sudo scope launch $WHOLE_IPLIST $WHOLE_PRIVIPLIST"
-    LAUNCHCMD="sudo scope launch $WHOLE_IPLIST"
-	#echo $LAUNCHCMD
+#LAUNCHCMD="sudo scope launch $WHOLE_IPLIST $WHOLE_PRIVIPLIST"
+LAUNCHCMD="sudo scope launch $WHOLE_IPLIST"
+#echo $LAUNCHCMD
 
-    echo "Launching Weavescope for master node..."
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
+echo "Launching Weavescope for master node..."
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
 	{
 	"command"        : "${LAUNCHCMD}"
 	}
 EOF
 
-    
 # 	echo ""
 # 	echo "[MCIS Weavescope: master node only] Access to"
 #     echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
-# 	echo ""	
+# 	echo ""
 
 #     LAUNCHCMD="sudo scope launch $LORDIP $WHOLE_PRIVIPLIST"
-# 	echo "Working on clustring..."	
+# 	echo "Working on clustring..."
 
 #     for MCISID in "$@" ; do
 
@@ -147,12 +141,12 @@ EOF
 
 #     done
 
+echo "Done!"
+duration=$SECONDS
+echo "[CMD] ${_self}"
+echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+echo ""
 
-	echo "Done!"	
-	duration=$SECONDS
-	echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
-	echo ""
-	
-	echo "[MCIS Weavescope: complete cluster] Access to"
-	echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
-	echo ""	
+echo "[MCIS Weavescope: complete cluster] Access to"
+echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
+echo ""

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
@@ -1,158 +1,152 @@
 #!/bin/bash
 
+SECONDS=0
 
-	SECONDS=0
+echo "[Check jq package (if not, install)]"
+if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
+source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
+echo "####################################################################"
+echo "## Command (SSH) to MCIS "
+echo "####################################################################"
 
-	echo "[Check jq package (if not, install)]"
-	if ! dpkg-query -W -f='${Status}' jq  | grep "ok installed"; then sudo apt install -y jq; fi
-	
+source ../common-functions.sh
 
-    source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+# CSP=${1}
+# REGION=${2:-1}
+# POSTFIX=${3:-developer}
 
-	echo "####################################################################"
-	echo "## Command (SSH) to MCIS "
-	echo "####################################################################"
+# NUM_MCIS=${1}
 
-    source ../common-functions.sh
+# if [ "${NUM_MCIS}" == "" ]; then
+#     echo "Usage: ./script.sh <NUM_MCIS> <MCIS_1> <MCIS_2> <MCIS_3> ..."
+#     exit 1
+# fi
 
-	# CSP=${1}
-	# REGION=${2:-1}
-	# POSTFIX=${3:-developer}
+# for (( i=0; i<${NUM_MCIS}; i++ ));
+# do
+#     j=$((i+2))
+#     echo ${$j};
+# done
 
-    # NUM_MCIS=${1}
-    
-    # if [ "${NUM_MCIS}" == "" ]; then
-    #     echo "Usage: ./script.sh <NUM_MCIS> <MCIS_1> <MCIS_2> <MCIS_3> ..."
-    #     exit 1
-    # fi
+NUM_MCIS=$#
 
-    # for (( i=0; i<${NUM_MCIS}; i++ ));
-    # do
-    #     j=$((i+2))
-    #     echo ${$j};
-    # done
+WHOLE_IPLIST=""
+WHOLE_PRIVIPLIST=""
+LORDIP=""
+LORDVM=""
+LORDMCIS=""
 
-    NUM_MCIS=$#
+for MCISID in "$@"; do
+    MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status)
+    VMARRAY=$(jq -r '.status.vm' <<<"$MCISINFO")
+    MASTERIP=$(jq -r '.status.masterIp' <<<"$MCISINFO")
+    MASTERVM=$(jq -r '.status.masterVmId' <<<"$MCISINFO")
 
-    WHOLE_IPLIST=""
-    WHOLE_PRIVIPLIST=""
-    LORDIP=""
-    LORDVM=""
-    LORDMCIS=""
+    echo "MASTERIP: $MASTERIP"
+    echo "MASTERVM: $MASTERVM"
+    echo "VMARRAY: $VMARRAY"
 
-    for MCISID in "$@" ; do
-        MCISINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status`
-        VMARRAY=$(jq -r '.status.vm' <<< "$MCISINFO")
-        MASTERIP=$(jq -r '.status.masterIp' <<< "$MCISINFO")
-        MASTERVM=$(jq -r '.status.masterVmId' <<< "$MCISINFO")
-        
-        echo "MASTERIP: $MASTERIP"
-        echo "MASTERVM: $MASTERVM"	
-        echo "VMARRAY: $VMARRAY"
+    IPLIST=""
 
-        IPLIST=""
-
-        for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-            _jq() {
+    for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+        _jq() {
             echo ${row} | base64 --decode | jq -r ${1}
-            }
+        }
 
-            IPLIST+=$(_jq '.public_ip')
-            IPLIST+=" "
-        done
-
-        IPLIST=`echo ${IPLIST}`
-        echo "PublicIPList: $IPLIST"
-
-        PRIVIPLIST=""
-
-        for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-            _jq() {
-            echo ${row} | base64 --decode | jq -r ${1}
-            }
-
-            PRIVIPLIST+=$(_jq '.private_ip')
-            PRIVIPLIST+=" "
-        done
-
-        PRIVIPLIST=`echo ${PRIVIPLIST}`
-        echo "PrivateIPList: $PRIVIPLIST"
-
-        WHOLE_IPLIST+=$IPLIST
-        WHOLE_IPLIST+=" "
-        WHOLE_PRIVIPLIST+=$PRIVIPLIST
-        WHOLE_PRIVIPLIST+=" "
-        # WHOLE_IPLIST=(${WHOLE_IPLIST[@]} ${IPLIST[@]})
-        # WHOLE_PRIVIPLIST=(${WHOLE_PRIVIPLIST[@]} ${PRIVIPLIST[@]})
-        LORDIP=$MASTERIP
-        LORDVM=$MASTERVM
-        LORDMCIS=$MCISID
+        IPLIST+=$(_jq '.public_ip')
+        IPLIST+=" "
     done
 
+    IPLIST=$(echo ${IPLIST})
+    echo "PublicIPList: $IPLIST"
+
+    PRIVIPLIST=""
+
+    for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+        _jq() {
+            echo ${row} | base64 --decode | jq -r ${1}
+        }
+
+        PRIVIPLIST+=$(_jq '.private_ip')
+        PRIVIPLIST+=" "
+    done
+
+    PRIVIPLIST=$(echo ${PRIVIPLIST})
+    echo "PrivateIPList: $PRIVIPLIST"
+
+    WHOLE_IPLIST+=$IPLIST
+    WHOLE_IPLIST+=" "
+    WHOLE_PRIVIPLIST+=$PRIVIPLIST
+    WHOLE_PRIVIPLIST+=" "
+    # WHOLE_IPLIST=(${WHOLE_IPLIST[@]} ${IPLIST[@]})
+    # WHOLE_PRIVIPLIST=(${WHOLE_PRIVIPLIST[@]} ${PRIVIPLIST[@]})
+    LORDIP=$MASTERIP
+    LORDVM=$MASTERVM
+    LORDMCIS=$MCISID
+done
+
+echo ""
+echo "WHOLE_PublicIPList: $WHOLE_IPLIST"
+echo "WHOLE_PrivateIPList: $WHOLE_PRIVIPLIST"
+
+for MCISID in "$@"; do
     echo ""
-    echo "WHOLE_PublicIPList: $WHOLE_IPLIST"
-    echo "WHOLE_PrivateIPList: $WHOLE_PRIVIPLIST"
-
-
-    for MCISID in "$@" ; do
-        echo ""
-        echo "Installing Weavescope to MCIS..."	
-        echo ""
-        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
+    echo "Installing Weavescope to MCIS..."
+    echo ""
+    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
         '{
         "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
-        }' | jq '' 
-        echo ""
-    done
+        }' | jq ''
+    echo ""
+done
 
-	LAUNCHCMD="sudo scope stop"
-    echo "Stopping Weavescope for master node if exist..."
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
+LAUNCHCMD="sudo scope stop"
+echo "Stopping Weavescope for master node if exist..."
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
 	{
 	"command"        : "${LAUNCHCMD}"
 	}
 EOF
 
-	#LAUNCHCMD="sudo scope launch $WHOLE_IPLIST $WHOLE_PRIVIPLIST"
-    LAUNCHCMD="sudo scope launch $WHOLE_IPLIST"
-	#echo $LAUNCHCMD
+#LAUNCHCMD="sudo scope launch $WHOLE_IPLIST $WHOLE_PRIVIPLIST"
+LAUNCHCMD="sudo scope launch $WHOLE_IPLIST"
+#echo $LAUNCHCMD
 
-    echo "Launching Weavescope for master node..."
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
+echo "Launching Weavescope for master node..."
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
 	{
 	"command"        : "${LAUNCHCMD}"
 	}
 EOF
 
-    
-	echo ""
-	echo "[MCIS Weavescope: master node only] Access to"
-    echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
-	echo ""	
+echo ""
+echo "[MCIS Weavescope: master node only] Access to"
+echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
+echo ""
 
-    LAUNCHCMD="sudo scope launch $LORDIP $WHOLE_PRIVIPLIST"
-	echo "Working on clustring..."	
+LAUNCHCMD="sudo scope launch $LORDIP $WHOLE_PRIVIPLIST"
+echo "Working on clustring..."
 
-    for MCISID in "$@" ; do
+for MCISID in "$@"; do
 
-        echo "Launching Weavescope for the other nodes..."
-        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+    echo "Launching Weavescope for the other nodes..."
+    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
         {
         "command"        : "${LAUNCHCMD}"
         }
 EOF
 
-    done
+done
 
+echo "Done!"
+duration=$SECONDS
+echo "[CMD] ${_self}"
+echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+echo ""
 
-	echo "Done!"	
-	duration=$SECONDS
-	echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
-	echo ""
-	
-	echo "[MCIS Weavescope: complete cluster] Access to"
-	echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
-	echo ""	
+echo "[MCIS Weavescope: complete cluster] Access to"
+echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
+echo ""

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
@@ -95,11 +95,19 @@ echo "WHOLE_PrivateIPList: $WHOLE_PRIVIPLIST"
 for MCISID in "$@"; do
     echo ""
     echo "Installing Weavescope to MCIS..."
+    ScopeInstallFile="git.io/scope"
+    ScopeInstallFile="https://gist.githubusercontent.com/seokho-son/bb2703ca49555f9afe0d0097894c74fa/raw/9eb65b296b85bc53f53af3e8733603d807fb9287/scope"
+    INSTALLCMD="sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L $ScopeInstallFile -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
     echo ""
-    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
-        '{
-        "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
-        }' | jq ''
+
+    VAR1=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${INSTALLCMD}"
+	}
+EOF
+    )
+    echo "${VAR1}" | jq ''
     echo ""
 done
 

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
@@ -151,7 +151,7 @@ done
 
 echo "Done!"
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 echo ""
 

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
@@ -1,145 +1,140 @@
 #!/bin/bash
 
+SECONDS=0
 
-	SECONDS=0
+echo "[Check jq package (if not, install)]"
+if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
+source ../conf.env
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
+echo "####################################################################"
+echo "## Command (SSH) to MCIS "
+echo "####################################################################"
 
-	echo "[Check jq package (if not, install)]"
-	if ! dpkg-query -W -f='${Status}' jq  | grep "ok installed"; then sudo apt install -y jq; fi
-	
+source ../common-functions.sh
 
-    source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
+# CSP=${1}
+# REGION=${2:-1}
+# POSTFIX=${3:-developer}
 
-	echo "####################################################################"
-	echo "## Command (SSH) to MCIS "
-	echo "####################################################################"
+# NUM_MCIS=${1}
 
-    source ../common-functions.sh
+# if [ "${NUM_MCIS}" == "" ]; then
+#     echo "Usage: ./script.sh <NUM_MCIS> <MCIS_1> <MCIS_2> <MCIS_3> ..."
+#     exit 1
+# fi
 
-	# CSP=${1}
-	# REGION=${2:-1}
-	# POSTFIX=${3:-developer}
+# for (( i=0; i<${NUM_MCIS}; i++ ));
+# do
+#     j=$((i+2))
+#     echo ${$j};
+# done
 
-    # NUM_MCIS=${1}
-    
-    # if [ "${NUM_MCIS}" == "" ]; then
-    #     echo "Usage: ./script.sh <NUM_MCIS> <MCIS_1> <MCIS_2> <MCIS_3> ..."
-    #     exit 1
-    # fi
+NUM_MCIS=$#
 
-    # for (( i=0; i<${NUM_MCIS}; i++ ));
-    # do
-    #     j=$((i+2))
-    #     echo ${$j};
-    # done
+WHOLE_IPLIST=""
+WHOLE_PRIVIPLIST=""
+LORDIP=""
+LORDVM=""
+LORDMCIS=""
 
-    NUM_MCIS=$#
+for MCISID in "$@"; do
+    MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status)
+    VMARRAY=$(jq -r '.status.vm' <<<"$MCISINFO")
+    MASTERIP=$(jq -r '.status.masterIp' <<<"$MCISINFO")
+    MASTERVM=$(jq -r '.status.masterVmId' <<<"$MCISINFO")
 
-    WHOLE_IPLIST=""
-    WHOLE_PRIVIPLIST=""
-    LORDIP=""
-    LORDVM=""
-    LORDMCIS=""
+    echo "MASTERIP: $MASTERIP"
+    echo "MASTERVM: $MASTERVM"
+    echo "VMARRAY: $VMARRAY"
 
-    for MCISID in "$@" ; do
-        MCISINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NS_ID/mcis/${MCISID}?action=status`
-        VMARRAY=$(jq -r '.status.vm' <<< "$MCISINFO")
-        MASTERIP=$(jq -r '.status.masterIp' <<< "$MCISINFO")
-        MASTERVM=$(jq -r '.status.masterVmId' <<< "$MCISINFO")
-        
-        echo "MASTERIP: $MASTERIP"
-        echo "MASTERVM: $MASTERVM"	
-        echo "VMARRAY: $VMARRAY"
+    IPLIST=""
 
-        IPLIST=""
-
-        for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-            _jq() {
+    for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+        _jq() {
             echo ${row} | base64 --decode | jq -r ${1}
-            }
+        }
 
-            IPLIST+=$(_jq '.public_ip')
-            IPLIST+=" "
-        done
-
-        IPLIST=`echo ${IPLIST}`
-        echo "IPLIST: $IPLIST"
-
-        PRIVIPLIST=""
-
-        for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-            _jq() {
-            echo ${row} | base64 --decode | jq -r ${1}
-            }
-
-            PRIVIPLIST+=$(_jq '.private_ip')
-            PRIVIPLIST+=" "
-        done
-
-        PRIVIPLIST=`echo ${PRIVIPLIST}`
-        echo "PRIVIPLIST: $PRIVIPLIST"
-
-        WHOLE_IPLIST+=$IPLIST
-        WHOLE_IPLIST+=" "
-        WHOLE_PRIVIPLIST+=$PRIVIPLIST
-        WHOLE_PRIVIPLIST+=" "
-        # WHOLE_IPLIST=(${WHOLE_IPLIST[@]} ${IPLIST[@]})
-        # WHOLE_PRIVIPLIST=(${WHOLE_PRIVIPLIST[@]} ${PRIVIPLIST[@]})
-        LORDIP=$MASTERIP
-        LORDVM=$MASTERVM
-        LORDMCIS=$MCISID
+        IPLIST+=$(_jq '.public_ip')
+        IPLIST+=" "
     done
 
-    echo $WHOLE_IPLIST
-    echo $WHOLE_PRIVIPLIST
+    IPLIST=$(echo ${IPLIST})
+    echo "IPLIST: $IPLIST"
 
-	LAUNCHCMD="sudo scope launch $WHOLE_IPLIST $WHOLE_PRIVIPLIST"
-	#echo $LAUNCHCMD
+    PRIVIPLIST=""
 
-    for MCISID in "$@" ; do
-        echo ""
-        echo "Installing Weavescope to MCIS..."	
-        echo ""
-        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
+    for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+        _jq() {
+            echo ${row} | base64 --decode | jq -r ${1}
+        }
+
+        PRIVIPLIST+=$(_jq '.private_ip')
+        PRIVIPLIST+=" "
+    done
+
+    PRIVIPLIST=$(echo ${PRIVIPLIST})
+    echo "PRIVIPLIST: $PRIVIPLIST"
+
+    WHOLE_IPLIST+=$IPLIST
+    WHOLE_IPLIST+=" "
+    WHOLE_PRIVIPLIST+=$PRIVIPLIST
+    WHOLE_PRIVIPLIST+=" "
+    # WHOLE_IPLIST=(${WHOLE_IPLIST[@]} ${IPLIST[@]})
+    # WHOLE_PRIVIPLIST=(${WHOLE_PRIVIPLIST[@]} ${PRIVIPLIST[@]})
+    LORDIP=$MASTERIP
+    LORDVM=$MASTERVM
+    LORDMCIS=$MCISID
+done
+
+echo $WHOLE_IPLIST
+echo $WHOLE_PRIVIPLIST
+
+LAUNCHCMD="sudo scope launch $WHOLE_IPLIST $WHOLE_PRIVIPLIST"
+#echo $LAUNCHCMD
+
+for MCISID in "$@"; do
+    echo ""
+    echo "Installing Weavescope to MCIS..."
+    echo ""
+    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
         '{
         "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
-        }' | jq '' 
-        echo ""
-    done
+        }' | jq ''
+    echo ""
+done
 
-    echo "Launching Weavescope for master node..."
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
+echo "Launching Weavescope for master node..."
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$LORDMCIS/vm/$LORDVM -H 'Content-Type: application/json' -d @- <<EOF
 	{
 	"command"        : "${LAUNCHCMD}"
 	}
 EOF
 
+echo ""
+echo "[MCIS Weavescope: complete cluster] Access to"
+echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
+echo ""
+echo "Working on clustring..."
 
-	echo ""
-	echo "[MCIS Weavescope: complete cluster] Access to"
-	echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
-	echo ""	
-	echo "Working on clustring..."	
+for MCISID in "$@"; do
 
-    for MCISID in "$@" ; do
-
-        echo "Launching Weavescope for the other nodes..."
-        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+    echo "Launching Weavescope for the other nodes..."
+    curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
         {
         "command"        : "${LAUNCHCMD}"
         }
 EOF
 
-    done
+done
 
+echo "Done!"
+duration=$SECONDS
+echo "[CMD] ${_self}"
+echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
+echo ""
 
-	echo "Done!"	
-	duration=$SECONDS
-	echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
-	echo ""
-	
-	echo "[MCIS Weavescope: complete cluster] Access to"
-	echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
-	echo ""	
+echo "[MCIS Weavescope: complete cluster] Access to"
+echo " $LORDIP:4040/#!/state/{\"contrastMode\":true,\"topologyId\":\"containers-by-hostname\"}"
+echo ""

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
@@ -133,7 +133,7 @@ done
 
 echo "Done!"
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 echo ""
 

--- a/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
+++ b/test/official/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
@@ -97,10 +97,12 @@ LAUNCHCMD="sudo scope launch $WHOLE_IPLIST $WHOLE_PRIVIPLIST"
 for MCISID in "$@"; do
     echo ""
     echo "Installing Weavescope to MCIS..."
+    ScopeInstallFile="git.io/scope"
+    ScopeInstallFile="https://gist.githubusercontent.com/seokho-son/bb2703ca49555f9afe0d0097894c74fa/raw/9eb65b296b85bc53f53af3e8733603d807fb9287/scope"
     echo ""
     curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NS_ID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d \
         '{
-        "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L git.io/scope -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
+        "command": "sudo apt-get update > /dev/null;  sudo apt install docker.io -y; sudo curl -L ${ScopeInstallFile} -o /usr/local/bin/scope; sudo chmod a+x /usr/local/bin/scope"
         }' | jq ''
     echo ""
 done

--- a/test/official/sequentialFullTest/prepare-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/prepare-mcir-ns-cloud.sh
@@ -34,6 +34,7 @@ function test_sequence() {
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 }
 
@@ -67,6 +68,7 @@ function test_sequence_allcsp_mcir() {
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
+	cp ./executionStatus ./executionStatus.back
 	echo ""
 
 }

--- a/test/official/sequentialFullTest/prepare-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/prepare-mcir-ns-cloud.sh
@@ -30,7 +30,7 @@ function test_sequence() {
 
 	echo ""
 	echo "[Logging to notify latest command history]"
-	echo "[CMD] (MCIR) ${_self} ${CSP} ${REGION} ${POSTFIX} ${NUMVM}" >>./executionStatus
+	echo "[MCIR:${MCIRRegionName}] ${_self} ${CSP} ${REGION} ${POSTFIX} ${NUMVM}" >>./executionStatus
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
@@ -63,7 +63,7 @@ function test_sequence_allcsp_mcir() {
 
 	echo ""
 	echo "[Logging to notify latest command history]"
-	echo "[CMD] (MCIR) ${_self} ${CSP} ${REGION} ${POSTFIX} ${TestSetFile}" >>./executionStatus
+	echo "[MCIR:${MCIRRegionName}] ${_self} ${CSP} ${REGION} ${POSTFIX} ${TestSetFile}" >>./executionStatus
 	echo ""
 	echo "[Executed Command List]"
 	cat ./executionStatus
@@ -95,12 +95,13 @@ echo "####################################################################"
 echo "## Create MCIS from Zero Base"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
+# CSP=${1}
+# REGION=${2:-1}
+# POSTFIX=${3:-developer}
 NUMVM=${5:-1}
 
 source ../common-functions.sh
+readParameters "$@"
 getCloudIndex $CSP
 
 if [ "${INDEX}" == "0" ]; then
@@ -116,10 +117,11 @@ if [ "${INDEX}" == "0" ]; then
 			REGION=$cspj
 			#echo $CSP
 			#echo $REGION
-			echo "- Create MCIR in ${CONN_CONFIG[$cspi, $REGION]}"
+			MCIRRegionName=${RegionName[$cspi,$cspj]}
+			echo "- Create MCIR in ${MCIRRegionName}"		
 
 			test_sequence_allcsp_mcir $CSP $REGION $POSTFIX $TestSetFile ${0##*/} &
-			dozing 1
+			# dozing 1
 
 		done
 
@@ -134,12 +136,14 @@ else
 	echo ""
 	TOTALVM=$((1 * 1 * NUMVM))
 	echo "[Create MCIS] VMs($TOTALVM) = Cloud(1) * Region(1) * VMgroup($NUMVM)"
+	MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
 
 	test_sequence $CSP $REGION $POSTFIX $NUMVM $TestSetFile ${0##*/}
 
 fi
 
 duration=$SECONDS
+echo "[CMD] ${_self}"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 
 echo ""

--- a/test/official/sequentialFullTest/prepare-mcir-ns-cloud.sh
+++ b/test/official/sequentialFullTest/prepare-mcir-ns-cloud.sh
@@ -145,7 +145,7 @@ else
 fi
 
 duration=$SECONDS
-echo "[CMD] ${_self}"
+echo "[CMD] $0"
 echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 
 echo ""


### PR DESCRIPTION

// Spider https://github.com/cloud-barista/cb-spider/releases/tag/v0.3.7 연동
- Fix location error
/

- Enable weavescope in ch regions
/
- Feature for change hostname based on TB info
/
- Assign isolated CIDR per cloud regions
/

- Add command-mcis-vm-custom script
/

- Enhance test history style
- Backup machanism for teset history
- Enhance script output message


## [CB-TB 도메인 네임 변경 도구]
 - 기존: VM의 도메인 네임이 클라우드 타입에 따라서 상이하며, MCIS와 관계 파악이 어려움 
            (예: 192-168-3-1, zwf23f2f, ip-xxx-vvv-eee)
 - 개선: VM의 도메인 네임을 "인지하기 편한 명칭으로 변경"  [prefix]-[connectionConfig]-[PublicIP]
(예: c-alibaba-ap-northeast-1-47.74.3.124, b-aws-ap-northeast-1-18.182.26.230, ... )
 - 사용 방법: /cb-tumblebug/test/official/sequentialFullTest$ ./change-mcis-hostname.sh all 1 shson42

## [도메인 네임 변경을 통해서 Weavescope 형상 개선]
 - 기존: 클라우드별로 아이콘이 명확히 구분되지 않았음
 - 개선: 클라우드별로 아이콘 색 구분 (도메인 네임에 prefix로 조정. a,b,c,...,z)
![image](https://user-images.githubusercontent.com/5966944/115153138-6d652c00-a0af-11eb-8cdf-91c1e6d89f20.png)

 - 기존: 도메인 네임에 특별한 의미가 없었음.
 - 개선: 의미있는 도메인 네임 제공
![image](https://user-images.githubusercontent.com/5966944/115153141-6fc78600-a0af-11eb-8e3a-9854296efbb7.png)

 - 기존: 클라우드 및 리전별 VPC의 subnet 주소가 겹쳐서 Private IP의 대역이 겹침. (WeaveScope에서 VM들이 상호 간섭하던 문제)
 - 개선: VPC생성시, 클라우드 및 리전별 "구분된 Subnet CIDR"을 자동으로 사용하도록 테스트 스크립트 개선 (WeaveScope에서 VM들이 상호 간섭하던 문제 해결)
 
![image](https://user-images.githubusercontent.com/5966944/115153144-78b85780-a0af-11eb-9f4b-469c0ff2cfff.png)

(Private IP를 기준으로 상호 정확히 연결함)
