### PR TITLE
Fix misspell in comments

### DIFF
--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -142,12 +142,12 @@ func GetResourcesCspType(nsId string, resourceType string, resourceId string) st
 	keyValue, err := CBStore.Get(key)
 	if err != nil {
 		CBLog.Error(err)
-		// if there is no matched value for the key, return empty string. Error will be handled in a parent fucntion
+		// if there is no matched value for the key, return empty string. Error will be handled in a parent function
 		return ""
 	}
 	if keyValue == nil {
 		//CBLog.Error(err)
-		// if there is no matched value for the key, return empty string. Error will be handled in a parent fucntion
+		// if there is no matched value for the key, return empty string. Error will be handled in a parent function
 		return ""
 	}
 
@@ -215,12 +215,12 @@ func GetCspResourceId(nsId string, resourceType string, resourceId string) (stri
 	keyValue, err := CBStore.Get(key)
 	if err != nil {
 		CBLog.Error(err)
-		// if there is no matched value for the key, return empty string. Error will be handled in a parent fucntion
+		// if there is no matched value for the key, return empty string. Error will be handled in a parent function
 		return "", err
 	}
 	if keyValue == nil {
 		//CBLog.Error(err)
-		// if there is no matched value for the key, return empty string. Error will be handled in a parent fucntion
+		// if there is no matched value for the key, return empty string. Error will be handled in a parent function
 		return "", err
 	}
 
@@ -259,7 +259,7 @@ func GetCspResourceId(nsId string, resourceType string, resourceId string) (stri
 			err = json.Unmarshal([]byte(keyValue.Value), &content)
 			if err != nil {
 				CBLog.Error(err)
-				// if there is no matched value for the key, return empty string. Error will be handled in a parent fucntion
+				// if there is no matched value for the key, return empty string. Error will be handled in a parent function
 				return ""
 			}
 			return content.CspVNicName

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -1106,7 +1106,7 @@ func DelMcis(nsId string, mcisId string) error {
 		common.CBLog.Error(err)
 		return err
 	}
-	// for deletion, need to wait untill termination is finished
+	// for deletion, need to wait until termination is finished
 	// Sleep for 5 seconds
 	fmt.Printf("\n\n[Info] Sleep for 5 seconds for safe MCIS-VMs termination.\n\n")
 	time.Sleep(5 * time.Second)
@@ -1193,7 +1193,7 @@ func DelMcisVm(nsId string, mcisId string, vmId string) error {
 		common.CBLog.Error(err)
 		return err
 	}
-	// for deletion, need to wait untill termination is finished
+	// for deletion, need to wait until termination is finished
 	// Sleep for 5 seconds
 	fmt.Printf("\n\n[Info] Sleep for 20 seconds for safe VM termination.\n\n")
 	time.Sleep(5 * time.Second)
@@ -1221,7 +1221,7 @@ func DelMcisVm(nsId string, mcisId string, vmId string) error {
 	return nil
 }
 
-//// Info manage for MCIS recommandation
+//// Info manage for MCIS recommendation
 func GetRecommendList(nsId string, cpuSize string, memSize string, diskSize string) ([]TbVmPriority, error) {
 
 	fmt.Println("GetRecommendList")

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -125,7 +125,7 @@ func OrchestrationController() {
 					fmt.Println("[Check MCIS Policy] " + mcisPolicyTmp.Id)
 					//check, _, _ := LowerizeAndCheckMcis(nsId, mcisPolicyTmp.Id )
 					check, _ := CheckMcis(nsId, mcisPolicyTmp.Id)
-					fmt.Println("[Check existance of MCIS] " + mcisPolicyTmp.Id)
+					fmt.Println("[Check existence of MCIS] " + mcisPolicyTmp.Id)
 					//keyValueMcis, _ := common.CBStore.Get(common.GenMcisKey(nsId, mcisPolicyTmp.Id, ""))
 
 					if !check {


### PR DESCRIPTION
Resolves misspells

```
misspell97%
Misspell Finds commonly misspelled English words

cb-tumblebug/src/core/mcis/orchestration.go
Line 128: warning: "existance" is a misspelling of "existence" (misspell)
cb-tumblebug/src/core/common/utility.go
Line 145: warning: "fucntion" is a misspelling of "function" (misspell)
Line 150: warning: "fucntion" is a misspelling of "function" (misspell)
Line 218: warning: "fucntion" is a misspelling of "function" (misspell)
Line 223: warning: "fucntion" is a misspelling of "function" (misspell)
Line 262: warning: "fucntion" is a misspelling of "function" (misspell)
cb-tumblebug/src/core/mcis/control.go
Line 1109: warning: "untill" is a misspelling of "until" (misspell)
Line 1196: warning: "untill" is a misspelling of "until" (misspell)
Line 1224: warning: "recommandation" is a misspelling of "recommendation" (misspell)
```