### PR TITLE
Fix registerImageWithId.sh

### DIFF
--- a/src/testclient/scripts/1.configureSpider/get-cloud.sh
+++ b/src/testclient/scripts/1.configureSpider/get-cloud.sh
@@ -11,17 +11,14 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
     source ../credentials.conf
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Get Cloud Connction Config"
     echo "####################################################################"

--- a/src/testclient/scripts/1.configureSpider/list-cloud.sh
+++ b/src/testclient/scripts/1.configureSpider/list-cloud.sh
@@ -4,17 +4,14 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
     #source ../credentials.conf
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. List Cloud Connction Config(s)"
     echo "####################################################################"

--- a/src/testclient/scripts/1.configureSpider/register-cloud.sh
+++ b/src/testclient/scripts/1.configureSpider/register-cloud.sh
@@ -10,17 +10,14 @@
     fi
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
     source ../credentials.conf
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 1. Create Cloud Connction Config"
     echo "####################################################################"

--- a/src/testclient/scripts/1.configureSpider/unregister-cloud.sh
+++ b/src/testclient/scripts/1.configureSpider/unregister-cloud.sh
@@ -11,16 +11,14 @@
 
 	TestSetFile=${5:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
 	source ../credentials.conf
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 1. Remove All Cloud Connction Config(s)"
 	echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/check-ns.sh
+++ b/src/testclient/scripts/2.configureTumblebug/check-ns.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Namespace: Get"
     echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/create-ns.sh
+++ b/src/testclient/scripts/2.configureTumblebug/create-ns.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 2. Namespace: Create"
 	echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/delete-all-config.sh
+++ b/src/testclient/scripts/2.configureTumblebug/delete-all-config.sh
@@ -3,17 +3,14 @@
 #function delete_ns() {
 
 
-    TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
-        exit
-    fi
-	source $TestSetFile
+    # TestSetFile=${4:-../testSet.env}
+    # if [ ! -f "$TestSetFile" ]; then
+    #     echo "$TestSetFile does not exist."
+    #     exit
+    # fi
+	# source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Config: Delete ALL"
     echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/delete-all-ns.sh
+++ b/src/testclient/scripts/2.configureTumblebug/delete-all-ns.sh
@@ -3,22 +3,19 @@
 #function delete_ns() {
 
 
-    TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
-        exit
-    fi
-	source $TestSetFile
+    # TestSetFile=${4:-../testSet.env}
+    # if [ ! -f "$TestSetFile" ]; then
+    #     echo "$TestSetFile does not exist."
+    #     exit
+    # fi
+	# source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Namespace: Delete"
     echo "####################################################################"
 
-    INDEX=${1}
+    # INDEX=${1}
 
     curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns | jq ''
     echo ""

--- a/src/testclient/scripts/2.configureTumblebug/delete-ns.sh
+++ b/src/testclient/scripts/2.configureTumblebug/delete-ns.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Namespace: Delete"
     echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/get-config.sh
+++ b/src/testclient/scripts/2.configureTumblebug/get-config.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Config: Get (option: spider-rest-url, dragonfly-rest-url, ...)"
     echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/get-ns.sh
+++ b/src/testclient/scripts/2.configureTumblebug/get-ns.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Namespace: Get"
     echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/list-config.sh
+++ b/src/testclient/scripts/2.configureTumblebug/list-config.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Config: List"
     echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/list-ns.sh
+++ b/src/testclient/scripts/2.configureTumblebug/list-ns.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Namespace: List"
     echo "####################################################################"

--- a/src/testclient/scripts/2.configureTumblebug/update-config.sh
+++ b/src/testclient/scripts/2.configureTumblebug/update-config.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 2. Config: Create or Update (Param1: Key, Param2: Value)"
 	echo "####################################################################"

--- a/src/testclient/scripts/3.vNet/create-vNet.sh
+++ b/src/testclient/scripts/3.vNet/create-vNet.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 3. vNet: Create"
 	echo "####################################################################"

--- a/src/testclient/scripts/3.vNet/delete-vNet.sh
+++ b/src/testclient/scripts/3.vNet/delete-vNet.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 3. vNet: Delete"
 	echo "####################################################################"

--- a/src/testclient/scripts/3.vNet/get-vNet.sh
+++ b/src/testclient/scripts/3.vNet/get-vNet.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 3. vNet: Get"
 	echo "####################################################################"

--- a/src/testclient/scripts/3.vNet/list-vNet.sh
+++ b/src/testclient/scripts/3.vNet/list-vNet.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 1. VPC: Get"
     echo "####################################################################"

--- a/src/testclient/scripts/3.vNet/spider-create-vNet.sh
+++ b/src/testclient/scripts/3.vNet/spider-create-vNet.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 3. vNet: Create"
 	echo "####################################################################"

--- a/src/testclient/scripts/3.vNet/spider-delete-vNet.sh
+++ b/src/testclient/scripts/3.vNet/spider-delete-vNet.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/3.vNet/spider-get-vNet.sh
+++ b/src/testclient/scripts/3.vNet/spider-get-vNet.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/3.vNet/testAddAsso.sh
+++ b/src/testclient/scripts/3.vNet/testAddAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 3. vNet : Add test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/3.vNet/testDeleteAsso.sh
+++ b/src/testclient/scripts/3.vNet/testDeleteAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 3. vNet : Delete test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/3.vNet/testGetAssoCount.sh
+++ b/src/testclient/scripts/3.vNet/testGetAssoCount.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 3. vNet : Get association count"
 	echo "####################################################################"

--- a/src/testclient/scripts/4.securityGroup/create-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/create-securityGroup.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 4. SecurityGroup: Create"
 	echo "####################################################################"

--- a/src/testclient/scripts/4.securityGroup/delete-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/delete-securityGroup.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 4. SecurityGroup: Delete"
 	echo "####################################################################"

--- a/src/testclient/scripts/4.securityGroup/get-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/get-securityGroup.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 4. SecurityGroup: Get"
 	echo "####################################################################"

--- a/src/testclient/scripts/4.securityGroup/list-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/list-securityGroup.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 4. SecurityGroup: List"
     echo "####################################################################"

--- a/src/testclient/scripts/4.securityGroup/spider-get-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/spider-get-securityGroup.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/4.securityGroup/testAddAsso.sh
+++ b/src/testclient/scripts/4.securityGroup/testAddAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 4. securityGroup : Add test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/4.securityGroup/testDeleteAsso.sh
+++ b/src/testclient/scripts/4.securityGroup/testDeleteAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 4. securityGroup : Delete test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/4.securityGroup/testGetAssoCount.sh
+++ b/src/testclient/scripts/4.securityGroup/testGetAssoCount.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 4. securityGroup : Get association count"
 	echo "####################################################################"

--- a/src/testclient/scripts/5.sshKey/create-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/create-sshKey.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 5. sshKey: Create"
 	echo "####################################################################"

--- a/src/testclient/scripts/5.sshKey/delete-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/delete-sshKey.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 5. sshKey: Delete"
 	echo "####################################################################"

--- a/src/testclient/scripts/5.sshKey/force-delete-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/force-delete-sshKey.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 5. sshKey: Delete"
 	echo "####################################################################"

--- a/src/testclient/scripts/5.sshKey/get-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/get-sshKey.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 5. sshKey: Get"
 	echo "####################################################################"

--- a/src/testclient/scripts/5.sshKey/list-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/list-sshKey.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 5. sshKey: List"
     echo "####################################################################"

--- a/src/testclient/scripts/5.sshKey/spider-delete-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/spider-delete-sshKey.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/5.sshKey/spider-get-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/spider-get-sshKey.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/5.sshKey/testAddAsso.sh
+++ b/src/testclient/scripts/5.sshKey/testAddAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 5. sshKey: Add test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/5.sshKey/testDeleteAsso.sh
+++ b/src/testclient/scripts/5.sshKey/testDeleteAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 5. sshKey: Delete test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/5.sshKey/testGetAssoCount.sh
+++ b/src/testclient/scripts/5.sshKey/testGetAssoCount.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 5. sshKey: Get association count"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/fetch-images.sh
+++ b/src/testclient/scripts/6.image/fetch-images.sh
@@ -11,7 +11,6 @@ if [ ! -f "$FILE" ]; then
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 6. image: Fetch"

--- a/src/testclient/scripts/6.image/get-image.sh
+++ b/src/testclient/scripts/6.image/get-image.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image: Get"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/list-image.sh
+++ b/src/testclient/scripts/6.image/list-image.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 6. image: List"
     echo "####################################################################"

--- a/src/testclient/scripts/6.image/lookupImage.sh
+++ b/src/testclient/scripts/6.image/lookupImage.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image: Lookup Image"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/lookupImageList.sh
+++ b/src/testclient/scripts/6.image/lookupImageList.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec: Lookup Spec List"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/obsolete_registerImageWithInfo.sh
+++ b/src/testclient/scripts/6.image/obsolete_registerImageWithInfo.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 6. image: Register"
     echo "####################################################################"

--- a/src/testclient/scripts/6.image/registerImageWithId.sh
+++ b/src/testclient/scripts/6.image/registerImageWithId.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image: Register"
 	echo "####################################################################"
@@ -26,7 +23,7 @@
 	getCloudIndex $CSP
 
 	resp=$(
-        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/resources/image?action=registerWithInfo -H 'Content-Type: application/json' -d @- <<EOF
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/resources/image?action=registerWithId -H 'Content-Type: application/json' -d @- <<EOF
 		{ 
 			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}", 
 			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",

--- a/src/testclient/scripts/6.image/spider-get-image.sh
+++ b/src/testclient/scripts/6.image/spider-get-image.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image: Fetch"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/spider-get-imagelist.sh
+++ b/src/testclient/scripts/6.image/spider-get-imagelist.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. image: Fetch"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/test-search-image.sh
+++ b/src/testclient/scripts/6.image/test-search-image.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 6. image: Search"
     echo "####################################################################"

--- a/src/testclient/scripts/6.image/testAddAsso.sh
+++ b/src/testclient/scripts/6.image/testAddAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image : Add test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/testDeleteAsso.sh
+++ b/src/testclient/scripts/6.image/testDeleteAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image : Delete test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/testGetAssoCount.sh
+++ b/src/testclient/scripts/6.image/testGetAssoCount.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image : Get association count"
 	echo "####################################################################"

--- a/src/testclient/scripts/6.image/unregister-all-images.sh
+++ b/src/testclient/scripts/6.image/unregister-all-images.sh
@@ -2,31 +2,30 @@
 
 #function unregister_image() {
 
+    SECONDS=0
 
-	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
-        exit
-    fi
-	source $TestSetFile
+	# TestSetFile=${4:-../testSet.env}
+    # if [ ! -f "$TestSetFile" ]; then
+    #     echo "$TestSetFile does not exist."
+    #     exit
+    # fi
+	# source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image: Unregister"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+	# CSP=${1}
+	# REGION=${2:-1}
+	# POSTFIX=${3:-developer}
 
 	source ../common-functions.sh
-	getCloudIndex $CSP
+	# getCloudIndex $CSP
 
 	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/image | jq ''
 
+    printElapsed $@
 #}
 
 #unregister_image

--- a/src/testclient/scripts/6.image/unregister-image.sh
+++ b/src/testclient/scripts/6.image/unregister-image.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 6. image: Unregister"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/fetch-specs.sh
+++ b/src/testclient/scripts/7.spec/fetch-specs.sh
@@ -13,7 +13,6 @@ if [ ! -f "$FILE" ]; then
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 7. spec: Fetch"

--- a/src/testclient/scripts/7.spec/filter-specs.sh
+++ b/src/testclient/scripts/7.spec/filter-specs.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 7. spec: filter"
     echo "####################################################################"

--- a/src/testclient/scripts/7.spec/get-spec.sh
+++ b/src/testclient/scripts/7.spec/get-spec.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec: Get"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/list-spec.sh
+++ b/src/testclient/scripts/7.spec/list-spec.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 7. spec: List"
     echo "####################################################################"

--- a/src/testclient/scripts/7.spec/lookupSpec.sh
+++ b/src/testclient/scripts/7.spec/lookupSpec.sh
@@ -5,15 +5,12 @@
 SECONDS=0
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 7. spec: Lookup Spec"

--- a/src/testclient/scripts/7.spec/lookupSpecList.sh
+++ b/src/testclient/scripts/7.spec/lookupSpecList.sh
@@ -5,15 +5,12 @@
 SECONDS=0
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 7. spec: Lookup Spec List"

--- a/src/testclient/scripts/7.spec/range-filter-specs.sh
+++ b/src/testclient/scripts/7.spec/range-filter-specs.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 7. spec: filter"
     echo "####################################################################"

--- a/src/testclient/scripts/7.spec/register-spec.sh
+++ b/src/testclient/scripts/7.spec/register-spec.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec: Register"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/spider-get-spec.sh
+++ b/src/testclient/scripts/7.spec/spider-get-spec.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec: Fetch"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/spider-get-speclist.sh
+++ b/src/testclient/scripts/7.spec/spider-get-speclist.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec: Fetch"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/test-sort-specs.sh
+++ b/src/testclient/scripts/7.spec/test-sort-specs.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 7. spec: filter"
     echo "####################################################################"

--- a/src/testclient/scripts/7.spec/testAddAsso.sh
+++ b/src/testclient/scripts/7.spec/testAddAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec : Add test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/testDeleteAsso.sh
+++ b/src/testclient/scripts/7.spec/testDeleteAsso.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec : Delete test association"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/testGetAssoCount.sh
+++ b/src/testclient/scripts/7.spec/testGetAssoCount.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec : Get association count"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/unregister-all-specs.sh
+++ b/src/testclient/scripts/7.spec/unregister-all-specs.sh
@@ -3,27 +3,24 @@
 
 SECONDS=0
 
-TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
-	exit
-fi
-source $TestSetFile
+# TestSetFile=${4:-../testSet.env}
+# if [ ! -f "$TestSetFile" ]; then
+# 	echo "$TestSetFile does not exist."
+# 	exit
+# fi
+# source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 7. spec: Unregister"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
+# CSP=${1}
+# REGION=${2:-1}
+# POSTFIX=${3:-developer}
 
 source ../common-functions.sh
-getCloudIndex $CSP
+# getCloudIndex $CSP
 
 curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/spec | jq ''
 

--- a/src/testclient/scripts/7.spec/unregister-spec.sh
+++ b/src/testclient/scripts/7.spec/unregister-spec.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec: Unregister"
 	echo "####################################################################"

--- a/src/testclient/scripts/7.spec/update-spec.sh
+++ b/src/testclient/scripts/7.spec/update-spec.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 7. spec: Update"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/add-vm-to-mcis.sh
+++ b/src/testclient/scripts/8.mcis/add-vm-to-mcis.sh
@@ -5,15 +5,13 @@
 
 	TestSetFile=${5:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. vm: Create MCIS"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/add-vmgroup-to-mcis.sh
+++ b/src/testclient/scripts/8.mcis/add-vmgroup-to-mcis.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. vm: Create MCIS"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/create-mcis-no-agent.sh
+++ b/src/testclient/scripts/8.mcis/create-mcis-no-agent.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. vm: Create MCIS"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/create-mcis-policy.sh
+++ b/src/testclient/scripts/8.mcis/create-mcis-policy.sh
@@ -5,15 +5,13 @@
 
 	TestSetFile=${5:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. Create MCIS Policy"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/create-mcis.sh
+++ b/src/testclient/scripts/8.mcis/create-mcis.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. vm: Create MCIS"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/create-single-vm-mcis.sh
+++ b/src/testclient/scripts/8.mcis/create-single-vm-mcis.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. Create MCIS with a single VM"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/delete-mcis-policy-all.sh
+++ b/src/testclient/scripts/8.mcis/delete-mcis-policy-all.sh
@@ -5,15 +5,13 @@
 
 	TestSetFile=${5:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. Delete MCIS Policy ALL"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/delete-mcis-policy.sh
+++ b/src/testclient/scripts/8.mcis/delete-mcis-policy.sh
@@ -5,15 +5,13 @@
 
 	TestSetFile=${5:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. Delete MCIS Policy"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/get-mcis-policy.sh
+++ b/src/testclient/scripts/8.mcis/get-mcis-policy.sh
@@ -5,15 +5,13 @@
 
 	TestSetFile=${5:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. VM: Get MCIS Policy"
 	echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/get-mcis.sh
+++ b/src/testclient/scripts/8.mcis/get-mcis.sh
@@ -2,15 +2,12 @@
 
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 8. Get MCIS"

--- a/src/testclient/scripts/8.mcis/just-terminate-mcis.sh
+++ b/src/testclient/scripts/8.mcis/just-terminate-mcis.sh
@@ -3,15 +3,12 @@
 #function just_terminate_mcis() {
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 8. VM: Just Terminate MCIS"

--- a/src/testclient/scripts/8.mcis/list-mcis-policy.sh
+++ b/src/testclient/scripts/8.mcis/list-mcis-policy.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 8. VM: List MCIS"
     echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/list-mcis-status.sh
+++ b/src/testclient/scripts/8.mcis/list-mcis-status.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 8. VM: List MCIS"
     echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/list-mcis.sh
+++ b/src/testclient/scripts/8.mcis/list-mcis.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 8. VM: List MCIS"
     echo "####################################################################"

--- a/src/testclient/scripts/8.mcis/reboot-mcis.sh
+++ b/src/testclient/scripts/8.mcis/reboot-mcis.sh
@@ -3,15 +3,12 @@
 #function reboot_mcis() {
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 8. VM: Reboot MCIS"

--- a/src/testclient/scripts/8.mcis/resume-mcis.sh
+++ b/src/testclient/scripts/8.mcis/resume-mcis.sh
@@ -3,15 +3,12 @@
 #function resume_mcis() {
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 8. VM: Resume from suspended MCIS"

--- a/src/testclient/scripts/8.mcis/spider-create-vm.sh
+++ b/src/testclient/scripts/8.mcis/spider-create-vm.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/8.mcis/spider-delete-vm.sh
+++ b/src/testclient/scripts/8.mcis/spider-delete-vm.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/8.mcis/spider-get-vm.sh
+++ b/src/testclient/scripts/8.mcis/spider-get-vm.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/8.mcis/spider-get-vmstatus.sh
+++ b/src/testclient/scripts/8.mcis/spider-get-vmstatus.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	CSP=${1}
 	REGION=${2:-1}
 	POSTFIX=${3:-developer}

--- a/src/testclient/scripts/8.mcis/status-mcis.sh
+++ b/src/testclient/scripts/8.mcis/status-mcis.sh
@@ -3,15 +3,12 @@
 #function status_mcis() {
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 8. VM: Status MCIS"

--- a/src/testclient/scripts/8.mcis/suspend-mcis.sh
+++ b/src/testclient/scripts/8.mcis/suspend-mcis.sh
@@ -3,15 +3,12 @@
 #function suspend_mcis() {
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 8. VM: Suspend MCIS"

--- a/src/testclient/scripts/8.mcis/terminate-and-delete-mcis.sh
+++ b/src/testclient/scripts/8.mcis/terminate-and-delete-mcis.sh
@@ -3,15 +3,12 @@
 #function terminate_and_delete_mcis() {
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## 8. VM: Terminate and Delete MCIS"

--- a/src/testclient/scripts/9.monitoring/get-monitoring-data.sh
+++ b/src/testclient/scripts/9.monitoring/get-monitoring-data.sh
@@ -5,15 +5,13 @@
 
 	TestSetFile=${5:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Get monitoring data for MCIS (cpu/memory/disk/network)"
 	echo "####################################################################"

--- a/src/testclient/scripts/9.monitoring/install-agent.sh
+++ b/src/testclient/scripts/9.monitoring/install-agent.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Install monitoring agent to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -8,6 +8,7 @@ TumblebugServer=localhost:1323
 # API BasicAuth Header
 ApiUsername=default
 ApiPassword=default
+AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 ## NSID for Tumblebug
 NSID=ns-01

--- a/src/testclient/scripts/misc/get-conn-config.sh
+++ b/src/testclient/scripts/misc/get-conn-config.sh
@@ -10,17 +10,14 @@
     fi
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
     source ../credentials.conf
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Get Cloud Connction Config"
     echo "####################################################################"

--- a/src/testclient/scripts/misc/get-region.sh
+++ b/src/testclient/scripts/misc/get-region.sh
@@ -10,17 +10,14 @@
     fi
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
     source ../credentials.conf
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Get Cloud Connction Config"
     echo "####################################################################"

--- a/src/testclient/scripts/misc/list-conn-config.sh
+++ b/src/testclient/scripts/misc/list-conn-config.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Conn Config: List"
     echo "####################################################################"

--- a/src/testclient/scripts/misc/list-region.sh
+++ b/src/testclient/scripts/misc/list-region.sh
@@ -4,16 +4,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Region: List"
     echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/change-mcis-hostname.sh
+++ b/src/testclient/scripts/sequentialFullTest/change-mcis-hostname.sh
@@ -6,15 +6,12 @@ echo "[Check jq package (if not, install)]"
 if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS to change-mcis-hostname"

--- a/src/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
+++ b/src/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
@@ -130,15 +130,12 @@ if [ ! -f "$FILE" ]; then
 fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 source ../credentials.conf
 
 echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/clean-mcis-only.sh
+++ b/src/testclient/scripts/sequentialFullTest/clean-mcis-only.sh
@@ -30,15 +30,12 @@ if [ ! -f "$FILE" ]; then
 fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 source ../credentials.conf
 
 echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/command-mcis-custom.sh
+++ b/src/testclient/scripts/sequentialFullTest/command-mcis-custom.sh
@@ -3,15 +3,12 @@
 #function command_mcis_custom() {
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS "

--- a/src/testclient/scripts/sequentialFullTest/command-mcis-vm-custom.sh
+++ b/src/testclient/scripts/sequentialFullTest/command-mcis-vm-custom.sh
@@ -3,15 +3,12 @@
 #function command_mcis_custom() {
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS "

--- a/src/testclient/scripts/sequentialFullTest/command-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/command-mcis.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/create-mcir-ns-cloud.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcir-ns-cloud.sh
@@ -86,16 +86,13 @@ if [ ! -f "$FILE" ]; then
 fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
 source ../credentials.conf
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Create MCIS from Zero Base"

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
@@ -48,16 +48,13 @@ function test_sequence()
     fi
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-	source ../credentials.conf
+		source ../credentials.conf
 
 	echo "####################################################################"
 	echo "## Create MCIS from Zero Base"

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-for-ws.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-for-ws.sh
@@ -44,15 +44,12 @@ if [ ! -f "$FILE" ]; then
 fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 source ../credentials.conf
 
 echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-only.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-only.sh
@@ -70,16 +70,13 @@ if [ ! -f "$FILE" ]; then
 fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
 source ../credentials.conf
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Create MCIS from Zero Base"

--- a/src/testclient/scripts/sequentialFullTest/delete-object.sh
+++ b/src/testclient/scripts/sequentialFullTest/delete-object.sh
@@ -2,16 +2,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Object: Delete"
     echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/delete-objects-becareful.sh
+++ b/src/testclient/scripts/sequentialFullTest/delete-objects-becareful.sh
@@ -2,16 +2,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Object: Delete Child Objects"
     echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/deploy-dragonfly-docker.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-dragonfly-docker.sh
@@ -8,16 +8,13 @@
 	
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/deploy-jitsi-to-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-jitsi-to-mcis.sh
@@ -6,15 +6,12 @@ echo "[Check jq package (if not, install)]"
 if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## deploy-jitsi-to-mcis "

--- a/src/testclient/scripts/sequentialFullTest/deploy-loadMaker-to-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-loadMaker-to-mcis.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/deploy-nginx-mcis-vm-withGivenName.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-nginx-mcis-vm-withGivenName.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS VM with given ID"
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/deploy-nginx-mcis-with-loadmaker.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-nginx-mcis-with-loadmaker.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/deploy-nginx-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-nginx-mcis.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/deploy-spider-docker.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-spider-docker.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/deploy-tumblebug.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-tumblebug.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/deploy-weavescope-to-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-weavescope-to-mcis.sh
@@ -6,15 +6,12 @@ echo "[Check jq package (if not, install)]"
 if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS "

--- a/src/testclient/scripts/sequentialFullTest/deploy-weavescope-to-multi-mcis-update-noinstall.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-weavescope-to-multi-mcis-update-noinstall.sh
@@ -6,7 +6,6 @@ echo "[Check jq package (if not, install)]"
 if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS "

--- a/src/testclient/scripts/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-weavescope-to-multi-mcis-update.sh
@@ -6,7 +6,6 @@ echo "[Check jq package (if not, install)]"
 if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS "

--- a/src/testclient/scripts/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-weavescope-to-multi-mcis.sh
@@ -6,7 +6,6 @@ echo "[Check jq package (if not, install)]"
 if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
 
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## Command (SSH) to MCIS "

--- a/src/testclient/scripts/sequentialFullTest/expand-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/expand-mcis.sh
@@ -5,15 +5,13 @@
 
 	TestSetFile=${6:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## 8. vm: Create MCIS"
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/gen-sshKey-withGivenMcisName.sh
+++ b/src/testclient/scripts/sequentialFullTest/gen-sshKey-withGivenMcisName.sh
@@ -8,15 +8,13 @@
 
 	TestSetFile=${5:-../testSet.env}
     
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Generate SSH KEY (PEM, PPK)" 
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/gen-sshKey.sh
+++ b/src/testclient/scripts/sequentialFullTest/gen-sshKey.sh
@@ -7,16 +7,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Generate SSH KEY (PEM, PPK)" 
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/get-object.sh
+++ b/src/testclient/scripts/sequentialFullTest/get-object.sh
@@ -2,16 +2,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Object: Get value"
     echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/list-object.sh
+++ b/src/testclient/scripts/sequentialFullTest/list-object.sh
@@ -2,16 +2,13 @@
 
 
     TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-    AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+    
     echo "####################################################################"
     echo "## 0. Object: List"
     echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/start-weavescope-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/start-weavescope-mcis.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/stop-weavescope-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/stop-weavescope-mcis.sh
@@ -4,16 +4,13 @@
 
 
 	TestSetFile=${4:-../testSet.env}
-    
-    FILE=$TestSetFile
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
         exit
     fi
 	source $TestSetFile
     source ../conf.env
-	AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
-
+	
 	echo "####################################################################"
 	echo "## Command (SSH) to MCIS "
 	echo "####################################################################"

--- a/src/testclient/scripts/sequentialFullTest/update-dns-for-mcis-ip.sh
+++ b/src/testclient/scripts/sequentialFullTest/update-dns-for-mcis-ip.sh
@@ -16,15 +16,12 @@ then
 fi
 
 TestSetFile=${4:-../testSet.env}
-
-FILE=$TestSetFile
-if [ ! -f "$FILE" ]; then
-	echo "$FILE does not exist."
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
 	exit
 fi
 source $TestSetFile
 source ../conf.env
-AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 echo "####################################################################"
 echo "## update-dns-for-mcis-ip "


### PR DESCRIPTION
- `registerImageWithId.sh` 파일 관련
  - 일전에 테스트를 위해 `?action=registerWithInfo` 로 변경했었습니다.
  - 이를 다시 `?action=registerWithId` 로 수정합니다.
- 다음의 스크립트가 호출하는 REST API 는 TB object 들을 삭제하는 것이므로 
`CSP`, `REGION`, `POSTFIX`, `INDEX` 등의 shell 변수가 필요하지 않아
해당 부분을 주석처리 했습니다.
  - `2.configureTumblebug/delete-all-config.sh`
  - `2.configureTumblebug/delete-all-ns.sh`
  - `6.image/unregister-all-images.sh`
  - `7.spec/unregister-all-specs.sh`
- `AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"` 라인을 
`conf.env` 로 옮겼습니다.
- 아래의 코드를 좀 더 간략하게 바꿨습니다.

[As-is]
```bash
    TestSetFile=${4:-../testSet.env}

    FILE=$TestSetFile
    if [ ! -f "$FILE" ]; then
        echo "$FILE does not exist."
        exit
    fi
```

[To-be]
```bash
    TestSetFile=${4:-../testSet.env}
    if [ ! -f "$TestSetFile" ]; then
        echo "$TestSetFile does not exist."
        exit
    fi
```