### PR TITLE
Add `inspectVMs` function

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -312,7 +312,7 @@ func RestDeleteObjects(c echo.Context) error {
 // Request struct for RestInspectResources
 type RestInspectResourcesRequest struct {
 	ConnectionName string `json:"connectionName"`
-	Type           string `json:"type"`
+	Type           string `json:"type" example:"vNet" enums:"vNet,securityGroup,sshKey,vm"`
 }
 
 // RestInspectResources godoc

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -338,7 +338,7 @@ func RestInspectResources(c echo.Context) error {
 	fmt.Printf("[List Resource Status: %s]", u.Type)
 	var content interface{}
 	var err error
-	if u.Type == common.StrVNet || u.Type == common.StrSecurityGroup || u.Type == common.StrVNet {
+	if u.Type == common.StrVNet || u.Type == common.StrSecurityGroup || u.Type == common.StrSSHKey {
 		content, err = mcir.InspectResources(u.ConnectionName, u.Type)
 	} else if u.Type == "vm" {
 		content, err = mcis.InspectVMs(u.ConnectionName)

--- a/src/api/rest/server/mcir/common.go
+++ b/src/api/rest/server/mcir/common.go
@@ -1,7 +1,6 @@
 package mcir
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -237,42 +236,4 @@ func RestTestGetAssociatedObjectCount(c echo.Context) error {
 	}
 	mapA := map[string]int{"associatedObjectCount": associatedObjectCount}
 	return c.JSON(http.StatusOK, &mapA)
-}
-
-// Request struct for RestInspectResources
-type RestInspectResourcesRequest struct {
-	ConnectionName string `json:"connectionName"`
-	Type           string `json:"type"`
-}
-
-// RestInspectResources godoc
-// @Summary Inspect Resources
-// @Description Inspect Resources
-// @Tags [Admin] Cloud environment management
-// @Accept  json
-// @Produce  json
-// @Param connectionName body RestInspectResourcesRequest true "Specify connectionName and type"
-// @Success 200 {object} TbInspectResourcesResponse
-// @Failure 404 {object} common.SimpleMsg
-// @Failure 500 {object} common.SimpleMsg
-// @Router /inspectResources [post]
-func RestInspectResources(c echo.Context) error {
-
-	fmt.Println("RestListResourceStatus called;") // for debug
-
-	u := &RestInspectResourcesRequest{}
-	if err := c.Bind(u); err != nil {
-		return err
-	}
-
-	fmt.Printf("[List Resource Status: %s]", u.Type)
-	content, err := mcir.ListResourceStatus(u.ConnectionName, u.Type)
-	if err != nil {
-		common.CBLog.Error(err)
-		mapA := map[string]string{"message": err.Error()}
-		return c.JSON(http.StatusInternalServerError, &mapA)
-	}
-
-	return c.JSON(http.StatusOK, &content)
-
 }

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -108,7 +108,7 @@ func ApiServer() {
 	e.GET("/tumblebug/lookupImages", rest_mcir.RestLookupImageList)
 	e.GET("/tumblebug/lookupImage", rest_mcir.RestLookupImage)
 
-	e.POST("/tumblebug/inspectResources", rest_mcir.RestInspectResources)
+	e.POST("/tumblebug/inspectResources", rest_common.RestInspectResources)
 
 	e.GET("/tumblebug/webadmin", webadmin.Mainpage)
 	e.GET("/tumblebug/webadmin/menu", webadmin.Menu)

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -489,13 +489,13 @@ type resourceOnTumblebug struct {
 	Id          string `json:"id"`
 	CspNativeId string `json:"cspNativeId"`
 	NsId        string `json:"nsId"`
-	McisId      string `json:"mcisId"`
-	Type        string `json:"type"`
-	ObjectKey   string `json:"objectKey"`
+	//McisId      string `json:"mcisId"`
+	Type      string `json:"type"`
+	ObjectKey string `json:"objectKey"`
 }
 
-// ListResourceStatus returns the state list of TB MCIR objects of given resourceType
-func ListResourceStatus(connConfig string, resourceType string) (interface{}, error) {
+// InspectResources returns the state list of TB MCIR objects of given connConfig and resourceType
+func InspectResources(connConfig string, resourceType string) (interface{}, error) {
 
 	nsList := common.ListNsId()
 	// var TbResourceList []string
@@ -523,44 +523,49 @@ func ListResourceStatus(connConfig string, resourceType string) (interface{}, er
 		case common.StrVNet:
 			resourcesInNs := resourceListInNs.([]TbVNetInfo) // type assertion
 			for _, resource := range resourcesInNs {
-				temp := resourceOnTumblebug{}
-				temp.Id = resource.Id
-				temp.CspNativeId = resource.CspVNetId
-				temp.NsId = ns
-				//temp.McisId = ""
-				temp.Type = resourceType
-				temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
+				if resource.ConnectionName == connConfig { // filtering
+					temp := resourceOnTumblebug{}
+					temp.Id = resource.Id
+					temp.CspNativeId = resource.CspVNetId
+					temp.NsId = ns
+					//temp.McisId = ""
+					temp.Type = resourceType
+					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
-				TbResourceList = append(TbResourceList, temp)
+					TbResourceList = append(TbResourceList, temp)
+				}
 			}
 		case common.StrSecurityGroup:
 			resourcesInNs := resourceListInNs.([]TbSecurityGroupInfo) // type assertion
 			for _, resource := range resourcesInNs {
-				temp := resourceOnTumblebug{}
-				temp.Id = resource.Id
-				temp.CspNativeId = resource.CspSecurityGroupId
-				temp.NsId = ns
-				//temp.McisId = ""
-				temp.Type = resourceType
-				temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
+				if resource.ConnectionName == connConfig { // filtering
+					temp := resourceOnTumblebug{}
+					temp.Id = resource.Id
+					temp.CspNativeId = resource.CspSecurityGroupId
+					temp.NsId = ns
+					//temp.McisId = ""
+					temp.Type = resourceType
+					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
-				TbResourceList = append(TbResourceList, temp)
+					TbResourceList = append(TbResourceList, temp)
+				}
 			}
 		case common.StrSSHKey:
 			resourcesInNs := resourceListInNs.([]TbSshKeyInfo) // type assertion
 			for _, resource := range resourcesInNs {
-				temp := resourceOnTumblebug{}
-				temp.Id = resource.Id
-				temp.CspNativeId = resource.CspSshKeyName
-				temp.NsId = ns
-				//temp.McisId = ""
-				temp.Type = resourceType
-				temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
+				if resource.ConnectionName == connConfig { // filtering
+					temp := resourceOnTumblebug{}
+					temp.Id = resource.Id
+					temp.CspNativeId = resource.CspSshKeyName
+					temp.NsId = ns
+					//temp.McisId = ""
+					temp.Type = resourceType
+					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
-				TbResourceList = append(TbResourceList, temp)
+					TbResourceList = append(TbResourceList, temp)
+				}
 			}
 		}
-
 	}
 
 	client := resty.New()

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -19,6 +19,8 @@ import (
 	//"github.com/cloud-barista/cb-spider/cloud-control-manager/vm-ssh"
 	//"github.com/cloud-barista/cb-tumblebug/src/core/mcism"
 	//"github.com/cloud-barista/cb-tumblebug/src/core/common"
+
+	"github.com/go-resty/resty/v2"
 )
 
 // CB-Store
@@ -58,39 +60,6 @@ type mcirIds struct {
 }
 */
 
-/*
-func LowerizeAndCheckMcis(nsId string, mcisId string) (bool, string, error) {
-
-	// Check parameters' emptiness
-	if nsId == "" {
-		err := fmt.Errorf("CheckMcis failed; nsId given is null.")
-		return false, "", err
-	} else if mcisId == "" {
-		err := fmt.Errorf("CheckMcis failed; mcisId given is null.")
-		return false, "", err
-	}
-
-	lowerizedNsId := common.ToLower(nsId)
-	nsId = lowerizedNsId
-
-	lowerizedMcisId := common.ToLower(mcisId)
-	mcisId = lowerizedMcisId
-
-	fmt.Println("[Check mcis] " + mcisId)
-
-	//key := "/ns/" + nsId + "/mcis/" + mcisId
-	key := common.GenMcisKey(nsId, mcisId, "")
-	//fmt.Println(key)
-
-	keyValue, _ := common.CBStore.Get(key)
-	if keyValue != nil {
-		return true, mcisId, nil
-	}
-	return false, mcisId, nil
-
-}
-*/
-
 func CheckMcis(nsId string, mcisId string) (bool, error) {
 
 	// Check parameters' emptiness
@@ -121,44 +90,6 @@ func CheckMcis(nsId string, mcisId string) (bool, error) {
 	return false, nil
 
 }
-
-/*
-func LowerizeAndCheckVm(nsId string, mcisId string, vmId string) (bool, string, error) {
-
-	// Check parameters' emptiness
-	if nsId == "" {
-		err := fmt.Errorf("CheckVm failed; nsId given is null.")
-		return false, "", err
-	} else if mcisId == "" {
-		err := fmt.Errorf("CheckVm failed; mcisId given is null.")
-		return false, "", err
-	} else if vmId == "" {
-		err := fmt.Errorf("CheckVm failed; vmId given is null.")
-		return false, "", err
-	}
-
-	lowerizedNsId := common.ToLower(nsId)
-	nsId = lowerizedNsId
-
-	lowerizedMcisId := common.ToLower(mcisId)
-	mcisId = lowerizedMcisId
-
-	lowerizedVmId := common.ToLower(vmId)
-	vmId = lowerizedVmId
-
-	fmt.Println("[Check vm] " + mcisId + ", " + vmId)
-
-	key := common.GenMcisKey(nsId, mcisId, vmId)
-	//fmt.Println(key)
-
-	keyValue, _ := common.CBStore.Get(key)
-	if keyValue != nil {
-		return true, lowerizedVmId, nil
-	}
-	return false, lowerizedVmId, nil
-
-}
-*/
 
 func CheckVm(nsId string, mcisId string, vmId string) (bool, error) {
 
@@ -195,40 +126,6 @@ func CheckVm(nsId string, mcisId string, vmId string) (bool, error) {
 	return false, nil
 
 }
-
-/*
-func LowerizeAndCheckMcisPolicy(nsId string, mcisId string) (bool, string, error) {
-
-	// Check parameters' emptiness
-	if nsId == "" {
-		err := fmt.Errorf("CheckMcis failed; nsId given is null.")
-		return false, "", err
-	} else if mcisId == "" {
-		err := fmt.Errorf("CheckMcis failed; mcisId given is null.")
-		return false, "", err
-	}
-
-	lowerizedNsId := common.ToLower(nsId)
-	nsId = lowerizedNsId
-
-	lowerizedMcisId := common.ToLower(mcisId)
-	mcisId = lowerizedMcisId
-
-	fmt.Println("[Check McisPolicy] " + mcisId)
-
-	//key := "/ns/" + nsId + "/mcis/" + mcisId
-	key := common.GenMcisPolicyKey(nsId, mcisId, "")
-	//fmt.Println(key)
-
-	keyValue, _ := common.CBStore.Get(key)
-
-	if keyValue != nil {
-		return true, mcisId, nil
-	}
-	return false, mcisId, nil
-
-}
-*/
 
 func CheckMcisPolicy(nsId string, mcisId string) (bool, error) {
 
@@ -333,4 +230,174 @@ func TrimIP(sshAccessPoint string) (string, error) {
 		err := fmt.Errorf("In TrimIP(), detected port number seems wrong: " + port_string)
 		return strconv.Itoa(0), err
 	}
+}
+
+type SpiderNameIdSystemId struct {
+	NameId   string
+	SystemId string
+}
+
+type SpiderAllListWrapper struct {
+	AllList SpiderAllList
+}
+
+type SpiderAllList struct {
+	MappedList     []SpiderNameIdSystemId
+	OnlySpiderList []SpiderNameIdSystemId
+	OnlyCSPList    []SpiderNameIdSystemId
+}
+
+// Response struct for InspectResources
+type TbInspectResourcesResponse struct {
+	// ResourcesOnCsp       interface{} `json:"resourcesOnCsp"`
+	// ResourcesOnSpider    interface{} `json:"resourcesOnSpider"`
+	// ResourcesOnTumblebug interface{} `json:"resourcesOnTumblebug"`
+	ResourcesOnCsp       []resourceOnCspOrSpider `json:"resourcesOnCsp"`
+	ResourcesOnSpider    []resourceOnCspOrSpider `json:"resourcesOnSpider"`
+	ResourcesOnTumblebug []resourceOnTumblebug   `json:"resourcesOnTumblebug"`
+}
+
+type resourceOnCspOrSpider struct {
+	Id          string `json:"id"`
+	CspNativeId string `json:"cspNativeId"`
+}
+
+type resourceOnTumblebug struct {
+	Id          string `json:"id"`
+	CspNativeId string `json:"cspNativeId"`
+	NsId        string `json:"nsId"`
+	McisId      string `json:"mcisId"`
+	Type        string `json:"type"`
+	ObjectKey   string `json:"objectKey"`
+}
+
+// InspectVMs returns the state list of TB VM objects of given connConfig
+func InspectVMs(connConfig string) (interface{}, error) {
+
+	nsList := common.ListNsId()
+	// var TbResourceList []string
+	var TbResourceList []resourceOnTumblebug
+	for _, ns := range nsList {
+
+		mcisListinNs := ListMcisId(ns)
+		if mcisListinNs == nil {
+			continue
+		}
+
+		for _, mcis := range mcisListinNs {
+			vmListInMcis, err := ListVmId(ns, mcis)
+			if err != nil {
+				common.CBLog.Error(err)
+				err := fmt.Errorf("an error occurred while getting resource list")
+				return nil, err
+			}
+			if vmListInMcis == nil {
+				continue
+			}
+
+			for _, vmId := range vmListInMcis {
+				vm, err := GetVmObject(ns, mcis, vmId)
+				if err != nil {
+					common.CBLog.Error(err)
+					err := fmt.Errorf("an error occurred while getting resource list")
+					return nil, err
+				}
+
+				if vm.ConnectionName == connConfig { // filtering
+					temp := resourceOnTumblebug{}
+					temp.Id = vm.Id
+					temp.CspNativeId = vm.CspViewVmDetail.IId.SystemId
+					temp.NsId = ns
+					temp.McisId = mcis
+					temp.Type = "vm"
+					temp.ObjectKey = common.GenMcisKey(ns, mcis, vm.Id)
+
+					TbResourceList = append(TbResourceList, temp)
+				}
+			}
+		}
+	}
+
+	client := resty.New()
+	client.SetAllowGetMethodPayload(true)
+
+	// Create Req body
+	type JsonTemplate struct {
+		ConnectionName string
+	}
+	tempReq := JsonTemplate{}
+	tempReq.ConnectionName = connConfig
+
+	spiderRequestURL := common.SPIDER_REST_URL + "/allvm"
+
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(tempReq).
+		SetResult(&SpiderAllListWrapper{}). // or SetResult(AuthSuccess{}).
+		//SetError(&AuthError{}).       // or SetError(AuthError{}).
+		Get(spiderRequestURL)
+
+	if err != nil {
+		common.CBLog.Error(err)
+		err := fmt.Errorf("an error occurred while requesting to CB-Spider")
+		return nil, err
+	}
+
+	fmt.Println("HTTP Status code " + strconv.Itoa(resp.StatusCode()))
+	switch {
+	case resp.StatusCode() >= 400 || resp.StatusCode() < 200:
+		err := fmt.Errorf(string(resp.Body()))
+		common.CBLog.Error(err)
+		//return res.StatusCode, body, err
+		return nil, err
+	default:
+	}
+
+	temp, _ := resp.Result().(*SpiderAllListWrapper) // type assertion
+
+	result := TbInspectResourcesResponse{}
+
+	/*
+		// Implementation style 1
+		if len(TbResourceList) > 0 {
+			result.ResourcesOnTumblebug = TbResourceList
+		} else {
+			result.ResourcesOnTumblebug = []resourceOnTumblebug{}
+		}
+	*/
+	// Implementation style 2
+	result.ResourcesOnTumblebug = []resourceOnTumblebug{}
+	result.ResourcesOnTumblebug = append(result.ResourcesOnTumblebug, TbResourceList...)
+
+	// result.ResourcesOnCsp = append((*temp).AllList.MappedList, (*temp).AllList.OnlyCSPList...)
+	// result.ResourcesOnSpider = append((*temp).AllList.MappedList, (*temp).AllList.OnlySpiderList...)
+	result.ResourcesOnCsp = []resourceOnCspOrSpider{}
+	result.ResourcesOnSpider = []resourceOnCspOrSpider{}
+
+	for _, v := range (*temp).AllList.MappedList {
+		tmpObj := resourceOnCspOrSpider{}
+		tmpObj.Id = v.NameId
+		tmpObj.CspNativeId = v.SystemId
+
+		result.ResourcesOnCsp = append(result.ResourcesOnCsp, tmpObj)
+		result.ResourcesOnSpider = append(result.ResourcesOnSpider, tmpObj)
+	}
+
+	for _, v := range (*temp).AllList.OnlySpiderList {
+		tmpObj := resourceOnCspOrSpider{}
+		tmpObj.Id = v.NameId
+		tmpObj.CspNativeId = v.SystemId
+
+		result.ResourcesOnSpider = append(result.ResourcesOnSpider, tmpObj)
+	}
+
+	for _, v := range (*temp).AllList.OnlyCSPList {
+		tmpObj := resourceOnCspOrSpider{}
+		tmpObj.Id = v.NameId
+		tmpObj.CspNativeId = v.SystemId
+
+		result.ResourcesOnCsp = append(result.ResourcesOnCsp, tmpObj)
+	}
+
+	return result, nil
 }

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -3869,7 +3869,14 @@ var doc = `{
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "vNet",
+                        "securityGroup",
+                        "sshKey",
+                        "vm"
+                    ],
+                    "example": "vNet"
                 }
             }
         },

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -317,7 +317,7 @@ var doc = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestInspectResourcesRequest"
+                            "$ref": "#/definitions/common.RestInspectResourcesRequest"
                         }
                     }
                 ],
@@ -325,7 +325,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbInspectResourcesResponse"
+                            "$ref": "#/definitions/mcis.TbInspectResourcesResponse"
                         }
                     },
                     "404": {
@@ -3862,6 +3862,17 @@ var doc = `{
                 }
             }
         },
+        "common.RestInspectResourcesRequest": {
+            "type": "object",
+            "properties": {
+                "connectionName": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "common.SimpleMsg": {
             "type": "object",
             "properties": {
@@ -4016,17 +4027,6 @@ var doc = `{
                     "items": {
                         "$ref": "#/definitions/mcir.TbVNetInfo"
                     }
-                }
-            }
-        },
-        "mcir.RestInspectResourcesRequest": {
-            "type": "object",
-            "properties": {
-                "connectionName": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
                 }
             }
         },
@@ -4285,30 +4285,6 @@ var doc = `{
                 },
                 "name": {
                     "type": "string"
-                }
-            }
-        },
-        "mcir.TbInspectResourcesResponse": {
-            "type": "object",
-            "properties": {
-                "resourcesOnCsp": {
-                    "description": "ResourcesOnCsp       interface{} ` + "`" + `json:\"resourcesOnCsp\"` + "`" + `\nResourcesOnSpider    interface{} ` + "`" + `json:\"resourcesOnSpider\"` + "`" + `\nResourcesOnTumblebug interface{} ` + "`" + `json:\"resourcesOnTumblebug\"` + "`" + `",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcir.resourceOnCspOrSpider"
-                    }
-                },
-                "resourcesOnSpider": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcir.resourceOnCspOrSpider"
-                    }
-                },
-                "resourcesOnTumblebug": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcir.resourceOnTumblebug"
-                    }
                 }
             }
         },
@@ -4643,40 +4619,6 @@ var doc = `{
                     "items": {
                         "$ref": "#/definitions/mcir.SpiderSubnetReqInfo"
                     }
-                }
-            }
-        },
-        "mcir.resourceOnCspOrSpider": {
-            "type": "object",
-            "properties": {
-                "cspNativeId": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            }
-        },
-        "mcir.resourceOnTumblebug": {
-            "type": "object",
-            "properties": {
-                "cspNativeId": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "mcisId": {
-                    "type": "string"
-                },
-                "nsId": {
-                    "type": "string"
-                },
-                "objectKey": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
                 }
             }
         },
@@ -5183,6 +5125,30 @@ var doc = `{
                 }
             }
         },
+        "mcis.TbInspectResourcesResponse": {
+            "type": "object",
+            "properties": {
+                "resourcesOnCsp": {
+                    "description": "ResourcesOnCsp       interface{} ` + "`" + `json:\"resourcesOnCsp\"` + "`" + `\nResourcesOnSpider    interface{} ` + "`" + `json:\"resourcesOnSpider\"` + "`" + `\nResourcesOnTumblebug interface{} ` + "`" + `json:\"resourcesOnTumblebug\"` + "`" + `",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnCspOrSpider"
+                    }
+                },
+                "resourcesOnSpider": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnCspOrSpider"
+                    }
+                },
+                "resourcesOnTumblebug": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnTumblebug"
+                    }
+                }
+            }
+        },
         "mcis.TbMcisInfo": {
             "type": "object",
             "properties": {
@@ -5531,6 +5497,40 @@ var doc = `{
                     "type": "string"
                 },
                 "targetStatus": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.resourceOnCspOrSpider": {
+            "type": "object",
+            "properties": {
+                "cspNativeId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.resourceOnTumblebug": {
+            "type": "object",
+            "properties": {
+                "cspNativeId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "mcisId": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                },
+                "objectKey": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3854,7 +3854,14 @@
                     "type": "string"
                 },
                 "type": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "vNet",
+                        "securityGroup",
+                        "sshKey",
+                        "vm"
+                    ],
+                    "example": "vNet"
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -302,7 +302,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestInspectResourcesRequest"
+                            "$ref": "#/definitions/common.RestInspectResourcesRequest"
                         }
                     }
                 ],
@@ -310,7 +310,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcir.TbInspectResourcesResponse"
+                            "$ref": "#/definitions/mcis.TbInspectResourcesResponse"
                         }
                     },
                     "404": {
@@ -3847,6 +3847,17 @@
                 }
             }
         },
+        "common.RestInspectResourcesRequest": {
+            "type": "object",
+            "properties": {
+                "connectionName": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
         "common.SimpleMsg": {
             "type": "object",
             "properties": {
@@ -4001,17 +4012,6 @@
                     "items": {
                         "$ref": "#/definitions/mcir.TbVNetInfo"
                     }
-                }
-            }
-        },
-        "mcir.RestInspectResourcesRequest": {
-            "type": "object",
-            "properties": {
-                "connectionName": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
                 }
             }
         },
@@ -4270,30 +4270,6 @@
                 },
                 "name": {
                     "type": "string"
-                }
-            }
-        },
-        "mcir.TbInspectResourcesResponse": {
-            "type": "object",
-            "properties": {
-                "resourcesOnCsp": {
-                    "description": "ResourcesOnCsp       interface{} `json:\"resourcesOnCsp\"`\nResourcesOnSpider    interface{} `json:\"resourcesOnSpider\"`\nResourcesOnTumblebug interface{} `json:\"resourcesOnTumblebug\"`",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcir.resourceOnCspOrSpider"
-                    }
-                },
-                "resourcesOnSpider": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcir.resourceOnCspOrSpider"
-                    }
-                },
-                "resourcesOnTumblebug": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcir.resourceOnTumblebug"
-                    }
                 }
             }
         },
@@ -4628,40 +4604,6 @@
                     "items": {
                         "$ref": "#/definitions/mcir.SpiderSubnetReqInfo"
                     }
-                }
-            }
-        },
-        "mcir.resourceOnCspOrSpider": {
-            "type": "object",
-            "properties": {
-                "cspNativeId": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            }
-        },
-        "mcir.resourceOnTumblebug": {
-            "type": "object",
-            "properties": {
-                "cspNativeId": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "mcisId": {
-                    "type": "string"
-                },
-                "nsId": {
-                    "type": "string"
-                },
-                "objectKey": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
                 }
             }
         },
@@ -5168,6 +5110,30 @@
                 }
             }
         },
+        "mcis.TbInspectResourcesResponse": {
+            "type": "object",
+            "properties": {
+                "resourcesOnCsp": {
+                    "description": "ResourcesOnCsp       interface{} `json:\"resourcesOnCsp\"`\nResourcesOnSpider    interface{} `json:\"resourcesOnSpider\"`\nResourcesOnTumblebug interface{} `json:\"resourcesOnTumblebug\"`",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnCspOrSpider"
+                    }
+                },
+                "resourcesOnSpider": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnCspOrSpider"
+                    }
+                },
+                "resourcesOnTumblebug": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnTumblebug"
+                    }
+                }
+            }
+        },
         "mcis.TbMcisInfo": {
             "type": "object",
             "properties": {
@@ -5516,6 +5482,40 @@
                     "type": "string"
                 },
                 "targetStatus": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.resourceOnCspOrSpider": {
+            "type": "object",
+            "properties": {
+                "cspNativeId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.resourceOnTumblebug": {
+            "type": "object",
+            "properties": {
+                "cspNativeId": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "mcisId": {
+                    "type": "string"
+                },
+                "nsId": {
+                    "type": "string"
+                },
+                "objectKey": {
+                    "type": "string"
+                },
+                "type": {
                     "type": "string"
                 }
             }

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -115,6 +115,12 @@ definitions:
       connectionName:
         type: string
       type:
+        enum:
+        - vNet
+        - securityGroup
+        - sshKey
+        - vm
+        example: vNet
         type: string
     type: object
   common.SimpleMsg:

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -110,6 +110,13 @@ definitions:
           $ref: '#/definitions/common.NsInfo'
         type: array
     type: object
+  common.RestInspectResourcesRequest:
+    properties:
+      connectionName:
+        type: string
+      type:
+        type: string
+    type: object
   common.SimpleMsg:
     properties:
       message:
@@ -211,13 +218,6 @@ definitions:
         items:
           $ref: '#/definitions/mcir.TbVNetInfo'
         type: array
-    type: object
-  mcir.RestInspectResourcesRequest:
-    properties:
-      connectionName:
-        type: string
-      type:
-        type: string
     type: object
   mcir.RestLookupImageRequest:
     properties:
@@ -388,25 +388,6 @@ definitions:
         type: string
       name:
         type: string
-    type: object
-  mcir.TbInspectResourcesResponse:
-    properties:
-      resourcesOnCsp:
-        description: |-
-          ResourcesOnCsp       interface{} `json:"resourcesOnCsp"`
-          ResourcesOnSpider    interface{} `json:"resourcesOnSpider"`
-          ResourcesOnTumblebug interface{} `json:"resourcesOnTumblebug"`
-        items:
-          $ref: '#/definitions/mcir.resourceOnCspOrSpider'
-        type: array
-      resourcesOnSpider:
-        items:
-          $ref: '#/definitions/mcir.resourceOnCspOrSpider'
-        type: array
-      resourcesOnTumblebug:
-        items:
-          $ref: '#/definitions/mcir.resourceOnTumblebug'
-        type: array
     type: object
   mcir.TbSecurityGroupInfo:
     properties:
@@ -627,28 +608,6 @@ definitions:
         items:
           $ref: '#/definitions/mcir.SpiderSubnetReqInfo'
         type: array
-    type: object
-  mcir.resourceOnCspOrSpider:
-    properties:
-      cspNativeId:
-        type: string
-      id:
-        type: string
-    type: object
-  mcir.resourceOnTumblebug:
-    properties:
-      cspNativeId:
-        type: string
-      id:
-        type: string
-      mcisId:
-        type: string
-      nsId:
-        type: string
-      objectKey:
-        type: string
-      type:
-        type: string
     type: object
   mcis.AgentInstallContent:
     properties:
@@ -985,6 +944,25 @@ definitions:
       vpcname:
         type: string
     type: object
+  mcis.TbInspectResourcesResponse:
+    properties:
+      resourcesOnCsp:
+        description: |-
+          ResourcesOnCsp       interface{} `json:"resourcesOnCsp"`
+          ResourcesOnSpider    interface{} `json:"resourcesOnSpider"`
+          ResourcesOnTumblebug interface{} `json:"resourcesOnTumblebug"`
+        items:
+          $ref: '#/definitions/mcis.resourceOnCspOrSpider'
+        type: array
+      resourcesOnSpider:
+        items:
+          $ref: '#/definitions/mcis.resourceOnCspOrSpider'
+        type: array
+      resourcesOnTumblebug:
+        items:
+          $ref: '#/definitions/mcis.resourceOnTumblebug'
+        type: array
+    type: object
   mcis.TbMcisInfo:
     properties:
       description:
@@ -1226,6 +1204,28 @@ definitions:
       targetStatus:
         type: string
     type: object
+  mcis.resourceOnCspOrSpider:
+    properties:
+      cspNativeId:
+        type: string
+      id:
+        type: string
+    type: object
+  mcis.resourceOnTumblebug:
+    properties:
+      cspNativeId:
+        type: string
+      id:
+        type: string
+      mcisId:
+        type: string
+      nsId:
+        type: string
+      objectKey:
+        type: string
+      type:
+        type: string
+    type: object
 host: localhost:1323
 info:
   contact:
@@ -1425,14 +1425,14 @@ paths:
         name: connectionName
         required: true
         schema:
-          $ref: '#/definitions/mcir.RestInspectResourcesRequest'
+          $ref: '#/definitions/common.RestInspectResourcesRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcir.TbInspectResourcesResponse'
+            $ref: '#/definitions/mcis.TbInspectResourcesResponse'
         "404":
           description: Not Found
           schema:

--- a/src/testclient/scripts/3.vNet/create-vNet.sh
+++ b/src/testclient/scripts/3.vNet/create-vNet.sh
@@ -22,8 +22,8 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	CIRDNum=$(($INDEX+1))
-	CIDRDiff=$(($CIRDNum*$REGION))
+	CIDRNum=$(($INDEX+1))
+	CIDRDiff=$(($CIDRNum*$REGION))
 	CIDRDiff=$(($CIDRDiff%254))
 
     resp=$(

--- a/src/testclient/scripts/3.vNet/inspect-vNet.sh
+++ b/src/testclient/scripts/3.vNet/inspect-vNet.sh
@@ -22,10 +22,6 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	CIRDNum=$(($INDEX+1))
-	CIDRDiff=$(($CIRDNum*$REGION))
-	CIDRDiff=$(($CIDRDiff%254))
-
     resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/inspectResources -H 'Content-Type: application/json' -d @- <<EOF
         {

--- a/src/testclient/scripts/4.securityGroup/inspect-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/inspect-securityGroup.sh
@@ -22,10 +22,6 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	CIRDNum=$(($INDEX+1))
-	CIDRDiff=$(($CIRDNum*$REGION))
-	CIDRDiff=$(($CIDRDiff%254))
-
     resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/inspectResources -H 'Content-Type: application/json' -d @- <<EOF
         {

--- a/src/testclient/scripts/5.sshKey/inspect-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/inspect-sshKey.sh
@@ -22,10 +22,6 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	CIRDNum=$(($INDEX+1))
-	CIDRDiff=$(($CIRDNum*$REGION))
-	CIDRDiff=$(($CIDRDiff%254))
-
     resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/inspectResources -H 'Content-Type: application/json' -d @- <<EOF
         {

--- a/src/testclient/scripts/8.mcis/inspect-vm.sh
+++ b/src/testclient/scripts/8.mcis/inspect-vm.sh
@@ -19,10 +19,6 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-	CIRDNum=$(($INDEX+1))
-	CIDRDiff=$(($CIRDNum*$REGION))
-	CIDRDiff=$(($CIDRDiff%254))
-
     resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/inspectResources -H 'Content-Type: application/json' -d @- <<EOF
         {

--- a/src/testclient/scripts/8.mcis/inspect-vm.sh
+++ b/src/testclient/scripts/8.mcis/inspect-vm.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+	TestSetFile=${4:-../testSet.env}
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
+        exit
+    fi
+	source $TestSetFile
+    source ../conf.env
+	
+	echo "####################################################################"
+	echo "## 8. vm: inspect"
+	echo "####################################################################"
+
+	CSP=${1}
+	REGION=${2:-1}
+	POSTFIX=${3:-developer}
+
+	source ../common-functions.sh
+	getCloudIndex $CSP
+
+	CIRDNum=$(($INDEX+1))
+	CIDRDiff=$(($CIRDNum*$REGION))
+	CIDRDiff=$(($CIDRDiff%254))
+
+    resp=$(
+        curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/inspectResources -H 'Content-Type: application/json' -d @- <<EOF
+        {
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
+			"type": "vm"
+		}
+EOF
+    ); echo ${resp} | jq ''
+    echo ""
+#}
+

--- a/src/testclient/scripts/sequentialFullTest/create-all.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-all.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 SECONDS=0
 
@@ -10,3 +11,4 @@ duration=$SECONDS
 source ../common-functions.sh
 printElapsed $@
 echo "" >>./executionStatus.history
+


### PR DESCRIPTION
- Related PR: #501 (Add `inspectResources` function)
  - #501 에서는 TB 의 모든 리소스를 (`connectionName` 으로 필터링하지 않고) 출력하는 버그가 있었고,
  이 PR에서 이를 수정했습니다.
- Related discussion: #503 (import cycle regarding `inspectResources` function)

[테스트 결과]

```JSON
❯ ../8.mcis/inspect-vm.sh aws 1 jhseo
####################################################################
## 8. vm: inspect
####################################################################
{
  "resourcesOnCsp": [
    {
      "id": "aws-ap-southeast-1-jhseo-0",
      "cspNativeId": "i-039ab7e96112287cd"
    },
    {
      "id": "kimy-etcd-host",
      "cspNativeId": "i-061fba35c45e36c80"
    }
  ],
  "resourcesOnSpider": [
    {
      "id": "aws-ap-southeast-1-jhseo-0",
      "cspNativeId": "i-039ab7e96112287cd"
    }
  ],
  "resourcesOnTumblebug": [
    {
      "id": "aws-ap-southeast-1-jhseo-0",
      "cspNativeId": "i-039ab7e96112287cd",
      "nsId": "ns-01",
      "mcisId": "aws-ap-southeast-1-jhseo",
      "type": "vm",
      "objectKey": "/ns/ns-01/mcis/aws-ap-southeast-1-jhseo/vm/aws-ap-southeast-1-jhseo-0"
    }
  ]
}
```

```JSON
❯ ../8.mcis/inspect-vm.sh mock 1 jhseo
####################################################################
## 8. vm: inspect
####################################################################
{
  "resourcesOnCsp": [
    {
      "id": "mock-seoul-jhseo-0",
      "cspNativeId": "mock-seoul-jhseo-0"
    }
  ],
  "resourcesOnSpider": [
    {
      "id": "mock-seoul-jhseo-0",
      "cspNativeId": "mock-seoul-jhseo-0"
    }
  ],
  "resourcesOnTumblebug": [
    {
      "id": "mock-seoul-jhseo-0",
      "cspNativeId": "mock-seoul-jhseo-0",
      "nsId": "ns-01",
      "mcisId": "mock-seoul-jhseo",
      "type": "vm",
      "objectKey": "/ns/ns-01/mcis/mock-seoul-jhseo/vm/mock-seoul-jhseo-0"
    }
  ]
}
```