### PR TITLE
Add script for deploying web game server

### DIFF
--- a/assets/scripts/setgame.sh
+++ b/assets/scripts/setgame.sh
@@ -1,0 +1,27 @@
+curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
+
+sudo apt-get update > /dev/null; sudo apt-get -y install nodejs > /dev/null; sudo apt-get -y install git > /dev/null
+
+git clone https://github.com/Jerenaux/westward.git > /dev/null
+
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 > /dev/null
+
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
+
+sudo apt-get update > /dev/null
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y install mongodb-org=4.0.5 mongodb-org-server=4.0.5 mongodb-org-shell=4.0.5 mongodb-org-mongos=4.0.5 mongodb-org-tools=4.0.5 > /dev/null
+
+sudo service mongod start
+
+cd ~/westward
+
+sudo npm install > /dev/null
+
+touch .env
+
+sudo nohup node dist/server.js 1>/dev/null 2>&1 &
+
+str=$(curl https://api.ipify.org)
+
+printf "\nGameServer is ready. Access http://%s:8081\n" $str

--- a/src/testclient/scripts/sequentialFullTest/deploy-game-js.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-game-js.sh
@@ -1,0 +1,37 @@
+TestSetFile=${4:-../testSet.env}
+if [ ! -f "$TestSetFile" ]; then
+	echo "$TestSetFile does not exist."
+	exit
+fi
+source $TestSetFile
+source ../conf.env
+
+echo "####################################################################"
+echo "## Command (SSH) to MCIS "
+echo "####################################################################"
+
+CSP=${1}
+REGION=${2:-1}
+POSTFIX=${3:-developer}
+
+source ../common-functions.sh
+getCloudIndex $CSP
+
+MCISID=${CONN_CONFIG[$INDEX, $REGION]}-${POSTFIX}
+
+if [ "${INDEX}" == "0" ]; then
+	# MCISPREFIX=avengers
+	MCISID=${MCISPREFIX}-${POSTFIX}
+fi
+
+CMD="wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/master/assets/scripts/setgame.sh -O ~/setgame.sh; chmod +x ~/setgame.sh; sudo ~/setgame.sh"
+echo "CMD: $CMD"
+
+VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${CMD}"
+	}
+EOF
+)
+echo "${VAR1}" | jq ''
+echo ""


### PR DESCRIPTION

Add script for deploying web game server

- Game server (MIT): https://github.com/Jerenaux/westward

How to use (1: Create MCIS, 2: Deploy Game)

- ./create-all.sh all 1 game6 ../testSetCombination.env 
- ./deploy-game-js.sh all 1 game6 ../testSetCombination.env 

How to access the Game server (access with your web browser)

- http://{{VM-Public-IP}}:8081


![Hnet-image (1)](https://user-images.githubusercontent.com/5966944/121786688-95c75d80-cbfc-11eb-8f57-995e774f844c.gif)


Note
- Tested with aws, gcp, alibaba, azure