### PR TITLE
Fix set close connection after rest call

### DIFF
--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -227,7 +227,7 @@ func GetConnConfig(ConnConfigName string) (ConnConfig, error) {
 
 		url := SPIDER_REST_URL + "/connectionconfig/" + ConnConfigName
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetResult(&ConnConfig{}).
@@ -300,7 +300,7 @@ func GetRegionInfo(RegionName string) (RegionInfo, error) {
 
 		url := SPIDER_REST_URL + "/region/" + RegionName
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetResult(&RegionInfo{}).
@@ -349,7 +349,7 @@ func GetConnConfigList() (ConnConfigList, error) {
 
 		url := SPIDER_REST_URL + "/connectionconfig"
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetResult(&ConnConfigList{}).
@@ -422,7 +422,7 @@ func GetRegion(RegionName string) (Region, error) {
 
 		url := SPIDER_REST_URL + "/region/" + RegionName
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetResult(&Region{}).
@@ -495,7 +495,7 @@ func GetRegionList() (RegionList, error) {
 
 		url := SPIDER_REST_URL + "/region"
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetResult(&RegionList{}).

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -244,7 +244,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 		fmt.Println("url: " + url)
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetHeader("Content-Type", "application/json").
@@ -563,7 +563,7 @@ func InspectResources(connConfig string, resourceType string) (interface{}, erro
 		}
 	}
 
-	client := resty.New()
+	client := resty.New().SetCloseConnection(true)
 	client.SetAllowGetMethodPayload(true)
 
 	// Create Req body

--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -315,7 +315,7 @@ func LookupImageList(connConfig string) (SpiderImageList, error) {
 		tempReq := common.SpiderConnectionName{}
 		tempReq.ConnectionName = connConfig
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 		client.SetAllowGetMethodPayload(true)
 
 		resp, err := client.R().
@@ -402,7 +402,7 @@ func LookupImage(connConfig string, imageId string) (SpiderImageInfo, error) {
 		tempReq := common.SpiderConnectionName{}
 		tempReq.ConnectionName = connConfig
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 		client.SetAllowGetMethodPayload(true)
 
 		resp, err := client.R().

--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -119,7 +119,7 @@ func CreateSecurityGroup(nsId string, u *TbSecurityGroupReq) (TbSecurityGroupInf
 
 		url := common.SPIDER_REST_URL + "/securitygroup"
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetHeader("Content-Type", "application/json").

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -132,7 +132,7 @@ func LookupSpecList(connConfig string) (SpiderSpecList, error) {
 		tempReq := common.SpiderConnectionName{}
 		tempReq.ConnectionName = connConfig
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 		client.SetAllowGetMethodPayload(true)
 
 		resp, err := client.R().
@@ -220,7 +220,7 @@ func LookupSpec(connConfig string, specName string) (SpiderSpecInfo, error) {
 		tempReq := common.SpiderConnectionName{}
 		tempReq.ConnectionName = connConfig
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 		client.SetAllowGetMethodPayload(true)
 
 		resp, err := client.R().

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -101,7 +101,7 @@ func CreateSshKey(nsId string, u *TbSshKeyReq) (TbSshKeyInfo, error) {
 
 		url := common.SPIDER_REST_URL + "/keypair"
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetHeader("Content-Type", "application/json").

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -114,7 +114,7 @@ func CreateVNet(nsId string, u *TbVNetReq) (TbVNetInfo, error) {
 
 		url := common.SPIDER_REST_URL + "/vpc"
 
-		client := resty.New()
+		client := resty.New().SetCloseConnection(true)
 
 		resp, err := client.R().
 			SetHeader("Content-Type", "application/json").

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -3925,19 +3925,19 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 					return http.ErrUseLastResponse
 				},
 			}
-			req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
-
-			errorInfo.Status = StatusFailed
-
-			if err != nil {
-				fmt.Println(err)
-				return errorInfo, err
-			}
-			req.Header.Add("Content-Type", "application/json")
 
 			// Retry to get right VM status from cb-spider. Sometimes cb-spider returns not approriate status.
 			retrycheck := 2
 			for i := 0; i < retrycheck; i++ {
+
+				req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
+				errorInfo.Status = StatusFailed
+				if err != nil {
+					fmt.Println(err)
+					return errorInfo, err
+				}
+				req.Header.Add("Content-Type", "application/json")
+
 				res, err := client.Do(req)
 				if err != nil {
 					fmt.Println(err)

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -340,7 +340,7 @@ func InspectVMs(connConfig string) (interface{}, error) {
 		}
 	}
 
-	client := resty.New()
+	client := resty.New().SetCloseConnection(true)
 	client.SetAllowGetMethodPayload(true)
 
 	// Create Req body


### PR DESCRIPTION
- rest call 하고 나서 connection 이 계속 살아 있어 자동 close 하게 설정
  => close 를 안하면 가끔 Unsolicited response received on idle HTTP channel ... 로그가 화면에 표시

- control.go 의 GetVmStatus() 에서 가끔 "Body length 0" 에러 발생 
  => 참고 : https://stackoverflow.com/questions/31337891/net-http-http-contentlength-222-with-body-length-0
  => for 문에서 client.Do() 를 호출할 때 request 도 새로 생성해야 함