### PR TITLE
Update script for a better output for private VM IP

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/change-mcis-hostname.sh
+++ b/src/testclient/scripts/sequentialFullTest/change-mcis-hostname.sh
@@ -50,7 +50,8 @@ for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
 
     getCloudIndexGeneral $cloudType
 
-    ChangeHostCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${connectionName}-${publicIP}; sudo hostname -f"
+    # ChangeHostCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${connectionName}-${publicIP}; sudo hostname -f"
+    ChangeHostCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${VMID}; sudo hostname -f"
     ./command-mcis-vm-custom.sh "${1}" "${2}" "${3}" "${4}" "${VMID}" "${ChangeHostCMD}" &
 done
 wait

--- a/src/testclient/scripts/sequentialFullTest/gen-sshKey.sh
+++ b/src/testclient/scripts/sequentialFullTest/gen-sshKey.sh
@@ -85,6 +85,7 @@ for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
 
 	id=$(_jq '.id')
 	ip=$(_jq '.publicIp')
+	privIp=$(_jq '.privateIp')
 
 	VMINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${id})
 	VMKEYID=$(jq -r '.sshKeyId' <<<"$VMINFO")
@@ -97,7 +98,7 @@ for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
 
 	echo ""
 	# USERNAME="ubuntu"
-	printf ' [VMIP]: %s   [MCISID]: %s   [VMID]: %s\n' "$ip" "$MCISID" "$id"
+	printf ' [VMIP]: %s (priv: %s)   [MCISID]: %s   [VMID]: %s\n' "$ip" "$privIp" "$MCISID" "$id"
 	printf ' ssh -i ./sshkey-tmp/%s.pem %s@%s -o StrictHostKeyChecking=no\n' "$KEYFILENAME" "$USERNAME" "$ip"
 done
 


### PR DESCRIPTION
Update script for a better output for private VM IP

1. gen-sshKey.sh 의 출력에 private IP 추가하여, private IP 를 쉽게 확인할 수 있도록 처리
2. change-mcis-hostname.sh를 통해 hostname을 Public IP 주소(xxx.xxx.xxx.xxx)를 포함한 문자열로 제공하고 있었으나, hostname에 `.` 가 포함되면 오류가 발생할 수 있는 프로그램들이 있음을 감안하여, Public IP 대신 VM ID를 hostname으로 사용하도록 수정.