### PR TITLE
Update cspImageId field

### DIFF
--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -72,9 +72,9 @@ func ConvertSpiderImageToTumblebugImage(spiderImage SpiderImageInfo) (TbImageInf
 	}
 
 	tumblebugImage := TbImageInfo{}
-	tumblebugImage.Id = spiderImage.IId.SystemId
+	tumblebugImage.Id = spiderImage.IId.NameId
 	tumblebugImage.Name = common.LookupKeyValueList(spiderImage.KeyValueList, "Name")
-	tumblebugImage.CspImageId = spiderImage.IId.SystemId
+	tumblebugImage.CspImageId = spiderImage.IId.NameId
 	tumblebugImage.CspImageName = common.LookupKeyValueList(spiderImage.KeyValueList, "Name")
 	tumblebugImage.Description = common.LookupKeyValueList(spiderImage.KeyValueList, "Description")
 	tumblebugImage.CreationDate = common.LookupKeyValueList(spiderImage.KeyValueList, "CreationDate")

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -1541,8 +1541,8 @@ RegionName[$IX,$IY]=cloudit-region01
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=default
 CONN_CONFIG[$IX,$IY]=cloudit-region01
-IMAGE_NAME[$IX,$IY]=
-SPEC_NAME[$IX,$IY]=
+IMAGE_NAME[$IX,$IY]=CentOS-7
+SPEC_NAME[$IX,$IY]=micro-1
 
 
 


### PR DESCRIPTION
- Cloudit 의 경우, `spiderImage.IId.SystemId` 에 UUID 가 담겨져 리턴되어 옴.
하지만 VM 생성에는 `spiderImage.IId.NameId` 에 담긴 값 (예: `CentOS-7`) 이 필요함.
- @powerkimhub 님의 말에 따르면, Tumblebug 에서는 Spider 가 주는 값 중
`SystemId` 는 이용할 일이 없을 것이며
`NameId` 를 이용하면 된다고 함.
- Cloudit 은 테스트 완료하였으나
다른 CSP 에 대해서는 테스트가 필요함. (AI to @jihoon-seo)