### PR TITLE
Update test configs

### DIFF
--- a/src/api/grpc/cbadm/testclient/scripts/conf.env
+++ b/src/api/grpc/cbadm/testclient/scripts/conf.env
@@ -11,7 +11,7 @@ ApiPassword=default
 AUTH="Authorization: Basic $(echo -n $ApiUsername:$ApiPassword | base64)"
 
 ## NSID for Tumblebug
-NSID=cb
+NSID=tb01
 
 ## Declare Array-like (You don't need to change)
 declare -A RegionName
@@ -1450,7 +1450,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=KR
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=KR-1
-CONN_CONFIG[$IX,$IY]=ncp-korea1
+CONN_CONFIG[$IX,$IY]=ncpkr1
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000073
 
@@ -1462,7 +1462,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=USWN
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=USWN-1
-CONN_CONFIG[$IX,$IY]=ncp-us-western
+CONN_CONFIG[$IX,$IY]=ncpusw
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 
@@ -1474,7 +1474,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=DEN
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=DEN-1
-CONN_CONFIG[$IX,$IY]=ncp-germany
+CONN_CONFIG[$IX,$IY]=ncpde
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 
@@ -1486,7 +1486,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=SGN
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=SGN-1
-CONN_CONFIG[$IX,$IY]=ncp-singapore
+CONN_CONFIG[$IX,$IY]=ncpsg
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 
@@ -1498,7 +1498,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=JPN
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=JPN-1
-CONN_CONFIG[$IX,$IY]=ncp-japan
+CONN_CONFIG[$IX,$IY]=ncpjp
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 
@@ -1540,9 +1540,9 @@ IY=$ClouditRegion01
 RegionName[$IX,$IY]=cloudit-region01
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=default
-CONN_CONFIG[$IX,$IY]=cloudit-region01
+CONN_CONFIG[$IX,$IY]=cit
 IMAGE_NAME[$IX,$IY]=CentOS-7
-SPEC_NAME[$IX,$IY]=micro-1
+SPEC_NAME[$IX,$IY]=small-2
 
 
 

--- a/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
@@ -101,13 +101,13 @@ function clean_sequence() {
 
 	#../2.configureTumblebug/delete-ns.sh $CSP $REGION $POSTFIX
 
-	CNT=$(grep -c "${CSP}" ./executionStatus)
-	if [ "${CNT}" -ge 2 ]; then
-		../1.configureSpider/unregister-cloud.sh $CSP $REGION $POSTFIX leave $TestSetFile
-	else
-		echo "[No dependancy, this CSP can be removed.]"
-		../1.configureSpider/unregister-cloud.sh $CSP $REGION $POSTFIX doit $TestSetFile
-	fi
+	# CNT=$(grep -c "${CSP}" ./executionStatus)
+	# if [ "${CNT}" -ge 2 ]; then
+	# 	../1.configureSpider/unregister-cloud.sh $CSP $REGION $POSTFIX leave $TestSetFile
+	# else
+	# 	echo "[No dependancy, this CSP can be removed.]"
+	# 	../1.configureSpider/unregister-cloud.sh $CSP $REGION $POSTFIX doit $TestSetFile
+	# fi
 
 	echo ""
 	echo "[Cleaning related commands in history file executionStatus]"

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -1450,7 +1450,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=KR
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=KR-1
-CONN_CONFIG[$IX,$IY]=ncp-korea1
+CONN_CONFIG[$IX,$IY]=ncpkr1
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000073
 
@@ -1462,7 +1462,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=USWN
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=USWN-1
-CONN_CONFIG[$IX,$IY]=ncp-us-western
+CONN_CONFIG[$IX,$IY]=ncpusw
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 
@@ -1474,7 +1474,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=DEN
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=DEN-1
-CONN_CONFIG[$IX,$IY]=ncp-germany
+CONN_CONFIG[$IX,$IY]=ncpde
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 
@@ -1486,7 +1486,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=SGN
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=SGN-1
-CONN_CONFIG[$IX,$IY]=ncp-singapore
+CONN_CONFIG[$IX,$IY]=ncpsg
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 
@@ -1498,7 +1498,7 @@ RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=JPN
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=JPN-1
-CONN_CONFIG[$IX,$IY]=ncp-japan
+CONN_CONFIG[$IX,$IY]=ncpjp
 IMAGE_NAME[$IX,$IY]=SPSW0LINUX000130
 SPEC_NAME[$IX,$IY]=SPSVRSTAND000025
 
@@ -1540,9 +1540,9 @@ IY=$ClouditRegion01
 RegionName[$IX,$IY]=cloudit-region01
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=default
-CONN_CONFIG[$IX,$IY]=cloudit-region01
+CONN_CONFIG[$IX,$IY]=cit
 IMAGE_NAME[$IX,$IY]=CentOS-7
-SPEC_NAME[$IX,$IY]=micro-1
+SPEC_NAME[$IX,$IY]=small-2
 
 
 


### PR DESCRIPTION
- #625 변경사항을 `cbadm` test script 에도 반영
  - Remove removing cloud infos in script
  - Change default ns name in script
- VM 이름 길이 제한 (Cloudit: 45자, NCP: 30자) 충족을 위해 conn config 이름 단축