### PR TITLE
Englishfy Korean comments in cbadm codes

### DIFF
--- a/src/api/grpc/cbadm/cmd/config.go
+++ b/src/api/grpc/cbadm/cmd/config.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewConfigCmd - Config 관리 기능을 수행하는 Cobra Command 생성
+// NewConfigCmd : "cbadm config *" (for CB-Tumblebug)
 func NewConfigCmd() *cobra.Command {
 
 	configCmd := &cobra.Command{
@@ -34,7 +34,7 @@ func NewConfigCmd() *cobra.Command {
 	return configCmd
 }
 
-// NewConfigCreateCmd - Config 생성 기능을 수행하는 Cobra Command 생성
+// NewConfigCreateCmd : "cbadm config create"
 func NewConfigCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -61,7 +61,7 @@ func NewConfigCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewConfigListCmd - Config 목록 기능을 수행하는 Cobra Command 생성
+// NewConfigListCmd : "cbadm config list"
 func NewConfigListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -76,7 +76,7 @@ func NewConfigListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewConfigGetCmd - Config 조회 기능을 수행하는 Cobra Command 생성
+// NewConfigGetCmd : "cbadm config get"
 func NewConfigGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -100,12 +100,12 @@ func NewConfigGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewConfigDeleteAllCmd - Config 모든 삭제 기능을 수행하는 Cobra Command 생성
+// NewConfigDeleteAllCmd : "cbadm config delete-all"
 func NewConfigDeleteAllCmd() *cobra.Command {
 
 	deleteAllCmd := &cobra.Command{
 		Use:   "delete-all",
-		Short: "This is delete alll command for config",
+		Short: "This is delete all command for config",
 		Long:  "This is delete all command for config",
 		Run: func(cmd *cobra.Command, args []string) {
 

--- a/src/api/grpc/cbadm/cmd/connectinfo.go
+++ b/src/api/grpc/cbadm/cmd/connectinfo.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewConnectInfosCmd - 연결설정 관리 기능을 수행하는 Cobra Command 생성
+// NewConnectInfosCmd : "cbadm connect-info *" (for CB-Spider)
 func NewConnectInfosCmd() *cobra.Command {
 
 	connectionCmd := &cobra.Command{
@@ -34,7 +34,7 @@ func NewConnectInfosCmd() *cobra.Command {
 	return connectionCmd
 }
 
-// NewConnectInfosCreateCmd - 연결설정 생성 기능을 수행하는 Cobra Command 생성
+// NewConnectInfosCreateCmd : "cbadm connect-info create"
 func NewConnectInfosCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -61,7 +61,7 @@ func NewConnectInfosCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewConnectInfosListCmd - 연결설정 목록 기능을 수행하는 Cobra Command 생성
+// NewConnectInfosListCmd : "cbadm connect-info list"
 func NewConnectInfosListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -76,7 +76,7 @@ func NewConnectInfosListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewCConnectInfosGetCmd - 연결설정 조회 기능을 수행하는 Cobra Command 생성
+// NewCConnectInfosGetCmd : "cbadm connect-info get"
 func NewCConnectInfosGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -100,7 +100,7 @@ func NewCConnectInfosGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewConnectInfosDeleteCmd - 연결설정 삭제 기능을 수행하는 Cobra Command 생성
+// NewConnectInfosDeleteCmd : "cbadm connect-info delete"
 func NewConnectInfosDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/credential.go
+++ b/src/api/grpc/cbadm/cmd/credential.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewCredentialCmd - Credential 관리 기능을 수행하는 Cobra Command 생성
+// NewCredentialCmd : "cbadm credential *" (for CB-Spider)
 func NewCredentialCmd() *cobra.Command {
 
 	credentialCmd := &cobra.Command{
@@ -34,7 +34,7 @@ func NewCredentialCmd() *cobra.Command {
 	return credentialCmd
 }
 
-// NewCredentialCreateCmd -Credential 생성 기능을 수행하는 Cobra Command 생성
+// NewCredentialCreateCmd : "cbadm credential create"
 func NewCredentialCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -61,7 +61,7 @@ func NewCredentialCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewCredentialListCmd - Credential 목록 기능을 수행하는 Cobra Command 생성
+// NewCredentialListCmd : "cbadm credential list"
 func NewCredentialListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -76,7 +76,7 @@ func NewCredentialListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewCredentialGetCmd - Credential 조회 기능을 수행하는 Cobra Command 생성
+// NewCredentialGetCmd : "cbadm credential get"
 func NewCredentialGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -100,7 +100,7 @@ func NewCredentialGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewCredentialDeleteCmd - Credential 삭제 기능을 수행하는 Cobra Command 생성
+// NewCredentialDeleteCmd : "cbadm credential delete"
 func NewCredentialDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/driver.go
+++ b/src/api/grpc/cbadm/cmd/driver.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewDriverCmd - Cloud Driver 관리 기능을 수행하는 Cobra Command 생성
+// NewDriverCmd : "cbadm driver *" (for CB-Spider)
 func NewDriverCmd() *cobra.Command {
 
 	driverCmd := &cobra.Command{
@@ -34,7 +34,7 @@ func NewDriverCmd() *cobra.Command {
 	return driverCmd
 }
 
-// NewDriverCreateCmd - Cloud Driver 생성 기능을 수행하는 Cobra Command 생성
+// NewDriverCreateCmd : "cbadm driver create"
 func NewDriverCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -61,7 +61,7 @@ func NewDriverCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewDriverListCmd - Cloud Driver 목록 기능을 수행하는 Cobra Command 생성
+// NewDriverListCmd : "cbadm driver list"
 func NewDriverListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -76,7 +76,7 @@ func NewDriverListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewDriverGetCmd - Cloud Driver 조회 기능을 수행하는 Cobra Command 생성
+// NewDriverGetCmd : "cbadm driver get"
 func NewDriverGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -100,7 +100,7 @@ func NewDriverGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewDriverDeleteCmd - Cloud Driver 삭제 기능을 수행하는 Cobra Command 생성
+// NewDriverDeleteCmd : "cbadm driver delete"
 func NewDriverDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/gclient.go
+++ b/src/api/grpc/cbadm/cmd/gclient.go
@@ -36,7 +36,7 @@ func readInDataFromFile() {
 
 // ===== [ Public Functions ] =====
 
-// SetupAndRun - SPIDER GRPC CLI 구동
+// SetupAndRun : setup and run Cloud-Barista gRPC CLI
 func SetupAndRun(cmd *cobra.Command, args []string) {
 	logger := logger.NewLogger()
 
@@ -52,7 +52,7 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 		tbutil *tb_api.UTILITYApi = nil
 	)
 
-	// panic 처리
+	// panic handling
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Error("tbctl is stopped : ", r)
@@ -60,7 +60,7 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 	}()
 
 	if cmd.Parent().Name() == "driver" || cmd.Parent().Name() == "credential" || cmd.Parent().Name() == "region" || cmd.Parent().Name() == "connect-info" {
-		// CIM API 설정
+		// CIM API
 		cim = sp_api.NewCloudInfoManager()
 		err = cim.SetConfigPath(configFile)
 		if err != nil {
@@ -76,7 +76,7 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Parent().Name() == "namespace" {
-		// NS API 설정
+		// NS API
 		ns = tb_api.NewNSManager()
 		err = ns.SetConfigPath(configFile)
 		if err != nil {
@@ -92,7 +92,7 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Parent().Name() == "image" || cmd.Parent().Name() == "network" || cmd.Parent().Name() == "securitygroup" || cmd.Parent().Name() == "keypair" || cmd.Parent().Name() == "spec" {
-		// MCIR API 설정
+		// MCIR API
 		mcir = tb_api.NewMCIRManager()
 		err = mcir.SetConfigPath(configFile)
 		if err != nil {
@@ -108,7 +108,7 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Parent().Name() == "mcis" {
-		// MCIS API 설정
+		// MCIS API
 		mcis = tb_api.NewMCISManager()
 		err = mcis.SetConfigPath(configFile)
 		if err != nil {
@@ -124,7 +124,7 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Parent().Name() == "util" || cmd.Parent().Name() == "config" {
-		// UTILITY API 설정
+		// Utility API
 		tbutil = tb_api.NewUTILITYManager()
 		err = tbutil.SetConfigPath(configFile)
 		if err != nil {
@@ -139,7 +139,7 @@ func SetupAndRun(cmd *cobra.Command, args []string) {
 		defer tbutil.Close()
 	}
 
-	// 입력 파라미터 처리
+	// Validate input parameters
 	if outType != "json" && outType != "yaml" {
 		logger.Error("failed to validate --output parameter : ", outType)
 		return

--- a/src/api/grpc/cbadm/cmd/image.go
+++ b/src/api/grpc/cbadm/cmd/image.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewImageCmd - Image 관리 기능을 수행하는 Cobra Command 생성
+// NewImageCmd : "cbadm image *" (for CB-Tumblebug)
 func NewImageCmd() *cobra.Command {
 
 	imageCmd := &cobra.Command{
@@ -40,7 +40,7 @@ func NewImageCmd() *cobra.Command {
 	return imageCmd
 }
 
-// NewImageCreateWithInfoCmd - Image 생성 기능을 수행하는 Cobra Command 생성
+// NewImageCreateWithInfoCmd : "cbadm image create"
 func NewImageCreateWithInfoCmd() *cobra.Command {
 
 	createWithInfoCmd := &cobra.Command{
@@ -67,7 +67,7 @@ func NewImageCreateWithInfoCmd() *cobra.Command {
 	return createWithInfoCmd
 }
 
-// NewImageCreateWithIdCmd - Image 생성 기능을 수행하는 Cobra Command 생성
+// NewImageCreateWithIdCmd : "cbadm image create-id"
 func NewImageCreateWithIdCmd() *cobra.Command {
 
 	createWithIdCmd := &cobra.Command{
@@ -94,7 +94,7 @@ func NewImageCreateWithIdCmd() *cobra.Command {
 	return createWithIdCmd
 }
 
-// NewImageListCmd - Image 목록 기능을 수행하는 Cobra Command 생성
+// NewImageListCmd : "cbadm image list"
 func NewImageListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -118,7 +118,7 @@ func NewImageListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewImageListCspCmd - CSP Image 목록 기능을 수행하는 Cobra Command 생성
+// NewImageListCspCmd : "cbadm image list-csp"
 func NewImageListCspCmd() *cobra.Command {
 
 	listCspCmd := &cobra.Command{
@@ -142,7 +142,7 @@ func NewImageListCspCmd() *cobra.Command {
 	return listCspCmd
 }
 
-// NewImageGetCmd - Image 조회 기능을 수행하는 Cobra Command 생성
+// NewImageGetCmd : "cbadm image get"
 func NewImageGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -172,7 +172,7 @@ func NewImageGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewImageGetCspCmd - CSP Image 조회 기능을 수행하는 Cobra Command 생성
+// NewImageGetCspCmd : "cbadm image get-csp"
 func NewImageGetCspCmd() *cobra.Command {
 
 	getCspCmd := &cobra.Command{
@@ -202,7 +202,7 @@ func NewImageGetCspCmd() *cobra.Command {
 	return getCspCmd
 }
 
-// NewImageDeleteCmd - Image 삭제 기능을 수행하는 Cobra Command 생성
+// NewImageDeleteCmd : "cbadm image delete"
 func NewImageDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{
@@ -238,7 +238,7 @@ func NewImageDeleteCmd() *cobra.Command {
 	return deleteCmd
 }
 
-// NewImageDeleteAllCmd - 전체 Image 삭제 기능을 수행하는 Cobra Command 생성
+// NewImageDeleteAllCmd : "cbadm image delete-all"
 func NewImageDeleteAllCmd() *cobra.Command {
 
 	deleteAllCmd := &cobra.Command{
@@ -268,7 +268,7 @@ func NewImageDeleteAllCmd() *cobra.Command {
 	return deleteAllCmd
 }
 
-// NewImageFetchCmd - Image Fetch 기능을 수행하는 Cobra Command 생성
+// NewImageFetchCmd : "cbadm image fetch"
 func NewImageFetchCmd() *cobra.Command {
 
 	fetchCmd := &cobra.Command{
@@ -298,7 +298,7 @@ func NewImageFetchCmd() *cobra.Command {
 	return fetchCmd
 }
 
-// NewImageSearchCmd - Image 검색 기능을 수행하는 Cobra Command 생성
+// NewImageSearchCmd : "cbadm image search"
 func NewImageSearchCmd() *cobra.Command {
 
 	searchCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/keypair.go
+++ b/src/api/grpc/cbadm/cmd/keypair.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewKeypairCmd - Keypair 관리 기능을 수행하는 Cobra Command 생성
+// NewKeypairCmd : "cbadm keypair *" (for CB-Tumblebug)
 func NewKeypairCmd() *cobra.Command {
 
 	keypairCmd := &cobra.Command{
@@ -36,7 +36,7 @@ func NewKeypairCmd() *cobra.Command {
 	return keypairCmd
 }
 
-// NewKeypairCreateCmd - Keypair 생성 기능을 수행하는 Cobra Command 생성
+// NewKeypairCreateCmd : "cbadm keypair create"
 func NewKeypairCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -63,7 +63,7 @@ func NewKeypairCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewKeypairListCmd - Keypair 목록 기능을 수행하는 Cobra Command 생성
+// NewKeypairListCmd : "cbadm keypair list"
 func NewKeypairListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -87,7 +87,7 @@ func NewKeypairListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewKeypairGetCmd - Keypair 조회 기능을 수행하는 Cobra Command 생성
+// NewKeypairGetCmd : "cbadm keypair get"
 func NewKeypairGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -117,7 +117,7 @@ func NewKeypairGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewKeypairSaveCmd - Keypair 저장 기능을 수행하는 Cobra Command 생성
+// NewKeypairSaveCmd : "cbadm keypair save"
 func NewKeypairSaveCmd() *cobra.Command {
 
 	saveCmd := &cobra.Command{
@@ -153,7 +153,7 @@ func NewKeypairSaveCmd() *cobra.Command {
 	return saveCmd
 }
 
-// NewKeypairDeleteCmd - Keypair 삭제 기능을 수행하는 Cobra Command 생성
+// NewKeypairDeleteCmd : "cbadm keypair delete"
 func NewKeypairDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{
@@ -189,7 +189,7 @@ func NewKeypairDeleteCmd() *cobra.Command {
 	return deleteCmd
 }
 
-// NewKeypairDeleteAllCmd - 전체 Keypair 삭제 기능을 수행하는 Cobra Command 생성
+// NewKeypairDeleteAllCmd : "cbadm keypair delete-all"
 func NewKeypairDeleteAllCmd() *cobra.Command {
 
 	deleteAllCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/mcis.go
+++ b/src/api/grpc/cbadm/cmd/mcis.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewMcisCmd - Mcis 관리 기능을 수행하는 Cobra Command 생성
+// NewMcisCmd : "cbadm mcis *" (for CB-Tumblebug)
 func NewMcisCmd() *cobra.Command {
 
 	mcisCmd := &cobra.Command{
@@ -72,7 +72,7 @@ func NewMcisCmd() *cobra.Command {
 	return mcisCmd
 }
 
-// NewMcisCreateCmd - Mcis 생성 기능을 수행하는 Cobra Command 생성
+// NewMcisCreateCmd : "cbadm mcis create"
 func NewMcisCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -99,7 +99,7 @@ func NewMcisCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewMcisListCmd - Mcis 목록 기능을 수행하는 Cobra Command 생성
+// NewMcisListCmd : "cbadm mcis list"
 func NewMcisListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -123,7 +123,7 @@ func NewMcisListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewMcisGetCmd - Mcis 조회 기능을 수행하는 Cobra Command 생성
+// NewMcisGetCmd : "cbadm mcis get"
 func NewMcisGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -153,7 +153,7 @@ func NewMcisGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewMcisDeleteCmd - Mcis 삭제 기능을 수행하는 Cobra Command 생성
+// NewMcisDeleteCmd : "cbadm mcis delete"
 func NewMcisDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{
@@ -183,7 +183,7 @@ func NewMcisDeleteCmd() *cobra.Command {
 	return deleteCmd
 }
 
-// NewMcisDeleteAllCmd - 전체 Mcis 삭제 기능을 수행하는 Cobra Command 생성
+// NewMcisDeleteAllCmd : "cbadm mcis delete-all"
 func NewMcisDeleteAllCmd() *cobra.Command {
 
 	deleteAllCmd := &cobra.Command{
@@ -207,7 +207,7 @@ func NewMcisDeleteAllCmd() *cobra.Command {
 	return deleteAllCmd
 }
 
-// NewMcisStatusListCmd - Mcis 상태 목록 기능을 수행하는 Cobra Command 생성
+// NewMcisStatusListCmd : "cbadm mcis status-list"
 func NewMcisStatusListCmd() *cobra.Command {
 
 	statusListCmd := &cobra.Command{
@@ -231,7 +231,7 @@ func NewMcisStatusListCmd() *cobra.Command {
 	return statusListCmd
 }
 
-// NewMcisStatusCmd - Mcis 상태 조회 기능을 수행하는 Cobra Command 생성
+// NewMcisStatusCmd : "cbadm mcis status"
 func NewMcisStatusCmd() *cobra.Command {
 
 	statusCmd := &cobra.Command{
@@ -261,7 +261,7 @@ func NewMcisStatusCmd() *cobra.Command {
 	return statusCmd
 }
 
-// NewMcisSuspendCmd - Mcis Suspend 기능을 수행하는 Cobra Command 생성
+// NewMcisSuspendCmd : "cbadm mcis suspend"
 func NewMcisSuspendCmd() *cobra.Command {
 
 	suspendCmd := &cobra.Command{
@@ -291,7 +291,7 @@ func NewMcisSuspendCmd() *cobra.Command {
 	return suspendCmd
 }
 
-// NewMcisResumeCmd - Mcis Resume 기능을 수행하는 Cobra Command 생성
+// NewMcisResumeCmd : "cbadm mcis resume"
 func NewMcisResumeCmd() *cobra.Command {
 
 	resumeCmd := &cobra.Command{
@@ -321,7 +321,7 @@ func NewMcisResumeCmd() *cobra.Command {
 	return resumeCmd
 }
 
-// NewMcisRebootCmd - Mcis Reboot 기능을 수행하는 Cobra Command 생성
+// NewMcisRebootCmd : "cbadm mcis reboot"
 func NewMcisRebootCmd() *cobra.Command {
 
 	rebootCmd := &cobra.Command{
@@ -351,7 +351,7 @@ func NewMcisRebootCmd() *cobra.Command {
 	return rebootCmd
 }
 
-// NewMcisTerminateCmd - Mcis Terminate 기능을 수행하는 Cobra Command 생성
+// NewMcisTerminateCmd : "cbadm mcis terminate"
 func NewMcisTerminateCmd() *cobra.Command {
 
 	terminateCmd := &cobra.Command{
@@ -381,7 +381,7 @@ func NewMcisTerminateCmd() *cobra.Command {
 	return terminateCmd
 }
 
-// NewMcisVmAddCmd - Mcis VM 생성 기능을 수행하는 Cobra Command 생성
+// NewMcisVmAddCmd : "cbadm mcis add-vm"
 func NewMcisVmAddCmd() *cobra.Command {
 
 	vmAddCmd := &cobra.Command{
@@ -408,7 +408,7 @@ func NewMcisVmAddCmd() *cobra.Command {
 	return vmAddCmd
 }
 
-// NewMcisVmGroupCmd - Mcis VM 그룹 생성 기능을 수행하는 Cobra Command 생성
+// NewMcisVmGroupCmd : "cbadm mcis group-vm"
 func NewMcisVmGroupCmd() *cobra.Command {
 
 	vmGroupCmd := &cobra.Command{
@@ -435,7 +435,7 @@ func NewMcisVmGroupCmd() *cobra.Command {
 	return vmGroupCmd
 }
 
-// NewMcisVmListCmd - Mcis VM 목록 기능을 수행하는 Cobra Command 생성
+// NewMcisVmListCmd : "cbadm mcis list-vm"
 func NewMcisVmListCmd() *cobra.Command {
 
 	vmListCmd := &cobra.Command{
@@ -465,7 +465,7 @@ func NewMcisVmListCmd() *cobra.Command {
 	return vmListCmd
 }
 
-// NewMcisVmGetCmd - Mcis VM 조회 기능을 수행하는 Cobra Command 생성
+// NewMcisVmGetCmd : "cbadm mcis get-vm"
 func NewMcisVmGetCmd() *cobra.Command {
 
 	vmGetCmd := &cobra.Command{
@@ -501,7 +501,7 @@ func NewMcisVmGetCmd() *cobra.Command {
 	return vmGetCmd
 }
 
-// NewMcisVmDeleteCmd - Mcis VM 삭제 기능을 수행하는 Cobra Command 생성
+// NewMcisVmDeleteCmd : "cbadm mcis del-vm"
 func NewMcisVmDeleteCmd() *cobra.Command {
 
 	vmDeleteCmd := &cobra.Command{
@@ -537,7 +537,7 @@ func NewMcisVmDeleteCmd() *cobra.Command {
 	return vmDeleteCmd
 }
 
-// NewMcisVmStatusCmd - Mcis VM 상태 조회 기능을 수행하는 Cobra Command 생성
+// NewMcisVmStatusCmd : "cbadm mcis status-vm"
 func NewMcisVmStatusCmd() *cobra.Command {
 
 	vmStatusCmd := &cobra.Command{
@@ -573,7 +573,7 @@ func NewMcisVmStatusCmd() *cobra.Command {
 	return vmStatusCmd
 }
 
-// NewMcisVmSuspendCmd - Mcis VM Suspend 기능을 수행하는 Cobra Command 생성
+// NewMcisVmSuspendCmd : "cbadm mcis suspend-vm"
 func NewMcisVmSuspendCmd() *cobra.Command {
 
 	vmSuspendCmd := &cobra.Command{
@@ -609,7 +609,7 @@ func NewMcisVmSuspendCmd() *cobra.Command {
 	return vmSuspendCmd
 }
 
-// NewMcisVmResumeCmd - Mcis VM Resume 기능을 수행하는 Cobra Command 생성
+// NewMcisVmResumeCmd : "cbadm mcis resume-vm"
 func NewMcisVmResumeCmd() *cobra.Command {
 
 	vmResumeCmd := &cobra.Command{
@@ -645,7 +645,7 @@ func NewMcisVmResumeCmd() *cobra.Command {
 	return vmResumeCmd
 }
 
-// NewMcisVmRebootCmd - Mcis VM Reboot 기능을 수행하는 Cobra Command 생성
+// NewMcisVmRebootCmd : "cbadm mcis reboot-vm"
 func NewMcisVmRebootCmd() *cobra.Command {
 
 	vmRebootCmd := &cobra.Command{
@@ -681,7 +681,7 @@ func NewMcisVmRebootCmd() *cobra.Command {
 	return vmRebootCmd
 }
 
-// NewMcisVmTerminateCmd - Mcis VM Terminate 기능을 수행하는 Cobra Command 생성
+// NewMcisVmTerminateCmd : "cbadm mcis terminate-vm"
 func NewMcisVmTerminateCmd() *cobra.Command {
 
 	vmTerminateCmd := &cobra.Command{
@@ -717,7 +717,7 @@ func NewMcisVmTerminateCmd() *cobra.Command {
 	return vmTerminateCmd
 }
 
-// NewMcisRecommendCmd - Mcis 추천 기능을 수행하는 Cobra Command 생성
+// NewMcisRecommendCmd : "cbadm mcis recommend"
 func NewMcisRecommendCmd() *cobra.Command {
 
 	recommendCmd := &cobra.Command{
@@ -744,7 +744,7 @@ func NewMcisRecommendCmd() *cobra.Command {
 	return recommendCmd
 }
 
-// NewMcisRecommendVmCmd - Mcis VM 추천 기능을 수행하는 Cobra Command 생성
+// NewMcisRecommendVmCmd : "cbadm mcis recommend-vm"
 func NewMcisRecommendVmCmd() *cobra.Command {
 
 	recommendVmCmd := &cobra.Command{
@@ -771,7 +771,7 @@ func NewMcisRecommendVmCmd() *cobra.Command {
 	return recommendVmCmd
 }
 
-// NewCmdMcisCmd - MCIS 명령 실행 기능을 수행하는 Cobra Command 생성
+// NewCmdMcisCmd : "cbadm mcis command"
 func NewCmdMcisCmd() *cobra.Command {
 
 	mcisCmdCmd := &cobra.Command{
@@ -798,7 +798,7 @@ func NewCmdMcisCmd() *cobra.Command {
 	return mcisCmdCmd
 }
 
-// NewCmdMcisVmCmd - MCIS VM 명령 실행 기능을 수행하는 Cobra Command 생성
+// NewCmdMcisVmCmd : "cbadm mcis command-vm"
 func NewCmdMcisVmCmd() *cobra.Command {
 
 	vmCmdCmd := &cobra.Command{
@@ -825,7 +825,7 @@ func NewCmdMcisVmCmd() *cobra.Command {
 	return vmCmdCmd
 }
 
-// NewDeployMilkywayCmd - MCIS Agent 설치 기능을 수행하는 Cobra Command 생성
+// NewDeployMilkywayCmd : "cbadm mcis deploy-milkyway"
 func NewDeployMilkywayCmd() *cobra.Command {
 
 	deployMilkywayCmd := &cobra.Command{
@@ -852,7 +852,7 @@ func NewDeployMilkywayCmd() *cobra.Command {
 	return deployMilkywayCmd
 }
 
-// NewAccessVmCmd - MCIS VM 에 SSH 접속 기능을 수행하는 Cobra Command 생성
+// NewAccessVmCmd : "cbadm mcis access-vm"
 func NewAccessVmCmd() *cobra.Command {
 
 	accessVmCmd := &cobra.Command{
@@ -867,7 +867,7 @@ func NewAccessVmCmd() *cobra.Command {
 	return accessVmCmd
 }
 
-// NewBenchmarkCmd - MCIS VM 에 벤치마크 기능을 수행하는 Cobra Command 생성
+// NewBenchmarkCmd : "cbadm mcis benchmark"
 func NewBenchmarkCmd() *cobra.Command {
 
 	benchmarkCmd := &cobra.Command{
@@ -901,7 +901,7 @@ func NewBenchmarkCmd() *cobra.Command {
 	return benchmarkCmd
 }
 
-// NewInstallMonAgentCmd - MCIS Monitor Agent 설치 기능을 수행하는 Cobra Command 생성
+// NewInstallMonAgentCmd : "cbadm mcis install-mon"
 func NewInstallMonAgentCmd() *cobra.Command {
 
 	installMonCmd := &cobra.Command{
@@ -928,7 +928,7 @@ func NewInstallMonAgentCmd() *cobra.Command {
 	return installMonCmd
 }
 
-// NewGetMonDataCmd - MCIS Monitor 정보 조회 기능을 수행하는 Cobra Command 생성
+// NewGetMonDataCmd : "cbadm mcis get-mon"
 func NewGetMonDataCmd() *cobra.Command {
 
 	getMonCmd := &cobra.Command{
@@ -964,7 +964,7 @@ func NewGetMonDataCmd() *cobra.Command {
 	return getMonCmd
 }
 
-// NewMcisCreatePolicyCmd - Mcis Policy 생성 기능을 수행하는 Cobra Command 생성
+// NewMcisCreatePolicyCmd : "cbadm mcis create-policy"
 func NewMcisCreatePolicyCmd() *cobra.Command {
 
 	createPolicyCmd := &cobra.Command{
@@ -991,7 +991,7 @@ func NewMcisCreatePolicyCmd() *cobra.Command {
 	return createPolicyCmd
 }
 
-// NewMcisListPolicyCmd - Mcis Policy 목록 기능을 수행하는 Cobra Command 생성
+// NewMcisListPolicyCmd : "cbadm mcis list-policy"
 func NewMcisListPolicyCmd() *cobra.Command {
 
 	listPolicyCmd := &cobra.Command{
@@ -1016,7 +1016,7 @@ func NewMcisListPolicyCmd() *cobra.Command {
 	return listPolicyCmd
 }
 
-// NewMcisGetPolicyCmd - Mcis Policy 조회 기능을 수행하는 Cobra Command 생성
+// NewMcisGetPolicyCmd : "cbadm mcis get-policy"
 func NewMcisGetPolicyCmd() *cobra.Command {
 
 	getPolicyCmd := &cobra.Command{
@@ -1046,7 +1046,7 @@ func NewMcisGetPolicyCmd() *cobra.Command {
 	return getPolicyCmd
 }
 
-// NewMcisDeletePolicyCmd - Mcis Policy 삭제 기능을 수행하는 Cobra Command 생성
+// NewMcisDeletePolicyCmd : "cbadm mcis delete-policy"
 func NewMcisDeletePolicyCmd() *cobra.Command {
 
 	deletePolicyCmd := &cobra.Command{
@@ -1076,7 +1076,7 @@ func NewMcisDeletePolicyCmd() *cobra.Command {
 	return deletePolicyCmd
 }
 
-// NewMcisDeleteAllPolicyCmd - 전체 Mcis Policy 삭제 기능을 수행하는 Cobra Command 생성
+// NewMcisDeleteAllPolicyCmd : "cbadm mcis delete-all-policy"
 func NewMcisDeleteAllPolicyCmd() *cobra.Command {
 
 	deleteAllPolicyCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/namespace.go
+++ b/src/api/grpc/cbadm/cmd/namespace.go
@@ -16,13 +16,14 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewNameSpaceCmd - Namespace 관리 기능을 수행하는 Cobra Command 생성
+// NewNameSpaceCmd : "cbadm namespace *" (for CB-Tumblebug)
 func NewNameSpaceCmd() *cobra.Command {
 
 	nameSpaceCmd := &cobra.Command{
-		Use:   "namespace",
-		Short: "This is a manageable command for namespace",
-		Long:  "This is a manageable command for namespace",
+		Use:     "namespace",
+		Aliases: []string{"ns"},
+		Short:   "This is a manageable command for namespace",
+		Long:    "This is a manageable command for namespace",
 	}
 
 	//  Adds the commands for application.
@@ -36,7 +37,7 @@ func NewNameSpaceCmd() *cobra.Command {
 	return nameSpaceCmd
 }
 
-// NewNameSpaceCreateCmd - Namespace 생성 기능을 수행하는 Cobra Command 생성
+// NewNameSpaceCreateCmd : "cbadm namespace create"
 func NewNameSpaceCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -63,7 +64,7 @@ func NewNameSpaceCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewNameSpaceListCmd - Namespace 목록 기능을 수행하는 Cobra Command 생성
+// NewNameSpaceListCmd : "cbadm namespace list"
 func NewNameSpaceListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -78,7 +79,7 @@ func NewNameSpaceListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewNameSpaceGetCmd - Namespace 조회 기능을 수행하는 Cobra Command 생성
+// NewNameSpaceGetCmd : "cbadm namespace get"
 func NewNameSpaceGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -102,7 +103,7 @@ func NewNameSpaceGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewNameSpaceDeleteCmd - Namespace 삭제 기능을 수행하는 Cobra Command 생성
+// NewNameSpaceDeleteCmd : "cbadm namespace delete"
 func NewNameSpaceDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{
@@ -126,7 +127,7 @@ func NewNameSpaceDeleteCmd() *cobra.Command {
 	return deleteCmd
 }
 
-// NewNameSpaceDeleteAllCmd - 전체 Namespace 삭제 기능을 수행하는 Cobra Command 생성
+// NewNameSpaceDeleteAllCmd : "cbadm namespace delete-all"
 func NewNameSpaceDeleteAllCmd() *cobra.Command {
 
 	deleteAllCmd := &cobra.Command{
@@ -141,7 +142,7 @@ func NewNameSpaceDeleteAllCmd() *cobra.Command {
 	return deleteAllCmd
 }
 
-// NewNameSpaceCheckCmd - Namespace 체크 기능을 수행하는 Cobra Command 생성
+// NewNameSpaceCheckCmd : "cbadm namespace check"
 func NewNameSpaceCheckCmd() *cobra.Command {
 
 	checkCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/network.go
+++ b/src/api/grpc/cbadm/cmd/network.go
@@ -16,13 +16,14 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewNetworkCmd - VNet 관리 기능을 수행하는 Cobra Command 생성
+// NewNetworkCmd : "cbadm network *" (for CB-Tumblebug)
 func NewNetworkCmd() *cobra.Command {
 
 	networkCmd := &cobra.Command{
-		Use:   "network",
-		Short: "This is a manageable command for network",
-		Long:  "This is a manageable command for network",
+		Use:     "network",
+		Short:   "This is a manageable command for network",
+		Long:    "This is a manageable command for network",
+		Aliases: []string{"vnet", "net", "vpc"},
 	}
 
 	//  Adds the commands for application.
@@ -35,7 +36,7 @@ func NewNetworkCmd() *cobra.Command {
 	return networkCmd
 }
 
-// NewNetworkCreateCmd - VNet 생성 기능을 수행하는 Cobra Command 생성
+// NewNetworkCreateCmd : "cbadm network create"
 func NewNetworkCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -62,7 +63,7 @@ func NewNetworkCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewNetworkListCmd - VNet 목록 기능을 수행하는 Cobra Command 생성
+// NewNetworkListCmd : "cbadm network list"
 func NewNetworkListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -86,7 +87,7 @@ func NewNetworkListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewNetworkGetCmd - VNet 조회 기능을 수행하는 Cobra Command 생성
+// NewNetworkGetCmd : "cbadm network get"
 func NewNetworkGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -116,7 +117,7 @@ func NewNetworkGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewNetworkDeleteCmd - VNet 삭제 기능을 수행하는 Cobra Command 생성
+// NewNetworkDeleteCmd : "cbadm network delete"
 func NewNetworkDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{
@@ -152,7 +153,7 @@ func NewNetworkDeleteCmd() *cobra.Command {
 	return deleteCmd
 }
 
-// NewNetworkDeleteAllCmd - 전체 VNet 삭제 기능을 수행하는 Cobra Command 생성
+// NewNetworkDeleteAllCmd : "cbadm network delete-all"
 func NewNetworkDeleteAllCmd() *cobra.Command {
 
 	deleteAllCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/region.go
+++ b/src/api/grpc/cbadm/cmd/region.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewRegionCmd - Region 관리 기능을 수행하는 Cobra Command 생성
+// NewRegionCmd : "cbadm region *" (for CB-Spider)
 func NewRegionCmd() *cobra.Command {
 
 	regionCmd := &cobra.Command{
@@ -34,7 +34,7 @@ func NewRegionCmd() *cobra.Command {
 	return regionCmd
 }
 
-// NewRegionCreateCmd - Region 생성 기능을 수행하는 Cobra Command 생성
+// NewRegionCreateCmd : "cbadm region create"
 func NewRegionCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -61,7 +61,7 @@ func NewRegionCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewRegionListCmd - Region 목록 기능을 수행하는 Cobra Command 생성
+// NewRegionListCmd : "cbadm region list"
 func NewRegionListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -76,7 +76,7 @@ func NewRegionListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewRegionGetCmd - Region 조회 기능을 수행하는 Cobra Command 생성
+// NewRegionGetCmd : "cbadm region get"
 func NewRegionGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -100,7 +100,7 @@ func NewRegionGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewRegionDeleteCmd - Region 삭제 기능을 수행하는 Cobra Command 생성
+// NewRegionDeleteCmd : "cbadm region delete"
 func NewRegionDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/root.go
+++ b/src/api/grpc/cbadm/cmd/root.go
@@ -9,7 +9,7 @@ import (
 // ===== [ Constants and Variables ] =====
 
 const (
-	// CLIVersion - cbadm cli 버전
+	// CLIVersion : version of cbadm cli
 	CLIVersion = "1.0"
 )
 
@@ -57,7 +57,7 @@ var (
 
 // ===== [ Public Functions ] =====
 
-// NewRootCmd - 어플리케이션 진입점으로 사용할 Root Cobra Command 생성
+// NewRootCmd : Create Root Cobra Command
 func NewRootCmd() *cobra.Command {
 
 	rootCmd := &cobra.Command{
@@ -66,15 +66,15 @@ func NewRootCmd() *cobra.Command {
 		Long:  "This is a lightweight grpc cli tool for Cloud-Barista",
 	}
 
-	// 옵션 플래그 설정
+	// Option flags
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "./grpc_conf.yaml", "config file")
 	rootCmd.PersistentFlags().StringVarP(&inType, "input", "i", "yaml", "input format (json/yaml)")
 	rootCmd.PersistentFlags().StringVarP(&outType, "output", "o", "yaml", "output format (json/yaml)")
 
-	// Viper 를 사용하는 설정 파서 생성
+	// Make new config parser (which uses Viper)
 	parser = config.MakeParser()
 
-	//  Adds the commands for application.
+	//  Add subcommands for application.
 	rootCmd.AddCommand(NewVersionCmd())
 
 	rootCmd.AddCommand(NewDriverCmd())

--- a/src/api/grpc/cbadm/cmd/securitygroup.go
+++ b/src/api/grpc/cbadm/cmd/securitygroup.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewSecurityCmd - Security Group 관리 기능을 수행하는 Cobra Command 생성
+// NewSecurityCmd : "cbadm securitygroup *" (for CB-Tumblebug)
 func NewSecurityCmd() *cobra.Command {
 
 	securityCmd := &cobra.Command{
@@ -36,7 +36,7 @@ func NewSecurityCmd() *cobra.Command {
 	return securityCmd
 }
 
-// NewSecurityCreateCmd - Security Group 생성 기능을 수행하는 Cobra Command 생성
+// NewSecurityCreateCmd : "cbadm securitygroup create"
 func NewSecurityCreateCmd() *cobra.Command {
 
 	createCmd := &cobra.Command{
@@ -63,7 +63,7 @@ func NewSecurityCreateCmd() *cobra.Command {
 	return createCmd
 }
 
-// NewSecurityListCmd - Security Group 목록 기능을 수행하는 Cobra Command 생성
+// NewSecurityListCmd : "cbadm securitygroup list"
 func NewSecurityListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -87,7 +87,7 @@ func NewSecurityListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewSecurityGetCmd - Security Group 조회 기능을 수행하는 Cobra Command 생성
+// NewSecurityGetCmd : "cbadm securitygroup get"
 func NewSecurityGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -117,7 +117,7 @@ func NewSecurityGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewSecurityDeleteCmd - Security Group 삭제 기능을 수행하는 Cobra Command 생성
+// NewSecurityDeleteCmd : "cbadm securitygroup delete"
 func NewSecurityDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{
@@ -153,7 +153,7 @@ func NewSecurityDeleteCmd() *cobra.Command {
 	return deleteCmd
 }
 
-// NewSecurityDeleteAllCmd - 전체 Security Group 삭제 기능을 수행하는 Cobra Command 생성
+// NewSecurityDeleteAllCmd : "cbadm securitygroup delete-all"
 func NewSecurityDeleteAllCmd() *cobra.Command {
 
 	deleteAllCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/spec.go
+++ b/src/api/grpc/cbadm/cmd/spec.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewSpecCmd - Spec 관리 기능을 수행하는 Cobra Command 생성
+// NewSpecCmd : "cbadm spec *" (for CB-Tumblebug)
 func NewSpecCmd() *cobra.Command {
 
 	specCmd := &cobra.Command{
@@ -43,7 +43,7 @@ func NewSpecCmd() *cobra.Command {
 	return specCmd
 }
 
-// NewSpecWithInfoCreateCmd - Spec 생성 기능을 수행하는 Cobra Command 생성
+// NewSpecWithInfoCreateCmd : "cbadm spec create"
 func NewSpecWithInfoCreateCmd() *cobra.Command {
 
 	createWithInfoCmd := &cobra.Command{
@@ -70,7 +70,7 @@ func NewSpecWithInfoCreateCmd() *cobra.Command {
 	return createWithInfoCmd
 }
 
-// NewSpecWithIdCreateCmd - Spec 생성 기능을 수행하는 Cobra Command 생성
+// NewSpecWithIdCreateCmd : "cbadm spec create-id"
 func NewSpecWithIdCreateCmd() *cobra.Command {
 
 	createWithIdCmd := &cobra.Command{
@@ -97,7 +97,7 @@ func NewSpecWithIdCreateCmd() *cobra.Command {
 	return createWithIdCmd
 }
 
-// NewSpecListCmd - Spec 목록 기능을 수행하는 Cobra Command 생성
+// NewSpecListCmd : "cbadm spec list"
 func NewSpecListCmd() *cobra.Command {
 
 	listCmd := &cobra.Command{
@@ -121,7 +121,7 @@ func NewSpecListCmd() *cobra.Command {
 	return listCmd
 }
 
-// NewSpecListCspCmd - CSP Spec 목록 기능을 수행하는 Cobra Command 생성
+// NewSpecListCspCmd : "cbadm spec list-csp"
 func NewSpecListCspCmd() *cobra.Command {
 
 	listCspCmd := &cobra.Command{
@@ -145,7 +145,7 @@ func NewSpecListCspCmd() *cobra.Command {
 	return listCspCmd
 }
 
-// NewSpecGetCmd - Spec 조회 기능을 수행하는 Cobra Command 생성
+// NewSpecGetCmd : "cbadm spec get"
 func NewSpecGetCmd() *cobra.Command {
 
 	getCmd := &cobra.Command{
@@ -175,7 +175,7 @@ func NewSpecGetCmd() *cobra.Command {
 	return getCmd
 }
 
-// NewSpecGetCspCmd - CSP Spec 조회 기능을 수행하는 Cobra Command 생성
+// NewSpecGetCspCmd : "cbadm spec get-csp"
 func NewSpecGetCspCmd() *cobra.Command {
 
 	getCspCmd := &cobra.Command{
@@ -205,7 +205,7 @@ func NewSpecGetCspCmd() *cobra.Command {
 	return getCspCmd
 }
 
-// NewSpecDeleteCmd - Spec 삭제 기능을 수행하는 Cobra Command 생성
+// NewSpecDeleteCmd : "cbadm spec delete"
 func NewSpecDeleteCmd() *cobra.Command {
 
 	deleteCmd := &cobra.Command{
@@ -241,7 +241,7 @@ func NewSpecDeleteCmd() *cobra.Command {
 	return deleteCmd
 }
 
-// NewSpecDeleteAllCmd - 전체 Spec 삭제 기능을 수행하는 Cobra Command 생성
+// NewSpecDeleteAllCmd : "cbadm spec delete-all"
 func NewSpecDeleteAllCmd() *cobra.Command {
 
 	deleteAllCmd := &cobra.Command{
@@ -271,7 +271,7 @@ func NewSpecDeleteAllCmd() *cobra.Command {
 	return deleteAllCmd
 }
 
-// NewSpecFetchCmd - Spec Fetch 기능을 수행하는 Cobra Command 생성
+// NewSpecFetchCmd : "cbadm spec fetch"
 func NewSpecFetchCmd() *cobra.Command {
 
 	fetchCmd := &cobra.Command{
@@ -301,7 +301,7 @@ func NewSpecFetchCmd() *cobra.Command {
 	return fetchCmd
 }
 
-// NewSpecFilterCmd
+// NewSpecFilterCmd : "cbadm spec filter"
 func NewSpecFilterCmd() *cobra.Command {
 
 	filterCmd := &cobra.Command{
@@ -336,7 +336,7 @@ func NewSpecFilterCmd() *cobra.Command {
 	return filterCmd
 }
 
-// NewSpecFilterByRangeCmd
+// NewSpecFilterByRangeCmd : "cbadm spec filter-by-range"
 func NewSpecFilterByRangeCmd() *cobra.Command {
 
 	filterByRangeCmd := &cobra.Command{
@@ -371,7 +371,7 @@ func NewSpecFilterByRangeCmd() *cobra.Command {
 	return filterByRangeCmd
 }
 
-// NewSpecSortCmd
+// NewSpecSortCmd : "cbadm spec sort"
 func NewSpecSortCmd() *cobra.Command {
 
 	sortCmd := &cobra.Command{
@@ -406,7 +406,7 @@ func NewSpecSortCmd() *cobra.Command {
 	return sortCmd
 }
 
-// NewSpecUpdateCmd
+// NewSpecUpdateCmd : "cbadm spec update"
 func NewSpecUpdateCmd() *cobra.Command {
 
 	updateCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/tbutil.go
+++ b/src/api/grpc/cbadm/cmd/tbutil.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewUtilCmd - Tumblebug Util 관리 기능을 수행하는 Cobra Command 생성
+// NewUtilCmd : "cbadm util *" (for CB-Tumblebug)
 func NewUtilCmd() *cobra.Command {
 
 	utilCmd := &cobra.Command{
@@ -43,7 +43,7 @@ func NewUtilCmd() *cobra.Command {
 	return utilCmd
 }
 
-// NewConnConfigListCmd - Connection Config 목록 기능을 수행하는 Cobra Command 생성
+// NewConnConfigListCmd : "cbadm util list-cc"
 func NewConnConfigListCmd() *cobra.Command {
 
 	listCCCmd := &cobra.Command{
@@ -58,7 +58,7 @@ func NewConnConfigListCmd() *cobra.Command {
 	return listCCCmd
 }
 
-// NewConnConfigGetCmd -  Connection Config 조회 기능을 수행하는 Cobra Command 생성
+// NewConnConfigGetCmd : "cbadm util get-cc"
 func NewConnConfigGetCmd() *cobra.Command {
 
 	getCCCmd := &cobra.Command{
@@ -82,7 +82,7 @@ func NewConnConfigGetCmd() *cobra.Command {
 	return getCCCmd
 }
 
-// NewRegionSpiderListCmd - Region 목록 기능을 수행하는 Cobra Command 생성
+// NewRegionSpiderListCmd : "cbadm util list-region"
 func NewRegionSpiderListCmd() *cobra.Command {
 
 	listRegionCmd := &cobra.Command{
@@ -97,7 +97,7 @@ func NewRegionSpiderListCmd() *cobra.Command {
 	return listRegionCmd
 }
 
-// NewRegionSpiderGetCmd - Region 조회 기능을 수행하는 Cobra Command 생성
+// NewRegionSpiderGetCmd : "cbadm util get-region"
 func NewRegionSpiderGetCmd() *cobra.Command {
 
 	getRegionCmd := &cobra.Command{
@@ -121,7 +121,7 @@ func NewRegionSpiderGetCmd() *cobra.Command {
 	return getRegionCmd
 }
 
-// NewMcirResourcesInspectCmd - MCIR 리소스 점검 기능을 수행하는 Cobra Command 생성
+// NewMcirResourcesInspectCmd : "cbadm util inspect-mcir"
 func NewMcirResourcesInspectCmd() *cobra.Command {
 
 	inspectMcirCmd := &cobra.Command{
@@ -151,7 +151,7 @@ func NewMcirResourcesInspectCmd() *cobra.Command {
 	return inspectMcirCmd
 }
 
-// NewVmResourcesInspectCmd - VM 리소스 점검 기능을 수행하는 Cobra Command 생성
+// NewVmResourcesInspectCmd : "cbadm util inspect-vm"
 func NewVmResourcesInspectCmd() *cobra.Command {
 
 	inspectVmCmd := &cobra.Command{
@@ -175,7 +175,7 @@ func NewVmResourcesInspectCmd() *cobra.Command {
 	return inspectVmCmd
 }
 
-// NewObjectListCmd - 객체 목록 기능을 수행하는 Cobra Command 생성
+// NewObjectListCmd : "cbadm util list-obj"
 func NewObjectListCmd() *cobra.Command {
 
 	listObjCmd := &cobra.Command{
@@ -199,7 +199,7 @@ func NewObjectListCmd() *cobra.Command {
 	return listObjCmd
 }
 
-// NewObjectGetCmd - 객체 조회 기능을 수행하는 Cobra Command 생성
+// NewObjectGetCmd : "cbadm util get-obj"
 func NewObjectGetCmd() *cobra.Command {
 
 	getObjCmd := &cobra.Command{
@@ -223,7 +223,7 @@ func NewObjectGetCmd() *cobra.Command {
 	return getObjCmd
 }
 
-// NewObjectDeleteCmd - 객체 삭제 기능을 수행하는 Cobra Command 생성
+// NewObjectDeleteCmd : "cbadm util delete-obj"
 func NewObjectDeleteCmd() *cobra.Command {
 
 	deleteObjCmd := &cobra.Command{
@@ -247,7 +247,7 @@ func NewObjectDeleteCmd() *cobra.Command {
 	return deleteObjCmd
 }
 
-// NewObjectDeleteAllCmd - 객체 전체 삭제 기능을 수행하는 Cobra Command 생성
+// NewObjectDeleteAllCmd : "cbadm util delete-all-obj"
 func NewObjectDeleteAllCmd() *cobra.Command {
 
 	deleteAllObjCmd := &cobra.Command{

--- a/src/api/grpc/cbadm/cmd/version.go
+++ b/src/api/grpc/cbadm/cmd/version.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewVersionCmd - 버전 표시 기능을 수행하는 Cobra Command 생성
+// NewVersionCmd : "cbadm version"
 func NewVersionCmd() *cobra.Command {
 
 	versionCmd := &cobra.Command{
@@ -24,7 +24,7 @@ func NewVersionCmd() *cobra.Command {
 		Short: "This is a version command for cbadm",
 		Long:  "This is a version command for cbadm",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("CBADM CLI VERSION %s\n", CLIVersion)
+			fmt.Printf("cbadm cli version %s\n", CLIVersion)
 		},
 	}
 

--- a/src/api/grpc/cbadm/cmd/yamlproc.go
+++ b/src/api/grpc/cbadm/cmd/yamlproc.go
@@ -14,7 +14,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// NewYamlApplyCmd - YAML 파일에 있는 항목을 생성하는 기능을 수행하는 Cobra Command 생성
+// NewYamlApplyCmd : "cbadm apply" (create/update objects according to YAML description)
 func NewYamlApplyCmd() *cobra.Command {
 
 	yamlApplyCmd := &cobra.Command{
@@ -29,7 +29,7 @@ func NewYamlApplyCmd() *cobra.Command {
 	return yamlApplyCmd
 }
 
-// NewYamlGetCmd - YAML 파일에 있는 항목을 조회하는 기능을 수행하는 Cobra Command 생성
+// NewYamlGetCmd : "cbadm get" (get objects according to YAML description)
 func NewYamlGetCmd() *cobra.Command {
 
 	yamlGetCmd := &cobra.Command{
@@ -44,7 +44,7 @@ func NewYamlGetCmd() *cobra.Command {
 	return yamlGetCmd
 }
 
-// NewYamlListCmd - YAML 파일에 있는 항목의 목록 조회하는 기능을 수행하는 Cobra Command 생성
+// NewYamlListCmd : "cbadm list" (list objects according to YAML description)
 func NewYamlListCmd() *cobra.Command {
 
 	yamlListCmd := &cobra.Command{
@@ -59,13 +59,14 @@ func NewYamlListCmd() *cobra.Command {
 	return yamlListCmd
 }
 
-// NewYamlRemoveCmd - YAML 파일에 있는 항목을 삭제하는 기능을 수행하는 Cobra Command 생성
+// NewYamlRemoveCmd : "cbadm remove" (remove objects according to YAML description)
 func NewYamlRemoveCmd() *cobra.Command {
 
 	yamlRemoveCmd := &cobra.Command{
-		Use:   "remove",
-		Short: "This is a remove command for yaml",
-		Long:  "This is a remove command for yaml",
+		Use:     "remove",
+		Aliases: []string{"rm", "delete"},
+		Short:   "This is a remove command for yaml",
+		Long:    "This is a remove command for yaml",
 		Run: func(cmd *cobra.Command, args []string) {
 			SetupAndRun(cmd, args)
 		},

--- a/src/api/grpc/cbadm/proc/connectinfos.go
+++ b/src/api/grpc/cbadm/proc/connectinfos.go
@@ -11,19 +11,19 @@ import (
 // ===== [ Constants and Variables ] =====
 
 const (
-	// ConfigVersion - 설정 구조에 대한 버전
+	// ConfigVersion - version of config structs
 	ConfigVersion = 1
 )
 
 // ===== [ Types ] =====
 
-// ConnectInfosConfig - 연결 정보 목록 구조 정의
+// ConnectInfosConfig
 type ConnectInfosConfig struct {
 	Version         int           `yaml:"Version" json:"Version"`
 	ConnectInfoList []ConnectInfo `yaml:"ConnectInfos" json:"ConnectInfos"`
 }
 
-// ConnectInfo - 연결 정보 구조 정의
+// ConnectInfo
 type ConnectInfo struct {
 	ConfigName   string         `yaml:"ConfigName" json:"ConfigName"`
 	ProviderName string         `yaml:"ProviderName" json:"ProviderName"`
@@ -32,25 +32,25 @@ type ConnectInfo struct {
 	Region       RegionInfo     `yaml:"Region" json:"Region"`
 }
 
-// DriverInfo - Driver 정보 구조 정의
+// DriverInfo
 type DriverInfo struct {
 	DriverName        string `yaml:"DriverName" json:"DriverName"`
 	DriverLibFileName string `yaml:"DriverLibFileName" json:"DriverLibFileName"`
 }
 
-// CredentialInfo - Credential 정보 구조 정의
+// CredentialInfo
 type CredentialInfo struct {
 	CredentialName   string         `yaml:"CredentialName" json:"CredentialName"`
 	KeyValueInfoList []KeyValueInfo `yaml:"KeyValueInfoList" json:"KeyValueInfoList"`
 }
 
-// RegionInfo - Region 정보 구조 정의
+// RegionInfo
 type RegionInfo struct {
 	RegionName       string         `yaml:"RegionName" json:"RegionName"`
 	KeyValueInfoList []KeyValueInfo `yaml:"KeyValueInfoList" json:"KeyValueInfoList"`
 }
 
-// KeyValueInfo - Key Value 정보 구조 정의
+// KeyValueInfo (Key-Value pair)
 type KeyValueInfo struct {
 	Key   string `yaml:"Key" json:"Key"`
 	Value string `yaml:"Value" json:"Value"`
@@ -62,7 +62,7 @@ type KeyValueInfo struct {
 
 // ===== [ Public Functions ] =====
 
-// ListConnectInfos - 연결정보 목록 통합 제공
+// ListConnectInfos : List Connection Infos recursively
 func ListConnectInfos(cim *sp_api.CIMApi) (string, error) {
 
 	holdType, _ := cim.GetOutType()
@@ -149,7 +149,7 @@ func ListConnectInfos(cim *sp_api.CIMApi) (string, error) {
 	return gc.ConvertToOutput(holdType, &cfg)
 }
 
-// GetConnectInfos - 연결정보 통합 제공
+// GetConnectInfos : Get Connection Info recursively
 func GetConnectInfos(cim *sp_api.CIMApi, configName string) (string, error) {
 
 	holdType, _ := cim.GetOutType()

--- a/src/api/grpc/cbadm/proc/keypair.go
+++ b/src/api/grpc/cbadm/proc/keypair.go
@@ -16,7 +16,7 @@ import (
 
 // ===== [ Public Functions ] =====
 
-// SaveSshKey - Keypair 파일로 저장
+// SaveSshKey : Write keypair to file
 func SaveSshKey(mcir *tb_api.MCIRApi, nameSpaceID string, resourceID string, sshSaveFileName string) (string, error) {
 
 	holdType, _ := mcir.GetOutType()

--- a/src/api/grpc/cbadm/proc/mcis.go
+++ b/src/api/grpc/cbadm/proc/mcis.go
@@ -10,7 +10,7 @@ import (
 
 // ===== [ Constants and Variables ] =====
 
-// VMListInfo - VM 목록 구조 정의
+// VMListInfo
 type VMListInfo struct {
 	Id   string   `yaml:"id" json:"id"`
 	Name string   `yaml:"name" json:"name"`
@@ -23,7 +23,7 @@ type VMListInfo struct {
 
 // ===== [ Public Functions ] =====
 
-// ListMcisVM - VM 목록
+// ListMcisVM
 func ListMcisVM(mcis *tb_api.MCISApi, nameSpaceID string, mcisID string) (string, error) {
 
 	holdType, _ := mcis.GetOutType()

--- a/src/api/grpc/cbadm/testclient/scripts/8.mcis/delete-mcis.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/8.mcis/delete-mcis.sh
@@ -11,7 +11,7 @@ source $TestSetFile
 source ../conf.env
 
 echo "####################################################################"
-echo "## 8. VM: Terminate and Delete MCIS"
+echo "## 8. VM: Delete MCIS"
 echo "####################################################################"
 
 CSP=${1}
@@ -35,7 +35,7 @@ echo "${INDEX} ${REGION} ${MCISID}"
 
 
 echo ""
-echo "Terminate and Delete [MCIS: $MCISID]"
+echo "Delete [MCIS: $MCISID]"
 $CBTUMBLEBUG_ROOT/src/api/grpc/cbadm/cbadm mcis delete --config $CBTUMBLEBUG_ROOT/src/api/grpc/cbadm/grpc_conf.yaml -o json --ns $NSID --mcis ${MCISID} | jq ''
 
 #}

--- a/src/api/rest/server/common/namespace.go
+++ b/src/api/rest/server/common/namespace.go
@@ -121,7 +121,7 @@ func RestDelNs(c echo.Context) error {
 		return SendMessage(c, http.StatusBadRequest, err.Error())
 	}
 
-	return SendMessage(c, http.StatusOK, "The ns has been deleted")
+	return SendMessage(c, http.StatusOK, "The ns "+c.Param("nsId")+" has been deleted")
 }
 
 // Response structure for RestGetAllNs

--- a/src/testclient/scripts/8.mcis/delete-mcis.sh
+++ b/src/testclient/scripts/8.mcis/delete-mcis.sh
@@ -11,7 +11,7 @@ source $TestSetFile
 source ../conf.env
 
 echo "####################################################################"
-echo "## 8. VM: Terminate and Delete MCIS"
+echo "## 8. VM: Delete MCIS"
 echo "####################################################################"
 
 CSP=${1}
@@ -36,7 +36,7 @@ echo "${INDEX} ${REGION} ${MCISID}"
 
 
 echo ""
-echo "Terminate and Delete [MCIS: $MCISID]"
+echo "Delete [MCIS: $MCISID]"
 curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?option=${OPTION} | jq ''
 
 #}


### PR DESCRIPTION
- Englishfy Korean comments in cbadm codes (Related issue: #566)
- Update messages in `delete-mcis.sh` (Related issue: #586)
- Update return message in `RestDelNs`

```diff
-"The ns has been deleted"
+"The ns "+c.Param("nsId")+" has been deleted"
```