### PR TITLE
Replace jwt-go with currently-being-maintained ver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloud-barista/cb-tumblebug
 go 1.16
 
 replace (
-	//	github.com/coreos/bbolt => go.etcd.io/bbolt v1.3.3
+	github.com/coreos/bbolt => go.etcd.io/bbolt v1.3.3
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0
 	google.golang.org/grpc => google.golang.org/grpc v1.26.0
 )
@@ -15,13 +15,14 @@ require (
 	github.com/cloud-barista/cb-log v0.4.0
 	github.com/cloud-barista/cb-spider v0.4.5
 	github.com/cloud-barista/cb-store v0.4.1
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/coreos/bbolt v1.3.4 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/spec v0.20.3 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/cloud-barista/cb-store v0.4.1 h1:/4Y8SWO3QAvQU2YUc8i72aBp+W5X8rvgk5w4
 github.com/cloud-barista/cb-store v0.4.1/go.mod h1:d3mwxDF2gC4lc7a+DFc2eo1OqqS9sHygLGUrU94hhj0=
 github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58/go.mod h1:EOBUe0h4xcZ5GoxqC5SDxFQ8gwyZPKQoEzownBlhI80=
 github.com/containerd/containerd v1.4.3/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/coreos/bbolt v1.3.2 h1:wZwiHHUieZCquLkDL0B8UhzreNWsPHooDAG3q34zk0s=
-github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.25+incompatible h1:0GQEw6h3YnuOVdtwygkIfJ+Omx0tZ8/QkVyXI4LkbeY=
 github.com/coreos/etcd v3.3.25+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
@@ -204,6 +202,8 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
+github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -574,6 +574,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v0.0.0-20171031051903-609c9cd26973/go.mod h1:aEV29XrmTYFr3CiRxZeGHpkvbwq+prZduBqMaascyCU=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
+go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
+go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v3.3.25+incompatible/go.mod h1:yaeTdrJi5lOmYerz05bd8+V7KubZs8YSFZfzsF9A6aI=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=

--- a/src/api/grpc/cbadm/Makefile
+++ b/src/api/grpc/cbadm/Makefile
@@ -1,5 +1,5 @@
 default:
-	        go build -o cbadm
+	        go build -mod=mod -o cbadm
 run:
 	        ./cbadm
 clean:

--- a/src/api/grpc/interceptors/authjwt/auth.go
+++ b/src/api/grpc/interceptors/authjwt/auth.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/cloud-barista/cb-tumblebug/src/api/grpc/logger"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"

--- a/src/api/grpc/jwt-gen/jwt_gen.go
+++ b/src/api/grpc/jwt-gen/jwt_gen.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 var (

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -4194,15 +4194,18 @@ var doc = `{
             "type": "object",
             "properties": {
                 "keyValueInfoList": {
+                    "description": "ex) { {region, us-east1}, {zone, us-east1-c} }",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/common.KeyValue"
                     }
                 },
                 "providerName": {
+                    "description": "ex) \"GCP\"",
                     "type": "string"
                 },
                 "regionName": {
+                    "description": "ex) \"region01\"",
                     "type": "string"
                 }
             }

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -4179,15 +4179,18 @@
             "type": "object",
             "properties": {
                 "keyValueInfoList": {
+                    "description": "ex) { {region, us-east1}, {zone, us-east1-c} }",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/common.KeyValue"
                     }
                 },
                 "providerName": {
+                    "description": "ex) \"GCP\"",
                     "type": "string"
                 },
                 "regionName": {
+                    "description": "ex) \"region01\"",
                     "type": "string"
                 }
             }

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -88,12 +88,15 @@ definitions:
   common.Region:
     properties:
       keyValueInfoList:
+        description: ex) { {region, us-east1}, {zone, us-east1-c} }
         items:
           $ref: '#/definitions/common.KeyValue'
         type: array
       providerName:
+        description: ex) "GCP"
         type: string
       regionName:
+        description: ex) "region01"
         type: string
     type: object
   common.RegionList:


### PR DESCRIPTION
- Replace jwt-go with currently-being-maintained ver
  - As-is: https://github.com/dgrijalva/jwt-go
  - To-be: https://github.com/golang-jwt/jwt
  - Closes #656
- `src/api/grpc/cbadm/Makefile` 에도 `go build` 명령에 `-mod=mod` 옵션 추가
  - `go.mod` 파일도 있고 `vendor/` 디렉토리도 있는 경우, `go.mod` 파일을 참고하라는 옵션임
  - `src/Makefile` 에는 이미 적용되어 있음
- #658 에서 
  `type Region struct` 의 각 필드에 주석을 추가했으나 Swagger doc을 업데이트하지 않아서
  이 PR에서 Swagger doc 업데이트
