### PR TITLE
Provide SystemMessage to vm status object

### DIFF
--- a/assets/cloudlocation.csv
+++ b/assets/cloudlocation.csv
@@ -111,8 +111,6 @@ alibaba,eu-central-1,Germany (Frankfurt),50.4000,8.7000
 alibaba,eu-west-1,UK (London),51.8000,-0.2000
 alibaba,me-east-1,UAE (Dubai),25.2770,55.2962
 cloudit,default,South Korea (Seoul),37.2665,126.7780
-mock,default,South Korea (Seoul),37.0000,126.0000
-openstack,regionone,South Korea (Daejeon),36.3804,127.3650
 ncp,kr-1,South Korea (Seoul),37.4767,126.8841
 ncp,kr-2,South Korea (Seoul),37.3881,126.9705
 ncp,hk-1,Hong Kong,22.3964,114.1095
@@ -120,5 +118,7 @@ ncp,sgn-1,Singapore,1.3400,103.7041
 ncp,jpn-1,Japan,35.6895,139.6917
 ncp,uswn-1,US Western,37.3500,-121.9600
 ncp,den-1,Germany,50.1109,8.6821
-ufc,ufc,South Korea (Seoul),37.4767,126.8841
+openstack,regionone,South Korea (Daejeon),36.3804,127.3650
 cloudtwin,default,South Korea (Daejeon),36.3804,127.3650
+mock,default,South Korea (Seoul),37.0000,126.0000
+ufc,ufc,South Korea (Seoul),37.4767,126.8841

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -4870,7 +4870,7 @@ var doc = `{
                     "type": "string"
                 },
                 "region": {
-                    "description": "Provided by CB-Spider",
+                    "description": "AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}",
                     "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
@@ -5047,6 +5047,11 @@ var doc = `{
         "mcis.TbVmStatusInfo": {
             "type": "object",
             "properties": {
+                "createdTime": {
+                    "description": "Created time",
+                    "type": "string",
+                    "example": "2022-11-10 23:00:00"
+                },
                 "csp_vm_id": {
                     "type": "string"
                 },
@@ -5079,6 +5084,11 @@ var doc = `{
                 },
                 "status": {
                     "type": "string"
+                },
+                "systemMessage": {
+                    "description": "Latest system message such as error message",
+                    "type": "string",
+                    "example": "Failed because ..."
                 },
                 "targetAction": {
                     "type": "string"

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -4855,7 +4855,7 @@
                     "type": "string"
                 },
                 "region": {
-                    "description": "Provided by CB-Spider",
+                    "description": "AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}",
                     "type": "object",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
@@ -5032,6 +5032,11 @@
         "mcis.TbVmStatusInfo": {
             "type": "object",
             "properties": {
+                "createdTime": {
+                    "description": "Created time",
+                    "type": "string",
+                    "example": "2022-11-10 23:00:00"
+                },
                 "csp_vm_id": {
                     "type": "string"
                 },
@@ -5064,6 +5069,11 @@
                 },
                 "status": {
                     "type": "string"
+                },
+                "systemMessage": {
+                    "description": "Latest system message such as error message",
+                    "type": "string",
+                    "example": "Failed because ..."
                 },
                 "targetAction": {
                     "type": "string"

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -995,7 +995,7 @@ definitions:
         type: string
       region:
         $ref: '#/definitions/mcis.RegionInfo'
-        description: Provided by CB-Spider
+        description: AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
         type: object
       securityGroupIds:
         items:
@@ -1114,6 +1114,10 @@ definitions:
     type: object
   mcis.TbVmStatusInfo:
     properties:
+      createdTime:
+        description: Created time
+        example: "2022-11-10 23:00:00"
+        type: string
       csp_vm_id:
         type: string
       id:
@@ -1136,6 +1140,10 @@ definitions:
       sshPort:
         type: string
       status:
+        type: string
+      systemMessage:
+        description: Latest system message such as error message
+        example: Failed because ...
         type: string
       targetAction:
         type: string


### PR DESCRIPTION


Provide SystemMessage to vm status object

son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/test/official/sequentialFullTest$ ./cleanAll-mcis-mcir-ns-cloud.sh all 1 shson14 ../testSetCustom.env

VM: Status MCIS
####################################################################
{
  "status": {
    "id": "mcis-shson14",
    "name": "mcis-shson14",
    **"status": "Failed-(1/4)",**
    "targetStatus": "Running",
    "targetAction": "Create",
    "installMonAgent": "no",
    "masterVmId": "alibaba-ap-northeast-1-shson14-0",
    "masterIp": "47.74.2.",
    "masterSSHPort": "22",
    "vm": [
      {
        "id": "aws-ap-southeast-1-shson14-0",
        "name": "aws-ap-southeast-1-shson14-0",
        "csp_vm_id": "",
        **"status": "Failed",**
        "targetStatus": "Running",
        "targetAction": "Create",
        "native_status": "",
        "monAgentStatus": "",
        **"systemMessage": "{\"message\":\"InvalidAMIID.Malformed: Invalid id: \\\"ami-a061eb2b23f9f8839c\\\"\\n\\tstatus code: 400, request id: 591a9175-7c60-4833-9ba6-1bf87105dedf\"}\n",**
        "createdTime": "",
        "public_ip": "",
        "private_ip": "",
        "sshPort": "0",
        "location": {
          "latitude": "1.3700",
          "longitude": "103.8000",
          "briefAddr": "Singapore",
          "cloudType": "aws",
          "nativeRegion": "ap-southeast-1"
        }
      },
      {
        "id": "aws-ap-northeast-1-shson14-lead-0",
        "name": "aws-ap-northeast-1-shson14-lead-0",
        "csp_vm_id": "aws-ap-northeast-1-shson14-lead-0",
        "status": "Running",
        "targetStatus": "None",
        "targetAction": "None",
        "native_status": "Running",
        "monAgentStatus": "notInstalled",
        "systemMessage": "",
        "createdTime": "2021-04-20 15:49:27",
        "public_ip": "52.68.184.",
        "private_ip": "192.168.2.6",
        "sshPort": "22",
        "location": {
          "latitude": "35.4100",
          "longitude": "139.4200",
          "briefAddr": "Tokyo",
          "cloudType": "aws",
          "nativeRegion": "ap-northeast-1"
        }
      },
