### PR TITLE
Fix jitsi script for multiple CSPs

### DIFF
--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -557,7 +557,7 @@ SPEC_NAME[$IX,$IY]=ecs.g6.large
 
 # region22 
 IY=$AlibabaCnWulanchabu
-# Location: China (Ulanqab) - ERR: InvalidSystemDiskCategory.ValueNotSupported - NEED TO CHECK NETWORK OUTBOUND. no ecs.t5 available. 
+# Location: China (Ulanqab) - NEED TO CHECK NETWORK OUTBOUND. ERR: InvalidSystemDiskCategory with ecs.g6.large type
 RegionName[$IX,$IY]=alibaba-cn-wulanchabu
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=cn-wulanchabu
@@ -565,7 +565,7 @@ RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=cn-wulanchabu-c
 CONN_CONFIG[$IX,$IY]=alibaba-cn-wulanchabu
 IMAGE_NAME[$IX,$IY]=${CommonImage[$IX]}
-SPEC_NAME[$IX,$IY]=ecs.g6e.large
+SPEC_NAME[$IX,$IY]=ecs.g6.large
 
 # region23 
 IY=$AlibabaCnGuangzhou

--- a/src/testclient/scripts/sequentialFullTest/deploy-jitsi-to-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-jitsi-to-mcis.sh
@@ -67,7 +67,7 @@ for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
 	VMID=$(_jq '.id')
 	PublicIP=$(_jq '.publicIp')
 
-	SetHostCMD="sudo -- sh -c \\\"echo $PublicIP $PublicDNS >> /etc/hosts\\\"; sudo hostnamectl set-hostname etri.cloud-barista.org; hostname -f"
+	SetHostCMD="sudo -- sh -c \\\"echo $PublicIP $PublicDNS >> /etc/hosts\\\"; sudo hostnamectl set-hostname $PublicDNS; hostname -f"
 	echo "SetHostCMD: $SetHostCMD"
 
 	VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d @- <<EOF
@@ -79,7 +79,20 @@ EOF
 	echo "${VAR1}" | jq ''
 	echo ""
 
-	InstallJitsiCMD="sudo sh -c \\\"echo 'deb https://download.jitsi.org stable/' > /etc/apt/sources.list.d/jitsi-stable.list\\\"; sudo wget -qO -  https://download.jitsi.org/jitsi-key.gpg.key | sudo apt-key add -; sudo echo \\\"jitsi-videobridge jitsi-videobridge/jvb-hostname string $PublicDNS\\\" | sudo debconf-set-selections; sudo echo \\\"jitsi-meet-web-config jitsi-meet/cert-choice select 'Generate a new self-signed certificate (You will later get a chance to obtain a Let's encrypt certificate)'\\\" | sudo debconf-set-selections; export DEBIAN_FRONTEND=noninteractive; sudo apt update > /dev/null; sudo apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet install jitsi-meet > /dev/null"
+
+	InstallJitsiDependencyCMD="sudo sh -c \\\"echo 'deb https://download.jitsi.org stable/' > /etc/apt/sources.list.d/jitsi-stable.list\\\"; sudo wget -qO -  https://download.jitsi.org/jitsi-key.gpg.key | sudo apt-key add -; sudo apt-get update > /dev/null; sudo apt-get -y install apt-utils; sudo DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-8-jre-headless libssl1.1"
+	echo "InstallJitsiDependencyCMD: $InstallJitsiDependencyCMD"
+
+	VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${InstallJitsiDependencyCMD}"
+	}
+EOF
+	)
+	echo "${VAR1}" | jq ''
+	echo ""
+
+	InstallJitsiCMD="sudo echo \\\"jitsi-videobridge jitsi-videobridge/jvb-hostname string $PublicDNS\\\" | sudo debconf-set-selections; sudo echo \\\"jitsi-meet-web-config jitsi-meet/cert-choice select 'Generate a new self-signed certificate (You will later get a chance to obtain a Let's encrypt certificate)'\\\" | sudo debconf-set-selections; sudo DEBIAN_FRONTEND=noninteractive apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet install jitsi-meet"
 	echo "InstallJitsiCMD: $InstallJitsiCMD"
 
 	VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d @- <<EOF
@@ -92,7 +105,7 @@ EOF
 	echo ""
 
 	# ConfigJitsiCMD="sudo echo $EMAIL | sudo /usr/share/jitsi-meet/scripts/install-letsencrypt-cert.sh; sudo -- sh -c \\\"echo DefaultLimitNOFILE=65000 >> /etc/systemd/system.conf\\\"; sudo -- sh -c \\\"echo DefaultLimitNPROC=65000 >> /etc/systemd/system.conf\\\"; sudo -- sh -c \\\"echo DefaultTasksMax=65000 >> /etc/systemd/system.conf\\\"; sudo cat /etc/systemd/system.conf; sudo systemctl daemon-reload; sudo systemctl restart prosody; sudo systemctl restart jicofo; sudo systemctl restart jitsi-videobridge2; sudo cat /proc/`sudo cat /var/run/jitsi-videobridge/jitsi-videobridge.pid`/limits"
-	CertJitsiCMD="sudo echo $EMAIL | sudo /usr/share/jitsi-meet/scripts/install-letsencrypt-cert.sh"
+	CertJitsiCMD="sudo echo $EMAIL | sudo DEBIAN_FRONTEND=noninteractive /usr/share/jitsi-meet/scripts/install-letsencrypt-cert.sh"
 	echo "CertJitsiCMD: $CertJitsiCMD"
 
 	VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d @- <<EOF

--- a/src/testclient/scripts/testSet.env
+++ b/src/testclient/scripts/testSet.env
@@ -16,7 +16,6 @@ IndexAWS=$((++IX))
 IndexAzure=$((++IX))
 IndexGCP=$((++IX))
 IndexAlibaba=$((++IX))
-
 IndexMock=$((++IX))
 IndexOpenstack=$((++IX))
 IndexNCP=$((++IX))


### PR DESCRIPTION
AWS에서만 가능하던 Jisti 배포 스크립트를
GCP, Alibaba, Azure 까지 확대

++
src/core/mcis/control.go 일부 코드 보완