### PR TITLE
Fix credentials.conf.example

### DIFF
--- a/src/testclient/scripts/credentials.conf.example
+++ b/src/testclient/scripts/credentials.conf.example
@@ -1,7 +1,6 @@
 ### Cloud credentials for auto testing
 
-#source ./testSet.env
-source ../testSet.env
+
 
 ## AWS
 CredentialName[$IndexAWS]=aws-credential01


### PR DESCRIPTION

We don't need `source ../testSet.env` in `credentials.conf` any more since the sourced xx.env will be provided by users as a cli parameter.

So, this PR fixes `credentials.conf.example` by removing `source ../testSet.env`