### PR TITLE
Add MCIS Ansible environment automation script

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/ansibleAutoConf/add-key.yml
+++ b/src/testclient/scripts/sequentialFullTest/ansibleAutoConf/add-key.yml
@@ -1,0 +1,14 @@
+---
+- name: "Playbook to Add Key to Newly Provisioned EC2 Instance"
+  hosts: mcis_hosts
+  vars:
+    - status : "present"
+    - key : "~/.ssh/id_rsa.pub"
+
+  tasks:
+
+  - name: "Copy the authorized key file from"
+    authorized_key:
+      user: "{{ansible_user}}"
+      state: "{{status}}"
+      key: "{{ lookup('file', '{{ key }}')}}"

--- a/src/testclient/scripts/sequentialFullTest/ansibleAutoConf/helloworld.yml
+++ b/src/testclient/scripts/sequentialFullTest/ansibleAutoConf/helloworld.yml
@@ -1,0 +1,19 @@
+---
+- hosts: localhost
+  tasks:
+    - name: test
+      shell: echo "hello world"
+      register: shell_result
+
+    - debug:
+        var: shell_result.stdout_lines
+
+- hosts: all
+  tasks:
+    - name: test
+      shell: echo "hello world"
+      register: shell_result
+
+    - debug:
+        var: shell_result.stdout_lines
+  

--- a/src/testclient/scripts/sequentialFullTest/ansibleAutoConf/mcis-shson01-host-example
+++ b/src/testclient/scripts/sequentialFullTest/ansibleAutoConf/mcis-shson01-host-example
@@ -1,0 +1,3 @@
+[mcis_hosts]
+52.221.254.214 ansible_ssh_port=22 ansible_user=ubuntu ansible_ssh_private_key_file=./sshkey-tmp/aws-ap-southeast-1-shson01.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no"
+99.79.72.18 ansible_ssh_port=22 ansible_user=ubuntu ansible_ssh_private_key_file=./sshkey-tmp/aws-ca-central-1-shson01.pem ansible_ssh_common_args="-o StrictHostKeyChecking=no"

--- a/src/testclient/scripts/sequentialFullTest/conf-ansible-env.sh
+++ b/src/testclient/scripts/sequentialFullTest/conf-ansible-env.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+TestSetFile=${4:-../testSet.env}
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
+	exit
+fi
+source $TestSetFile
+source ../conf.env
+
+echo "####################################################################"
+echo "## Config Ansible environment (generate host file)"
+echo "####################################################################"
+
+CSP=${1}
+REGION=${2:-1}
+POSTFIX=${3:-developer}
+
+source ../common-functions.sh
+getCloudIndex $CSP
+
+MCISID=${CONN_CONFIG[$INDEX, $REGION]}-${POSTFIX}
+
+if [ "${INDEX}" == "0" ]; then
+	# MCISPREFIX=avengers
+	MCISID=${MCISPREFIX}-${POSTFIX}
+fi
+
+#install jq and puttygen
+echo "[Check jq and putty-tools package (if not, install)]"
+if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
+if ! dpkg-query -W -f='${Status}' putty-tools | grep "ok installed"; then sudo apt install -y putty-tools; fi
+
+echo "[Check Ansible (if not, Exit)]"
+
+printf ' [Command to install Ansible]\n 1. apt install python-pip\n 2. pip install ansible\n 3. ansible -h\n 4. ansible localhost -m ping'
+
+# apt install python-pip
+# pip install ansible
+# ansible -h
+# ansible localhost -m ping
+if ! dpkg-query -W -f='${Status}' ansible | grep "ok installed"; then exit; fi
+
+# curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/$MCIRID -H 'Content-Type: application/json' | jq '.privateKey' | sed -e 's/\\n/\n/g' -e 's/\"//g' > ./ansibleAutoConf/sshkey-tmp/$MCISID.pem
+# chmod 600 ./ansibleAutoConf/sshkey-tmp/$MCISID.pem
+# puttygen ./ansibleAutoConf/sshkey-tmp/$MCISID.pem -o ./ansibleAutoConf/sshkey-tmp/$MCISID.ppk -O private
+
+echo ""
+echo "[CHECK REMOTE COMMAND BY CB-TB API]"
+echo " This will retrieve verified SSH username"
+
+./command-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+
+MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=status)
+VMARRAY=$(jq '.status.vm' <<<"$MCISINFO")
+
+echo "$VMARRAY" | jq ''
+
+echo ""
+echo "[GENERATED PRIVATE KEY (PEM, PPK)]"
+# echo -e " ./ansibleAutoConf/sshkey-tmp/$MCISID.pem \n ./ansibleAutoConf/sshkey-tmp/$MCISID.ppk"
+echo ""
+
+echo "[MCIS INFO: $MCISID]"
+for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+	_jq() {
+		echo ${row} | base64 --decode | jq -r ${1}
+	}
+
+	id=$(_jq '.id')
+	ip=$(_jq '.publicIp')
+
+	VMINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${id})
+	VMKEYID=$(jq -r '.sshKeyId' <<<"$VMINFO")
+
+	# KEYFILENAME="MCIS_${MCISID}_VM_${id}"
+	KEYFILENAME="${VMKEYID}"
+
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/$VMKEYID -H 'Content-Type: application/json' | jq '.privateKey' | sed -e 's/\\n/\n/g' -e 's/\"//g' >./ansibleAutoConf/sshkey-tmp/$KEYFILENAME.pem
+	chmod 600 ./ansibleAutoConf/sshkey-tmp/$KEYFILENAME.pem
+	puttygen ./ansibleAutoConf/sshkey-tmp/$KEYFILENAME.pem -o ./ansibleAutoConf/sshkey-tmp/$KEYFILENAME.ppk -O private
+
+	printf ' [VMIP]: %s   [MCISID]: %s   [VMID]: %s\n' "$ip" "MCISID" "$id"
+
+	echo -e " ./ansibleAutoConf/sshkey-tmp/$KEYFILENAME.pem \n ./ansibleAutoConf/sshkey-tmp/$KEYFILENAME.ppk"
+	echo ""
+done
+
+echo ""
+echo "[Configure Ansible Host File based on MCIS Info]"
+
+HostFileName="${MCISID}-host"
+echo "[mcis_hosts]" >./ansibleAutoConf/${HostFileName}
+
+for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+	_jq() {
+		echo ${row} | base64 --decode | jq -r ${1}
+	}
+
+	id=$(_jq '.id')
+	ip=$(_jq '.publicIp')
+
+	VMINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${id})
+	VMKEYID=$(jq -r '.sshKeyId' <<<"$VMINFO")
+
+	KEYINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/${NSID}/resources/sshKey/${VMKEYID})
+	USERNAME=$(jq -r '.verifiedUsername' <<<"$KEYINFO")
+
+	# KEYFILENAME="MCIS_${MCISID}_VM_${id}"
+	KEYFILENAME="${VMKEYID}"
+
+	echo ""
+	# USERNAME="ubuntu"
+	printf ' [VMIP]: %s   [MCISID]: %s   [VMID]: %s\n' "$ip" "MCISID" "$id"
+	printf ' ssh -i ./ansibleAutoConf/sshkey-tmp/%s.pem %s@%s -o StrictHostKeyChecking=no\n' "$KEYFILENAME" "$USERNAME" "$ip"
+
+	echo "Add ansible hosts to ./ansibleAutoConf/${HostFileName}"
+	echo "- $ip ansible_ssh_port=22 ansible_user=$USERNAME ansible_ssh_private_key_file=./sshkey-tmp/$KEYFILENAME.pem ansible_ssh_common_args=\"-o StrictHostKeyChecking=no\""
+	echo "$ip ansible_ssh_port=22 ansible_user=$USERNAME ansible_ssh_private_key_file=./sshkey-tmp/$KEYFILENAME.pem ansible_ssh_common_args=\"-o StrictHostKeyChecking=no\"" >>./ansibleAutoConf/${HostFileName}
+
+	echo ""
+	echo "[You can use Asible in ./ansibleAutoConf/"
+	echo "[1] cd ansibleAutoConf/"
+	echo "[2] ansible-playbook helloworld.yml -i ${HostFileName}"
+
+done
+
+echo ""

--- a/src/testclient/scripts/sequentialFullTest/gen-sshKey.sh
+++ b/src/testclient/scripts/sequentialFullTest/gen-sshKey.sh
@@ -1,121 +1,104 @@
 #!/bin/bash
 
-#function get_sshKey() {
+TestSetFile=${4:-../testSet.env}
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
+	exit
+fi
+source $TestSetFile
+source ../conf.env
 
+echo "####################################################################"
+echo "## Generate SSH KEY (PEM, PPK)"
+echo "####################################################################"
 
+CSP=${1}
+REGION=${2:-1}
+POSTFIX=${3:-developer}
 
+source ../common-functions.sh
+getCloudIndex $CSP
 
+MCIRID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
 
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
-	echo "####################################################################"
-	echo "## Generate SSH KEY (PEM, PPK)" 
-	echo "####################################################################"
+if [ "${INDEX}" == "0" ]; then
+	# MCISPREFIX=avengers
+	MCISID=${MCISPREFIX}-${POSTFIX}
+fi
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+#install jq and puttygen
+echo "[Check jq and putty-tools package (if not, install)]"
+if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
+if ! dpkg-query -W -f='${Status}' putty-tools | grep "ok installed"; then sudo apt install -y putty-tools; fi
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+# curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/$MCIRID -H 'Content-Type: application/json' | jq '.privateKey' | sed -e 's/\\n/\n/g' -e 's/\"//g' > ./sshkey-tmp/$MCISID.pem
+# chmod 600 ./sshkey-tmp/$MCISID.pem
+# puttygen ./sshkey-tmp/$MCISID.pem -o ./sshkey-tmp/$MCISID.ppk -O private
 
+echo ""
+echo "[CHECK REMOTE COMMAND BY CB-TB API]"
+echo " This will retrieve verified SSH username"
 
-	MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
-	MCIRID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+./command-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
 
-	if [ "${INDEX}" == "0" ]; then
-		# MCISPREFIX=avengers
-		MCISID=${MCISPREFIX}-${POSTFIX}
-	fi
+MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=status)
+VMARRAY=$(jq '.status.vm' <<<"$MCISINFO")
 
+echo "$VMARRAY" | jq ''
 
-	#install jq and puttygen
-	echo "[Check jq and putty-tools package (if not, install)]"
-	if ! dpkg-query -W -f='${Status}' jq  | grep "ok installed"; then sudo apt install -y jq; fi
-	if ! dpkg-query -W -f='${Status}' putty-tools  | grep "ok installed"; then sudo apt install -y putty-tools; fi
+echo ""
+echo "[GENERATED PRIVATE KEY (PEM, PPK)]"
+# echo -e " ./sshkey-tmp/$MCISID.pem \n ./sshkey-tmp/$MCISID.ppk"
+echo ""
 
+echo "[MCIS INFO: $MCISID]"
+for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+	_jq() {
+		echo ${row} | base64 --decode | jq -r ${1}
+	}
 
-	# curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/$MCIRID -H 'Content-Type: application/json' | jq '.privateKey' | sed -e 's/\\n/\n/g' -e 's/\"//g' > ./sshkey-tmp/$MCISID.pem
-	# chmod 600 ./sshkey-tmp/$MCISID.pem
-	# puttygen ./sshkey-tmp/$MCISID.pem -o ./sshkey-tmp/$MCISID.ppk -O private
+	id=$(_jq '.id')
+	ip=$(_jq '.publicIp')
+
+	VMINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${id})
+	VMKEYID=$(jq -r '.sshKeyId' <<<"$VMINFO")
+
+	# KEYFILENAME="MCIS_${MCISID}_VM_${id}"
+	KEYFILENAME="${VMKEYID}"
+
+	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/$VMKEYID -H 'Content-Type: application/json' | jq '.privateKey' | sed -e 's/\\n/\n/g' -e 's/\"//g' >./sshkey-tmp/$KEYFILENAME.pem
+	chmod 600 ./sshkey-tmp/$KEYFILENAME.pem
+	puttygen ./sshkey-tmp/$KEYFILENAME.pem -o ./sshkey-tmp/$KEYFILENAME.ppk -O private
+
+	printf ' [VMIP]: %s   [MCISID]: %s   [VMID]: %s\n' "$ip" "MCISID" "$id"
+
+	echo -e " ./sshkey-tmp/$KEYFILENAME.pem \n ./sshkey-tmp/$KEYFILENAME.ppk"
+	echo ""
+done
+
+echo ""
+echo "[SSH COMMAND EXAMPLE]"
+for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+	_jq() {
+		echo ${row} | base64 --decode | jq -r ${1}
+	}
+
+	id=$(_jq '.id')
+	ip=$(_jq '.publicIp')
+
+	VMINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${id})
+	VMKEYID=$(jq -r '.sshKeyId' <<<"$VMINFO")
+
+	KEYINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/${NSID}/resources/sshKey/${VMKEYID})
+	USERNAME=$(jq -r '.verifiedUsername' <<<"$KEYINFO")
+
+	# KEYFILENAME="MCIS_${MCISID}_VM_${id}"
+	KEYFILENAME="${VMKEYID}"
 
 	echo ""
-	echo "[CHECK REMOTE COMMAND BY CB-TB API]"
-	echo " This will retrieve verified SSH username"
+	# USERNAME="ubuntu"
+	printf ' [VMIP]: %s   [MCISID]: %s   [VMID]: %s\n' "$ip" "MCISID" "$id"
+	printf ' ssh -i ./sshkey-tmp/%s.pem %s@%s -o StrictHostKeyChecking=no\n' "$KEYFILENAME" "$USERNAME" "$ip"
+done
 
-	./command-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
-
-	MCISINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=status`
-	VMARRAY=$(jq '.status.vm' <<< "$MCISINFO")
-
-	echo "$VMARRAY" | jq ''
-
-
-	echo ""
-	echo "[GENERATED PRIVATE KEY (PEM, PPK)]"
-	# echo -e " ./sshkey-tmp/$MCISID.pem \n ./sshkey-tmp/$MCISID.ppk"
-	echo ""
-
-	echo "[MCIS INFO: $MCISID]"
-	for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-            _jq() {
-            echo ${row} | base64 --decode | jq -r ${1}
-            }
-
-			id=$(_jq '.id')
-            ip=$(_jq '.publicIp')
-
-			VMINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${id}`
-			VMKEYID=$(jq -r '.sshKeyId' <<< "$VMINFO")
-
-			# KEYFILENAME="MCIS_${MCISID}_VM_${id}"
-			KEYFILENAME="${VMKEYID}"
-
-			curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/$VMKEYID -H 'Content-Type: application/json' | jq '.privateKey' | sed -e 's/\\n/\n/g' -e 's/\"//g' > ./sshkey-tmp/$KEYFILENAME.pem
-			chmod 600 ./sshkey-tmp/$KEYFILENAME.pem
-			puttygen ./sshkey-tmp/$KEYFILENAME.pem -o ./sshkey-tmp/$KEYFILENAME.ppk -O private
-
-			printf ' [VMIP]: %s   [MCISID]: %s   [VMID]: %s\n' "$ip" "MCISID" "$id";
-
-			echo -e " ./sshkey-tmp/$KEYFILENAME.pem \n ./sshkey-tmp/$KEYFILENAME.ppk"
-			echo ""
-    done
-
-	echo ""
-	echo "[SSH COMMAND EXAMPLE]"
-	for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-            _jq() {
-            echo ${row} | base64 --decode | jq -r ${1}
-            }
-
-			id=$(_jq '.id')
-            ip=$(_jq '.publicIp')
-
-			VMINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${id}`
-			VMKEYID=$(jq -r '.sshKeyId' <<< "$VMINFO")
-
-			KEYINFO=`curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/${NSID}/resources/sshKey/${VMKEYID}`
-			USERNAME=$(jq -r '.verifiedUsername' <<< "$KEYINFO")
-
-			# KEYFILENAME="MCIS_${MCISID}_VM_${id}"
-			KEYFILENAME="${VMKEYID}"
-
-			echo ""
-			# USERNAME="ubuntu"
-			printf ' [VMIP]: %s   [MCISID]: %s   [VMID]: %s\n' "$ip" "MCISID" "$id";
-			printf ' ssh -i ./sshkey-tmp/%s.pem %s@%s -o StrictHostKeyChecking=no\n' "$KEYFILENAME" "$USERNAME" "$ip";
-    done
-
-
-	echo ""
-
-
-#}
-
-#get_sshKey
+echo ""


### PR DESCRIPTION

CB-TB를 통해 생성된, MCIS에

Ansible 을 바로 동작시킬 수 있도록 스크립트 도구 제공.

MCIS를 생성 후, `./creat-all.sh all 1 shson04 ../testSetAws.env`

cb-tumblebug/src/testclient/scripts/sequentialFullTest$ 
**./conf-ansible-env.sh** all 1 shson04 ../testSetAws.env

를 사용하면,
Ansible이 필요로하는 정보를 포함하는 파일을 자동으로 생성하여, ansibleAutoConf/MCISID-host 파일에 추가함.

```
son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/src/testclient/scripts/sequentialFullTest$ ./conf-ansible-env.sh all 1 shson04 ../testSetAws.env
####################################################################
## Config Ansible environment (generate host file)
####################################################################
...
[Check Ansible (if not, Exit)]
 [Command to install Ansible]
 1. apt install python-pip
 2. pip install ansible
 3. ansible -h
 4. ansible localhost -m pinginstall ok installed

[CHECK REMOTE COMMAND BY CB-TB API]
 This will retrieve verified SSH username
...

[Configure Ansible Host File based on MCIS Info]
...

[You can use Asible in ./ansibleAutoConf/]
 Ex) ansible-playbook ./ansibleAutoConf/helloworld.yml -i ./ansibleAutoConf/mcis-shson04-host
```

예시와 같이, `ansible-playbook ./ansibleAutoConf/helloworld.yml -i ./ansibleAutoConf/mcis-shson04-host` 를 입력하면
`ansibleAutoConf/helloworld.yml` Ansible playbook이 실행됨.


예시 Ansible playbook 이외에 다른 playbook은 다양한 채널을 통해 구할 수 있음.



PTAL @jihoon-seo @hermitkim1 @powerkimhub 

참고) `Add SSH Key to EC2 instances with Ansible – Automated` https://www.middlewareinventory.com/blog/ansible-ec2-ssh-key/
참고) `Ansible Galaxy` https://galaxy.ansible.com/
