### PR TITLE
Enhance and expedite mcis lifecycle handling

### DIFF
--- a/src/core/common/namespace.go
+++ b/src/core/common/namespace.go
@@ -29,7 +29,7 @@ type NsInfo struct {
 func NsValidation() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			fmt.Printf("%v\n", "[API request!]")
+			fmt.Printf("%v\n", "[Handle API Request]")
 			nsId := c.Param("nsId")
 			if nsId == "" {
 				return next(c)

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -11,7 +11,7 @@ ApiPassword=default
 AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 ## NSID for Tumblebug
-NSID=cb
+NSID=tb01
 
 ## Declare Array-like (You don't need to change)
 declare -A RegionName

--- a/src/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
+++ b/src/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
@@ -101,13 +101,13 @@ function clean_sequence() {
 
 	#../2.configureTumblebug/delete-ns.sh $CSP $REGION $POSTFIX
 
-	CNT=$(grep -c "${CSP}" ./executionStatus)
-	if [ "${CNT}" -ge 2 ]; then
-		../1.configureSpider/unregister-cloud.sh $CSP $REGION $POSTFIX leave $TestSetFile
-	else
-		echo "[No dependancy, this CSP can be removed.]"
-		../1.configureSpider/unregister-cloud.sh $CSP $REGION $POSTFIX doit $TestSetFile
-	fi
+	# CNT=$(grep -c "${CSP}" ./executionStatus)
+	# if [ "${CNT}" -ge 2 ]; then
+	# 	../1.configureSpider/unregister-cloud.sh $CSP $REGION $POSTFIX leave $TestSetFile
+	# else
+	# 	echo "[No dependancy, this CSP can be removed.]"
+	# 	../1.configureSpider/unregister-cloud.sh $CSP $REGION $POSTFIX doit $TestSetFile
+	# fi
 
 	echo ""
 	echo "[Cleaning related commands in history file executionStatus]"


### PR DESCRIPTION
Enhance and expedite mcis lifecycle handling.

1) 대규모 MCIS의 상태 제어시, terminated 상태가 가끔씩 undefined 상태로 처리되던 버그를 때려잡음... (데이터를 읽어와서 처리해서 다시 저장하는 중간에, 데이터를 수정하는 상황.. 그러나 락을 잡지 않고 최대한 처리함)
2) mcis, vm 등 오브젝트 데이터의 업데이트가 빈번하여, 오브젝트를 조회하여 값이 동일한 경우 업데이트하지 않도록 처리
3) 상태 조회시 public ip 를 지속적으로 업데이트(csp에서 확인)하였으나, 자원 절약을 위해 필요한 상황(vm의 상태가 변경되는 시점)에만 public ip를 조회하도록 처리하여, 처리 고속화
4) 전체 삭제 Script에서 등록된 클라우드(커넥션컨피그)는 삭제하지 않도록 처리 (등록해두어도 특별히 자원을 먹지 않음으로 편의상)