### PR TITLE
Hotfix for ListVmId malfunctioning

### DIFF
--- a/conf/log_conf.yaml
+++ b/conf/log_conf.yaml
@@ -5,14 +5,14 @@ cblog:
   loopcheck: true # This temp method for development is busy wait. cf) cblogger.go:levelSetupLoop().
 
   ## debug | info | warn | error
-  loglevel: error # If loopcheck is true, You can set this online.
+  loglevel: info # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false 
+  logfile: true 
 
 ## Config for File Output ##
 logfileinfo:
-  filename: ./log/cblogs.log
+  filename: $CBTUMBLEBUG_ROOT/log/cblogs.log
   maxsize: 10 # megabytes
   maxbackups: 50
   maxage: 31 # days

--- a/conf/setup.env
+++ b/conf/setup.env
@@ -1,6 +1,6 @@
-export CBSTORE_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
-export CBLOG_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
-export CBTUMBLEBUG_ROOT=$GOPATH/src/github.com/cloud-barista/cb-tumblebug
+export CBTUMBLEBUG_ROOT=$HOME/go/src/github.com/cloud-barista/cb-tumblebug
+export CBSTORE_ROOT=$CBTUMBLEBUG_ROOT
+export CBLOG_ROOT=$CBTUMBLEBUG_ROOT
 export SPIDER_CALL_METHOD=REST
 export SPIDER_REST_URL=http://localhost:1024/spider
 export DRAGONFLY_REST_URL=http://localhost:9090/dragonfly
@@ -15,7 +15,7 @@ export API_PASSWORD=default
 
 export AUTOCONTROL_DURATION_MS=10000
 
-export API_DOC_PATH=$GOPATH/src/github.com/cloud-barista/cb-tumblebug/src/docs/swagger.json
+export API_DOC_PATH=$CBTUMBLEBUG_ROOT/src/docs/swagger.json
 
 # Set SELF_ENDPOINT, if you want to access Swagger API dashboard from outside.
 # Ex) export SELF_ENDPOINT=xxx.xxx.xxx.xxx:1323

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -49,6 +49,20 @@ type JSONResult struct {
 	//Data    interface{}  `json:"data"`
 }
 
+func RestTestListVmId(c echo.Context) error { // for debug
+	nsId := c.Param("nsId")
+	mcisId := c.Param("mcisId")
+
+	vmList, err := mcis.ListVmId(nsId, mcisId)
+	if err != nil {
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(http.StatusInternalServerError, &mapA)
+	}
+
+	// mapA := map[string]string{"message": result}
+	return c.JSON(http.StatusOK, &vmList)
+}
+
 // TODO: swag does not support multiple response types (success 200) in an API.
 // Annotation for API documention Need to be revised.
 
@@ -241,7 +255,7 @@ func RestDelAllMcis(c echo.Context) error {
 
 type RestPostMcisRecommandResponse struct {
 	//VmReq          []TbVmRecommendReq    `json:"vmReq"`
-	Vm_recommend    []mcis.TbVmRecommendInfo `json:"vm_recommend"`
+	Vm_recommend   []mcis.TbVmRecommendInfo `json:"vm_recommend"`
 	PlacementAlgo  string                   `json:"placementAlgo"`
 	PlacementParam []common.KeyValue        `json:"placementParam"`
 }

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -152,6 +152,8 @@ func ApiServer() {
 	g.DELETE("/:nsId/mcis/:mcisId/vm/:vmId", rest_mcis.RestDelMcisVm)
 	//g.DELETE("/:nsId/mcis/:mcisId/vm", rest_mcis.RestDelAllMcisVm)
 
+	g.GET("/:nsId/mcis/:mcisId/testListVmId", rest_mcis.RestTestListVmId) // for debug
+
 	g.POST("/:nsId/mcis/recommend", rest_mcis.RestPostMcisRecommand)
 
 	g.POST("/:nsId/testRecommendVm", rest_mcis.RestRecommendVm)


### PR DESCRIPTION
- Related issue: #541
- Related issue: #546 

---

- `ListVmId` 함수는 결과를 `mzc01-c-1-1yn8c` 형태로 리턴하도록 작성되어 있음.
- `testListVmId` REST API를 만들어 `ListVmId` 함수를 테스트해 보면, 정상적으로 처리함. (https://github.com/cloud-barista/cb-tumblebug/issues/546#issuecomment-847715413)
- 그러나, `ListVmId` 함수가 다른 함수에 의해 호출되는 경우, 
vmId 가 `/ns/ns-01/mcis/mzc01-import/vm/mzc01-c-1-1yn8c` 형태로 리턴하는 경우가 있음.
- 위의 현상이 발생한 경우, 
CBStore Get 위한 key 생성할 때
key = nsId + mcisId + vmId 하지 않고
key = vmId 하는 hotfix 임.