### PR TITLE
Fix connectionconfig name to prevent length err

### DIFF
--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -611,7 +611,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=europe-west3
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=europe-west3-a
-CONN_CONFIG[$IX,$IY]=gcp-europe-west3
+CONN_CONFIG[$IX,$IY]=gcp-eu-west3
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 
@@ -707,7 +707,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=europe-north1
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=europe-north1-a
-CONN_CONFIG[$IX,$IY]=gcp-europe-north1
+CONN_CONFIG[$IX,$IY]=gcp-eu-north1
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 
@@ -719,7 +719,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=europe-west1
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=europe-west1-b
-CONN_CONFIG[$IX,$IY]=gcp-europe-west1
+CONN_CONFIG[$IX,$IY]=gcp-eu-west1
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 
@@ -731,7 +731,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=europe-west2
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=europe-west2-b
-CONN_CONFIG[$IX,$IY]=gcp-europe-west2
+CONN_CONFIG[$IX,$IY]=gcp-eu-west2
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 
@@ -743,7 +743,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=europe-west4
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=europe-west4-a
-CONN_CONFIG[$IX,$IY]=gcp-europe-west4
+CONN_CONFIG[$IX,$IY]=gcp-eu-west4
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 
@@ -755,7 +755,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=europe-west6
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=europe-west6-a
-CONN_CONFIG[$IX,$IY]=gcp-europe-west6
+CONN_CONFIG[$IX,$IY]=gcp-eu-west6
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 
@@ -791,7 +791,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=us-central1
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=us-central1-a
-CONN_CONFIG[$IX,$IY]=gcp-us-central1
+CONN_CONFIG[$IX,$IY]=gcp-us-cent1
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 
@@ -887,7 +887,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=europe-central2
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=europe-central2-a
-CONN_CONFIG[$IX,$IY]=gcp-europe-central2
+CONN_CONFIG[$IX,$IY]=gcp-eu-cent2
 IMAGE_NAME[$IX,$IY]="https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024"
 SPEC_NAME[$IX,$IY]=e2-standard-2
 


### PR DESCRIPTION
Fix connectionconfig name to prevent length err

`CONN_CONFIG[$IX,$IY]=gcp-europe-central2`

에 의해 리소스 명칭이 너무 길어지면, gcp의 경우 오류가 발생함.

test script에서는 정상 동작하도록 CONN_CONFIG 명칭 간소화