### PR TITLE
Fix lookupImages' & lookupSpecs' Swagger docs

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -15,6 +15,10 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/mcis"
 )
 
+type TbConnectionName struct {
+	ConnectionName string `json:"connectionName"`
+}
+
 type Existence struct {
 	Exists bool `json:"exists"`
 }

--- a/src/api/rest/server/mcir/image.go
+++ b/src/api/rest/server/mcir/image.go
@@ -28,7 +28,7 @@ func RestPostImage(c echo.Context) error {
 	nsId := c.Param("nsId")
 
 	action := c.QueryParam("action")
-	fmt.Println("[POST Image requested action: " + action)
+	fmt.Println("[POST Image] (action: " + action + ")")
 	/*
 		if action == "create" {
 			fmt.Println("[Creating Image]")
@@ -103,8 +103,7 @@ type RestLookupImageRequest struct {
 // @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
-// @Param connectionName body RestLookupImageRequest true "Specify connectionName"
-// @Param imageId path string true "Image ID"
+// @Param lookupImageReq body RestLookupImageRequest true "Specify connectionName & cspImageId"
 // @Success 200 {object} mcir.SpiderImageInfo
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -116,7 +115,7 @@ func RestLookupImage(c echo.Context) error {
 		return err
 	}
 
-	fmt.Println("[Lookup image]" + u.CspImageId)
+	fmt.Println("[Lookup image]: " + u.CspImageId)
 	content, err := mcir.LookupImage(u.ConnectionName, u.CspImageId)
 	if err != nil {
 		common.CBLog.Error(err)
@@ -133,7 +132,7 @@ func RestLookupImage(c echo.Context) error {
 // @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
-// @Param connectionName body RestLookupImageRequest true "Specify connectionName"
+// @Param lookupImagesReq body common.TbConnectionName true "Specify connectionName"
 // @Success 200 {object} mcir.SpiderImageList
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -149,7 +148,7 @@ func RestLookupImageList(c echo.Context) error {
 		return err
 	}
 
-	fmt.Println("[Get Region List]")
+	fmt.Println("[Lookup images]")
 	content, err := mcir.LookupImageList(u.ConnectionName)
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/api/rest/server/mcir/spec.go
+++ b/src/api/rest/server/mcir/spec.go
@@ -28,7 +28,7 @@ func RestPostSpec(c echo.Context) error {
 	nsId := c.Param("nsId")
 
 	action := c.QueryParam("action")
-	fmt.Println("[POST Spec requested action: " + action)
+	fmt.Println("[POST Spec] (action: " + action + ")")
 
 	if action == "registerWithInfo" { // `RegisterSpecWithInfo` will be deprecated in Cappuccino.
 		fmt.Println("[Registering Spec with info]")
@@ -122,20 +122,18 @@ type RestLookupSpecRequest struct {
 // @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
-// @Param connectionName body RestLookupSpecRequest true "Specify connectionName"
-// @Param specName path string true "Spec name"
+// @Param lookupSpecReq body RestLookupSpecRequest true "Specify connectionName & cspSpecName"
 // @Success 200 {object} mcir.SpiderSpecInfo
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /lookupSpec [get]
 func RestLookupSpec(c echo.Context) error {
-
 	u := &RestLookupSpecRequest{}
 	if err := c.Bind(u); err != nil {
 		return err
 	}
 
-	fmt.Println("[Lookup spec]" + u.CspSpecName)
+	fmt.Println("[Lookup spec]: " + u.CspSpecName)
 	content, err := mcir.LookupSpec(u.ConnectionName, u.CspSpecName)
 	if err != nil {
 		common.CBLog.Error(err)
@@ -152,7 +150,7 @@ func RestLookupSpec(c echo.Context) error {
 // @Tags [Admin] Cloud environment management
 // @Accept  json
 // @Produce  json
-// @Param connectionName body RestLookupSpecRequest true "Specify connectionName"
+// @Param lookupSpecsReq body common.TbConnectionName true "Specify connectionName"
 // @Success 200 {object} mcir.SpiderSpecList
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -168,7 +166,7 @@ func RestLookupSpecList(c echo.Context) error {
 		return err
 	}
 
-	fmt.Println("[Get Region List]")
+	fmt.Println("[Lookup specs]")
 	content, err := mcir.LookupSpecList(u.ConnectionName)
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/core/common/common.go
+++ b/src/core/common/common.go
@@ -63,6 +63,10 @@ type IID struct {
 	SystemId string // SystemID by CloudOS
 }
 
+type SpiderConnectionName struct {
+	ConnectionName string `json:"ConnectionName"`
+}
+
 func OpenSQL(path string) error {
 	/*
 		common.MYDB, err = sql.Open("mysql", //"root:pwd@tcp(127.0.0.1:3306)/testdb")

--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -272,15 +272,19 @@ type SpiderImageList struct {
 // in the form of the list of Spider image objects
 func LookupImageList(connConfig string) (SpiderImageList, error) {
 
+	if connConfig == "" {
+		content := SpiderImageList{}
+		err := fmt.Errorf("LookupImage() called with empty connConfig.")
+		common.CBLog.Error(err)
+		return content, err
+	}
+
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
 		url := common.SPIDER_REST_URL + "/vmimage"
 
 		// Create Req body
-		type JsonTemplate struct {
-			ConnectionName string `json:"ConnectionName"`
-		}
-		tempReq := JsonTemplate{}
+		tempReq := common.SpiderConnectionName{}
 		tempReq.ConnectionName = connConfig
 
 		client := resty.New()
@@ -349,15 +353,24 @@ func LookupImageList(connConfig string) (SpiderImageList, error) {
 // LookupImage accepts Spider conn config and CSP image ID, lookups and returns the Spider image object
 func LookupImage(connConfig string, imageId string) (SpiderImageInfo, error) {
 
+	if connConfig == "" {
+		content := SpiderImageInfo{}
+		err := fmt.Errorf("LookupImage() called with empty connConfig.")
+		common.CBLog.Error(err)
+		return content, err
+	} else if imageId == "" {
+		content := SpiderImageInfo{}
+		err := fmt.Errorf("LookupImage() called with empty imageId.")
+		common.CBLog.Error(err)
+		return content, err
+	}
+
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
 		url := common.SPIDER_REST_URL + "/vmimage/" + url.QueryEscape(imageId)
 
 		// Create Req body
-		type JsonTemplate struct {
-			ConnectionName string `json:"ConnectionName"`
-		}
-		tempReq := JsonTemplate{}
+		tempReq := common.SpiderConnectionName{}
 		tempReq.ConnectionName = connConfig
 
 		client := resty.New()

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -116,15 +116,19 @@ type SpiderSpecList struct {
 // in the form of the list of Spider spec objects
 func LookupSpecList(connConfig string) (SpiderSpecList, error) {
 
+	if connConfig == "" {
+		content := SpiderSpecList{}
+		err := fmt.Errorf("LookupSpec() called with empty connConfig.")
+		common.CBLog.Error(err)
+		return content, err
+	}
+
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
 		url := common.SPIDER_REST_URL + "/vmspec"
 
 		// Create Req body
-		type JsonTemplate struct {
-			ConnectionName string `json:"ConnectionName"`
-		}
-		tempReq := JsonTemplate{}
+		tempReq := common.SpiderConnectionName{}
 		tempReq.ConnectionName = connConfig
 
 		client := resty.New()
@@ -193,16 +197,25 @@ func LookupSpecList(connConfig string) (SpiderSpecList, error) {
 // LookupSpec accepts Spider conn config and CSP spec name, lookups and returns the Spider spec object
 func LookupSpec(connConfig string, specName string) (SpiderSpecInfo, error) {
 
+	if connConfig == "" {
+		content := SpiderSpecInfo{}
+		err := fmt.Errorf("LookupSpec() called with empty connConfig.")
+		common.CBLog.Error(err)
+		return content, err
+	} else if specName == "" {
+		content := SpiderSpecInfo{}
+		err := fmt.Errorf("LookupSpec() called with empty specName.")
+		common.CBLog.Error(err)
+		return content, err
+	}
+
 	if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
 		//url := common.SPIDER_REST_URL + "/vmspec/" + u.CspSpecName
 		url := common.SPIDER_REST_URL + "/vmspec/" + specName
 
 		// Create Req body
-		type JsonTemplate struct {
-			ConnectionName string `json:"ConnectionName"`
-		}
-		tempReq := JsonTemplate{}
+		tempReq := common.SpiderConnectionName{}
 		tempReq.ConnectionName = connConfig
 
 		client := resty.New()

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -358,20 +358,13 @@ var doc = `{
                 "summary": "Lookup image",
                 "parameters": [
                     {
-                        "description": "Specify connectionName",
-                        "name": "connectionName",
+                        "description": "Specify connectionName \u0026 cspImageId",
+                        "name": "lookupImageReq",
                         "in": "body",
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/mcir.RestLookupImageRequest"
                         }
-                    },
-                    {
-                        "type": "string",
-                        "description": "Image ID",
-                        "name": "imageId",
-                        "in": "path",
-                        "required": true
                     }
                 ],
                 "responses": {
@@ -412,11 +405,11 @@ var doc = `{
                 "parameters": [
                     {
                         "description": "Specify connectionName",
-                        "name": "connectionName",
+                        "name": "lookupImagesReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestLookupImageRequest"
+                            "$ref": "#/definitions/common.TbConnectionName"
                         }
                     }
                 ],
@@ -457,20 +450,13 @@ var doc = `{
                 "summary": "Lookup spec",
                 "parameters": [
                     {
-                        "description": "Specify connectionName",
-                        "name": "connectionName",
+                        "description": "Specify connectionName \u0026 cspSpecName",
+                        "name": "lookupSpecReq",
                         "in": "body",
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/mcir.RestLookupSpecRequest"
                         }
-                    },
-                    {
-                        "type": "string",
-                        "description": "Spec name",
-                        "name": "specName",
-                        "in": "path",
-                        "required": true
                     }
                 ],
                 "responses": {
@@ -511,11 +497,11 @@ var doc = `{
                 "parameters": [
                     {
                         "description": "Specify connectionName",
-                        "name": "connectionName",
+                        "name": "lookupSpecsReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestLookupSpecRequest"
+                            "$ref": "#/definitions/common.TbConnectionName"
                         }
                     }
                 ],
@@ -3886,6 +3872,14 @@ var doc = `{
                 "message": {
                     "type": "string",
                     "example": "Any message"
+                }
+            }
+        },
+        "common.TbConnectionName": {
+            "type": "object",
+            "properties": {
+                "connectionName": {
+                    "type": "string"
                 }
             }
         },

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -343,20 +343,13 @@
                 "summary": "Lookup image",
                 "parameters": [
                     {
-                        "description": "Specify connectionName",
-                        "name": "connectionName",
+                        "description": "Specify connectionName \u0026 cspImageId",
+                        "name": "lookupImageReq",
                         "in": "body",
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/mcir.RestLookupImageRequest"
                         }
-                    },
-                    {
-                        "type": "string",
-                        "description": "Image ID",
-                        "name": "imageId",
-                        "in": "path",
-                        "required": true
                     }
                 ],
                 "responses": {
@@ -397,11 +390,11 @@
                 "parameters": [
                     {
                         "description": "Specify connectionName",
-                        "name": "connectionName",
+                        "name": "lookupImagesReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestLookupImageRequest"
+                            "$ref": "#/definitions/common.TbConnectionName"
                         }
                     }
                 ],
@@ -442,20 +435,13 @@
                 "summary": "Lookup spec",
                 "parameters": [
                     {
-                        "description": "Specify connectionName",
-                        "name": "connectionName",
+                        "description": "Specify connectionName \u0026 cspSpecName",
+                        "name": "lookupSpecReq",
                         "in": "body",
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/mcir.RestLookupSpecRequest"
                         }
-                    },
-                    {
-                        "type": "string",
-                        "description": "Spec name",
-                        "name": "specName",
-                        "in": "path",
-                        "required": true
                     }
                 ],
                 "responses": {
@@ -496,11 +482,11 @@
                 "parameters": [
                     {
                         "description": "Specify connectionName",
-                        "name": "connectionName",
+                        "name": "lookupSpecsReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestLookupSpecRequest"
+                            "$ref": "#/definitions/common.TbConnectionName"
                         }
                     }
                 ],
@@ -3871,6 +3857,14 @@
                 "message": {
                     "type": "string",
                     "example": "Any message"
+                }
+            }
+        },
+        "common.TbConnectionName": {
+            "type": "object",
+            "properties": {
+                "connectionName": {
+                    "type": "string"
                 }
             }
         },

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -129,6 +129,11 @@ definitions:
         example: Any message
         type: string
     type: object
+  common.TbConnectionName:
+    properties:
+      connectionName:
+        type: string
+    type: object
   mcir.FilterSpecsByRangeRequest:
     properties:
       cost_per_hour:
@@ -1461,17 +1466,12 @@ paths:
       - application/json
       description: Lookup image
       parameters:
-      - description: Specify connectionName
+      - description: Specify connectionName & cspImageId
         in: body
-        name: connectionName
+        name: lookupImageReq
         required: true
         schema:
           $ref: '#/definitions/mcir.RestLookupImageRequest'
-      - description: Image ID
-        in: path
-        name: imageId
-        required: true
-        type: string
       produces:
       - application/json
       responses:
@@ -1498,10 +1498,10 @@ paths:
       parameters:
       - description: Specify connectionName
         in: body
-        name: connectionName
+        name: lookupImagesReq
         required: true
         schema:
-          $ref: '#/definitions/mcir.RestLookupImageRequest'
+          $ref: '#/definitions/common.TbConnectionName'
       produces:
       - application/json
       responses:
@@ -1526,17 +1526,12 @@ paths:
       - application/json
       description: Lookup spec
       parameters:
-      - description: Specify connectionName
+      - description: Specify connectionName & cspSpecName
         in: body
-        name: connectionName
+        name: lookupSpecReq
         required: true
         schema:
           $ref: '#/definitions/mcir.RestLookupSpecRequest'
-      - description: Spec name
-        in: path
-        name: specName
-        required: true
-        type: string
       produces:
       - application/json
       responses:
@@ -1563,10 +1558,10 @@ paths:
       parameters:
       - description: Specify connectionName
         in: body
-        name: connectionName
+        name: lookupSpecsReq
         required: true
         schema:
-          $ref: '#/definitions/mcir.RestLookupSpecRequest'
+          $ref: '#/definitions/common.TbConnectionName'
       produces:
       - application/json
       responses:

--- a/src/testclient/scripts/6.image/lookupImage.sh
+++ b/src/testclient/scripts/6.image/lookupImage.sh
@@ -22,12 +22,11 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-
 	resp=$(
         curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupImage -H 'Content-Type: application/json' -d @- <<EOF
 		{ 
 			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
-            "cspImageId": "${IMAGE_NAME[$INDEX,$REGION]}"
+			"cspImageId": "${IMAGE_NAME[$INDEX,$REGION]}"
 		}
 EOF
     ); echo ${resp} | jq ''

--- a/src/testclient/scripts/7.spec/lookupSpec.sh
+++ b/src/testclient/scripts/7.spec/lookupSpec.sh
@@ -2,39 +2,35 @@
 
 #function lookup_spec() {
 
-SECONDS=0
 
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
+	TestSetFile=${4:-../testSet.env}
+    if [ ! -f "$TestSetFile" ]; then
+        echo "$TestSetFile does not exist."
+        exit
+    fi
+	source $TestSetFile
+    source ../conf.env
+	
+	echo "####################################################################"
+	echo "## 7. spec: Lookup Spec"
+	echo "####################################################################"
 
-echo "####################################################################"
-echo "## 7. spec: Lookup Spec"
-echo "####################################################################"
+	CSP=${1}
+	REGION=${2:-1}
+	POSTFIX=${3:-developer}
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
+	source ../common-functions.sh
+	getCloudIndex $CSP
 
-source ../common-functions.sh
-getCloudIndex $CSP
-
-resp=$(
-	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d @- <<EOF
+	resp=$(
+        curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/lookupSpec -H 'Content-Type: application/json' -d @- <<EOF
 		{ 
-			"connectionName": "${CONN_CONFIG[$INDEX, $REGION]}",
-            "cspSpecName": "${SPEC_NAME[$INDEX, $REGION]}"
+			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
+			"cspSpecName": "${SPEC_NAME[$INDEX,$REGION]}"
 		}
 EOF
-)
-echo ${resp} | jq ''
-echo ""
-
-printElapsed $@
+    ); echo ${resp} | jq ''
+    echo ""
 #}
 
 #lookup_spec


### PR DESCRIPTION
- `lookupImages` API 요청의 JSON body 에는 
`connectionName` 만 있으면 되는데
Swagger doc 에는 `cspImageId` 도 필요하다고 되어 있어서 이를 수정했습니다.
- `lookupSpecs` API 요청의 JSON body 에는 
`connectionName` 만 있으면 되는데
Swagger doc 에는 `cspSpecName` 도 필요하다고 되어 있어서 이를 수정했습니다.
- `LookupImageList`, `LookupImage`, `LookupSpecList`, `LookupSpec` 함수에
args emptiness check 로직을 추가했습니다.
- `src/testclient/scripts/7.spec/lookupSpec.sh` 테스트 스크립트가 동작하지 않는 문제가 있었고
이를 수정했습니다.
- 그 외 기타 수정