### PR TITLE
Enhance swagger documentation and UI mechanism

### DIFF
--- a/conf/setup.env
+++ b/conf/setup.env
@@ -18,5 +18,5 @@ export AUTOCONTROL_DURATION_MS=10000
 export API_DOC_PATH=$GOPATH/src/github.com/cloud-barista/cb-tumblebug/src/docs/swagger.json
 
 # Set SELF_ENDPOINT, if you want to access Swagger API dashboard from outside.
+# Ex) export SELF_ENDPOINT=xxx.xxx.xxx.xxx:1323
 export SELF_ENDPOINT=localhost:1323
-# export SELF_ENDPOINT=xxx.xxx.xxx.xxx:1323

--- a/conf/setup.env
+++ b/conf/setup.env
@@ -14,3 +14,9 @@ export API_USERNAME=default
 export API_PASSWORD=default
 
 export AUTOCONTROL_DURATION_MS=10000
+
+export API_DOC_PATH=$GOPATH/src/github.com/cloud-barista/cb-tumblebug/src/docs/swagger.json
+
+# Set SELF_ENDPOINT, if you want to access Swagger API dashboard from outside.
+export SELF_ENDPOINT=localhost:1323
+# export SELF_ENDPOINT=xxx.xxx.xxx.xxx:1323

--- a/src/api/grpc/request/test/test_api.go
+++ b/src/api/grpc/request/test/test_api.go
@@ -50,7 +50,7 @@ func main() {
 	time.Sleep(3 * time.Second)
 }
 
-// SimpleNSApiTest - 간단한 NS API 호출
+// SimpleNSApiTest
 func SimpleNSApiTest() {
 
 	fmt.Print("\n\n============= SimpleNSApiTest() =============\n")
@@ -69,14 +69,14 @@ func SimpleNSApiTest() {
 		logger.Fatal(err)
 	}
 
-	/* 서버가 TLS 가 설정된 경우
+	/* TLS enabled
 	err = ns.SetTLSCA(os.Getenv("CBTUMBLEBUG_ROOT") + "/certs/ca.crt")
 	if err != nil {
 		logger.Fatal(err)
 	}
 	*/
 
-	/* 서버가 JWT 인증이 설정된 경우
+	/* JWT enabled
 	err = ns.SetJWTToken("xxxxxxxxxxxxxxxxxxx")
 	if err != nil {
 		logger.Fatal(err)
@@ -98,7 +98,7 @@ func SimpleNSApiTest() {
 	ns.Close()
 }
 
-// ConfigNSApiTest - 환경설정파일을 이용한 NS API 호출
+// ConfigNSApiTest - Call NS API using env config file
 func ConfigNSApiTest() {
 
 	fmt.Print("\n\n============= ConfigNSApiTest() =============\n")
@@ -127,7 +127,7 @@ func ConfigNSApiTest() {
 	ns.Close()
 }
 
-// DocTypeNSApiTest - 입력/출력 타입을 이용한 NS API 호출
+// DocTypeNSApiTest - Call NS API using input/output
 func DocTypeNSApiTest() {
 
 	fmt.Print("\n\n============= DocTypeNSApiTest() =============\n")
@@ -146,7 +146,7 @@ func DocTypeNSApiTest() {
 		logger.Fatal(err)
 	}
 
-	// 입력타입이 json 이고 출력타입이 Json 경우
+	// for JSON input JSON output
 	err = ns.SetInType("json")
 	if err != nil {
 		logger.Fatal(err)
@@ -175,7 +175,7 @@ func DocTypeNSApiTest() {
 
 	fmt.Printf("\njson result :\n%s\n", result)
 
-	// 출력타입을 yaml 로 변경
+	// Change output into yaml
 	err = ns.SetOutType("yaml")
 	if err != nil {
 		logger.Fatal(err)
@@ -188,7 +188,7 @@ func DocTypeNSApiTest() {
 
 	fmt.Printf("\nyaml result :\n%s\n", result)
 
-	// 입력타입을 yaml 로 변경
+	// Change input into yaml
 	err = ns.SetInType("yaml")
 	if err != nil {
 		logger.Fatal(err)
@@ -204,7 +204,7 @@ nsId: ns-test
 
 	fmt.Printf("\nyaml result :\n%s\n", result)
 
-	// 출력타입을 json 로 변경하고 파라미터로 정보 입력
+	// Change output into JSON and provide parameter info
 	err = ns.SetOutType("json")
 	if err != nil {
 		logger.Fatal(err)
@@ -230,7 +230,7 @@ nsId: ns-test
 	ns.Close()
 }
 
-// ConfigMCIRApiTest - 환경설정파일을 이용한 MCIR API 호출
+// ConfigMCIRApiTest - Call MCIR API using env config file
 func ConfigMCIRApiTest() {
 
 	fmt.Print("\n\n============= ConfigMCIRApiTest() =============\n")
@@ -259,7 +259,7 @@ func ConfigMCIRApiTest() {
 	mcir.Close()
 }
 
-// ConfigMCISApiTest - 환경설정파일을 이용한 MCIS API 호출
+// ConfigMCISApiTest - Call MCIS API using env config file
 func ConfigMCISApiTest() {
 
 	fmt.Print("\n\n============= ConfigMCISApiTest() =============\n")
@@ -288,7 +288,7 @@ func ConfigMCISApiTest() {
 	mcis.Close()
 }
 
-// CreateCIMApiTest - 파라미터를 이용한 Create CIM API 호출
+// CreateCIMApiTest - Call Create CIM API using parameter
 func CreateCIMApiTest() {
 
 	fmt.Print("\n\n============= CreateCIMApiTest() =============\n")
@@ -368,7 +368,7 @@ func CreateCIMApiTest() {
 	cim.Close()
 }
 
-// CreateNSApiTest - 파라미터를 이용한 Create NS API 호출
+// CreateNSApiTest - Call Create NS API using parameter
 func CreateNSApiTest() {
 
 	fmt.Print("\n\n============= CreateNSApiTest() =============\n")
@@ -401,7 +401,7 @@ func CreateNSApiTest() {
 	ns.Close()
 }
 
-// CreateMCIRApiTest - 파라미터를 이용한 Create MCIR API 호출
+// CreateMCIRApiTest - Call Create MCIR API using parameter
 func CreateMCIRApiTest() {
 
 	fmt.Print("\n\n============= CreateMCIRApiTest() =============\n")
@@ -539,7 +539,7 @@ func CreateMCIRApiTest() {
 	mcir.Close()
 }
 
-// CreateMCISApiTest - 파라미터를 이용한 Create MCIS API 호출
+// CreateMCISApiTest - Call Create MCIS API using parameter
 func CreateMCISApiTest() {
 
 	fmt.Print("\n\n============= CreateMCISApiTest() =============\n")
@@ -609,7 +609,7 @@ func CreateMCISApiTest() {
 	mcis.Close()
 }
 
-// DeleteMCISApiTest - 파라미터를 이용한 Delete MCIS API 호출
+// DeleteMCISApiTest - Call Delete MCIS API using parameter
 func DeleteMCISApiTest() {
 
 	fmt.Print("\n\n============= DeleteMCISApiTest() =============\n")
@@ -638,7 +638,7 @@ func DeleteMCISApiTest() {
 	mcis.Close()
 }
 
-// DeleteMCIRApiTest - 파라미터를 이용한 Delete MCIR API 호출
+// DeleteMCIRApiTest - Call Delete MCIR API using parameter
 func DeleteMCIRApiTest() {
 
 	fmt.Print("\n\n============= DeleteMCIRApiTest() =============\n")
@@ -695,7 +695,7 @@ func DeleteMCIRApiTest() {
 	mcir.Close()
 }
 
-// DeleteNSApiTest - 파라미터를 이용한 Delete NS API 호출
+// DeleteNSApiTest - Call Delete NS API using parameter
 func DeleteNSApiTest() {
 
 	fmt.Print("\n\n============= DeleteNSApiTest() =============\n")
@@ -724,7 +724,7 @@ func DeleteNSApiTest() {
 	ns.Close()
 }
 
-// DeleteCIMApiTest - 파라미터를 이용한 Delete CIM API 호출
+// DeleteCIMApiTest - Call Delete CIM API using parameter
 func DeleteCIMApiTest() {
 
 	fmt.Print("\n\n============= DeleteCIMApiTest() =============\n")

--- a/src/api/rest/server/common/config.go
+++ b/src/api/rest/server/common/config.go
@@ -18,7 +18,7 @@ type RestGetAllConfigResponse struct {
 // RestGetConfig godoc
 // @Summary Get config
 // @Description Get config
-// @Tags Config
+// @Tags [Admin] System environment config
 // @Accept  json
 // @Produce  json
 // @Param configId path string true "Config ID"
@@ -47,7 +47,7 @@ func RestGetConfig(c echo.Context) error {
 // RestGetAllConfig godoc
 // @Summary List all configs
 // @Description List all configs
-// @Tags Config
+// @Tags [Admin] System environment config
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} RestGetAllConfigResponse
@@ -80,7 +80,7 @@ func RestGetAllConfig(c echo.Context) error {
 // RestPostConfig godoc
 // @Summary Create or Update config
 // @Description Create or Update config (SPIDER_REST_URL, DRAGONFLY_REST_URL, ...)
-// @Tags Config
+// @Tags [Admin] System environment config
 // @Accept  json
 // @Produce  json
 // @Param config body common.ConfigInfo true "Key and Value for configuration"
@@ -113,7 +113,7 @@ func RestPostConfig(c echo.Context) error {
 // RestDelAllConfig godoc
 // @Summary Delete all configs
 // @Description Delete all configs
-// @Tags Config
+// @Tags [Admin] System environment config
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.SimpleMsg

--- a/src/api/rest/server/common/config.go
+++ b/src/api/rest/server/common/config.go
@@ -18,7 +18,7 @@ type RestGetAllConfigResponse struct {
 // RestGetConfig godoc
 // @Summary Get config
 // @Description Get config
-// @Tags [Admin] System environment config
+// @Tags [Admin] System environment
 // @Accept  json
 // @Produce  json
 // @Param configId path string true "Config ID"
@@ -47,7 +47,7 @@ func RestGetConfig(c echo.Context) error {
 // RestGetAllConfig godoc
 // @Summary List all configs
 // @Description List all configs
-// @Tags [Admin] System environment config
+// @Tags [Admin] System environment
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} RestGetAllConfigResponse
@@ -80,7 +80,7 @@ func RestGetAllConfig(c echo.Context) error {
 // RestPostConfig godoc
 // @Summary Create or Update config
 // @Description Create or Update config (SPIDER_REST_URL, DRAGONFLY_REST_URL, ...)
-// @Tags [Admin] System environment config
+// @Tags [Admin] System environment
 // @Accept  json
 // @Produce  json
 // @Param config body common.ConfigInfo true "Key and Value for configuration"
@@ -113,7 +113,7 @@ func RestPostConfig(c echo.Context) error {
 // RestDelAllConfig godoc
 // @Summary Delete all configs
 // @Description Delete all configs
-// @Tags [Admin] System environment config
+// @Tags [Admin] System environment
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.SimpleMsg

--- a/src/api/rest/server/common/namespace.go
+++ b/src/api/rest/server/common/namespace.go
@@ -50,7 +50,7 @@ func RestCheckNs(c echo.Context) error {
 // RestDelAllNs godoc
 // @Summary Delete all namespaces
 // @Description Delete all namespaces
-// @Tags Namespace
+// @Tags [Namespace] Namespace management
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.SimpleMsg
@@ -82,7 +82,7 @@ func RestDelAllNs(c echo.Context) error {
 // RestDelNs godoc
 // @Summary Delete namespace
 // @Description Delete namespace
-// @Tags Namespace
+// @Tags [Namespace] Namespace management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -128,7 +128,7 @@ type RestGetAllNsResponse struct {
 // RestGetAllNs godoc
 // @Summary List all namespaces
 // @Description List all namespaces
-// @Tags Namespace
+// @Tags [Namespace] Namespace management
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} RestGetAllNsResponse
@@ -161,7 +161,7 @@ func RestGetAllNs(c echo.Context) error {
 // RestGetNs godoc
 // @Summary Get namespace
 // @Description Get namespace
-// @Tags Namespace
+// @Tags [Namespace] Namespace management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -190,7 +190,7 @@ func RestGetNs(c echo.Context) error {
 // RestPostNs godoc
 // @Summary Create namespace
 // @Description Create namespace
-// @Tags Namespace
+// @Tags [Namespace] Namespace management
 // @Accept  json
 // @Produce  json
 // @Param nsReq body common.NsReq true "Details for a new namespace"
@@ -224,7 +224,7 @@ func RestPostNs(c echo.Context) error {
 // RestPutNs godoc
 // @Summary Update namespace
 // @Description Update namespace
-// @Tags Namespace
+// @Tags [Namespace] Namespace management
 // @Accept  json
 // @Produce  json
 // @Param namespace body common.NsInfo true "Details to update existing namespace"

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -52,7 +52,7 @@ func Validate(c echo.Context, params []string) error {
 // RestGetHealth godoc
 // @Summary Check Tumblebug is alive
 // @Description Check Tumblebug is alive
-// @Tags Admin
+// @Tags [Admin] System management
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.SimpleMsg
@@ -70,7 +70,7 @@ func RestGetHealth(c echo.Context) error {
 // RestGetSwagger godoc
 // @Summary Get API document web
 // @Description Get API document web
-// @Tags Admin
+// @Tags [Admin] System management
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.SimpleMsg
@@ -99,7 +99,7 @@ func RestGetSwagger(c echo.Context) error {
 // RestGetConnConfig godoc
 // @Summary Get registered ConnConfig info
 // @Description Get registered ConnConfig info
-// @Tags Cloud
+// @Tags [Cloud] Associated Cloud info
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.ConnConfig
@@ -124,7 +124,7 @@ func RestGetConnConfig(c echo.Context) error {
 // RestGetConnConfigList godoc
 // @Summary List all registered ConnConfig
 // @Description List all registered ConnConfig
-// @Tags Cloud
+// @Tags [Cloud] Associated Cloud info
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.ConnConfigList
@@ -148,7 +148,7 @@ func RestGetConnConfigList(c echo.Context) error {
 // RestGetRegion godoc
 // @Summary Get registered region info
 // @Description Get registered region info
-// @Tags Cloud
+// @Tags [Cloud] Associated Cloud info
 // @Accept  json
 // @Produce  json
 // @Param regionName path string true "Name of region to retrieve"
@@ -175,7 +175,7 @@ func RestGetRegion(c echo.Context) error {
 // RestGetRegionList godoc
 // @Summary List all registered regions
 // @Description List all registered regions
-// @Tags Cloud
+// @Tags [Cloud] Associated Cloud info
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.RegionList
@@ -204,7 +204,7 @@ type ObjectList struct {
 // RestGetObjects godoc
 // @Summary List all objects for a given key
 // @Description List all objects for a given key
-// @Tags Admin
+// @Tags [Admin] System management
 // @Accept  json
 // @Produce  json
 // @Param key query string true "retrieve objects by key"
@@ -230,7 +230,7 @@ func RestGetObjects(c echo.Context) error {
 // RestGetObject godoc
 // @Summary Get value of an object
 // @Description Get value of an object
-// @Tags Admin
+// @Tags [Admin] System management
 // @Accept  json
 // @Produce  json
 // @Param key query string true "get object value by key"
@@ -257,7 +257,7 @@ func RestGetObject(c echo.Context) error {
 // RestDeleteObject godoc
 // @Summary Delete an object
 // @Description Delete an object
-// @Tags Admin
+// @Tags [Admin] System management
 // @Accept  json
 // @Produce  json
 // @Param key query string true "delete object value by key"
@@ -286,7 +286,7 @@ func RestDeleteObject(c echo.Context) error {
 // RestDeleteObjects godoc
 // @Summary Delete child objects along with the given object
 // @Description Delete child objects along with the given object
-// @Tags Admin
+// @Tags [Admin] System management
 // @Accept  json
 // @Produce  json
 // @Param key query string true "Delete child objects based on the given key string"

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -51,6 +51,17 @@ func RestGetHealth(c echo.Context) error {
 	return c.String(http.StatusOK, "The API server of CB-Tumblebug is alive.")
 }
 
+// RestGetConnConfig func is a rest api wrapper for GetConnConfig.
+// RestGetConnConfig godoc
+// @Summary Get registered ConnConfig info
+// @Description Get registered ConnConfig info
+// @Tags Admin
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} common.ConnConfig
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /connConfig/{connConfigName} [get]
 func RestGetConnConfig(c echo.Context) error {
 
 	connConfigName := c.Param("connConfigName")
@@ -65,6 +76,17 @@ func RestGetConnConfig(c echo.Context) error {
 
 }
 
+// RestGetConnConfigList func is a rest api wrapper for GetConnConfigList.
+// RestGetConnConfigList godoc
+// @Summary List all registered ConnConfig
+// @Description List all registered ConnConfig
+// @Tags Admin
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} common.ConnConfigList
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /connConfig [get]
 func RestGetConnConfigList(c echo.Context) error {
 
 	fmt.Println("[Get ConnConfig List]")

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -78,6 +78,18 @@ func RestGetConnConfigList(c echo.Context) error {
 
 }
 
+// RestGetRegion func is a rest api wrapper for GetRegion.
+// RestGetRegion godoc
+// @Summary Get registered region info
+// @Description Get registered region info
+// @Tags Admin
+// @Accept  json
+// @Produce  json
+// @Param regionName path string true "Name of region to retrieve"
+// @Success 200 {object} common.Region
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /region/{regionName} [get]
 func RestGetRegion(c echo.Context) error {
 
 	regionName := c.Param("regionName")

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -99,7 +99,7 @@ func RestGetSwagger(c echo.Context) error {
 // RestGetConnConfig godoc
 // @Summary Get registered ConnConfig info
 // @Description Get registered ConnConfig info
-// @Tags [Cloud] Associated Cloud info
+// @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.ConnConfig
@@ -124,7 +124,7 @@ func RestGetConnConfig(c echo.Context) error {
 // RestGetConnConfigList godoc
 // @Summary List all registered ConnConfig
 // @Description List all registered ConnConfig
-// @Tags [Cloud] Associated Cloud info
+// @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.ConnConfigList
@@ -148,7 +148,7 @@ func RestGetConnConfigList(c echo.Context) error {
 // RestGetRegion godoc
 // @Summary Get registered region info
 // @Description Get registered region info
-// @Tags [Cloud] Associated Cloud info
+// @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
 // @Param regionName path string true "Name of region to retrieve"
@@ -175,7 +175,7 @@ func RestGetRegion(c echo.Context) error {
 // RestGetRegionList godoc
 // @Summary List all registered regions
 // @Description List all registered regions
-// @Tags [Cloud] Associated Cloud info
+// @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.RegionList

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -47,6 +47,17 @@ func Validate(c echo.Context, params []string) error {
 	return nil
 }
 
+// RestGetHealth func is for checking Tumblebug server health.
+// RestGetHealth godoc
+// @Summary Check Tumblebug is alive
+// @Description Check Tumblebug is alive
+// @Tags Admin
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /health [get]
 func RestGetHealth(c echo.Context) error {
 	return c.String(http.StatusOK, "The API server of CB-Tumblebug is alive.")
 }

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -59,7 +59,10 @@ func Validate(c echo.Context, params []string) error {
 // @Failure 500 {object} common.SimpleMsg
 // @Router /health [get]
 func RestGetHealth(c echo.Context) error {
-	return c.String(http.StatusOK, "The API server of CB-Tumblebug is alive.")
+	okMessage := common.SimpleMsg{}
+	okMessage.Message = "API server of CB-Tumblebug is alive"
+
+	return c.JSON(http.StatusOK, &okMessage)
 }
 
 // RestGetConnConfig func is a rest api wrapper for GetConnConfig.

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -99,7 +99,7 @@ func RestGetSwagger(c echo.Context) error {
 // RestGetConnConfig godoc
 // @Summary Get registered ConnConfig info
 // @Description Get registered ConnConfig info
-// @Tags Admin
+// @Tags Cloud
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.ConnConfig
@@ -124,7 +124,7 @@ func RestGetConnConfig(c echo.Context) error {
 // RestGetConnConfigList godoc
 // @Summary List all registered ConnConfig
 // @Description List all registered ConnConfig
-// @Tags Admin
+// @Tags Cloud
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.ConnConfigList
@@ -148,7 +148,7 @@ func RestGetConnConfigList(c echo.Context) error {
 // RestGetRegion godoc
 // @Summary Get registered region info
 // @Description Get registered region info
-// @Tags Admin
+// @Tags Cloud
 // @Accept  json
 // @Produce  json
 // @Param regionName path string true "Name of region to retrieve"
@@ -175,7 +175,7 @@ func RestGetRegion(c echo.Context) error {
 // RestGetRegionList godoc
 // @Summary List all registered regions
 // @Description List all registered regions
-// @Tags Admin
+// @Tags Cloud
 // @Accept  json
 // @Produce  json
 // @Success 200 {object} common.RegionList

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -1,10 +1,10 @@
 package common
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"encoding/json"
 
 	"github.com/beego/beego/v2/core/validation"
 	"github.com/labstack/echo/v4"
@@ -93,6 +93,17 @@ func RestGetRegion(c echo.Context) error {
 
 }
 
+// RestGetRegionList func is a rest api wrapper for GetRegionList.
+// RestGetRegionList godoc
+// @Summary List all registered regions
+// @Description List all registered regions
+// @Tags Admin
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} common.RegionList
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /region [get]
 func RestGetRegionList(c echo.Context) error {
 
 	fmt.Println("[Get Region List]")
@@ -107,7 +118,7 @@ func RestGetRegionList(c echo.Context) error {
 }
 
 // ObjectList struct consists of object IDs
-type ObjectList struct { 
+type ObjectList struct {
 	Object []string `json:"object"`
 }
 
@@ -155,9 +166,9 @@ func RestGetObject(c echo.Context) error {
 
 	content, err := common.GetObjectValue(parentKey)
 	if err != nil || content == "" {
-		return SendMessage(c, http.StatusOK, "Cannot find [" + parentKey+ "] object")
+		return SendMessage(c, http.StatusOK, "Cannot find ["+parentKey+"] object")
 	}
-	
+
 	var contentJSON map[string]interface{}
 	json.Unmarshal([]byte(content), &contentJSON)
 
@@ -182,12 +193,12 @@ func RestDeleteObject(c echo.Context) error {
 
 	content, err := common.GetObjectValue(parentKey)
 	if err != nil || content == "" {
-		return SendMessage(c, http.StatusOK, "Cannot find [" + parentKey+ "] object")
+		return SendMessage(c, http.StatusOK, "Cannot find ["+parentKey+"] object")
 	}
 
 	err = common.DeleteObject(parentKey)
 	if err != nil {
-		return SendMessage(c, http.StatusOK, "Cannot delete [" + parentKey+ "] object")
+		return SendMessage(c, http.StatusOK, "Cannot delete ["+parentKey+"] object")
 	}
 
 	return SendMessage(c, http.StatusOK, "The object has been deleted")

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/beego/beego/v2/core/validation"
 	"github.com/labstack/echo/v4"
@@ -63,6 +64,35 @@ func RestGetHealth(c echo.Context) error {
 	okMessage.Message = "API server of CB-Tumblebug is alive"
 
 	return c.JSON(http.StatusOK, &okMessage)
+}
+
+// RestGetSwagger func is to get API document web.
+// RestGetSwagger godoc
+// @Summary Get API document web
+// @Description Get API document web
+// @Tags Admin
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /swaggerActive [get]
+func RestGetSwagger(c echo.Context) error {
+	docFile := os.Getenv("API_DOC_PATH")
+
+	f, err := os.Open(docFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	dec := json.NewDecoder(f)
+	data := make(map[string]interface{}, 0)
+	if err := dec.Decode(&data); err != nil {
+		return err
+	}
+	data["host"] = os.Getenv("SELF_ENDPOINT")
+	return c.JSON(http.StatusOK, data)
 }
 
 // RestGetConnConfig func is a rest api wrapper for GetConnConfig.

--- a/src/api/rest/server/mcir/image.go
+++ b/src/api/rest/server/mcir/image.go
@@ -12,7 +12,7 @@ import (
 // RestPostImage godoc
 // @Summary Register image
 // @Description Register image
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param registeringMethod query string true "registerWithInfo or registerWithId"
@@ -76,7 +76,7 @@ func RestPostImage(c echo.Context) error {
 // RestPutImage godoc
 // @Summary Update image
 // @Description Update image
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param imageInfo body mcir.TbImageInfo true "Details for an image object"
@@ -100,7 +100,7 @@ type RestLookupImageRequest struct {
 // RestLookupImage godoc
 // @Summary Lookup image
 // @Description Lookup image
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param connectionName body RestLookupImageRequest true "Specify connectionName"
@@ -130,7 +130,7 @@ func RestLookupImage(c echo.Context) error {
 // RestLookupImageList godoc
 // @Summary Lookup image list
 // @Description Lookup image list
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param connectionName body RestLookupImageRequest true "Specify connectionName"
@@ -163,7 +163,7 @@ func RestLookupImageList(c echo.Context) error {
 // RestFetchImages godoc
 // @Summary Fetch images
 // @Description Fetch images
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -191,7 +191,7 @@ func RestFetchImages(c echo.Context) error {
 // RestGetImage godoc
 // @Summary Get image
 // @Description Get image
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -213,7 +213,7 @@ type RestGetAllImageResponse struct {
 // RestGetAllImage godoc
 // @Summary List all images
 // @Description List all images
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -229,7 +229,7 @@ func RestGetAllImage(c echo.Context) error {
 // RestDelImage godoc
 // @Summary Delete image
 // @Description Delete image
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -245,7 +245,7 @@ func RestDelImage(c echo.Context) error {
 // RestDelAllImage godoc
 // @Summary Delete all images
 // @Description Delete all images
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -265,7 +265,7 @@ type RestSearchImageRequest struct {
 // RestSearchImage godoc
 // @Summary Search image
 // @Description Search image
-// @Tags Image
+// @Tags [MCIR] Image management
 // @Accept  json
 // @Produce  json
 // @Param keywords body RestSearchImageRequest true "Keywords"

--- a/src/api/rest/server/mcir/image.go
+++ b/src/api/rest/server/mcir/image.go
@@ -100,7 +100,7 @@ type RestLookupImageRequest struct {
 // RestLookupImage godoc
 // @Summary Lookup image
 // @Description Lookup image
-// @Tags [MCIR] Image management
+// @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
 // @Param connectionName body RestLookupImageRequest true "Specify connectionName"
@@ -130,7 +130,7 @@ func RestLookupImage(c echo.Context) error {
 // RestLookupImageList godoc
 // @Summary Lookup image list
 // @Description Lookup image list
-// @Tags [MCIR] Image management
+// @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
 // @Param connectionName body RestLookupImageRequest true "Specify connectionName"

--- a/src/api/rest/server/mcir/securitygroup.go
+++ b/src/api/rest/server/mcir/securitygroup.go
@@ -12,7 +12,7 @@ import (
 // RestPostSecurityGroup godoc
 // @Summary Create Security Group
 // @Description Create Security Group
-// @Tags Security Group
+// @Tags [MCIR] Security group management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -50,7 +50,7 @@ func RestPostSecurityGroup(c echo.Context) error {
 // RestPutSecurityGroup godoc
 // @Summary Update Security Group
 // @Description Update Security Group
-// @Tags Security Group
+// @Tags [MCIR] Security group management
 // @Accept  json
 // @Produce  json
 // @Param securityGroupInfo body mcir.TbSecurityGroupInfo true "Details for an securityGroup object"
@@ -68,7 +68,7 @@ func RestPutSecurityGroup(c echo.Context) error {
 // RestGetSecurityGroup godoc
 // @Summary Get Security Group
 // @Description Get Security Group
-// @Tags Security Group
+// @Tags [MCIR] Security group management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -90,7 +90,7 @@ type RestGetAllSecurityGroupResponse struct {
 // RestGetAllSecurityGroup godoc
 // @Summary List all Security Groups
 // @Description List all Security Groups
-// @Tags Security Group
+// @Tags [MCIR] Security group management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -106,7 +106,7 @@ func RestGetAllSecurityGroup(c echo.Context) error {
 // RestDelSecurityGroup godoc
 // @Summary Delete Security Group
 // @Description Delete Security Group
-// @Tags Security Group
+// @Tags [MCIR] Security group management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -122,7 +122,7 @@ func RestDelSecurityGroup(c echo.Context) error {
 // RestDelAllSecurityGroup godoc
 // @Summary Delete all Security Groups
 // @Description Delete all Security Groups
-// @Tags Security Group
+// @Tags [MCIR] Security group management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcir/spec.go
+++ b/src/api/rest/server/mcir/spec.go
@@ -117,7 +117,7 @@ type RestLookupSpecRequest struct {
 // RestLookupSpec godoc
 // @Summary Lookup spec
 // @Description Lookup spec
-// @Tags [MCIR] Spec management
+// @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
 // @Param connectionName body RestLookupSpecRequest true "Specify connectionName"
@@ -147,7 +147,7 @@ func RestLookupSpec(c echo.Context) error {
 // RestLookupSpecList godoc
 // @Summary Lookup spec list
 // @Description Lookup spec list
-// @Tags [MCIR] Spec management
+// @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
 // @Param connectionName body RestLookupSpecRequest true "Specify connectionName"

--- a/src/api/rest/server/mcir/spec.go
+++ b/src/api/rest/server/mcir/spec.go
@@ -12,7 +12,7 @@ import (
 // RestPostSpec godoc
 // @Summary Register spec
 // @Description Register spec
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param registeringMethod query string true "registerWithInfo or else"
@@ -70,7 +70,7 @@ func RestPostSpec(c echo.Context) error {
 // RestPutSpec godoc
 // @Summary Update spec
 // @Description Update spec
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param specInfo body mcir.TbSpecInfo true "Details for an spec object"
@@ -117,7 +117,7 @@ type RestLookupSpecRequest struct {
 // RestLookupSpec godoc
 // @Summary Lookup spec
 // @Description Lookup spec
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param connectionName body RestLookupSpecRequest true "Specify connectionName"
@@ -147,7 +147,7 @@ func RestLookupSpec(c echo.Context) error {
 // RestLookupSpecList godoc
 // @Summary Lookup spec list
 // @Description Lookup spec list
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param connectionName body RestLookupSpecRequest true "Specify connectionName"
@@ -180,7 +180,7 @@ func RestLookupSpecList(c echo.Context) error {
 // RestFetchSpecs godoc
 // @Summary Fetch specs
 // @Description Fetch specs
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -213,7 +213,7 @@ type RestFilterSpecsResponse struct {
 // RestFilterSpecs godoc
 // @Summary Filter specs
 // @Description Filter specs
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -247,7 +247,7 @@ func RestFilterSpecs(c echo.Context) error {
 // RestFilterSpecsByRange godoc
 // @Summary Filter specs by range
 // @Description Filter specs by range
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -309,7 +309,7 @@ func RestTestSortSpecs(c echo.Context) error {
 // RestGetSpec godoc
 // @Summary Get spec
 // @Description Get spec
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -331,7 +331,7 @@ type RestGetAllSpecResponse struct {
 // RestGetAllSpec godoc
 // @Summary List all specs
 // @Description List all specs
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -347,7 +347,7 @@ func RestGetAllSpec(c echo.Context) error {
 // RestDelSpec godoc
 // @Summary Delete spec
 // @Description Delete spec
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -363,7 +363,7 @@ func RestDelSpec(c echo.Context) error {
 // RestDelAllSpec godoc
 // @Summary Delete all specs
 // @Description Delete all specs
-// @Tags Spec
+// @Tags [MCIR] Spec management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcir/sshkey.go
+++ b/src/api/rest/server/mcir/sshkey.go
@@ -12,7 +12,7 @@ import (
 // RestPostSshKey godoc
 // @Summary Create SSH Key
 // @Description Create SSH Key
-// @Tags [MCIR] VM access key management
+// @Tags [MCIR] Access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -53,7 +53,7 @@ func RestPostSshKey(c echo.Context) error {
 // RestPutSshKey godoc
 // @Summary Update SSH Key
 // @Description Update SSH Key
-// @Tags [MCIR] VM access key management
+// @Tags [MCIR] Access key management
 // @Accept  json
 // @Produce  json
 // @Param sshKeyInfo body mcir.TbSshKeyInfo true "Details for an SSH Key object"
@@ -71,7 +71,7 @@ func RestPutSshKey(c echo.Context) error {
 // RestGetSshKey godoc
 // @Summary Get SSH Key
 // @Description Get SSH Key
-// @Tags [MCIR] VM access key management
+// @Tags [MCIR] Access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -93,7 +93,7 @@ type RestGetAllSshKeyResponse struct {
 // RestGetAllSshKey godoc
 // @Summary List all SSH Keys
 // @Description List all SSH Keys
-// @Tags [MCIR] VM access key management
+// @Tags [MCIR] Access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -109,7 +109,7 @@ func RestGetAllSshKey(c echo.Context) error {
 // RestDelSshKey godoc
 // @Summary Delete SSH Key
 // @Description Delete SSH Key
-// @Tags [MCIR] VM access key management
+// @Tags [MCIR] Access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -125,7 +125,7 @@ func RestDelSshKey(c echo.Context) error {
 // RestDelAllSshKey godoc
 // @Summary Delete all SSH Keys
 // @Description Delete all SSH Keys
-// @Tags [MCIR] VM access key management
+// @Tags [MCIR] Access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcir/sshkey.go
+++ b/src/api/rest/server/mcir/sshkey.go
@@ -12,7 +12,7 @@ import (
 // RestPostSshKey godoc
 // @Summary Create SSH Key
 // @Description Create SSH Key
-// @Tags SSH Key
+// @Tags [MCIR] VM access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -53,7 +53,7 @@ func RestPostSshKey(c echo.Context) error {
 // RestPutSshKey godoc
 // @Summary Update SSH Key
 // @Description Update SSH Key
-// @Tags SSH Key
+// @Tags [MCIR] VM access key management
 // @Accept  json
 // @Produce  json
 // @Param sshKeyInfo body mcir.TbSshKeyInfo true "Details for an SSH Key object"
@@ -71,7 +71,7 @@ func RestPutSshKey(c echo.Context) error {
 // RestGetSshKey godoc
 // @Summary Get SSH Key
 // @Description Get SSH Key
-// @Tags SSH Key
+// @Tags [MCIR] VM access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -93,7 +93,7 @@ type RestGetAllSshKeyResponse struct {
 // RestGetAllSshKey godoc
 // @Summary List all SSH Keys
 // @Description List all SSH Keys
-// @Tags SSH Key
+// @Tags [MCIR] VM access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -109,7 +109,7 @@ func RestGetAllSshKey(c echo.Context) error {
 // RestDelSshKey godoc
 // @Summary Delete SSH Key
 // @Description Delete SSH Key
-// @Tags SSH Key
+// @Tags [MCIR] VM access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -125,7 +125,7 @@ func RestDelSshKey(c echo.Context) error {
 // RestDelAllSshKey godoc
 // @Summary Delete all SSH Keys
 // @Description Delete all SSH Keys
-// @Tags SSH Key
+// @Tags [MCIR] VM access key management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcir/vnet.go
+++ b/src/api/rest/server/mcir/vnet.go
@@ -12,7 +12,7 @@ import (
 // RestPostVNet godoc
 // @Summary Create VNet
 // @Description Create VNet
-// @Tags VNet
+// @Tags [MCIR] VNet management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -51,7 +51,7 @@ func RestPostVNet(c echo.Context) error {
 // RestPutVNet godoc
 // @Summary Update VNet
 // @Description Update VNet
-// @Tags VNet
+// @Tags [MCIR] VNet management
 // @Accept  json
 // @Produce  json
 // @Param vNetInfo body mcir.TbVNetInfo true "Details for an VNet object"
@@ -69,7 +69,7 @@ func RestPutVNet(c echo.Context) error {
 // RestGetVNet godoc
 // @Summary Get VNet
 // @Description Get VNet
-// @Tags VNet
+// @Tags [MCIR] VNet management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -91,7 +91,7 @@ type RestGetAllVNetResponse struct {
 // RestGetAllVNet godoc
 // @Summary List all VNets
 // @Description List all VNets
-// @Tags VNet
+// @Tags [MCIR] VNet management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -107,7 +107,7 @@ func RestGetAllVNet(c echo.Context) error {
 // RestDelVNet godoc
 // @Summary Delete VNet
 // @Description Delete VNet
-// @Tags VNet
+// @Tags [MCIR] VNet management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -123,7 +123,7 @@ func RestDelVNet(c echo.Context) error {
 // RestDelAllVNet godoc
 // @Summary Delete all VNets
 // @Description Delete all VNets
-// @Tags VNet
+// @Tags [MCIR] VNet management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcir/vnet.go
+++ b/src/api/rest/server/mcir/vnet.go
@@ -12,7 +12,7 @@ import (
 // RestPostVNet godoc
 // @Summary Create VNet
 // @Description Create VNet
-// @Tags [MCIR] VNet management
+// @Tags [MCIR] Network management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -51,7 +51,7 @@ func RestPostVNet(c echo.Context) error {
 // RestPutVNet godoc
 // @Summary Update VNet
 // @Description Update VNet
-// @Tags [MCIR] VNet management
+// @Tags [MCIR] Network management
 // @Accept  json
 // @Produce  json
 // @Param vNetInfo body mcir.TbVNetInfo true "Details for an VNet object"
@@ -69,7 +69,7 @@ func RestPutVNet(c echo.Context) error {
 // RestGetVNet godoc
 // @Summary Get VNet
 // @Description Get VNet
-// @Tags [MCIR] VNet management
+// @Tags [MCIR] Network management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -91,7 +91,7 @@ type RestGetAllVNetResponse struct {
 // RestGetAllVNet godoc
 // @Summary List all VNets
 // @Description List all VNets
-// @Tags [MCIR] VNet management
+// @Tags [MCIR] Network management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -107,7 +107,7 @@ func RestGetAllVNet(c echo.Context) error {
 // RestDelVNet godoc
 // @Summary Delete VNet
 // @Description Delete VNet
-// @Tags [MCIR] VNet management
+// @Tags [MCIR] Network management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -123,7 +123,7 @@ func RestDelVNet(c echo.Context) error {
 // RestDelAllVNet godoc
 // @Summary Delete all VNets
 // @Description Delete all VNets
-// @Tags [MCIR] VNet management
+// @Tags [MCIR] Network management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -387,7 +387,7 @@ func RestPostCmdMcis(c echo.Context) error {
 // RestPostInstallAgentToMcis godoc
 // @Summary Install the benchmark agent to specified MCIS
 // @Description Install the benchmark agent to specified MCIS
-// @Tags [MCIS] Performance benchmarking
+// @Tags [MCIS] Performance benchmarking (WIP)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -610,7 +610,7 @@ type RestGetAllBenchmarkRequest struct {
 // RestGetAllBenchmark godoc
 // @Summary List all MCISs
 // @Description List all MCISs
-// @Tags [MCIS] Performance benchmarking
+// @Tags [MCIS] Performance benchmarking (WIP)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -654,7 +654,7 @@ type RestGetBenchmarkRequest struct {
 // RestGetBenchmark godoc
 // @Summary Get MCIS
 // @Description Get MCIS
-// @Tags [MCIS] Performance benchmarking
+// @Tags [MCIS] Performance benchmarking (WIP)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -53,8 +53,8 @@ type JSONResult struct {
 // Annotation for API documention Need to be revised.
 
 // RestGetMcis godoc
-// @Summary Get MCIS
-// @Description Get MCIS
+// @Summary Get MCIS or Action to MCIS (status, suspend, resume, reboot, terminate)
+// @Description Get MCIS or Action to MCIS (status, suspend, resume, reboot, terminate)
 // @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -12,7 +12,7 @@ import (
 // RestPostMcis godoc
 // @Summary Create MCIS
 // @Description Create MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -55,7 +55,7 @@ type JSONResult struct {
 // RestGetMcis godoc
 // @Summary Get MCIS
 // @Description Get MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -132,7 +132,7 @@ type RestGetAllMcisStatusResponse struct {
 // RestGetAllMcis godoc
 // @Summary List all MCISs
 // @Description List all MCISs
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -176,7 +176,7 @@ func RestGetAllMcis(c echo.Context) error {
 // RestPutMcis godoc
 // @Summary Update MCIS
 // @Description Update MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param mcisInfo body TbMcisInfo true "Details for an MCIS object"
@@ -192,7 +192,7 @@ func RestPutMcis(c echo.Context) error {
 // RestDelMcis godoc
 // @Summary Delete MCIS
 // @Description Delete MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -219,7 +219,7 @@ func RestDelMcis(c echo.Context) error {
 // RestDelAllMcis godoc
 // @Summary Delete all MCISs
 // @Description Delete all MCISs
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -249,7 +249,7 @@ type RestPostMcisRecommandResponse struct {
 // RestPostMcisRecommand godoc
 // @Summary Get MCIS recommendation
 // @Description Get MCIS recommendation
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -419,7 +419,7 @@ func RestPostInstallAgentToMcis(c echo.Context) error {
 // RestPostMcisVm godoc
 // @Summary Create VM in specified MCIS
 // @Description Create VM in specified MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -453,7 +453,7 @@ func RestPostMcisVm(c echo.Context) error {
 // RestPostMcisVmGroup godoc
 // @Summary Create multiple VMs by VM group in specified MCIS
 // @Description Create multiple VMs by VM group in specified MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -490,7 +490,7 @@ func RestPostMcisVmGroup(c echo.Context) error {
 // RestGetMcisVm godoc
 // @Summary Get MCIS
 // @Description Get MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -557,7 +557,7 @@ func RestGetMcisVm(c echo.Context) error {
 // RestPutSshKey godoc
 // @Summary Update MCIS
 // @Description Update MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -576,7 +576,7 @@ func RestPutMcisVm(c echo.Context) error {
 // RestDelMcisVm godoc
 // @Summary Delete MCIS
 // @Description Delete MCIS
-// @Tags [MCIS] provisioning management
+// @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -12,7 +12,7 @@ import (
 // RestPostMcis godoc
 // @Summary Create MCIS
 // @Description Create MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -55,7 +55,7 @@ type JSONResult struct {
 // RestGetMcis godoc
 // @Summary Get MCIS
 // @Description Get MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -132,7 +132,7 @@ type RestGetAllMcisStatusResponse struct {
 // RestGetAllMcis godoc
 // @Summary List all MCISs
 // @Description List all MCISs
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -176,7 +176,7 @@ func RestGetAllMcis(c echo.Context) error {
 // RestPutMcis godoc
 // @Summary Update MCIS
 // @Description Update MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param mcisInfo body TbMcisInfo true "Details for an MCIS object"
@@ -192,7 +192,7 @@ func RestPutMcis(c echo.Context) error {
 // RestDelMcis godoc
 // @Summary Delete MCIS
 // @Description Delete MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -219,7 +219,7 @@ func RestDelMcis(c echo.Context) error {
 // RestDelAllMcis godoc
 // @Summary Delete all MCISs
 // @Description Delete all MCISs
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -249,7 +249,7 @@ type RestPostMcisRecommandResponse struct {
 // RestPostMcisRecommand godoc
 // @Summary Get MCIS recommendation
 // @Description Get MCIS recommendation
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -258,6 +258,7 @@ type RestPostMcisRecommandResponse struct {
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis/recommend [post]
+// @Deprecated
 func RestPostMcisRecommand(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -291,7 +292,7 @@ type RestPostCmdMcisVmResponse struct {
 // RestPostCmdMcisVm godoc
 // @Summary Send a command to specified VM
 // @Description Send a command to specified VM
-// @Tags MCIS
+// @Tags [MCIS] Remote command
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -337,7 +338,7 @@ type RestPostCmdMcisResponseWrapper struct {
 // RestPostCmdMcis godoc
 // @Summary Send a command to specified MCIS
 // @Description Send a command to specified MCIS
-// @Tags MCIS
+// @Tags [MCIS] Remote command
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -386,7 +387,7 @@ func RestPostCmdMcis(c echo.Context) error {
 // RestPostInstallAgentToMcis godoc
 // @Summary Install the benchmark agent to specified MCIS
 // @Description Install the benchmark agent to specified MCIS
-// @Tags MCIS
+// @Tags [MCIS] Performance benchmarking
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -418,7 +419,7 @@ func RestPostInstallAgentToMcis(c echo.Context) error {
 // RestPostMcisVm godoc
 // @Summary Create VM in specified MCIS
 // @Description Create VM in specified MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -452,7 +453,7 @@ func RestPostMcisVm(c echo.Context) error {
 // RestPostMcisVmGroup godoc
 // @Summary Create multiple VMs by VM group in specified MCIS
 // @Description Create multiple VMs by VM group in specified MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -489,7 +490,7 @@ func RestPostMcisVmGroup(c echo.Context) error {
 // RestGetMcisVm godoc
 // @Summary Get MCIS
 // @Description Get MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -552,11 +553,11 @@ func RestGetMcisVm(c echo.Context) error {
 	}
 }
 
-/* function RestPutMcisVm not yet implemented
+/* RestPutMcisVm function not yet implemented
 // RestPutSshKey godoc
 // @Summary Update MCIS
 // @Description Update MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -575,7 +576,7 @@ func RestPutMcisVm(c echo.Context) error {
 // RestDelMcisVm godoc
 // @Summary Delete MCIS
 // @Description Delete MCIS
-// @Tags MCIS
+// @Tags [MCIS] provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -609,7 +610,7 @@ type RestGetAllBenchmarkRequest struct {
 // RestGetAllBenchmark godoc
 // @Summary List all MCISs
 // @Description List all MCISs
-// @Tags MCIS
+// @Tags [MCIS] Performance benchmarking
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -653,7 +654,7 @@ type RestGetBenchmarkRequest struct {
 // RestGetBenchmark godoc
 // @Summary Get MCIS
 // @Description Get MCIS
-// @Tags MCIS
+// @Tags [MCIS] Performance benchmarking
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcis/monitor.go
+++ b/src/api/rest/server/mcis/monitor.go
@@ -11,7 +11,7 @@ import (
 // RestPostInstallMonitorAgentToMcis godoc
 // @Summary InstallMonitorAgent MCIS
 // @Description InstallMonitorAgent MCIS
-// @Tags Monitor
+// @Tags [MCIS] Resource monitor
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -43,7 +43,7 @@ func RestPostInstallMonitorAgentToMcis(c echo.Context) error {
 // RestGetMonitorData godoc
 // @Summary GetMonitorData MCIS
 // @Description GetMonitorData MCIS
-// @Tags Monitor
+// @Tags [MCIS] Resource monitor
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcis/monitor.go
+++ b/src/api/rest/server/mcis/monitor.go
@@ -15,9 +15,9 @@ import (
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
-// @Param nsId path string true "MCIS ID"
+// @Param mcisId path string true "MCIS ID"
 // @Param mcisInfo body mcis.McisCmdReq true "Details for an MCIS object"
-// @Success 200 {object} mcir.TbSshKeyInfo
+// @Success 200 {object} mcis.AgentInstallContentWrapper
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/monitoring/install/mcis/{mcisId} [post]
@@ -47,8 +47,9 @@ func RestPostInstallMonitorAgentToMcis(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
-// @Param nsId path string true "MCIS ID"
-// @Success 200 {object} mcir.TbSshKeyInfo
+// @Param mcisId path string true "MCIS ID"
+// @Param metric path string true "Metric type: cpu, memory, disk, network"
+// @Success 200 {object} mcis.MonResultSimpleResponse
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/monitoring/mcis/{mcisId}/metric/{metric} [get]

--- a/src/api/rest/server/mcis/monitor.go
+++ b/src/api/rest/server/mcis/monitor.go
@@ -11,7 +11,7 @@ import (
 // RestPostInstallMonitorAgentToMcis godoc
 // @Summary InstallMonitorAgent MCIS
 // @Description InstallMonitorAgent MCIS
-// @Tags [MCIS] Resource monitor (for Developers)
+// @Tags [MCIS] Resource monitor (Developer)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -43,7 +43,7 @@ func RestPostInstallMonitorAgentToMcis(c echo.Context) error {
 // RestGetMonitorData godoc
 // @Summary GetMonitorData MCIS
 // @Description GetMonitorData MCIS
-// @Tags [MCIS] Resource monitor (for Developers)
+// @Tags [MCIS] Resource monitor (Developer)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcis/monitor.go
+++ b/src/api/rest/server/mcis/monitor.go
@@ -11,7 +11,7 @@ import (
 // RestPostInstallMonitorAgentToMcis godoc
 // @Summary InstallMonitorAgent MCIS
 // @Description InstallMonitorAgent MCIS
-// @Tags [MCIS] Resource monitor
+// @Tags [MCIS] Resource monitor (for Developers)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -43,7 +43,7 @@ func RestPostInstallMonitorAgentToMcis(c echo.Context) error {
 // RestGetMonitorData godoc
 // @Summary GetMonitorData MCIS
 // @Description GetMonitorData MCIS
-// @Tags [MCIS] Resource monitor
+// @Tags [MCIS] Resource monitor (for Developers)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcis/orchestration.go
+++ b/src/api/rest/server/mcis/orchestration.go
@@ -12,7 +12,7 @@ import (
 // RestPostMcisPolicy godoc
 // @Summary Create MCIS Automation policy
 // @Description Create MCIS Automation policy
-// @Tags MCIS Policy
+// @Tags [MCIS] Auto control policy management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -44,7 +44,7 @@ func RestPostMcisPolicy(c echo.Context) error {
 // RestGetMcisPolicy godoc
 // @Summary Get MCIS Policy
 // @Description Get MCIS Policy
-// @Tags MCIS Policy
+// @Tags [MCIS] Auto control policy management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -83,7 +83,7 @@ type RestGetAllMcisPolicyResponse struct {
 // RestGetAllMcisPolicy godoc
 // @Summary List all MCIS Policys
 // @Description List all MCIS Policys
-// @Tags MCIS Policy
+// @Tags [MCIS] Auto control policy management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -116,7 +116,7 @@ func RestGetAllMcisPolicy(c echo.Context) error {
 // RestPutMcisPolicy godoc
 // @Summary Update MCIS Policy
 // @Description Update MCIS Policy
-// @Tags MCIS Policy
+// @Tags [MCIS] Auto control policy management
 // @Accept  json
 // @Produce  json
 // @Param mcisInfo body McisPolicyInfo true "Details for an MCIS Policy object"
@@ -132,7 +132,7 @@ func RestPutMcisPolicy(c echo.Context) error {
 // DelMcisPolicy godoc
 // @Summary Delete MCIS Policy
 // @Description Delete MCIS Policy
-// @Tags MCIS Policy
+// @Tags [MCIS] Auto control policy management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -159,7 +159,7 @@ func RestDelMcisPolicy(c echo.Context) error {
 // RestDelAllMcisPolicy godoc
 // @Summary Delete all MCIS Policys
 // @Description Delete all MCIS Policys
-// @Tags MCIS Policy
+// @Tags [MCIS] Auto control policy management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/mcis/orchestration.go
+++ b/src/api/rest/server/mcis/orchestration.go
@@ -12,7 +12,7 @@ import (
 // RestPostMcisPolicy godoc
 // @Summary Create MCIS Automation policy
 // @Description Create MCIS Automation policy
-// @Tags [MCIS] Auto control policy management
+// @Tags [MCIS] Auto control policy management (WIP)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -44,7 +44,7 @@ func RestPostMcisPolicy(c echo.Context) error {
 // RestGetMcisPolicy godoc
 // @Summary Get MCIS Policy
 // @Description Get MCIS Policy
-// @Tags [MCIS] Auto control policy management
+// @Tags [MCIS] Auto control policy management (WIP)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -83,7 +83,7 @@ type RestGetAllMcisPolicyResponse struct {
 // RestGetAllMcisPolicy godoc
 // @Summary List all MCIS Policys
 // @Description List all MCIS Policys
-// @Tags [MCIS] Auto control policy management
+// @Tags [MCIS] Auto control policy management (WIP)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -116,7 +116,7 @@ func RestGetAllMcisPolicy(c echo.Context) error {
 // RestPutMcisPolicy godoc
 // @Summary Update MCIS Policy
 // @Description Update MCIS Policy
-// @Tags [MCIS] Auto control policy management
+// @Tags [MCIS] Auto control policy management (WIP)
 // @Accept  json
 // @Produce  json
 // @Param mcisInfo body McisPolicyInfo true "Details for an MCIS Policy object"
@@ -132,7 +132,7 @@ func RestPutMcisPolicy(c echo.Context) error {
 // DelMcisPolicy godoc
 // @Summary Delete MCIS Policy
 // @Description Delete MCIS Policy
-// @Tags [MCIS] Auto control policy management
+// @Tags [MCIS] Auto control policy management (WIP)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
@@ -159,7 +159,7 @@ func RestDelMcisPolicy(c echo.Context) error {
 // RestDelAllMcisPolicy godoc
 // @Summary Delete all MCIS Policys
 // @Description Delete all MCIS Policys
-// @Tags [MCIS] Auto control policy management
+// @Tags [MCIS] Auto control policy management (WIP)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -114,6 +114,7 @@ func ApiServer() {
 	e.GET("/tumblebug/webadmin/ns", webadmin.Ns)
 	e.GET("/tumblebug/webadmin/spec", webadmin.Spec)
 
+	// @Tags [Admin] System environment
 	e.POST("/tumblebug/config", rest_common.RestPostConfig)
 	e.GET("/tumblebug/config/:configId", rest_common.RestGetConfig)
 	e.GET("/tumblebug/config", rest_common.RestGetAllConfig)
@@ -126,6 +127,7 @@ func ApiServer() {
 
 	g := e.Group("/tumblebug/ns", common.NsValidation())
 
+	//Namespace Management
 	g.POST("", rest_common.RestPostNs)
 	g.GET("/:nsId", rest_common.RestGetNs)
 	g.GET("", rest_common.RestGetAllNs)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -249,12 +249,10 @@ func ApiServer() {
 	g.GET("/:nsId/testGetAssociatedObjectCount/:resourceType/:resourceId", rest_mcir.RestTestGetAssociatedObjectCount)
 
 	selfEndpoint := os.Getenv("SELF_ENDPOINT")
-	apidashboard := "  http://" + selfEndpoint + "/tumblebug/swagger/index.html?url=http://" + selfEndpoint + "/tumblebug/swaggerActive"
+	apidashboard := " http://" + selfEndpoint + "/tumblebug/swagger/index.html?url=http://" + selfEndpoint + "/tumblebug/swaggerActive"
 
-	fmt.Println(" [Access to API dashboard]")
+	fmt.Println(" [Access to API dashboard]" + " username/password: (" + API_USERNAME + "/" + API_PASSWORD + ")")
 	fmt.Printf(noticeColor, apidashboard)
-	fmt.Println("\n ")
-	fmt.Println("  (REST API username/password: " + API_USERNAME + "/" + API_PASSWORD + ")")
 	fmt.Println("\n ")
 
 	e.Logger.Fatal(e.Start(":1323"))

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -63,14 +63,13 @@ func ApiServer() {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 
-	e.GET("/tumblebug/swagger/*", echoSwagger.WrapHandler)
-
-	e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
-
-	e.GET("/tumblebug/health", rest_common.RestGetHealth)
-
 	e.HideBanner = true
 	//e.colorer.Printf(banner, e.colorer.Red("v"+Version), e.colorer.Blue(website))
+
+	// Route for system management
+	e.GET("/tumblebug/swagger/*", echoSwagger.WrapHandler)
+	e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
+	e.GET("/tumblebug/health", rest_common.RestGetHealth)
 
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},
@@ -79,7 +78,7 @@ func ApiServer() {
 
 	API_USERNAME := os.Getenv("API_USERNAME")
 	API_PASSWORD := os.Getenv("API_PASSWORD")
-	fmt.Println("REST API username/password: " + API_USERNAME + "/" + API_PASSWORD)
+
 	e.Use(middleware.BasicAuth(func(username, password string, c echo.Context) (bool, error) {
 		// Be careful to use constant time comparison to prevent timing attacks
 		if subtle.ConstantTimeCompare([]byte(username), []byte(API_USERNAME)) == 1 &&
@@ -254,6 +253,8 @@ func ApiServer() {
 
 	fmt.Println(" [Access to API dashboard]")
 	fmt.Printf(noticeColor, apidashboard)
+	fmt.Println("\n ")
+	fmt.Println("  (REST API username/password: " + API_USERNAME + "/" + API_PASSWORD + ")")
 	fmt.Println("\n ")
 
 	e.Logger.Fatal(e.Start(":1323"))

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -92,17 +92,12 @@ func ApiServer() {
 	fmt.Println("")
 	fmt.Printf(banner)
 	fmt.Println("")
-	//	fmt.Printf(ErrorColor, Version)
 	fmt.Println("")
 	fmt.Printf(InfoColor, website)
 	fmt.Println("")
 	fmt.Println("")
 
 	// Route
-
-	//common.UpdateEnv()
-	//common.SPIDER_REST_URL = "TEST"
-
 	e.GET("/tumblebug/checkNs/:nsId", rest_common.RestCheckNs)
 
 	e.GET("/tumblebug/connConfig", rest_common.RestGetConnConfigList)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -136,6 +136,7 @@ func ApiServer() {
 	g.DELETE("/:nsId", rest_common.RestDelNs)
 	g.DELETE("", rest_common.RestDelAllNs)
 
+	//MCIS Management
 	g.POST("/:nsId/mcis", rest_mcis.RestPostMcis)
 	g.GET("/:nsId/mcis/:mcisId", rest_mcis.RestGetMcis)
 	g.GET("/:nsId/mcis", rest_mcis.RestGetAllMcis)
@@ -169,6 +170,7 @@ func ApiServer() {
 	g.POST("/:nsId/monitoring/install/mcis/:mcisId", rest_mcis.RestPostInstallMonitorAgentToMcis)
 	g.GET("/:nsId/monitoring/mcis/:mcisId/metric/:metric", rest_mcis.RestGetMonitorData)
 
+	//MCIR Management
 	g.POST("/:nsId/resources/image", rest_mcir.RestPostImage)
 	g.GET("/:nsId/resources/image/:resourceId", rest_mcir.RestGetResource)
 	g.GET("/:nsId/resources/image", rest_mcir.RestGetAllResources)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -65,6 +65,8 @@ func ApiServer() {
 
 	e.GET("/tumblebug/swagger/*", echoSwagger.WrapHandler)
 
+	e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
+
 	e.GET("/tumblebug/health", rest_common.RestGetHealth)
 
 	e.HideBanner = true

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -12,24 +12,25 @@ import (
 	"fmt"
 	"os"
 
-	// REST API (echo)
 	"net/http"
 
+	// REST API (echo)
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 
+	// echo-swagger middleware
 	_ "github.com/cloud-barista/cb-tumblebug/src/docs"
-	echoSwagger "github.com/swaggo/echo-swagger" // echo-swagger middleware
+	echoSwagger "github.com/swaggo/echo-swagger"
 )
 
 //var masterConfigInfos confighandler.MASTERCONFIGTYPE
 
 const (
-	InfoColor    = "\033[1;34m%s\033[0m"
-	NoticeColor  = "\033[1;36m%s\033[0m"
-	WarningColor = "\033[1;33m%s\033[0m"
-	ErrorColor   = "\033[1;31m%s\033[0m"
-	DebugColor   = "\033[0;36m%s\033[0m"
+	infoColor    = "\033[1;34m%s\033[0m"
+	noticeColor  = "\033[1;36m%s\033[0m"
+	warningColor = "\033[1;33m%s\033[0m"
+	errorColor   = "\033[1;31m%s\033[0m"
+	debugColor   = "\033[0;36m%s\033[0m"
 )
 
 const (
@@ -93,7 +94,7 @@ func ApiServer() {
 	fmt.Printf(banner)
 	fmt.Println("")
 	fmt.Println("")
-	fmt.Printf(InfoColor, website)
+	fmt.Printf(infoColor, website)
 	fmt.Println("")
 	fmt.Println("")
 

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -89,16 +89,11 @@ func ApiServer() {
 		return false, nil
 	}))
 
-	fmt.Println("")
-	fmt.Println("")
-	fmt.Println("")
-	fmt.Println("")
+	fmt.Println("\n \n \n ")
 	fmt.Printf(banner)
-	fmt.Println("")
-	fmt.Println("")
+	fmt.Println("\n \n ")
 	fmt.Printf(infoColor, website)
-	fmt.Println("")
-	fmt.Println("")
+	fmt.Println("\n \n ")
 
 	// Route
 	e.GET("/tumblebug/checkNs/:nsId", rest_common.RestCheckNs)
@@ -252,6 +247,12 @@ func ApiServer() {
 	g.PUT("/:nsId/testDeleteObjectAssociation/:resourceType/:resourceId", rest_mcir.RestTestDeleteObjectAssociation)
 	g.GET("/:nsId/testGetAssociatedObjectCount/:resourceType/:resourceId", rest_mcir.RestTestGetAssociatedObjectCount)
 
-	e.Logger.Fatal(e.Start(":1323"))
+	selfEndpoint := os.Getenv("SELF_ENDPOINT")
+	apidashboard := "  http://" + selfEndpoint + "/tumblebug/swagger/index.html?url=http://" + selfEndpoint + "/tumblebug/swaggerActive"
 
+	fmt.Println(" [Access to API dashboard]")
+	fmt.Printf(noticeColor, apidashboard)
+	fmt.Println("\n ")
+
+	e.Logger.Fatal(e.Start(":1323"))
 }

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -18,8 +18,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 
-	// CB-Store
-
 	_ "github.com/cloud-barista/cb-tumblebug/src/docs"
 	echoSwagger "github.com/swaggo/echo-swagger" // echo-swagger middleware
 )

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -537,10 +537,12 @@ func GetRegion(RegionName string) (Region, error) {
 	}
 }
 
-type RegionList struct { // Spider
+// RegionList is array struct for Region
+type RegionList struct {
 	Region []Region `json:"region"`
 }
 
+// GetRegionList retrieves region list
 func GetRegionList() (RegionList, error) {
 
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -421,9 +421,12 @@ type SshCmdResult struct { // Tumblebug
 	Err     error  `json:"err"`
 }
 
+// AgentInstallContentWrapper ...
 type AgentInstallContentWrapper struct {
 	Result_array []AgentInstallContent `json:"result_array"`
 }
+
+// AgentInstallContent ...
 type AgentInstallContent struct {
 	Mcis_id string `json:"mcis_id"`
 	Vm_id   string `json:"vm_id"`

--- a/src/core/mcis/monitor.go
+++ b/src/core/mcis/monitor.go
@@ -56,6 +56,7 @@ type DfTelegrafMetric struct {
 }
 */
 
+// MonResultSimple struct is for containing vm monitoring results
 type MonResultSimple struct {
 	Metric string `json:"metric"`
 	VmId   string `json:"vmId"`
@@ -63,6 +64,7 @@ type MonResultSimple struct {
 	Err    string `json:"err"`
 }
 
+// MonResultSimpleResponse struct is for containing Mcis monitoring results
 type MonResultSimpleResponse struct {
 	NsId           string            `json:"nsId"`
 	McisId         string            `json:"mcisId"`
@@ -287,6 +289,7 @@ func InstallMonitorAgentToMcis(nsId string, mcisId string, req *McisCmdReq) (Age
 
 }
 
+// GetMonitoringData func retrieves monitoring data from cb-dragonfly
 func GetMonitoringData(nsId string, mcisId string, metric string) (MonResultSimpleResponse, error) {
 
 	//check, lowerizedName, _ := LowerizeAndCheckMcis(nsId, mcisId)

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -298,7 +298,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Lookup image",
                 "parameters": [
@@ -351,7 +351,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Lookup image list",
                 "parameters": [
@@ -496,7 +496,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "List all namespaces",
                 "responses": {
@@ -529,7 +529,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "Create namespace",
                 "parameters": [
@@ -573,7 +573,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "Delete all namespaces",
                 "responses": {
@@ -602,7 +602,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "Get namespace",
                 "parameters": [
@@ -644,7 +644,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "Delete namespace",
                 "parameters": [
@@ -1900,7 +1900,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Fetch images",
                 "parameters": [
@@ -2092,7 +2092,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "List all images",
                 "parameters": [
@@ -2134,7 +2134,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Register image",
                 "parameters": [
@@ -2199,7 +2199,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Delete all images",
                 "parameters": [
@@ -2237,7 +2237,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Get image",
                 "parameters": [
@@ -2286,7 +2286,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Delete image",
                 "parameters": [
@@ -2331,7 +2331,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Search image",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3110,7 +3110,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "List all VNets",
                 "parameters": [
@@ -3152,7 +3152,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "Create VNet",
                 "parameters": [
@@ -3203,7 +3203,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "Delete all VNets",
                 "parameters": [
@@ -3241,7 +3241,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "Get VNet",
                 "parameters": [
@@ -3290,7 +3290,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "Delete VNet",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1166,7 +1166,7 @@ var doc = `{
         },
         "/ns/{nsId}/mcis/{mcisId}": {
             "get": {
-                "description": "Get MCIS",
+                "description": "Get MCIS or Action to MCIS (status, suspend, resume, reboot, terminate)",
                 "consumes": [
                     "application/json"
                 ],
@@ -1176,7 +1176,7 @@ var doc = `{
                 "tags": [
                     "[MCIS] Provisioning management"
                 ],
-                "summary": "Get MCIS",
+                "summary": "Get MCIS or Action to MCIS (status, suspend, resume, reboot, terminate)",
                 "parameters": [
                     {
                         "type": "string",
@@ -2893,7 +2893,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "List all SSH Keys",
                 "parameters": [
@@ -2935,7 +2935,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "Create SSH Key",
                 "parameters": [
@@ -2986,7 +2986,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "Delete all SSH Keys",
                 "parameters": [
@@ -3024,7 +3024,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "Get SSH Key",
                 "parameters": [
@@ -3073,7 +3073,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "Delete SSH Key",
                 "parameters": [
@@ -3118,7 +3118,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "List all VNets",
                 "parameters": [
@@ -3160,7 +3160,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "Create VNet",
                 "parameters": [
@@ -3211,7 +3211,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "Delete all VNets",
                 "parameters": [
@@ -3249,7 +3249,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "Get VNet",
                 "parameters": [
@@ -3298,7 +3298,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "Delete VNet",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -43,7 +43,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Config"
+                    "[Admin] System environment config"
                 ],
                 "summary": "List all configs",
                 "responses": {
@@ -76,7 +76,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Config"
+                    "[Admin] System environment config"
                 ],
                 "summary": "Create or Update config",
                 "parameters": [
@@ -120,7 +120,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Config"
+                    "[Admin] System environment config"
                 ],
                 "summary": "Delete all configs",
                 "responses": {
@@ -149,7 +149,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Config"
+                    "[Admin] System environment config"
                 ],
                 "summary": "Get config",
                 "parameters": [
@@ -193,7 +193,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "Cloud"
                 ],
                 "summary": "List all registered ConnConfig",
                 "responses": {
@@ -228,7 +228,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "Cloud"
                 ],
                 "summary": "Get registered ConnConfig info",
                 "responses": {
@@ -3507,7 +3507,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "Cloud"
                 ],
                 "summary": "List all registered regions",
                 "responses": {
@@ -3542,7 +3542,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "Cloud"
                 ],
                 "summary": "Get registered region info",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -397,7 +397,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Lookup spec",
                 "parameters": [
@@ -450,7 +450,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Lookup spec list",
                 "parameters": [
@@ -1944,7 +1944,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Fetch specs",
                 "parameters": [
@@ -1988,7 +1988,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Filter specs",
                 "parameters": [
@@ -2040,7 +2040,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Filter specs by range",
                 "parameters": [
@@ -2602,7 +2602,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "List all specs",
                 "parameters": [
@@ -2644,7 +2644,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Register spec",
                 "parameters": [
@@ -2709,7 +2709,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Delete all specs",
                 "parameters": [
@@ -2747,7 +2747,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Get spec",
                 "parameters": [
@@ -2796,7 +2796,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Update spec",
                 "parameters": [
@@ -2840,7 +2840,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Delete spec",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -989,7 +989,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "List all MCISs",
                 "parameters": [
@@ -1031,7 +1031,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Create MCIS",
                 "parameters": [
@@ -1082,7 +1082,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Delete all MCISs",
                 "parameters": [
@@ -1120,7 +1120,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Get MCIS recommendation",
                 "deprecated": true,
@@ -1174,7 +1174,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -1254,7 +1254,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Delete MCIS",
                 "parameters": [
@@ -1299,7 +1299,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Create VM in specified MCIS",
                 "parameters": [
@@ -1359,7 +1359,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -1446,7 +1446,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Delete MCIS",
                 "parameters": [
@@ -1498,7 +1498,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Create multiple VMs by VM group in specified MCIS",
                 "parameters": [
@@ -1572,7 +1572,7 @@ var doc = `{
                     {
                         "type": "string",
                         "description": "MCIS ID",
-                        "name": "nsId",
+                        "name": "mcisId",
                         "in": "path",
                         "required": true
                     },
@@ -1590,7 +1590,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.AgentInstallContentWrapper"
                         }
                     },
                     "404": {
@@ -1632,7 +1632,14 @@ var doc = `{
                     {
                         "type": "string",
                         "description": "MCIS ID",
-                        "name": "nsId",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Metric type: cpu, memory, disk, network",
+                        "name": "metric",
                         "in": "path",
                         "required": true
                     }
@@ -1641,7 +1648,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.MonResultSimpleResponse"
                         }
                     },
                     "404": {
@@ -4785,6 +4792,40 @@ var doc = `{
                     "items": {
                         "$ref": "#/definitions/mcis.TbVmStatusInfo"
                     }
+                }
+            }
+        },
+        "mcis.MonResultSimple": {
+            "type": "object",
+            "properties": {
+                "err": {
+                    "type": "string"
+                },
+                "metric": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                },
+                "vmId": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.MonResultSimpleResponse": {
+            "type": "object",
+            "properties": {
+                "mcisId": {
+                    "type": "string"
+                },
+                "mcisMonitoring": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.MonResultSimple"
+                    }
+                },
+                "nsId": {
+                    "type": "string"
                 }
             }
         },

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -43,7 +43,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Admin] System environment config"
+                    "[Admin] System environment"
                 ],
                 "summary": "List all configs",
                 "responses": {
@@ -76,7 +76,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Admin] System environment config"
+                    "[Admin] System environment"
                 ],
                 "summary": "Create or Update config",
                 "parameters": [
@@ -120,7 +120,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Admin] System environment config"
+                    "[Admin] System environment"
                 ],
                 "summary": "Delete all configs",
                 "responses": {
@@ -149,7 +149,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Admin] System environment config"
+                    "[Admin] System environment"
                 ],
                 "summary": "Get config",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -193,7 +193,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud] Associated Cloud info"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "List all registered ConnConfig",
                 "responses": {
@@ -228,7 +228,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud] Associated Cloud info"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Get registered ConnConfig info",
                 "responses": {
@@ -298,7 +298,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] Image management"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Lookup image",
                 "parameters": [
@@ -351,7 +351,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] Image management"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Lookup image list",
                 "parameters": [
@@ -397,7 +397,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] Spec management"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Lookup spec",
                 "parameters": [
@@ -450,7 +450,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] Spec management"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Lookup spec list",
                 "parameters": [
@@ -3515,7 +3515,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud] Associated Cloud info"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "List all registered regions",
                 "responses": {
@@ -3550,7 +3550,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud] Associated Cloud info"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Get registered region info",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1668,7 +1668,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "List all MCIS Policys",
                 "parameters": [
@@ -1710,7 +1710,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "Delete all MCIS Policys",
                 "parameters": [
@@ -1748,7 +1748,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "Get MCIS Policy",
                 "parameters": [
@@ -1797,7 +1797,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "Create MCIS Automation policy",
                 "parameters": [
@@ -1855,7 +1855,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "Delete MCIS Policy",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -183,6 +183,76 @@ var doc = `{
                 }
             }
         },
+        "/connConfig": {
+            "get": {
+                "description": "List all registered ConnConfig",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "List all registered ConnConfig",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.ConnConfigList"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/connConfig/{connConfigName}": {
+            "get": {
+                "description": "Get registered ConnConfig info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get registered ConnConfig info",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.ConnConfig"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/lookupImage": {
             "get": {
                 "description": "Lookup image",
@@ -3487,6 +3557,37 @@ var doc = `{
                 "value": {
                     "type": "string",
                     "example": "http://localhost:1024/spider"
+                }
+            }
+        },
+        "common.ConnConfig": {
+            "type": "object",
+            "properties": {
+                "configName": {
+                    "type": "string"
+                },
+                "credentialName": {
+                    "type": "string"
+                },
+                "driverName": {
+                    "type": "string"
+                },
+                "providerName": {
+                    "type": "string"
+                },
+                "regionName": {
+                    "type": "string"
+                }
+            }
+        },
+        "common.ConnConfigList": {
+            "type": "object",
+            "properties": {
+                "connectionconfig": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.ConnConfig"
+                    }
                 }
             }
         },

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -2885,7 +2885,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "List all SSH Keys",
                 "parameters": [
@@ -2927,7 +2927,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "Create SSH Key",
                 "parameters": [
@@ -2978,7 +2978,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "Delete all SSH Keys",
                 "parameters": [
@@ -3016,7 +3016,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "Get SSH Key",
                 "parameters": [
@@ -3065,7 +3065,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "Delete SSH Key",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3575,6 +3575,41 @@ var doc = `{
                     }
                 }
             }
+        },
+        "/swaggerActive": {
+            "get": {
+                "description": "Get API document web",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get API document web",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -1558,7 +1558,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Resource monitor (for Developers)"
+                    "[MCIS] Resource monitor (Developer)"
                 ],
                 "summary": "InstallMonitorAgent MCIS",
                 "parameters": [
@@ -1618,7 +1618,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Resource monitor (for Developers)"
+                    "[MCIS] Resource monitor (Developer)"
                 ],
                 "summary": "GetMonitorData MCIS",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3426,6 +3426,50 @@ var doc = `{
                     }
                 }
             }
+        },
+        "/region/{regionName}": {
+            "get": {
+                "description": "Get registered region info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get registered region info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name of region to retrieve",
+                        "name": "regionName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.Region"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3391,6 +3391,41 @@ var doc = `{
                     }
                 }
             }
+        },
+        "/region": {
+            "get": {
+                "description": "List all registered regions",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "List all registered regions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.RegionList"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -3460,6 +3495,34 @@ var doc = `{
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "common.Region": {
+            "type": "object",
+            "properties": {
+                "keyValueInfoList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "providerName": {
+                    "type": "string"
+                },
+                "regionName": {
+                    "type": "string"
+                }
+            }
+        },
+        "common.RegionList": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.Region"
+                    }
                 }
             }
         },

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -682,7 +682,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Performance benchmarking"
+                    "[MCIS] Performance benchmarking (WIP)"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -742,7 +742,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Performance benchmarking"
+                    "[MCIS] Performance benchmarking (WIP)"
                 ],
                 "summary": "List all MCISs",
                 "parameters": [
@@ -929,7 +929,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Performance benchmarking"
+                    "[MCIS] Performance benchmarking (WIP)"
                 ],
                 "summary": "Install the benchmark agent to specified MCIS",
                 "parameters": [
@@ -1558,7 +1558,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Resource monitor"
+                    "[MCIS] Resource monitor (for Developers)"
                 ],
                 "summary": "InstallMonitorAgent MCIS",
                 "parameters": [
@@ -1618,7 +1618,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Resource monitor"
+                    "[MCIS] Resource monitor (for Developers)"
                 ],
                 "summary": "GetMonitorData MCIS",
                 "parameters": [
@@ -1676,7 +1676,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "List all MCIS Policys",
                 "parameters": [
@@ -1718,7 +1718,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "Delete all MCIS Policys",
                 "parameters": [
@@ -1756,7 +1756,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "Get MCIS Policy",
                 "parameters": [
@@ -1805,7 +1805,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "Create MCIS Automation policy",
                 "parameters": [
@@ -1863,7 +1863,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "Delete MCIS Policy",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -253,6 +253,41 @@ var doc = `{
                 }
             }
         },
+        "/health": {
+            "get": {
+                "description": "Check Tumblebug is alive",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Check Tumblebug is alive",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/lookupImage": {
             "get": {
                 "description": "Lookup image",

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -682,7 +682,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Performance benchmarking"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -742,7 +742,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Performance benchmarking"
                 ],
                 "summary": "List all MCISs",
                 "parameters": [
@@ -802,7 +802,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Remote command"
                 ],
                 "summary": "Send a command to specified MCIS",
                 "parameters": [
@@ -862,7 +862,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Remote command"
                 ],
                 "summary": "Send a command to specified VM",
                 "parameters": [
@@ -929,7 +929,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Performance benchmarking"
                 ],
                 "summary": "Install the benchmark agent to specified MCIS",
                 "parameters": [
@@ -989,7 +989,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "List all MCISs",
                 "parameters": [
@@ -1031,7 +1031,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Create MCIS",
                 "parameters": [
@@ -1082,7 +1082,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Delete all MCISs",
                 "parameters": [
@@ -1120,9 +1120,10 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Get MCIS recommendation",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1173,7 +1174,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -1253,7 +1254,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Delete MCIS",
                 "parameters": [
@@ -1298,7 +1299,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Create VM in specified MCIS",
                 "parameters": [
@@ -1358,7 +1359,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -1445,7 +1446,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Delete MCIS",
                 "parameters": [
@@ -1497,7 +1498,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Create multiple VMs by VM group in specified MCIS",
                 "parameters": [
@@ -1557,7 +1558,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Monitor"
+                    "[MCIS] Resource monitor"
                 ],
                 "summary": "InstallMonitorAgent MCIS",
                 "parameters": [
@@ -1617,7 +1618,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Monitor"
+                    "[MCIS] Resource monitor"
                 ],
                 "summary": "GetMonitorData MCIS",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -2377,7 +2377,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "List all Security Groups",
                 "parameters": [
@@ -2419,7 +2419,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "Create Security Group",
                 "parameters": [
@@ -2470,7 +2470,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "Delete all Security Groups",
                 "parameters": [
@@ -2508,7 +2508,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "Get Security Group",
                 "parameters": [
@@ -2557,7 +2557,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "Delete Security Group",
                 "parameters": [

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -193,7 +193,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Cloud"
+                    "[Cloud] Associated Cloud info"
                 ],
                 "summary": "List all registered ConnConfig",
                 "responses": {
@@ -228,7 +228,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Cloud"
+                    "[Cloud] Associated Cloud info"
                 ],
                 "summary": "Get registered ConnConfig info",
                 "responses": {
@@ -263,7 +263,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Check Tumblebug is alive",
                 "responses": {
@@ -3335,7 +3335,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Get value of an object",
                 "parameters": [
@@ -3377,7 +3377,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Delete an object",
                 "parameters": [
@@ -3421,7 +3421,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "List all objects for a given key",
                 "parameters": [
@@ -3463,7 +3463,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Delete child objects along with the given object",
                 "parameters": [
@@ -3507,7 +3507,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Cloud"
+                    "[Cloud] Associated Cloud info"
                 ],
                 "summary": "List all registered regions",
                 "responses": {
@@ -3542,7 +3542,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Cloud"
+                    "[Cloud] Associated Cloud info"
                 ],
                 "summary": "Get registered region info",
                 "parameters": [
@@ -3586,7 +3586,7 @@ var doc = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Get API document web",
                 "responses": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -238,6 +238,41 @@
                 }
             }
         },
+        "/health": {
+            "get": {
+                "description": "Check Tumblebug is alive",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Check Tumblebug is alive",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/lookupImage": {
             "get": {
                 "description": "Lookup image",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3376,6 +3376,41 @@
                     }
                 }
             }
+        },
+        "/region": {
+            "get": {
+                "description": "List all registered regions",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "List all registered regions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.RegionList"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -3445,6 +3480,34 @@
                 },
                 "name": {
                     "type": "string"
+                }
+            }
+        },
+        "common.Region": {
+            "type": "object",
+            "properties": {
+                "keyValueInfoList": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.KeyValue"
+                    }
+                },
+                "providerName": {
+                    "type": "string"
+                },
+                "regionName": {
+                    "type": "string"
+                }
+            }
+        },
+        "common.RegionList": {
+            "type": "object",
+            "properties": {
+                "region": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.Region"
+                    }
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3411,6 +3411,50 @@
                     }
                 }
             }
+        },
+        "/region/{regionName}": {
+            "get": {
+                "description": "Get registered region info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get registered region info",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name of region to retrieve",
+                        "name": "regionName",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.Region"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3560,6 +3560,41 @@
                     }
                 }
             }
+        },
+        "/swaggerActive": {
+            "get": {
+                "description": "Get API document web",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get API document web",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -974,7 +974,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "List all MCISs",
                 "parameters": [
@@ -1016,7 +1016,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Create MCIS",
                 "parameters": [
@@ -1067,7 +1067,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Delete all MCISs",
                 "parameters": [
@@ -1105,7 +1105,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Get MCIS recommendation",
                 "deprecated": true,
@@ -1159,7 +1159,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -1239,7 +1239,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Delete MCIS",
                 "parameters": [
@@ -1284,7 +1284,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Create VM in specified MCIS",
                 "parameters": [
@@ -1344,7 +1344,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -1431,7 +1431,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Delete MCIS",
                 "parameters": [
@@ -1483,7 +1483,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] provisioning management"
+                    "[MCIS] Provisioning management"
                 ],
                 "summary": "Create multiple VMs by VM group in specified MCIS",
                 "parameters": [
@@ -1557,7 +1557,7 @@
                     {
                         "type": "string",
                         "description": "MCIS ID",
-                        "name": "nsId",
+                        "name": "mcisId",
                         "in": "path",
                         "required": true
                     },
@@ -1575,7 +1575,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.AgentInstallContentWrapper"
                         }
                     },
                     "404": {
@@ -1617,7 +1617,14 @@
                     {
                         "type": "string",
                         "description": "MCIS ID",
-                        "name": "nsId",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Metric type: cpu, memory, disk, network",
+                        "name": "metric",
                         "in": "path",
                         "required": true
                     }
@@ -1626,7 +1633,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbSshKeyInfo"
+                            "$ref": "#/definitions/mcis.MonResultSimpleResponse"
                         }
                     },
                     "404": {
@@ -4770,6 +4777,40 @@
                     "items": {
                         "$ref": "#/definitions/mcis.TbVmStatusInfo"
                     }
+                }
+            }
+        },
+        "mcis.MonResultSimple": {
+            "type": "object",
+            "properties": {
+                "err": {
+                    "type": "string"
+                },
+                "metric": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                },
+                "vmId": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.MonResultSimpleResponse": {
+            "type": "object",
+            "properties": {
+                "mcisId": {
+                    "type": "string"
+                },
+                "mcisMonitoring": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.MonResultSimple"
+                    }
+                },
+                "nsId": {
+                    "type": "string"
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -2362,7 +2362,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "List all Security Groups",
                 "parameters": [
@@ -2404,7 +2404,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "Create Security Group",
                 "parameters": [
@@ -2455,7 +2455,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "Delete all Security Groups",
                 "parameters": [
@@ -2493,7 +2493,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "Get Security Group",
                 "parameters": [
@@ -2542,7 +2542,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Security Group"
+                    "[MCIR] Security group management"
                 ],
                 "summary": "Delete Security Group",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -667,7 +667,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Performance benchmarking"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -727,7 +727,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Performance benchmarking"
                 ],
                 "summary": "List all MCISs",
                 "parameters": [
@@ -787,7 +787,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Remote command"
                 ],
                 "summary": "Send a command to specified MCIS",
                 "parameters": [
@@ -847,7 +847,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Remote command"
                 ],
                 "summary": "Send a command to specified VM",
                 "parameters": [
@@ -914,7 +914,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] Performance benchmarking"
                 ],
                 "summary": "Install the benchmark agent to specified MCIS",
                 "parameters": [
@@ -974,7 +974,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "List all MCISs",
                 "parameters": [
@@ -1016,7 +1016,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Create MCIS",
                 "parameters": [
@@ -1067,7 +1067,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Delete all MCISs",
                 "parameters": [
@@ -1105,9 +1105,10 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Get MCIS recommendation",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "string",
@@ -1158,7 +1159,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -1238,7 +1239,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Delete MCIS",
                 "parameters": [
@@ -1283,7 +1284,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Create VM in specified MCIS",
                 "parameters": [
@@ -1343,7 +1344,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -1430,7 +1431,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Delete MCIS",
                 "parameters": [
@@ -1482,7 +1483,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS"
+                    "[MCIS] provisioning management"
                 ],
                 "summary": "Create multiple VMs by VM group in specified MCIS",
                 "parameters": [
@@ -1542,7 +1543,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Monitor"
+                    "[MCIS] Resource monitor"
                 ],
                 "summary": "InstallMonitorAgent MCIS",
                 "parameters": [
@@ -1602,7 +1603,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Monitor"
+                    "[MCIS] Resource monitor"
                 ],
                 "summary": "GetMonitorData MCIS",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -28,7 +28,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Config"
+                    "[Admin] System environment config"
                 ],
                 "summary": "List all configs",
                 "responses": {
@@ -61,7 +61,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Config"
+                    "[Admin] System environment config"
                 ],
                 "summary": "Create or Update config",
                 "parameters": [
@@ -105,7 +105,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Config"
+                    "[Admin] System environment config"
                 ],
                 "summary": "Delete all configs",
                 "responses": {
@@ -134,7 +134,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Config"
+                    "[Admin] System environment config"
                 ],
                 "summary": "Get config",
                 "parameters": [
@@ -178,7 +178,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "Cloud"
                 ],
                 "summary": "List all registered ConnConfig",
                 "responses": {
@@ -213,7 +213,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "Cloud"
                 ],
                 "summary": "Get registered ConnConfig info",
                 "responses": {
@@ -3492,7 +3492,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "Cloud"
                 ],
                 "summary": "List all registered regions",
                 "responses": {
@@ -3527,7 +3527,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "Cloud"
                 ],
                 "summary": "Get registered region info",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -178,7 +178,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud] Associated Cloud info"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "List all registered ConnConfig",
                 "responses": {
@@ -213,7 +213,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud] Associated Cloud info"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Get registered ConnConfig info",
                 "responses": {
@@ -283,7 +283,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] Image management"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Lookup image",
                 "parameters": [
@@ -336,7 +336,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] Image management"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Lookup image list",
                 "parameters": [
@@ -382,7 +382,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] Spec management"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Lookup spec",
                 "parameters": [
@@ -435,7 +435,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] Spec management"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Lookup spec list",
                 "parameters": [
@@ -3500,7 +3500,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud] Associated Cloud info"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "List all registered regions",
                 "responses": {
@@ -3535,7 +3535,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Cloud] Associated Cloud info"
+                    "[Admin] Cloud environment management"
                 ],
                 "summary": "Get registered region info",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -283,7 +283,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Lookup image",
                 "parameters": [
@@ -336,7 +336,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Lookup image list",
                 "parameters": [
@@ -481,7 +481,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "List all namespaces",
                 "responses": {
@@ -514,7 +514,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "Create namespace",
                 "parameters": [
@@ -558,7 +558,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "Delete all namespaces",
                 "responses": {
@@ -587,7 +587,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "Get namespace",
                 "parameters": [
@@ -629,7 +629,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Namespace"
+                    "[Namespace] Namespace management"
                 ],
                 "summary": "Delete namespace",
                 "parameters": [
@@ -1885,7 +1885,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Fetch images",
                 "parameters": [
@@ -2077,7 +2077,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "List all images",
                 "parameters": [
@@ -2119,7 +2119,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Register image",
                 "parameters": [
@@ -2184,7 +2184,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Delete all images",
                 "parameters": [
@@ -2222,7 +2222,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Get image",
                 "parameters": [
@@ -2271,7 +2271,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Delete image",
                 "parameters": [
@@ -2316,7 +2316,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Image"
+                    "[MCIR] Image management"
                 ],
                 "summary": "Search image",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -178,7 +178,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Cloud"
+                    "[Cloud] Associated Cloud info"
                 ],
                 "summary": "List all registered ConnConfig",
                 "responses": {
@@ -213,7 +213,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Cloud"
+                    "[Cloud] Associated Cloud info"
                 ],
                 "summary": "Get registered ConnConfig info",
                 "responses": {
@@ -248,7 +248,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Check Tumblebug is alive",
                 "responses": {
@@ -3320,7 +3320,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Get value of an object",
                 "parameters": [
@@ -3362,7 +3362,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Delete an object",
                 "parameters": [
@@ -3406,7 +3406,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "List all objects for a given key",
                 "parameters": [
@@ -3448,7 +3448,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Delete child objects along with the given object",
                 "parameters": [
@@ -3492,7 +3492,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Cloud"
+                    "[Cloud] Associated Cloud info"
                 ],
                 "summary": "List all registered regions",
                 "responses": {
@@ -3527,7 +3527,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Cloud"
+                    "[Cloud] Associated Cloud info"
                 ],
                 "summary": "Get registered region info",
                 "parameters": [
@@ -3571,7 +3571,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Admin"
+                    "[Admin] System management"
                 ],
                 "summary": "Get API document web",
                 "responses": {

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -667,7 +667,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Performance benchmarking"
+                    "[MCIS] Performance benchmarking (WIP)"
                 ],
                 "summary": "Get MCIS",
                 "parameters": [
@@ -727,7 +727,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Performance benchmarking"
+                    "[MCIS] Performance benchmarking (WIP)"
                 ],
                 "summary": "List all MCISs",
                 "parameters": [
@@ -914,7 +914,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Performance benchmarking"
+                    "[MCIS] Performance benchmarking (WIP)"
                 ],
                 "summary": "Install the benchmark agent to specified MCIS",
                 "parameters": [
@@ -1543,7 +1543,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Resource monitor"
+                    "[MCIS] Resource monitor (for Developers)"
                 ],
                 "summary": "InstallMonitorAgent MCIS",
                 "parameters": [
@@ -1603,7 +1603,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Resource monitor"
+                    "[MCIS] Resource monitor (for Developers)"
                 ],
                 "summary": "GetMonitorData MCIS",
                 "parameters": [
@@ -1661,7 +1661,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "List all MCIS Policys",
                 "parameters": [
@@ -1703,7 +1703,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "Delete all MCIS Policys",
                 "parameters": [
@@ -1741,7 +1741,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "Get MCIS Policy",
                 "parameters": [
@@ -1790,7 +1790,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "Create MCIS Automation policy",
                 "parameters": [
@@ -1848,7 +1848,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Auto control policy management"
+                    "[MCIS] Auto control policy management (WIP)"
                 ],
                 "summary": "Delete MCIS Policy",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -168,6 +168,76 @@
                 }
             }
         },
+        "/connConfig": {
+            "get": {
+                "description": "List all registered ConnConfig",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "List all registered ConnConfig",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.ConnConfigList"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/connConfig/{connConfigName}": {
+            "get": {
+                "description": "Get registered ConnConfig info",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Get registered ConnConfig info",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.ConnConfig"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/lookupImage": {
             "get": {
                 "description": "Lookup image",
@@ -3472,6 +3542,37 @@
                 "value": {
                     "type": "string",
                     "example": "http://localhost:1024/spider"
+                }
+            }
+        },
+        "common.ConnConfig": {
+            "type": "object",
+            "properties": {
+                "configName": {
+                    "type": "string"
+                },
+                "credentialName": {
+                    "type": "string"
+                },
+                "driverName": {
+                    "type": "string"
+                },
+                "providerName": {
+                    "type": "string"
+                },
+                "regionName": {
+                    "type": "string"
+                }
+            }
+        },
+        "common.ConnConfigList": {
+            "type": "object",
+            "properties": {
+                "connectionconfig": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/common.ConnConfig"
+                    }
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1653,7 +1653,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "List all MCIS Policys",
                 "parameters": [
@@ -1695,7 +1695,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "Delete all MCIS Policys",
                 "parameters": [
@@ -1733,7 +1733,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "Get MCIS Policy",
                 "parameters": [
@@ -1782,7 +1782,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "Create MCIS Automation policy",
                 "parameters": [
@@ -1840,7 +1840,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "MCIS Policy"
+                    "[MCIS] Auto control policy management"
                 ],
                 "summary": "Delete MCIS Policy",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -382,7 +382,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Lookup spec",
                 "parameters": [
@@ -435,7 +435,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Lookup spec list",
                 "parameters": [
@@ -1929,7 +1929,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Fetch specs",
                 "parameters": [
@@ -1973,7 +1973,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Filter specs",
                 "parameters": [
@@ -2025,7 +2025,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Filter specs by range",
                 "parameters": [
@@ -2587,7 +2587,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "List all specs",
                 "parameters": [
@@ -2629,7 +2629,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Register spec",
                 "parameters": [
@@ -2694,7 +2694,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Delete all specs",
                 "parameters": [
@@ -2732,7 +2732,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Get spec",
                 "parameters": [
@@ -2781,7 +2781,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Update spec",
                 "parameters": [
@@ -2825,7 +2825,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Spec"
+                    "[MCIR] Spec management"
                 ],
                 "summary": "Delete spec",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -28,7 +28,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Admin] System environment config"
+                    "[Admin] System environment"
                 ],
                 "summary": "List all configs",
                 "responses": {
@@ -61,7 +61,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Admin] System environment config"
+                    "[Admin] System environment"
                 ],
                 "summary": "Create or Update config",
                 "parameters": [
@@ -105,7 +105,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Admin] System environment config"
+                    "[Admin] System environment"
                 ],
                 "summary": "Delete all configs",
                 "responses": {
@@ -134,7 +134,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Admin] System environment config"
+                    "[Admin] System environment"
                 ],
                 "summary": "Get config",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -2870,7 +2870,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "List all SSH Keys",
                 "parameters": [
@@ -2912,7 +2912,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "Create SSH Key",
                 "parameters": [
@@ -2963,7 +2963,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "Delete all SSH Keys",
                 "parameters": [
@@ -3001,7 +3001,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "Get SSH Key",
                 "parameters": [
@@ -3050,7 +3050,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "SSH Key"
+                    "[MCIR] VM access key management"
                 ],
                 "summary": "Delete SSH Key",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1543,7 +1543,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Resource monitor (for Developers)"
+                    "[MCIS] Resource monitor (Developer)"
                 ],
                 "summary": "InstallMonitorAgent MCIS",
                 "parameters": [
@@ -1603,7 +1603,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIS] Resource monitor (for Developers)"
+                    "[MCIS] Resource monitor (Developer)"
                 ],
                 "summary": "GetMonitorData MCIS",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1151,7 +1151,7 @@
         },
         "/ns/{nsId}/mcis/{mcisId}": {
             "get": {
-                "description": "Get MCIS",
+                "description": "Get MCIS or Action to MCIS (status, suspend, resume, reboot, terminate)",
                 "consumes": [
                     "application/json"
                 ],
@@ -1161,7 +1161,7 @@
                 "tags": [
                     "[MCIS] Provisioning management"
                 ],
-                "summary": "Get MCIS",
+                "summary": "Get MCIS or Action to MCIS (status, suspend, resume, reboot, terminate)",
                 "parameters": [
                     {
                         "type": "string",
@@ -2878,7 +2878,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "List all SSH Keys",
                 "parameters": [
@@ -2920,7 +2920,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "Create SSH Key",
                 "parameters": [
@@ -2971,7 +2971,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "Delete all SSH Keys",
                 "parameters": [
@@ -3009,7 +3009,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "Get SSH Key",
                 "parameters": [
@@ -3058,7 +3058,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VM access key management"
+                    "[MCIR] Access key management"
                 ],
                 "summary": "Delete SSH Key",
                 "parameters": [
@@ -3103,7 +3103,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "List all VNets",
                 "parameters": [
@@ -3145,7 +3145,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "Create VNet",
                 "parameters": [
@@ -3196,7 +3196,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "Delete all VNets",
                 "parameters": [
@@ -3234,7 +3234,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "Get VNet",
                 "parameters": [
@@ -3283,7 +3283,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[MCIR] VNet management"
+                    "[MCIR] Network management"
                 ],
                 "summary": "Delete VNet",
                 "parameters": [

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3095,7 +3095,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "List all VNets",
                 "parameters": [
@@ -3137,7 +3137,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "Create VNet",
                 "parameters": [
@@ -3188,7 +3188,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "Delete all VNets",
                 "parameters": [
@@ -3226,7 +3226,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "Get VNet",
                 "parameters": [
@@ -3275,7 +3275,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "VNet"
+                    "[MCIR] VNet management"
                 ],
                 "summary": "Delete VNet",
                 "parameters": [

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1220,7 +1220,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all configs
       tags:
-      - '[Admin] System environment config'
+      - '[Admin] System environment'
     get:
       consumes:
       - application/json
@@ -1242,7 +1242,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all configs
       tags:
-      - '[Admin] System environment config'
+      - '[Admin] System environment'
     post:
       consumes:
       - application/json
@@ -1271,7 +1271,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create or Update config
       tags:
-      - '[Admin] System environment config'
+      - '[Admin] System environment'
   /config/{configId}:
     get:
       consumes:
@@ -1300,7 +1300,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get config
       tags:
-      - '[Admin] System environment config'
+      - '[Admin] System environment'
   /connConfig:
     get:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1970,7 +1970,7 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get MCIS
+      description: Get MCIS or Action to MCIS (status, suspend, resume, reboot, terminate)
       parameters:
       - description: Namespace ID
         in: path
@@ -2016,7 +2016,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/common.SimpleMsg'
-      summary: Get MCIS
+      summary: Get MCIS or Action to MCIS (status, suspend, resume, reboot, terminate)
       tags:
       - '[MCIS] Provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vm:
@@ -3138,7 +3138,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all SSH Keys
       tags:
-      - '[MCIR] VM access key management'
+      - '[MCIR] Access key management'
     get:
       consumes:
       - application/json
@@ -3166,7 +3166,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all SSH Keys
       tags:
-      - '[MCIR] VM access key management'
+      - '[MCIR] Access key management'
     post:
       consumes:
       - application/json
@@ -3200,7 +3200,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create SSH Key
       tags:
-      - '[MCIR] VM access key management'
+      - '[MCIR] Access key management'
   /ns/{nsId}/resources/sshKey/{sshKeyId}:
     delete:
       consumes:
@@ -3230,7 +3230,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete SSH Key
       tags:
-      - '[MCIR] VM access key management'
+      - '[MCIR] Access key management'
     get:
       consumes:
       - application/json
@@ -3263,7 +3263,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get SSH Key
       tags:
-      - '[MCIR] VM access key management'
+      - '[MCIR] Access key management'
   /ns/{nsId}/resources/vNet:
     delete:
       consumes:
@@ -3288,7 +3288,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all VNets
       tags:
-      - '[MCIR] VNet management'
+      - '[MCIR] Network management'
     get:
       consumes:
       - application/json
@@ -3316,7 +3316,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all VNets
       tags:
-      - '[MCIR] VNet management'
+      - '[MCIR] Network management'
     post:
       consumes:
       - application/json
@@ -3350,7 +3350,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create VNet
       tags:
-      - '[MCIR] VNet management'
+      - '[MCIR] Network management'
   /ns/{nsId}/resources/vNet/{vNetId}:
     delete:
       consumes:
@@ -3380,7 +3380,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete VNet
       tags:
-      - '[MCIR] VNet management'
+      - '[MCIR] Network management'
     get:
       consumes:
       - application/json
@@ -3413,7 +3413,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get VNet
       tags:
-      - '[MCIR] VNet management'
+      - '[MCIR] Network management'
   /object:
     delete:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1684,7 +1684,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS
       tags:
-      - '[MCIS] Performance benchmarking'
+      - '[MCIS] Performance benchmarking (WIP)'
   /ns/{nsId}/benchmarkall/mcis/{mcisId}:
     get:
       consumes:
@@ -1724,7 +1724,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all MCISs
       tags:
-      - '[MCIS] Performance benchmarking'
+      - '[MCIS] Performance benchmarking (WIP)'
   /ns/{nsId}/cmd/mcis/{mcisId}:
     post:
       consumes:
@@ -1849,7 +1849,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Install the benchmark agent to specified MCIS
       tags:
-      - '[MCIS] Performance benchmarking'
+      - '[MCIS] Performance benchmarking (WIP)'
   /ns/{nsId}/mcis:
     delete:
       consumes:
@@ -2266,7 +2266,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: InstallMonitorAgent MCIS
       tags:
-      - '[MCIS] Resource monitor'
+      - '[MCIS] Resource monitor (for Developers)'
   /ns/{nsId}/monitoring/mcis/{mcisId}/metric/{metric}:
     get:
       consumes:
@@ -2305,7 +2305,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: GetMonitorData MCIS
       tags:
-      - '[MCIS] Resource monitor'
+      - '[MCIS] Resource monitor (for Developers)'
   /ns/{nsId}/policy/mcis:
     delete:
       consumes:
@@ -2330,7 +2330,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all MCIS Policys
       tags:
-      - '[MCIS] Auto control policy management'
+      - '[MCIS] Auto control policy management (WIP)'
     get:
       consumes:
       - application/json
@@ -2358,7 +2358,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all MCIS Policys
       tags:
-      - '[MCIS] Auto control policy management'
+      - '[MCIS] Auto control policy management (WIP)'
   /ns/{nsId}/policy/mcis/{mcisId}:
     delete:
       consumes:
@@ -2388,7 +2388,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete MCIS Policy
       tags:
-      - '[MCIS] Auto control policy management'
+      - '[MCIS] Auto control policy management (WIP)'
     get:
       consumes:
       - application/json
@@ -2421,7 +2421,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS Policy
       tags:
-      - '[MCIS] Auto control policy management'
+      - '[MCIS] Auto control policy management (WIP)'
     post:
       consumes:
       - application/json
@@ -2460,7 +2460,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create MCIS Automation policy
       tags:
-      - '[MCIS] Auto control policy management'
+      - '[MCIS] Auto control policy management (WIP)'
   /ns/{nsId}/resources/fetchImages:
     post:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -3552,6 +3552,29 @@ paths:
       summary: Get registered region info
       tags:
       - Admin
+  /swaggerActive:
+    get:
+      consumes:
+      - application/json
+      description: Get API document web
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get API document web
+      tags:
+      - Admin
 securityDefinitions:
   BasicAuth:
     type: basic

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -3434,6 +3434,35 @@ paths:
       summary: List all registered regions
       tags:
       - Admin
+  /region/{regionName}:
+    get:
+      consumes:
+      - application/json
+      description: Get registered region info
+      parameters:
+      - description: Name of region to retrieve
+        in: path
+        name: regionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.Region'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get registered region info
+      tags:
+      - Admin
 securityDefinitions:
   BasicAuth:
     type: basic

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1469,7 +1469,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup spec
       tags:
-      - Spec
+      - '[MCIR] Spec management'
   /lookupSpecs:
     get:
       consumes:
@@ -1499,7 +1499,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup spec list
       tags:
-      - Spec
+      - '[MCIR] Spec management'
   /ns:
     delete:
       consumes:
@@ -2490,7 +2490,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Fetch specs
       tags:
-      - Spec
+      - '[MCIR] Spec management'
   /ns/{nsId}/resources/filterSpecs:
     post:
       consumes:
@@ -2524,7 +2524,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Filter specs
       tags:
-      - Spec
+      - '[MCIR] Spec management'
   /ns/{nsId}/resources/filterSpecsByRange:
     post:
       consumes:
@@ -2558,7 +2558,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Filter specs by range
       tags:
-      - Spec
+      - '[MCIR] Spec management'
   /ns/{nsId}/resources/image:
     delete:
       consumes:
@@ -2922,7 +2922,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all specs
       tags:
-      - Spec
+      - '[MCIR] Spec management'
     get:
       consumes:
       - application/json
@@ -2950,7 +2950,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all specs
       tags:
-      - Spec
+      - '[MCIR] Spec management'
     post:
       consumes:
       - application/json
@@ -2993,7 +2993,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Register spec
       tags:
-      - Spec
+      - '[MCIR] Spec management'
   /ns/{nsId}/resources/spec/{specId}:
     delete:
       consumes:
@@ -3023,7 +3023,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete spec
       tags:
-      - Spec
+      - '[MCIR] Spec management'
     get:
       consumes:
       - application/json
@@ -3056,7 +3056,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get spec
       tags:
-      - Spec
+      - '[MCIR] Spec management'
     put:
       consumes:
       - application/json
@@ -3085,7 +3085,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Update spec
       tags:
-      - Spec
+      - '[MCIR] Spec management'
   /ns/{nsId}/resources/sshKey:
     delete:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -3260,7 +3260,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all VNets
       tags:
-      - VNet
+      - '[MCIR] VNet management'
     get:
       consumes:
       - application/json
@@ -3288,7 +3288,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all VNets
       tags:
-      - VNet
+      - '[MCIR] VNet management'
     post:
       consumes:
       - application/json
@@ -3322,7 +3322,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create VNet
       tags:
-      - VNet
+      - '[MCIR] VNet management'
   /ns/{nsId}/resources/vNet/{vNetId}:
     delete:
       consumes:
@@ -3352,7 +3352,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete VNet
       tags:
-      - VNet
+      - '[MCIR] VNet management'
     get:
       consumes:
       - application/json
@@ -3385,7 +3385,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get VNet
       tags:
-      - VNet
+      - '[MCIR] VNet management'
   /object:
     delete:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1347,6 +1347,29 @@ paths:
       summary: Get registered ConnConfig info
       tags:
       - Admin
+  /health:
+    get:
+      consumes:
+      - application/json
+      description: Check Tumblebug is alive
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Check Tumblebug is alive
+      tags:
+      - Admin
   /lookupImage:
     get:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1220,7 +1220,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all configs
       tags:
-      - Config
+      - '[Admin] System environment config'
     get:
       consumes:
       - application/json
@@ -1242,7 +1242,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all configs
       tags:
-      - Config
+      - '[Admin] System environment config'
     post:
       consumes:
       - application/json
@@ -1271,7 +1271,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create or Update config
       tags:
-      - Config
+      - '[Admin] System environment config'
   /config/{configId}:
     get:
       consumes:
@@ -1300,7 +1300,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get config
       tags:
-      - Config
+      - '[Admin] System environment config'
   /connConfig:
     get:
       consumes:
@@ -1323,7 +1323,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all registered ConnConfig
       tags:
-      - Admin
+      - Cloud
   /connConfig/{connConfigName}:
     get:
       consumes:
@@ -1346,7 +1346,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get registered ConnConfig info
       tags:
-      - Admin
+      - Cloud
   /health:
     get:
       consumes:
@@ -3522,7 +3522,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all registered regions
       tags:
-      - Admin
+      - Cloud
   /region/{regionName}:
     get:
       consumes:
@@ -3551,7 +3551,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get registered region info
       tags:
-      - Admin
+      - Cloud
   /swaggerActive:
     get:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -2772,7 +2772,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all Security Groups
       tags:
-      - Security Group
+      - '[MCIR] Security group management'
     get:
       consumes:
       - application/json
@@ -2800,7 +2800,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all Security Groups
       tags:
-      - Security Group
+      - '[MCIR] Security group management'
     post:
       consumes:
       - application/json
@@ -2834,7 +2834,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create Security Group
       tags:
-      - Security Group
+      - '[MCIR] Security group management'
   /ns/{nsId}/resources/securityGroup/{securityGroupId}:
     delete:
       consumes:
@@ -2864,7 +2864,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete Security Group
       tags:
-      - Security Group
+      - '[MCIR] Security group management'
     get:
       consumes:
       - application/json
@@ -2897,7 +2897,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get Security Group
       tags:
-      - Security Group
+      - '[MCIR] Security group management'
   /ns/{nsId}/resources/spec:
     delete:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1662,7 +1662,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS
       tags:
-      - MCIS
+      - '[MCIS] Performance benchmarking'
   /ns/{nsId}/benchmarkall/mcis/{mcisId}:
     get:
       consumes:
@@ -1702,7 +1702,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all MCISs
       tags:
-      - MCIS
+      - '[MCIS] Performance benchmarking'
   /ns/{nsId}/cmd/mcis/{mcisId}:
     post:
       consumes:
@@ -1742,7 +1742,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Send a command to specified MCIS
       tags:
-      - MCIS
+      - '[MCIS] Remote command'
   /ns/{nsId}/cmd/mcis/{mcisId}/vm/{vmId}:
     post:
       consumes:
@@ -1787,7 +1787,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Send a command to specified VM
       tags:
-      - MCIS
+      - '[MCIS] Remote command'
   /ns/{nsId}/install/mcis/{mcisId}:
     post:
       consumes:
@@ -1827,7 +1827,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Install the benchmark agent to specified MCIS
       tags:
-      - MCIS
+      - '[MCIS] Performance benchmarking'
   /ns/{nsId}/mcis:
     delete:
       consumes:
@@ -1852,7 +1852,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all MCISs
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
     get:
       consumes:
       - application/json
@@ -1880,7 +1880,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all MCISs
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
     post:
       consumes:
       - application/json
@@ -1914,7 +1914,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create MCIS
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
   /ns/{nsId}/mcis/{mcisId}:
     delete:
       consumes:
@@ -1944,7 +1944,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete MCIS
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
     get:
       consumes:
       - application/json
@@ -1996,7 +1996,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vm:
     post:
       consumes:
@@ -2036,7 +2036,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create VM in specified MCIS
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vm/{vmId}:
     delete:
       consumes:
@@ -2071,7 +2071,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete MCIS
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
     get:
       consumes:
       - application/json
@@ -2128,7 +2128,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vmgroup:
     post:
       consumes:
@@ -2168,11 +2168,12 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create multiple VMs by VM group in specified MCIS
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
   /ns/{nsId}/mcis/recommend:
     post:
       consumes:
       - application/json
+      deprecated: true
       description: Get MCIS recommendation
       parameters:
       - description: Namespace ID
@@ -2203,7 +2204,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS recommendation
       tags:
-      - MCIS
+      - '[MCIS] provisioning management'
   /ns/{nsId}/monitoring/install/mcis/{mcisId}:
     post:
       consumes:
@@ -2243,7 +2244,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: InstallMonitorAgent MCIS
       tags:
-      - Monitor
+      - '[MCIS] Resource monitor'
   /ns/{nsId}/monitoring/mcis/{mcisId}/metric/{metric}:
     get:
       consumes:
@@ -2277,7 +2278,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: GetMonitorData MCIS
       tags:
-      - Monitor
+      - '[MCIS] Resource monitor'
   /ns/{nsId}/policy/mcis:
     delete:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -3110,7 +3110,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all SSH Keys
       tags:
-      - SSH Key
+      - '[MCIR] VM access key management'
     get:
       consumes:
       - application/json
@@ -3138,7 +3138,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all SSH Keys
       tags:
-      - SSH Key
+      - '[MCIR] VM access key management'
     post:
       consumes:
       - application/json
@@ -3172,7 +3172,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create SSH Key
       tags:
-      - SSH Key
+      - '[MCIR] VM access key management'
   /ns/{nsId}/resources/sshKey/{sshKeyId}:
     delete:
       consumes:
@@ -3202,7 +3202,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete SSH Key
       tags:
-      - SSH Key
+      - '[MCIR] VM access key management'
     get:
       consumes:
       - application/json
@@ -3235,7 +3235,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get SSH Key
       tags:
-      - SSH Key
+      - '[MCIR] VM access key management'
   /ns/{nsId}/resources/vNet:
     delete:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -47,6 +47,24 @@ definitions:
       name:
         type: string
     type: object
+  common.Region:
+    properties:
+      keyValueInfoList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      providerName:
+        type: string
+      regionName:
+        type: string
+    type: object
+  common.RegionList:
+    properties:
+      region:
+        items:
+          $ref: '#/definitions/common.Region'
+        type: array
+    type: object
   common.RestGetAllConfigResponse:
     properties:
       config:
@@ -3391,6 +3409,29 @@ paths:
           schema:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all objects for a given key
+      tags:
+      - Admin
+  /region:
+    get:
+      consumes:
+      - application/json
+      description: List all registered regions
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.RegionList'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all registered regions
       tags:
       - Admin
 securityDefinitions:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -784,6 +784,28 @@ definitions:
           $ref: '#/definitions/mcis.TbVmStatusInfo'
         type: array
     type: object
+  mcis.MonResultSimple:
+    properties:
+      err:
+        type: string
+      metric:
+        type: string
+      value:
+        type: string
+      vmId:
+        type: string
+    type: object
+  mcis.MonResultSimpleResponse:
+    properties:
+      mcisId:
+        type: string
+      mcisMonitoring:
+        items:
+          $ref: '#/definitions/mcis.MonResultSimple'
+        type: array
+      nsId:
+        type: string
+    type: object
   mcis.Policy:
     properties:
       autoAction:
@@ -1852,7 +1874,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all MCISs
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
     get:
       consumes:
       - application/json
@@ -1880,7 +1902,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all MCISs
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
     post:
       consumes:
       - application/json
@@ -1914,7 +1936,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create MCIS
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
   /ns/{nsId}/mcis/{mcisId}:
     delete:
       consumes:
@@ -1944,7 +1966,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete MCIS
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
     get:
       consumes:
       - application/json
@@ -1996,7 +2018,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vm:
     post:
       consumes:
@@ -2036,7 +2058,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create VM in specified MCIS
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vm/{vmId}:
     delete:
       consumes:
@@ -2071,7 +2093,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete MCIS
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
     get:
       consumes:
       - application/json
@@ -2128,7 +2150,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vmgroup:
     post:
       consumes:
@@ -2168,7 +2190,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create multiple VMs by VM group in specified MCIS
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
   /ns/{nsId}/mcis/recommend:
     post:
       consumes:
@@ -2204,7 +2226,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS recommendation
       tags:
-      - '[MCIS] provisioning management'
+      - '[MCIS] Provisioning management'
   /ns/{nsId}/monitoring/install/mcis/{mcisId}:
     post:
       consumes:
@@ -2218,7 +2240,7 @@ paths:
         type: string
       - description: MCIS ID
         in: path
-        name: nsId
+        name: mcisId
         required: true
         type: string
       - description: Details for an MCIS object
@@ -2233,7 +2255,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.AgentInstallContentWrapper'
         "404":
           description: Not Found
           schema:
@@ -2258,7 +2280,12 @@ paths:
         type: string
       - description: MCIS ID
         in: path
-        name: nsId
+        name: mcisId
+        required: true
+        type: string
+      - description: 'Metric type: cpu, memory, disk, network'
+        in: path
+        name: metric
         required: true
         type: string
       produces:
@@ -2267,7 +2294,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbSshKeyInfo'
+            $ref: '#/definitions/mcis.MonResultSimpleResponse'
         "404":
           description: Not Found
           schema:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1345,7 +1345,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all registered ConnConfig
       tags:
-      - '[Cloud] Associated Cloud info'
+      - '[Admin] Cloud environment management'
   /connConfig/{connConfigName}:
     get:
       consumes:
@@ -1368,7 +1368,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get registered ConnConfig info
       tags:
-      - '[Cloud] Associated Cloud info'
+      - '[Admin] Cloud environment management'
   /health:
     get:
       consumes:
@@ -1426,7 +1426,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup image
       tags:
-      - '[MCIR] Image management'
+      - '[Admin] Cloud environment management'
   /lookupImages:
     get:
       consumes:
@@ -1456,7 +1456,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup image list
       tags:
-      - '[MCIR] Image management'
+      - '[Admin] Cloud environment management'
   /lookupSpec:
     get:
       consumes:
@@ -1491,7 +1491,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup spec
       tags:
-      - '[MCIR] Spec management'
+      - '[Admin] Cloud environment management'
   /lookupSpecs:
     get:
       consumes:
@@ -1521,7 +1521,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup spec list
       tags:
-      - '[MCIR] Spec management'
+      - '[Admin] Cloud environment management'
   /ns:
     delete:
       consumes:
@@ -3550,7 +3550,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all registered regions
       tags:
-      - '[Cloud] Associated Cloud info'
+      - '[Admin] Cloud environment management'
   /region/{regionName}:
     get:
       consumes:
@@ -3579,7 +3579,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get registered region info
       tags:
-      - '[Cloud] Associated Cloud info'
+      - '[Admin] Cloud environment management'
   /swaggerActive:
     get:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1404,7 +1404,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup image
       tags:
-      - Image
+      - '[MCIR] Image management'
   /lookupImages:
     get:
       consumes:
@@ -1434,7 +1434,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Lookup image list
       tags:
-      - Image
+      - '[MCIR] Image management'
   /lookupSpec:
     get:
       consumes:
@@ -1518,7 +1518,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all namespaces
       tags:
-      - Namespace
+      - '[Namespace] Namespace management'
     get:
       consumes:
       - application/json
@@ -1540,7 +1540,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all namespaces
       tags:
-      - Namespace
+      - '[Namespace] Namespace management'
     post:
       consumes:
       - application/json
@@ -1569,7 +1569,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create namespace
       tags:
-      - Namespace
+      - '[Namespace] Namespace management'
   /ns/{nsId}:
     delete:
       consumes:
@@ -1594,7 +1594,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete namespace
       tags:
-      - Namespace
+      - '[Namespace] Namespace management'
     get:
       consumes:
       - application/json
@@ -1622,7 +1622,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get namespace
       tags:
-      - Namespace
+      - '[Namespace] Namespace management'
   /ns/{nsId}/benchmark/mcis/{mcisId}:
     get:
       consumes:
@@ -2461,7 +2461,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Fetch images
       tags:
-      - Image
+      - '[MCIR] Image management'
   /ns/{nsId}/resources/fetchSpecs:
     post:
       consumes:
@@ -2583,7 +2583,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all images
       tags:
-      - Image
+      - '[MCIR] Image management'
     get:
       consumes:
       - application/json
@@ -2611,7 +2611,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all images
       tags:
-      - Image
+      - '[MCIR] Image management'
     post:
       consumes:
       - application/json
@@ -2654,7 +2654,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Register image
       tags:
-      - Image
+      - '[MCIR] Image management'
   /ns/{nsId}/resources/image/{imageId}:
     delete:
       consumes:
@@ -2684,7 +2684,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete image
       tags:
-      - Image
+      - '[MCIR] Image management'
     get:
       consumes:
       - application/json
@@ -2717,7 +2717,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get image
       tags:
-      - Image
+      - '[MCIR] Image management'
   /ns/{nsId}/resources/searchImage:
     get:
       consumes:
@@ -2747,7 +2747,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Search image
       tags:
-      - Image
+      - '[MCIR] Image management'
   /ns/{nsId}/resources/securityGroup:
     delete:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1323,7 +1323,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all registered ConnConfig
       tags:
-      - Cloud
+      - '[Cloud] Associated Cloud info'
   /connConfig/{connConfigName}:
     get:
       consumes:
@@ -1346,7 +1346,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get registered ConnConfig info
       tags:
-      - Cloud
+      - '[Cloud] Associated Cloud info'
   /health:
     get:
       consumes:
@@ -1369,7 +1369,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Check Tumblebug is alive
       tags:
-      - Admin
+      - '[Admin] System management'
   /lookupImage:
     get:
       consumes:
@@ -3414,7 +3414,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete an object
       tags:
-      - Admin
+      - '[Admin] System management'
     get:
       consumes:
       - application/json
@@ -3442,7 +3442,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get value of an object
       tags:
-      - Admin
+      - '[Admin] System management'
   /objects:
     delete:
       consumes:
@@ -3471,7 +3471,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete child objects along with the given object
       tags:
-      - Admin
+      - '[Admin] System management'
     get:
       consumes:
       - application/json
@@ -3499,7 +3499,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all objects for a given key
       tags:
-      - Admin
+      - '[Admin] System management'
   /region:
     get:
       consumes:
@@ -3522,7 +3522,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all registered regions
       tags:
-      - Cloud
+      - '[Cloud] Associated Cloud info'
   /region/{regionName}:
     get:
       consumes:
@@ -3551,7 +3551,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get registered region info
       tags:
-      - Cloud
+      - '[Cloud] Associated Cloud info'
   /swaggerActive:
     get:
       consumes:
@@ -3574,7 +3574,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get API document web
       tags:
-      - Admin
+      - '[Admin] System management'
 securityDefinitions:
   BasicAuth:
     type: basic

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -2266,7 +2266,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: InstallMonitorAgent MCIS
       tags:
-      - '[MCIS] Resource monitor (for Developers)'
+      - '[MCIS] Resource monitor (Developer)'
   /ns/{nsId}/monitoring/mcis/{mcisId}/metric/{metric}:
     get:
       consumes:
@@ -2305,7 +2305,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: GetMonitorData MCIS
       tags:
-      - '[MCIS] Resource monitor (for Developers)'
+      - '[MCIS] Resource monitor (Developer)'
   /ns/{nsId}/policy/mcis:
     delete:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -2302,7 +2302,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete all MCIS Policys
       tags:
-      - MCIS Policy
+      - '[MCIS] Auto control policy management'
     get:
       consumes:
       - application/json
@@ -2330,7 +2330,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List all MCIS Policys
       tags:
-      - MCIS Policy
+      - '[MCIS] Auto control policy management'
   /ns/{nsId}/policy/mcis/{mcisId}:
     delete:
       consumes:
@@ -2360,7 +2360,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Delete MCIS Policy
       tags:
-      - MCIS Policy
+      - '[MCIS] Auto control policy management'
     get:
       consumes:
       - application/json
@@ -2393,7 +2393,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get MCIS Policy
       tags:
-      - MCIS Policy
+      - '[MCIS] Auto control policy management'
     post:
       consumes:
       - application/json
@@ -2432,7 +2432,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create MCIS Automation policy
       tags:
-      - MCIS Policy
+      - '[MCIS] Auto control policy management'
   /ns/{nsId}/resources/fetchImages:
     post:
       consumes:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -12,6 +12,26 @@ definitions:
         example: http://localhost:1024/spider
         type: string
     type: object
+  common.ConnConfig:
+    properties:
+      configName:
+        type: string
+      credentialName:
+        type: string
+      driverName:
+        type: string
+      providerName:
+        type: string
+      regionName:
+        type: string
+    type: object
+  common.ConnConfigList:
+    properties:
+      connectionconfig:
+        items:
+          $ref: '#/definitions/common.ConnConfig'
+        type: array
+    type: object
   common.IID:
     properties:
       nameId:
@@ -1281,6 +1301,52 @@ paths:
       summary: Get config
       tags:
       - Config
+  /connConfig:
+    get:
+      consumes:
+      - application/json
+      description: List all registered ConnConfig
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.ConnConfigList'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all registered ConnConfig
+      tags:
+      - Admin
+  /connConfig/{connConfigName}:
+    get:
+      consumes:
+      - application/json
+      description: Get registered ConnConfig info
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.ConnConfig'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get registered ConnConfig info
+      tags:
+      - Admin
   /lookupImage:
     get:
       consumes:


### PR DESCRIPTION

Enhance swagger documentation and UI mechanism.

If you define (source) `SELF_ENDPOINT` in `setup.env`, 
you can access Swagger UI from outside.

```
# Set SELF_ENDPOINT, if you want to access Swagger API dashboard from outside.
# Ex) export SELF_ENDPOINT=xxx.xxx.xxx.xxx:1323
export SELF_ENDPOINT=localhost:1323
```

```

  ██████╗██████╗    ████████╗██████╗      
 ██╔════╝██╔══██╗   ╚══██╔══╝██╔══██╗     
 ██║     ██████╔╝█████╗██║   ██████╔╝     
 ██║     ██╔══██╗╚════╝██║   ██╔══██╗     
 ╚██████╗██████╔╝      ██║   ██████╔╝     
  ╚═════╝╚═════╝       ╚═╝   ╚═════╝      
                                         
 ██████╗ ███████╗ █████╗ ██████╗ ██╗   ██╗
 ██╔══██╗██╔════╝██╔══██╗██╔══██╗╚██╗ ██╔╝
 ██████╔╝█████╗  ███████║██║  ██║ ╚████╔╝ 
 ██╔══██╗██╔══╝  ██╔══██║██║  ██║  ╚██╔╝  
 ██║  ██║███████╗██║  ██║██████╔╝   ██║   
 ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝    ╚═╝   

 Multi-cloud infrastructure managemenet framework
 ________________________________________________
 
 
 Repository: https://github.com/cloud-barista/cb-tumblebug
 
 
 [Access to API dashboard] username/password: (xxxxxx/xxxxxxxxx)
 http://xxxxxxxxxx:1323/tumblebug/swagger/index.html?url=http://xxxxxxxxxx:1323/tumblebug/swaggerActive
 
⇨ http server started on [::]:1323
⇨ grpc server started on [::]:50252
```

![image](https://user-images.githubusercontent.com/5966944/116532498-47dfea00-a91b-11eb-9fbe-76f1b6aecc8b.png)

