### PR TITLE
Fix file format with gofmt

### DIFF
--- a/src/api/grpc/request/test/test_api.go
+++ b/src/api/grpc/request/test/test_api.go
@@ -327,11 +327,11 @@ func CreateCIMApiTest() {
 		CredentialName: "openstack-credential01",
 		ProviderName:   "OPENSTACK",
 		KeyValueInfoList: []sp_api.KeyValue{
-			sp_api.KeyValue{Key: "IdentityEndpoint", Value: "http://192.168.201.208:5000/v3"},
-			sp_api.KeyValue{Key: "Username", Value: "demo"},
-			sp_api.KeyValue{Key: "Password", Value: "openstack"},
-			sp_api.KeyValue{Key: "DomainName", Value: "Default"},
-			sp_api.KeyValue{Key: "ProjectID", Value: "b31474c562184bcbaf3496e08f5a6a4c"},
+			{Key: "IdentityEndpoint", Value: "http://192.168.201.208:5000/v3"},
+			{Key: "Username", Value: "demo"},
+			{Key: "Password", Value: "openstack"},
+			{Key: "DomainName", Value: "Default"},
+			{Key: "ProjectID", Value: "b31474c562184bcbaf3496e08f5a6a4c"},
 		},
 	}
 	result, err = cim.CreateCredentialByParam(reqCredential)
@@ -345,7 +345,7 @@ func CreateCIMApiTest() {
 		RegionName:   "openstack-region01",
 		ProviderName: "OPENSTACK",
 		KeyValueInfoList: []sp_api.KeyValue{
-			sp_api.KeyValue{Key: "Region", Value: "RegionOne"},
+			{Key: "Region", Value: "RegionOne"},
 		},
 	}
 	result, err = cim.CreateRegionByParam(reqRegion)
@@ -431,7 +431,7 @@ func CreateMCIRApiTest() {
 			ConnectionName: "openstack-config01",
 			CidrBlock:      "192.168.0.0/16",
 			SubnetInfoList: []core_mcir.SpiderSubnetReqInfo{
-				core_mcir.SpiderSubnetReqInfo{
+				{
 					Name:         "openstack-config01-test",
 					IPv4_CIDR:    "192.168.1.0/24",
 					KeyValueList: []core_common.KeyValue{},
@@ -477,7 +477,7 @@ func CreateMCIRApiTest() {
 			VNetId:         "openstack-config01-test",
 			Description:    "test description",
 			FirewallRules: &[]core_mcir.SpiderSecurityRuleInfo{
-				core_mcir.SpiderSecurityRuleInfo{
+				{
 					FromPort:   "1",
 					ToPort:     "65535",
 					IPProtocol: "tcp",
@@ -584,7 +584,7 @@ func CreateMCISApiTest() {
 			Description:     "",
 			Label:           "",
 			Vm: []core_mcis.TbVmReq{
-				core_mcis.TbVmReq{
+				{
 					VmGroupSize:    "0",
 					Name:           "openstack-config01-test-01",
 					ConnectionName: "openstack-config01",
@@ -601,7 +601,7 @@ func CreateMCISApiTest() {
 					Description:    "description",
 					Label:          "label",
 				},
-				core_mcis.TbVmReq{
+				{
 					VmGroupSize:    "0",
 					Name:           "openstack-config01-test-02",
 					ConnectionName: "openstack-config01",


### PR DESCRIPTION
fix cloud-barista/cb-tumblebug#680

jihoon-seo님께서 제안하신 issue에서는 gofmt-enabled 상태에서 파일을 저장하면 issue가 해결될 것이라고 하셨는데
제가 gofmt-enabled 상태에서 저장을 해도 file format이 변경되지 않았습니다. 
그래서 terminal에서 직접 `gofmt -s -w  test_api.go`를 입력하여 format을 맞추었습니다. 
아래는 제 저장소에서의 Go Report Card입니다.
[Go Report Card](https://goreportcard.com/report/github.com/atg0831/cb-tumblebug)

잘못된 부분이 있다면 알려주시면 감사하겠습니다.