### PR TITLE
Relieve MCIS delete condition

### DIFF
--- a/conf/log_conf.yaml
+++ b/conf/log_conf.yaml
@@ -5,7 +5,7 @@ cblog:
   loopcheck: true # This temp method for development is busy wait. cf) cblogger.go:levelSetupLoop().
 
   ## debug | info | warn | error
-  loglevel: info # If loopcheck is true, You can set this online.
+  loglevel: error # If loopcheck is true, You can set this online.
 
   ## true | false
   logfile: true 

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -3990,6 +3990,9 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 	if temp.Status == StatusFailed {
 		statusResponseTmp.Status = StatusFailed
 	}
+	if temp.Status == StatusTerminated {
+		statusResponseTmp.Status = StatusTerminated
+	}
 
 	vmStatusTmp.Status = statusResponseTmp.Status
 	/*

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -1196,8 +1196,8 @@ func DelMcis(nsId string, mcisId string, option string) error {
 		}
 	}
 	// Check MCIS status is Terminated (not Partial)
-	if !(!strings.Contains(mcisStatus.Status, "Partial-") && strings.Contains(mcisStatus.Status, StatusTerminated)) {
-		err := fmt.Errorf("MCIS " + mcisId + " is " + mcisStatus.Status + " and not " + StatusTerminated + ", Deletion is not allowed (use option=force for force deletion)")
+	if !(!strings.Contains(mcisStatus.Status, "Partial-") && (strings.Contains(mcisStatus.Status, StatusTerminated) || strings.Contains(mcisStatus.Status, StatusUndefined) || strings.Contains(mcisStatus.Status, StatusFailed))) {
+		err := fmt.Errorf("MCIS " + mcisId + " is " + mcisStatus.Status + " and not " + StatusTerminated + "/" + StatusUndefined + "/" + StatusFailed + ", Deletion is not allowed (use option=force for force deletion)")
 		common.CBLog.Error(err)
 		if option != "force" {
 			return err


### PR DESCRIPTION

기존에 MCIS delete 를 위해서는 

MCIS의 `terminated` 상태가 의무 조건이었으나,

MCIS를 terminate 하면, CSP의 경우 VM 정보 자체를 삭제하는 경우가 있으므로,
MCIS terminate 이후에 status를 조회하면, 문제가 있는 상태로 표시 될 수 있음.

따라서, MCIS delete의 조건에 비정상적인 VM 오브젝트도 삭제가 가능하도록

- StatusFailed
- StatusUndefined

를 추가하였습니다.
