### PR TITLE
Add cloud regions

### DIFF
--- a/assets/cloudlocation.csv
+++ b/assets/cloudlocation.csv
@@ -71,6 +71,7 @@ gcp,asia-northeast2,Osaka  Japan,34.6937,135.5022
 gcp,asia-northeast3,Seoul  South Korea,37.2000,127.0000
 gcp,asia-south1,Mumbai  India,19.0761,72.8774
 gcp,asia-southeast1,Jurong West  Singapore,1.3400,103.7041
+gcp,asia-southeast2,Jakarta  Indonesia,-6.2000,106.8160
 gcp,australia-southeast1,Sydney  Australia,-33.8651,151.2099
 gcp,europe-north1,Hamina  Finland,60.5700,27.2000
 gcp,europe-west1,St. Ghislain  Belgium,50.4482,3.8189
@@ -78,6 +79,7 @@ gcp,europe-west2,London  England  UK,51.5099,-0.1181
 gcp,europe-west3,Frankfurt  Germany,50.1109,8.6821
 gcp,europe-west4,Eemshaven  Netherlands,53.4423,6.8253
 gcp,europe-west6,Zurich  Switzerland,47.3667,8.5500
+gcp,europe-central2,Warsaw  Poland,52.237049,21.017532
 gcp,northamerica-northeast1,Montreal  Quebec  Canada,45.5089,-73.5617
 gcp,southamerica-east1,Osasco (Sao Paulo)  Brazil,-23.5325,-46.7917
 gcp,us-central1,Council Bluffs  Iowa  USA,41.2522,-95.8575

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -29,7 +29,7 @@ declare -A SPEC_NAME
 
 
 
-## AWS (20 Regions)
+## AWS (21 Regions)
 IX=$IndexAWS
 IY=0
 ProviderName[$IX]=AWS
@@ -38,7 +38,7 @@ DriverName[$IX]=aws-driver01
 
 # region01 
 IY=$AwsApSoutheast1
-# Location: AWS Singapore
+# Location: Asia Pacific (Singapore)
 RegionName[$IX,$IY]=aws-ap-southeast-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=ap-southeast-1
@@ -50,7 +50,7 @@ SPEC_NAME[$IX,$IY]=m4.4xlarge       #t3.xlarge t3.medium
 
 # region02 
 IY=$AwsCaCentral1
-# Location: AWS Canada Central
+# Location: Canada (Central)
 RegionName[$IX,$IY]=aws-ca-central-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=ca-central-1
@@ -62,7 +62,7 @@ SPEC_NAME[$IX,$IY]=t2.micro
 
 # region03 
 IY=$AwsUsWest1
-# Location: AWS US West
+# Location: US West (N. California)
 RegionName[$IX,$IY]=aws-us-west-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=us-west-1
@@ -74,7 +74,7 @@ SPEC_NAME[$IX,$IY]=t2.micro
 
 # region04 
 IY=$AwsUsEast1
-# Location: AWS US East
+# Location: US East (N. Virginia)
 RegionName[$IX,$IY]=aws-us-east-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=us-east-1
@@ -86,7 +86,7 @@ SPEC_NAME[$IX,$IY]=t2.micro
 
 # region05 
 IY=$AwsApNortheast1
-# Location: AWS Tokyo
+# Location: Asia Pacific (Tokyo)
 RegionName[$IX,$IY]=aws-ap-northeast-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=ap-northeast-1
@@ -98,7 +98,7 @@ SPEC_NAME[$IX,$IY]=m4.4xlarge       #t3.xlarge t3.medium
 
 # region06 
 IY=$AwsApSouth1
-# Location: AWS Mumbai
+# Location: Asia Pacific (Mumbai)
 RegionName[$IX,$IY]=aws-ap-south-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=ap-south-1
@@ -110,7 +110,7 @@ SPEC_NAME[$IX,$IY]=t2.micro
 
 # region07 
 IY=$AwsApSoutheast2
-# Location: AWS Sydney
+# Location: Asia Pacific (Sydney)
 RegionName[$IX,$IY]=aws-ap-southeast-2
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=ap-southeast-2
@@ -122,7 +122,7 @@ SPEC_NAME[$IX,$IY]=t2.micro
 
 # region08 
 IY=$AwsEuWest2
-# Location: AWS London
+# Location: Europe (London)
 RegionName[$IX,$IY]=aws-eu-west-2
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=eu-west-2
@@ -230,7 +230,7 @@ SPEC_NAME[$IX,$IY]=t2.micro
 
 # region17 
 IY=$AwsApNortheast2
-# Location: AWS Seoul
+# Location: Asia Pacific (Seoul)
 RegionName[$IX,$IY]=aws-ap-northeast-2
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=ap-northeast-2
@@ -242,7 +242,7 @@ SPEC_NAME[$IX,$IY]=t2.micro
 
 # region18 
 IY=$AwsApEast1
-# Location: AWS Hongkong  -  Opt-In required
+# Location: Asia Pacific (Hong Kong)  -  Opt-In required
 RegionName[$IX,$IY]=aws-ap-east-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=ap-east-1
@@ -254,7 +254,7 @@ SPEC_NAME[$IX,$IY]=t3.micro
 
 # region19 
 IY=$AwsMeSouth1
-# Location: AWS Middle East (Bahrain)  -  Opt-In required
+# Location: Middle East (Bahrain)  -  Opt-In required
 RegionName[$IX,$IY]=aws-me-south-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=me-south-1
@@ -266,7 +266,7 @@ SPEC_NAME[$IX,$IY]=t3.micro
 
 # region20
 IY=$AwsAfSouth1
-# Location: AWS Africa (Cape Town)  -  Opt-In required
+# Location: Africa (Cape Town)  -  Opt-In required
 RegionName[$IX,$IY]=aws-af-south-1
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=af-south-1
@@ -275,6 +275,19 @@ RegionVal02[$IX,$IY]=af-south-1b
 CONN_CONFIG[$IX,$IY]=aws-af-south-1
 IMAGE_NAME[$IX,$IY]=ami-0e4b4778694305983
 SPEC_NAME[$IX,$IY]=t3.micro
+
+# region21
+IY=$AwsEuSouth1
+# Location: Europe (Milan)  -  Opt-In required
+RegionName[$IX,$IY]=aws-eu-south-1
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=eu-south-1
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=eu-south-1b
+CONN_CONFIG[$IX,$IY]=aws-eu-south-1
+IMAGE_NAME[$IX,$IY]=ami-0f274cb646afd3475
+SPEC_NAME[$IX,$IY]=t3.micro
+
 
 
 
@@ -570,7 +583,7 @@ SPEC_NAME[$IX,$IY]=ecs.g6.large
 
 
 
-## GCP (23 Regions. Recommend 22 Regions.)
+## GCP (25 Regions. Recommend 22 Regions.)
 IX=$IndexGCP
 IY=0
 ProviderName[$IX]=GCP
@@ -851,6 +864,30 @@ RegionVal01[$IX,$IY]=asia-south1
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=asia-south1-b
 CONN_CONFIG[$IX,$IY]=gcp-asia-south1
+IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[$IX,$IY]=e2-standard-2
+
+# region24
+IY=$GcpAsiaSoutheast2
+# Location: Jakarta, Indonesia, APAC
+RegionName[$IX,$IY]=gcp-asia-southeast2
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=asia-southeast2
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=asia-southeast2-a
+CONN_CONFIG[$IX,$IY]=gcp-asia-se2
+IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
+SPEC_NAME[$IX,$IY]=e2-standard-2
+
+# region25
+IY=$GcpEuropeCentral2
+# Location: Warsaw, Poland, Europe
+RegionName[$IX,$IY]=gcp-europe-central2
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=europe-central2
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=europe-central2-a
+CONN_CONFIG[$IX,$IY]=gcp-europe-central2
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 

--- a/src/testclient/scripts/testSet.env
+++ b/src/testclient/scripts/testSet.env
@@ -38,18 +38,18 @@ CSPType[$IndexCloudTwin]=cloudtwin
 ## Test setting for Regions of Cloud types 
 # Note: you can change order by replacing lines (automatically assign continuous numbers starting from 1)
 
-# AWS (Total: 20 Regions / Recommend: 20 Regions)
+# AWS (Total: 21 Regions / Recommend: 20 Regions)
 NumRegion[$IndexAWS]=2
 
 IY=0
-AwsApSoutheast1=$((++IY))			# Location: AWS Singapore
-AwsCaCentral1=$((++IY))				# Location: AWS Canada Central
-AwsUsWest1=$((++IY))				# Location: AWS US West
-AwsUsEast1=$((++IY))				# Location: AWS US East
-AwsApNortheast1=$((++IY))			# Location: AWS Tokyo
-AwsApSouth1=$((++IY))				# Location: AWS Mumbai
-AwsApSoutheast2=$((++IY))			# Location: AWS Sydney
-AwsEuWest2=$((++IY))				# Location: AWS London
+AwsApSoutheast1=$((++IY))			# Location: Asia Pacific (Singapore)
+AwsCaCentral1=$((++IY))				# Location: Canada (Central)
+AwsUsWest1=$((++IY))				# Location: US West (N. California)
+AwsUsEast1=$((++IY))				# Location: US East (N. Virginia)
+AwsApNortheast1=$((++IY))			# Location: Asia Pacific (Tokyo)
+AwsApSouth1=$((++IY))				# Location: Asia Pacific (Mumbai)
+AwsApSoutheast2=$((++IY))			# Location: Asia Pacific (Sydney)
+AwsEuWest2=$((++IY))				# Location: Europe (London)
 AwsUsEast2=$((++IY))				# Location: US East (Ohio)
 AwsUsWest2=$((++IY))				# Location: US West (Oregon)
 AwsApNortheast3=$((++IY))			# Location: Asia Pacific (Osaka)
@@ -58,11 +58,11 @@ AwsEuWest1=$((++IY))				# Location: Europe (Ireland)
 AwsEuWest3=$((++IY))				# Location: Europe (Paris)
 AwsEuNorth1=$((++IY))				# Location: Europe (Stockholm) - No t2.xxx Specs. t3 c5 m5 r5 .. are availble
 AwsSaEast1=$((++IY))				# Location: South America (São Paulo)
-AwsApNortheast2=$((++IY))			# Location: AWS Seoul
-AwsApEast1=$((++IY))			    # Location: AWS Hongkong  -  Opt-In required
-
-AwsMeSouth1=$((++IY))			    # Location: AWS Middle East (Bahrain)  -  Opt-In required
-AwsAfSouth1=$((++IY))			    # Location: AWS Africa (Cape Town)  -  Opt-In required
+AwsApNortheast2=$((++IY))			# Location: Asia Pacific (Seoul)
+AwsApEast1=$((++IY))			    # Location: Asia Pacific (Hong Kong)  -  Opt-In required
+AwsMeSouth1=$((++IY))			    # Location: Middle East (Bahrain)  -  Opt-In required
+AwsAfSouth1=$((++IY))			    # Location: Africa (Cape Town)  -  Opt-In required
+AwsEuSouth1=$((++IY))				# Location: Europe (Milan)  -  Opt-In required
 
 
 
@@ -96,7 +96,7 @@ AlibabaCnGuangzhou=$((++IY))		# Location: China (Guangzhou) - NEED TO CHECK NETW
 
 
 
-# GCP (Total: 23 Regions / Recommend: 22 Regions)
+# GCP (Total: 25 Regions / Recommend: 22 Regions)
 NumRegion[$IndexGCP]=2
 
 IY=0
@@ -123,6 +123,8 @@ GcpUsWest1=$((++IY))				# Location: The Dalles  Oregon  USA
 GcpUsWest2=$((++IY))				# Location: Los Angeles  California  USA
 GcpUsWest3=$((++IY))				# Location: Salt Lake City  Utah  USA
 GcpAsiaSouth1=$((++IY))				# Location: Mumbai  India (zone b since zone a returns QUOTA_EXCEEDED)
+GcpAsiaSoutheast2=$((++IY))			# Location: Jakarta, Indonesia, APAC
+GcpEuropeCentral2=$((++IY))			# Location: Warsaw, Poland, Europe
 
 
 


### PR DESCRIPTION
- Ref: https://docs.google.com/spreadsheets/d/1zwlgGsBFmeiw41w0ZxTdqIBFQmx5fPICVrdyNi-p1ck/edit?usp=sharing
- Related discussion: #452
- Added cloud regions
  - AWS EU South 1 (Milan)  -  Opt-In required
  - GCP Asia Southeast 2 (Jakarta, Indonesia, APAC)
  - GCP Europe Central 2 (Warsaw, Poland, Europe)
- 기타: Alibaba ME East 1 (UAE Dubai) 는 
CB-Tumblebug 테스트 스크립트에는 있는데
https://www.alibabacloud.com/help/doc-detail/89155.htm 에는 없음