### PR TITLE
Separate `ControlMCIS` REST API & Update test scripts

### DIFF
--- a/src/api/grpc/protobuf/cbtumblebug/cbtumblebug.pb.go
+++ b/src/api/grpc/protobuf/cbtumblebug/cbtumblebug.pb.go
@@ -27980,10 +27980,7 @@ func (m *Empty) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28098,10 +28095,7 @@ func (m *KeyValue) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28216,10 +28210,7 @@ func (m *IID) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28290,10 +28281,7 @@ func (m *BooleanResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28364,10 +28352,7 @@ func (m *ExistsResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28450,10 +28435,7 @@ func (m *StringResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28536,10 +28518,7 @@ func (m *MessageResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28622,10 +28601,7 @@ func (m *StatusResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28712,10 +28688,7 @@ func (m *NSInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28800,10 +28773,7 @@ func (m *ListNSInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -28950,10 +28920,7 @@ func (m *NSInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29040,10 +29007,7 @@ func (m *NSCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29158,10 +29122,7 @@ func (m *NsReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29244,10 +29205,7 @@ func (m *NSQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29330,10 +29288,7 @@ func (m *ListIdResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29512,10 +29467,7 @@ func (m *ResourceQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29662,10 +29614,7 @@ func (m *ResourceAllQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29784,10 +29733,7 @@ func (m *TbImageInfoRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29874,10 +29820,7 @@ func (m *TbImageInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -29962,10 +29905,7 @@ func (m *ListTbImageInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -30422,10 +30362,7 @@ func (m *TbImageInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -30544,10 +30481,7 @@ func (m *TbImageCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -30726,10 +30660,7 @@ func (m *TbImageReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -30844,10 +30775,7 @@ func (m *FetchImageQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -30962,10 +30890,7 @@ func (m *SearchImageQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -31052,10 +30977,7 @@ func (m *SpiderImageInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -31140,10 +31062,7 @@ func (m *ListSpiderImageInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -31328,10 +31247,7 @@ func (m *SpiderImageInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -31414,10 +31330,7 @@ func (m *LookupImageListQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -31532,10 +31445,7 @@ func (m *LookupImageQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -31622,10 +31532,7 @@ func (m *TbSshKeyInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -31710,10 +31617,7 @@ func (m *ListTbSshKeyInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -32170,10 +32074,7 @@ func (m *TbSshKeyInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -32292,10 +32193,7 @@ func (m *TbSshKeyCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -32442,10 +32340,7 @@ func (m *TbSshKeyReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -32564,10 +32459,7 @@ func (m *TbSpecInfoRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -32654,10 +32546,7 @@ func (m *TbSpecInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -32742,10 +32631,7 @@ func (m *ListTbSpecInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -33517,10 +33403,7 @@ func (m *TbSpecInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -33639,10 +33522,7 @@ func (m *TbSpecCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -33821,10 +33701,7 @@ func (m *TbSpecReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -33939,10 +33816,7 @@ func (m *FetchSpecQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -34029,10 +33903,7 @@ func (m *SpiderSpecInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -34117,10 +33988,7 @@ func (m *ListSpiderSpecInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -34371,10 +34239,7 @@ func (m *SpiderSpecInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -34489,10 +34354,7 @@ func (m *SpiderVCpuInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -34671,10 +34533,7 @@ func (m *SpiderGpuInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -34757,10 +34616,7 @@ func (m *LookupSpecListQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -34875,10 +34731,7 @@ func (m *LookupSpecQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -34997,10 +34850,7 @@ func (m *FilterSpecsByRangeRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -36131,10 +35981,7 @@ func (m *SpecRangeFilter) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -36207,10 +36054,7 @@ func (m *Range) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -36359,10 +36203,7 @@ func (m *SortSpecsRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -36449,10 +36290,7 @@ func (m *TbSecurityGroupInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -36537,10 +36375,7 @@ func (m *ListTbSecurityGroupInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -36935,10 +36770,7 @@ func (m *TbSecurityGroupInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -37149,10 +36981,7 @@ func (m *SpiderSecurityRuleInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -37271,10 +37100,7 @@ func (m *TbSecurityGroupCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -37487,10 +37313,7 @@ func (m *TbSecurityGroupReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -37577,10 +37400,7 @@ func (m *TbVNetInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -37665,10 +37485,7 @@ func (m *ListTbVNetInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -38095,10 +37912,7 @@ func (m *TbVNetInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -38251,10 +38065,7 @@ func (m *SpiderSubnetInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -38373,10 +38184,7 @@ func (m *TbVNetCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -38589,10 +38397,7 @@ func (m *TbVNetReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -38741,10 +38546,7 @@ func (m *SpiderSubnetReqInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -38831,10 +38633,7 @@ func (m *TbMcisInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -38919,10 +38718,7 @@ func (m *ListTbMcisInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -39295,10 +39091,7 @@ func (m *TbMcisInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -40321,10 +40114,7 @@ func (m *TbVmInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -40535,10 +40325,7 @@ func (m *GeoLocation) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -40653,10 +40440,7 @@ func (m *RegionInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -41567,10 +41351,7 @@ func (m *SpiderVMInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -41689,10 +41470,7 @@ func (m *TbMcisCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -41937,10 +41715,7 @@ func (m *TbMcisReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -42407,10 +42182,7 @@ func (m *TbVmReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -42495,10 +42267,7 @@ func (m *ListTbMcisStatusInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -42585,10 +42354,7 @@ func (m *TbMcisStatusInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -42961,10 +42727,7 @@ func (m *McisStatusInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -43467,10 +43230,7 @@ func (m *TbVmStatusInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -43553,10 +43313,7 @@ func (m *TbMcisAllQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -43703,10 +43460,7 @@ func (m *TbMcisActionRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -43821,10 +43575,7 @@ func (m *TbMcisQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -43911,10 +43662,7 @@ func (m *TbVmInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -44065,10 +43813,7 @@ func (m *TbVmCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -44219,10 +43964,7 @@ func (m *TbVmGroupCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -44309,10 +44051,7 @@ func (m *TbVmStatusInfoesponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -44459,10 +44198,7 @@ func (m *TbVmQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -44641,10 +44377,7 @@ func (m *TbVmActionRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -44731,10 +44464,7 @@ func (m *McisRecommendInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -44885,10 +44615,7 @@ func (m *McisRecommendInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -45075,10 +44802,7 @@ func (m *TbVmRecommendInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -45197,10 +44921,7 @@ func (m *TbVmPriority) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -45319,10 +45040,7 @@ func (m *McisRecommendCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -45505,10 +45223,7 @@ func (m *McisRecommendReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -45785,10 +45500,7 @@ func (m *TbVmRecommendReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -45907,10 +45619,7 @@ func (m *McisRecommendVmCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -46065,10 +45774,7 @@ func (m *DeploymentPlan) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -46153,10 +45859,7 @@ func (m *FilterInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -46273,10 +45976,7 @@ func (m *FilterCondition) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -46391,10 +46091,7 @@ func (m *Operation) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -46479,10 +46176,7 @@ func (m *PriorityInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -46631,10 +46325,7 @@ func (m *PriorityCondition) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -46749,10 +46440,7 @@ func (m *ParameterKeyVal) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -46837,10 +46525,7 @@ func (m *ListCmdMcisResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -47019,10 +46704,7 @@ func (m *CmdMcisResult) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -47173,10 +46855,7 @@ func (m *McisCmdCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -47359,10 +47038,7 @@ func (m *McisCmdVmCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -47477,10 +47153,7 @@ func (m *McisCmdReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -47565,10 +47238,7 @@ func (m *ListAgentInstallResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -47655,10 +47325,7 @@ func (m *MonitorResultSimpleResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -47807,10 +47474,7 @@ func (m *MonResultSimpleInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -47989,10 +47653,7 @@ func (m *MonResultSimple) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -48139,10 +47800,7 @@ func (m *MonitorQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -48227,10 +47885,7 @@ func (m *ListBenchmarkInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -48475,10 +48130,7 @@ func (m *BenchmarkInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -48629,10 +48281,7 @@ func (m *BmQryAllRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -48815,10 +48464,7 @@ func (m *BmQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -48901,10 +48547,7 @@ func (m *BmReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -48991,10 +48634,7 @@ func (m *McisPolicyInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -49079,10 +48719,7 @@ func (m *ListMcisPolicyInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -49295,10 +48932,7 @@ func (m *McisPolicyInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -49453,10 +49087,7 @@ func (m *Policy) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -49667,10 +49298,7 @@ func (m *AutoCondition) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -49857,10 +49485,7 @@ func (m *AutoAction) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50011,10 +49636,7 @@ func (m *McisPolicyCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50097,10 +49719,7 @@ func (m *McisPolicyAllQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50215,10 +49834,7 @@ func (m *McisPolicyQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50305,10 +49921,7 @@ func (m *ConnConfigResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50393,10 +50006,7 @@ func (m *ListConnConfigResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50607,10 +50217,7 @@ func (m *ConnConfig) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50693,10 +50300,7 @@ func (m *ConnConfigQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50783,10 +50387,7 @@ func (m *RegionResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -50871,10 +50472,7 @@ func (m *ListRegionResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51023,10 +50621,7 @@ func (m *Region) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51109,10 +50704,7 @@ func (m *RegionQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51199,10 +50791,7 @@ func (m *ConfigInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51287,10 +50876,7 @@ func (m *ListConfigInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51437,10 +51023,7 @@ func (m *ConfigInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51527,10 +51110,7 @@ func (m *ConfigCreateRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51645,10 +51225,7 @@ func (m *ConfigReq) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51731,10 +51308,7 @@ func (m *ConfigQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51821,10 +51395,7 @@ func (m *InspectMcirInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -51909,10 +51480,7 @@ func (m *ListInspectMcirInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -52065,10 +51633,7 @@ func (m *InspectMcirInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -52183,10 +51748,7 @@ func (m *McirResourceOnCspOrSpider) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -52397,10 +51959,7 @@ func (m *McirResourceOnTumblebug) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -52487,10 +52046,7 @@ func (m *InspectVmInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -52575,10 +52131,7 @@ func (m *ListInspectVmInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -52731,10 +52284,7 @@ func (m *InspectVmInfo) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -52849,10 +52399,7 @@ func (m *VmResourceOnCspOrSpider) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -53095,10 +52642,7 @@ func (m *VmResourceOnTumblebug) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -53213,10 +52757,7 @@ func (m *InspectQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -53299,10 +52840,7 @@ func (m *ObjectInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -53385,10 +52923,7 @@ func (m *ListObjectInfoResponse) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {
@@ -53471,10 +53006,7 @@ func (m *ObjectQryRequest) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthCbtumblebug
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthCbtumblebug
 			}
 			if (iNdEx + skippy) > l {

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -1049,6 +1049,141 @@ var doc = `{
                 }
             }
         },
+        "/ns/{nsId}/control/mcis/{mcisId}": {
+            "get": {
+                "description": "Control the lifecycle of MCIS",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[MCIS] Control lifecycle"
+                ],
+                "summary": "Control the lifecycle of MCIS",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "status",
+                            "suspend",
+                            "resume",
+                            "reboot",
+                            "terminate"
+                        ],
+                        "type": "string",
+                        "description": "Action to MCIS",
+                        "name": "action",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/ns/{nsId}/control/mcis/{mcisId}/vm/{vmId}": {
+            "get": {
+                "description": "Control the lifecycle of VM",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[MCIS] Control lifecycle"
+                ],
+                "summary": "Control the lifecycle of VM",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "status",
+                            "suspend",
+                            "resume",
+                            "reboot",
+                            "terminate"
+                        ],
+                        "type": "string",
+                        "description": "Action to MCIS",
+                        "name": "action",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/ns/{nsId}/install/mcis/{mcisId}": {
             "post": {
                 "description": "Install the benchmark agent to specified MCIS",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -1034,6 +1034,141 @@
                 }
             }
         },
+        "/ns/{nsId}/control/mcis/{mcisId}": {
+            "get": {
+                "description": "Control the lifecycle of MCIS",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[MCIS] Control lifecycle"
+                ],
+                "summary": "Control the lifecycle of MCIS",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "status",
+                            "suspend",
+                            "resume",
+                            "reboot",
+                            "terminate"
+                        ],
+                        "type": "string",
+                        "description": "Action to MCIS",
+                        "name": "action",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/ns/{nsId}/control/mcis/{mcisId}/vm/{vmId}": {
+            "get": {
+                "description": "Control the lifecycle of VM",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[MCIS] Control lifecycle"
+                ],
+                "summary": "Control the lifecycle of VM",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "status",
+                            "suspend",
+                            "resume",
+                            "reboot",
+                            "terminate"
+                        ],
+                        "type": "string",
+                        "description": "Action to MCIS",
+                        "name": "action",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/ns/{nsId}/install/mcis/{mcisId}": {
             "post": {
                 "description": "Install the benchmark agent to specified MCIS",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -2107,6 +2107,99 @@ paths:
       summary: Send a command to specified VM
       tags:
       - '[MCIS] Remote command'
+  /ns/{nsId}/control/mcis/{mcisId}:
+    get:
+      consumes:
+      - application/json
+      description: Control the lifecycle of MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Action to MCIS
+        enum:
+        - status
+        - suspend
+        - resume
+        - reboot
+        - terminate
+        in: query
+        name: action
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Control the lifecycle of MCIS
+      tags:
+      - '[MCIS] Control lifecycle'
+  /ns/{nsId}/control/mcis/{mcisId}/vm/{vmId}:
+    get:
+      consumes:
+      - application/json
+      description: Control the lifecycle of VM
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
+      - description: Action to MCIS
+        enum:
+        - status
+        - suspend
+        - resume
+        - reboot
+        - terminate
+        in: query
+        name: action
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Control the lifecycle of VM
+      tags:
+      - '[MCIS] Control lifecycle'
   /ns/{nsId}/install/mcis/{mcisId}:
     post:
       consumes:

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -81,7 +81,6 @@ func RestTestListVmId(c echo.Context) error { // for debug
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis/{mcisId} [get]
 func RestGetMcis(c echo.Context) error {
-	//id, _ := strconv.Atoi(c.Param("id"))
 
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
@@ -326,6 +325,81 @@ func RestPostMcisRecommend(c echo.Context) error {
 	return c.JSON(http.StatusCreated, content)
 }
 
+// RestGetControlMcis godoc
+// @Summary Control the lifecycle of MCIS
+// @Description Control the lifecycle of MCIS
+// @Tags [MCIS] Control lifecycle
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID"
+// @Param mcisId path string true "MCIS ID"
+// @Param action query string false "Action to MCIS" Enums(status, suspend, resume, reboot, terminate)
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /ns/{nsId}/control/mcis/{mcisId} [get]
+func RestGetControlMcis(c echo.Context) error {
+	nsId := c.Param("nsId")
+	mcisId := c.Param("mcisId")
+
+	action := c.QueryParam("action")
+
+	if action == "suspend" || action == "resume" || action == "reboot" || action == "terminate" {
+
+		result, err := mcis.HandleMcisAction(nsId, mcisId, action)
+		if err != nil {
+			mapA := map[string]string{"message": err.Error()}
+			return c.JSON(http.StatusInternalServerError, &mapA)
+		}
+
+		mapA := map[string]string{"message": result}
+		return c.JSON(http.StatusOK, &mapA)
+
+	} else {
+		mapA := map[string]string{"message": "'action' should be one of these: suspend, resume, reboot, terminate"}
+		return c.JSON(http.StatusBadRequest, &mapA)
+	}
+}
+
+// RestGetControlMcisVm godoc
+// @Summary Control the lifecycle of VM
+// @Description Control the lifecycle of VM
+// @Tags [MCIS] Control lifecycle
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID"
+// @Param mcisId path string true "MCIS ID"
+// @Param vmId path string true "VM ID"
+// @Param action query string false "Action to MCIS" Enums(status, suspend, resume, reboot, terminate)
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /ns/{nsId}/control/mcis/{mcisId}/vm/{vmId} [get]
+func RestGetControlMcisVm(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+	mcisId := c.Param("mcisId")
+	vmId := c.Param("vmId")
+
+	action := c.QueryParam("action")
+
+	if action == "suspend" || action == "resume" || action == "reboot" || action == "terminate" {
+
+		result, err := mcis.CoreGetMcisVmAction(nsId, mcisId, vmId, action)
+		if err != nil {
+			mapA := map[string]string{"message": err.Error()}
+			return c.JSON(http.StatusInternalServerError, &mapA)
+		}
+
+		mapA := map[string]string{"message": result}
+		return c.JSON(http.StatusOK, &mapA)
+
+	} else {
+		mapA := map[string]string{"message": "'action' should be one of these: suspend, resume, reboot, terminate"}
+		return c.JSON(http.StatusBadRequest, &mapA)
+	}
+}
+
 type RestPostCmdMcisVmResponse struct {
 	Result string `json:"result"`
 }
@@ -543,7 +617,6 @@ func RestPostMcisVmGroup(c echo.Context) error {
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis/{mcisId}/vm/{vmId} [get]
 func RestGetMcisVm(c echo.Context) error {
-	//id, _ := strconv.Atoi(c.Param("id"))
 
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -153,6 +153,9 @@ func ApiServer() {
 
 	g.POST("/:nsId/testRecommendVm", rest_mcis.RestRecommendVm)
 
+	g.GET("/:nsId/control/mcis/:mcisId", rest_mcis.RestGetControlMcis)
+	g.GET("/:nsId/control/mcis/:mcisId/vm/:vmId", rest_mcis.RestGetControlMcisVm)
+
 	g.POST("/:nsId/cmd/mcis/:mcisId", rest_mcis.RestPostCmdMcis)
 	g.POST("/:nsId/cmd/mcis/:mcisId/vm/:vmId", rest_mcis.RestPostCmdMcisVm)
 	g.POST("/:nsId/install/mcis/:mcisId", rest_mcis.RestPostInstallAgentToMcis)

--- a/src/testclient/scripts/1.configureSpider/get-cloud.sh
+++ b/src/testclient/scripts/1.configureSpider/get-cloud.sh
@@ -30,8 +30,6 @@
 	source ../common-functions.sh
 	getCloudIndex $CSP
 
-    RESTSERVER=localhost
-
     # for Cloud Connection Config Info
     curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | jq ''
     echo ""

--- a/src/testclient/scripts/1.configureSpider/unregister-cloud.sh
+++ b/src/testclient/scripts/1.configureSpider/unregister-cloud.sh
@@ -1,45 +1,6 @@
 #!/bin/bash
 
-#function unregister_cloud() {
-
-
-    FILE=../credentials.conf
-    if [ ! -f "$FILE" ]; then
-        echo "$FILE does not exist."
-        exit
-    fi
-
-	TestSetFile=${5:-../testSet.env}
-    
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	source ../credentials.conf
-	
-	echo "####################################################################"
-	echo "## 1. Remove All Cloud Connction Config(s)"
-	echo "####################################################################"
-
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-
-	source ../common-functions.sh
-	getCloudIndex $CSP
-
-	OPTION=${4:-none}
-
-	RESTSERVER=localhost
-
-
-	if [ "${OPTION}" == "leave" ]; then
-		echo "[Leave Cloud Credential and Cloud Driver for other Regions]"
-		exit
-	fi
-	
+function CallSpider() {
 	# for Cloud Connection Config Info
 	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/connectionconfig/${CONN_CONFIG[$INDEX,$REGION]} | jq ''
     echo ""
@@ -58,7 +19,52 @@
 	# for Cloud Driver Info
 	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/driver/${DriverName[$INDEX]} | jq ''
     echo ""
+}
 
+#function unregister_cloud() {
+	
+	echo "####################################################################"
+	echo "## 1. Remove All Cloud Connction Config(s)"
+	echo "####################################################################"
+
+	source ../init.sh
+
+	if [ "${OPTION}" == "leave" ]; then
+		echo "[Leave Cloud Credential and Cloud Driver for other Regions]"
+		exit
+	fi
+	
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
+
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				
+				CallSpider
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		CallSpider
+
+	fi
 
 #}
 

--- a/src/testclient/scripts/3.vNet/create-vNet.sh
+++ b/src/testclient/scripts/3.vNet/create-vNet.sh
@@ -1,26 +1,7 @@
 #!/bin/bash
 
-#function create_vNet() {
-
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
-	echo "####################################################################"
-	echo "## 3. vNet: Create"
-	echo "####################################################################"
-
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-
-	source ../common-functions.sh
-	getCloudIndex $CSP
+function CallTB() {
+	echo "- Create vNet in ${MCIRRegionName}"
 
 	CIDRNum=$(($INDEX+1))
 	CIDRDiff=$(($CIDRNum*$REGION))
@@ -40,6 +21,51 @@
 EOF
     ); echo ${resp} | jq ''
     echo ""
+}
+
+#function create_vNet() {
+
+	echo "####################################################################"
+	echo "## 3. vNet: Create"
+	echo "####################################################################"
+
+	source ../init.sh
+
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
+
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+	
 #}
 
 #create_vNet

--- a/src/testclient/scripts/3.vNet/force-delete-vNet.sh
+++ b/src/testclient/scripts/3.vNet/force-delete-vNet.sh
@@ -3,7 +3,7 @@
 function CallTB() {
 	echo "- Delete vNet in ${MCIRRegionName}"
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true | jq ''
 }
 
 #function delete_vNet() {

--- a/src/testclient/scripts/4.securityGroup/create-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/create-securityGroup.sh
@@ -1,28 +1,9 @@
 #!/bin/bash
 
-#function create_securityGroup() {
+function CallTB() {
+	echo "- Create securityGroup in ${MCIRRegionName}"
 
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
-	echo "####################################################################"
-	echo "## 4. SecurityGroup: Create"
-	echo "####################################################################"
-
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-
-	source ../common-functions.sh
-	getCloudIndex $CSP
-
-    resp=$(
+	resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/resources/securityGroup -H 'Content-Type: application/json' -d @- <<EOF
         {
 			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
@@ -56,6 +37,51 @@
 EOF
     ); echo ${resp} | jq ''
     echo ""
+}
+
+#function create_securityGroup() {
+
+	echo "####################################################################"
+	echo "## 4. SecurityGroup: Create"
+	echo "####################################################################"
+
+	source ../init.sh
+
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
+
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+    
 #}
 
 #create_securityGroup

--- a/src/testclient/scripts/4.securityGroup/delete-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/delete-securityGroup.sh
@@ -1,29 +1,54 @@
 #!/bin/bash
 
+function CallTB() {
+	echo "- Delete securityGroup in ${MCIRRegionName}"
+
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
+}
+
 #function delete_securityGroup() {
 
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
 	echo "####################################################################"
 	echo "## 4. SecurityGroup: Delete"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+	source ../init.sh
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
 
-    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
-    echo ""
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+	
 #}
 
 #delete_securityGroup

--- a/src/testclient/scripts/4.securityGroup/force-delete-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/force-delete-securityGroup.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 function CallTB() {
-	echo "- Delete vNet in ${MCIRRegionName}"
+	echo "- Delete securityGroup in ${MCIRRegionName}"
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/securityGroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true | jq ''
 }
 
-#function delete_vNet() {
-	
+#function delete_securityGroup() {
+
 	echo "####################################################################"
-	echo "## 3. vNet: Delete"
+	echo "## 4. SecurityGroup: Delete"
 	echo "####################################################################"
 
 	source ../init.sh
@@ -48,7 +48,7 @@ function CallTB() {
 		CallTB
 
 	fi
-
+	
 #}
 
-#delete_vNet
+#delete_securityGroup

--- a/src/testclient/scripts/5.sshKey/delete-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/delete-sshKey.sh
@@ -1,29 +1,54 @@
 #!/bin/bash
 
+function CallTB() {
+	echo "- Delete sshKey in ${MCIRRegionName}"
+
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
+}
+
 #function delete_sshKey() {
 
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
 	echo "####################################################################"
 	echo "## 5. sshKey: Delete"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+	source ../init.sh
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
 
-    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
-    echo ""
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+	
 #}
 
 #delete_sshKey

--- a/src/testclient/scripts/5.sshKey/force-delete-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/force-delete-sshKey.sh
@@ -1,29 +1,54 @@
 #!/bin/bash
 
-#function force_delete_sshKey() {
+function CallTB() {
+	echo "- Delete sshKey in ${MCIRRegionName}"
 
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true | jq ''
+}
 
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
+#function delete_sshKey() {
+
 	echo "####################################################################"
 	echo "## 5. sshKey: Delete"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+	source ../init.sh
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
 
-    curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true | jq ''
-    echo ""
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+	
 #}
 
-#force_delete_sshKey
+#delete_sshKey

--- a/src/testclient/scripts/6.image/registerImageWithId.sh
+++ b/src/testclient/scripts/6.image/registerImageWithId.sh
@@ -1,26 +1,7 @@
 #!/bin/bash
 
-#function registerImageWithId() {
-
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
-	echo "####################################################################"
-	echo "## 6. image: Register"
-	echo "####################################################################"
-
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-
-	source ../common-functions.sh
-	getCloudIndex $CSP
+function CallTB() {
+	echo "- Register image in ${MCIRRegionName}"
 
 	resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/resources/image?action=registerWithId -H 'Content-Type: application/json' -d @- <<EOF
@@ -34,6 +15,51 @@
 EOF
     ); echo ${resp} | jq ''
     echo ""
+}
+
+#function registerImageWithId() {
+
+	echo "####################################################################"
+	echo "## 6. image: Register"
+	echo "####################################################################"
+
+	source ../init.sh
+
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
+
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+	
 #}
 
 #registerImageWithId

--- a/src/testclient/scripts/6.image/unregister-image.sh
+++ b/src/testclient/scripts/6.image/unregister-image.sh
@@ -1,29 +1,54 @@
 #!/bin/bash
 
+function CallTB() {
+	echo "- Unregister image in ${MCIRRegionName}"
+
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
+}
+
 #function unregister_image() {
 
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
 	echo "####################################################################"
 	echo "## 6. image: Unregister"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+	source ../init.sh
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/image/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
 
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+	
 #}
 
 #unregister_image

--- a/src/testclient/scripts/7.spec/register-spec.sh
+++ b/src/testclient/scripts/7.spec/register-spec.sh
@@ -1,26 +1,7 @@
 #!/bin/bash
 
-#function register_spec() {
-
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
-	echo "####################################################################"
-	echo "## 7. spec: Register"
-	echo "####################################################################"
-
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-
-	source ../common-functions.sh
-	getCloudIndex $CSP
+function CallTB() {
+	echo "- Register spec in ${MCIRRegionName}"
 
 	resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/resources/spec -H 'Content-Type: application/json' -d @- <<EOF
@@ -32,6 +13,51 @@
 EOF
     ); echo ${resp} | jq ''
     echo ""
+}
+
+#function register_spec() {
+
+	echo "####################################################################"
+	echo "## 7. spec: Register"
+	echo "####################################################################"
+
+	source ../init.sh
+
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
+
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+
 #}
 
 #register_spec

--- a/src/testclient/scripts/7.spec/unregister-spec.sh
+++ b/src/testclient/scripts/7.spec/unregister-spec.sh
@@ -1,28 +1,53 @@
 #!/bin/bash
 
+function CallTB() {
+	echo "- Unregister spec in ${MCIRRegionName}"
+
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
+}
+
 #function unregister_spec() {
 
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
 	echo "####################################################################"
 	echo "## 7. spec: Unregister"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+	source ../init.sh
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+	if [ "${INDEX}" == "0" ]; then
+		echo "[Parallel excution for all CSP regions]"
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/spec/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} | jq ''
+		INDEXX=${NumCSP}
+		for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+			echo $i
+			INDEXY=${NumRegion[$cspi]}
+			CSP=${CSPType[$cspi]}
+			for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+				# INDEX=$(($INDEX+1))
+
+				echo $j
+				INDEX=$cspi
+				REGION=$cspj
+				echo $CSP
+				echo $REGION
+				echo ${RegionName[$cspi,$cspj]}
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
 
 #}
 

--- a/src/testclient/scripts/8.mcis/add-vmgroup-to-mcis.sh
+++ b/src/testclient/scripts/8.mcis/add-vmgroup-to-mcis.sh
@@ -2,29 +2,13 @@
 
 #function add-vm-to-mcis() {
 
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
 	echo "####################################################################"
 	echo "## 8. vm: Create MCIS"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-	NUMVM=${5:-3}
+	source ../init.sh
 
-	MCISID=${MCISPREFIX}-${POSTFIX}
-
-	source ../common-functions.sh
-	getCloudIndex $CSP
-
+	NUMVM=${OPTION01:-1}
 	
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/mcis/$MCISID/vmgroup -H 'Content-Type: application/json' -d \
 		'{

--- a/src/testclient/scripts/8.mcis/create-mcis.sh
+++ b/src/testclient/scripts/8.mcis/create-mcis.sh
@@ -2,35 +2,23 @@
 
 #function create_mcis() {
 
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
 	echo "####################################################################"
 	echo "## 8. vm: Create MCIS"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-	
-	NUMVM=${5:-3}
+	source ../init.sh
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+	NUMVM=${OPTION01:-1}
 
 	echo "####################"
 	echo " AgentInstallOn: $AgentInstallOn"
 	echo "####################"
 
+# 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/mcis -H 'Content-Type: application/json' -d \
 		'{
-			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"name": "'${MCISID}'",
 			"description": "Tumblebug Demo",
 			"installMonAgent": "'${AgentInstallOn}'",
 			"vm": [ {

--- a/src/testclient/scripts/8.mcis/create-single-vm-mcis.sh
+++ b/src/testclient/scripts/8.mcis/create-single-vm-mcis.sh
@@ -2,29 +2,13 @@
 
 #function create_mcis() {
 
-
-	TestSetFile=${4:-../testSet.env}
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
 	echo "####################################################################"
 	echo "## 8. Create MCIS with a single VM"
 	echo "####################################################################"
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
+	source ../init.sh
 
-	NUMVM=${5:-3}
-
-	MCISID=${MCISPREFIX}-${POSTFIX}
-
-	source ../common-functions.sh
-	getCloudIndex $CSP
+	NUMVM=${OPTION01:-1}
 
 	echo "####################"
 	echo " AgentInstallOn: $AgentInstallOn"

--- a/src/testclient/scripts/8.mcis/delete-mcis.sh
+++ b/src/testclient/scripts/8.mcis/delete-mcis.sh
@@ -2,28 +2,11 @@
 
 #function terminate_and_delete_mcis() {
 
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## 8. VM: Delete MCIS"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
-
-OPTION=${5:-notforce}
-
-source ../common-functions.sh
-getCloudIndex $CSP
-
-
+source ../init.sh
 
 MCISID=TBD
 if [ "${INDEX}" == "0" ]; then
@@ -33,7 +16,6 @@ else
 fi
 
 echo "${INDEX} ${REGION} ${MCISID}"
-
 
 echo ""
 echo "Delete [MCIS: $MCISID]"

--- a/src/testclient/scripts/8.mcis/id-list-vm.sh
+++ b/src/testclient/scripts/8.mcis/id-list-vm.sh
@@ -1,25 +1,10 @@
 #!/bin/bash
 
-
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## 8. VM: List ID"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
-
-source ../common-functions.sh
-getCloudIndex $CSP
-
+source ../init.sh
 
 if [ "${INDEX}" == "0" ]; then
 	MCISID=${MCISPREFIX}-${POSTFIX}

--- a/src/testclient/scripts/8.mcis/reboot-mcis.sh
+++ b/src/testclient/scripts/8.mcis/reboot-mcis.sh
@@ -2,25 +2,11 @@
 
 #function reboot_mcis() {
 
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## 8. VM: Reboot MCIS"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
-
-source ../common-functions.sh
-getCloudIndex $CSP
-
+source ../init.sh
 
 if [ "${INDEX}" == "0" ]; then
 	MCISID=${MCISPREFIX}-${POSTFIX}
@@ -31,7 +17,7 @@ fi
 echo "${MCISID}"
 
 ControlCmd=reboot
-curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=${ControlCmd} | jq ''
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/control/mcis/${MCISID}?action=${ControlCmd} | jq ''
 
 #}
 

--- a/src/testclient/scripts/8.mcis/refine-mcis.sh
+++ b/src/testclient/scripts/8.mcis/refine-mcis.sh
@@ -1,25 +1,10 @@
 #!/bin/bash
 
-
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## 8. VM: Refine MCIS (remove failed VMs)"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
-
-source ../common-functions.sh
-getCloudIndex $CSP
-
+source ../init.sh
 
 if [ "${INDEX}" == "0" ]; then
 	MCISID=${MCISPREFIX}-${POSTFIX}

--- a/src/testclient/scripts/8.mcis/resume-mcis.sh
+++ b/src/testclient/scripts/8.mcis/resume-mcis.sh
@@ -2,24 +2,11 @@
 
 #function resume_mcis() {
 
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## 8. VM: Resume from suspended MCIS"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
-
-source ../common-functions.sh
-getCloudIndex $CSP
+source ../init.sh
 
 if [ "${INDEX}" == "0" ]; then
 	MCISID=${MCISPREFIX}-${POSTFIX}
@@ -30,7 +17,7 @@ fi
 echo "${MCISID}"
 
 ControlCmd=resume
-curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=${ControlCmd} | jq ''
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/control/mcis/${MCISID}?action=${ControlCmd} | jq ''
 
 #}
 

--- a/src/testclient/scripts/8.mcis/status-mcis.sh
+++ b/src/testclient/scripts/8.mcis/status-mcis.sh
@@ -2,30 +2,17 @@
 
 #function status_mcis() {
 
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## 8. VM: Status MCIS"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
+source ../init.sh
 
-source ../common-functions.sh
-getCloudIndex $CSP
-
-if [ "${INDEX}" == "0" ]; then
-	MCISID=${MCISPREFIX}-${POSTFIX}
-else
-	MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
-fi
+# if [ "${INDEX}" == "0" ]; then
+# 	MCISID=${MCISPREFIX}-${POSTFIX}
+# else
+# 	MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+# fi
 
 echo "${MCISID}"
 

--- a/src/testclient/scripts/8.mcis/suspend-mcis.sh
+++ b/src/testclient/scripts/8.mcis/suspend-mcis.sh
@@ -2,25 +2,11 @@
 
 #function suspend_mcis() {
 
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## 8. VM: Suspend MCIS"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
-
-source ../common-functions.sh
-getCloudIndex $CSP
-
+source ../init.sh
 
 if [ "${INDEX}" == "0" ]; then
 	MCISID=${MCISPREFIX}-${POSTFIX}
@@ -31,7 +17,7 @@ fi
 echo "${MCISID}"
 
 ControlCmd=suspend
-curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=${ControlCmd} | jq ''
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/control/mcis/${MCISID}?action=${ControlCmd} | jq ''
 
 
 #suspend_mcis

--- a/src/testclient/scripts/8.mcis/terminate-mcis.sh
+++ b/src/testclient/scripts/8.mcis/terminate-mcis.sh
@@ -2,24 +2,11 @@
 
 #function just_terminate_mcis() {
 
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## 8. VM: Just Terminate MCIS"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
-
-source ../common-functions.sh
-getCloudIndex $CSP
+source ../init.sh
 
 if [ "${INDEX}" == "0" ]; then
 	MCISID=${MCISPREFIX}-${POSTFIX}
@@ -30,7 +17,7 @@ fi
 echo "${MCISID}"
 
 ControlCmd=terminate
-curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=${ControlCmd} | jq ''
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/control/mcis/${MCISID}?action=${ControlCmd} | jq ''
 
 
 #just_terminate_mcis

--- a/src/testclient/scripts/sequentialFullTest/check-network-performance.sh
+++ b/src/testclient/scripts/sequentialFullTest/check-network-performance.sh
@@ -39,7 +39,7 @@ echo ""
 #echo "[CHECK REMOTE COMMAND BY CB-TB API]"
 #echo " This will retrieve verified SSH username"
 
-#./command-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+#./command-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=status)
 VMARRAY=$(jq '.status.vm' <<<"$MCISINFO")

--- a/src/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
+++ b/src/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
@@ -6,11 +6,11 @@ function clean_sequence() {
 	local POSTFIX=$3
 	local TestSetFile=$4
 
-	../7.spec/unregister-spec.sh $CSP $REGION $POSTFIX $TestSetFile
-	../6.image/unregister-image.sh $CSP $REGION $POSTFIX $TestSetFile
+	../7.spec/unregister-spec.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../6.image/unregister-image.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 	echo '## 5. sshKey: Delete'
-	OUTPUT=$(../5.sshKey/delete-sshKey.sh $CSP $REGION $POSTFIX $TestSetFile)
+	OUTPUT=$(../5.sshKey/delete-sshKey.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile)
 	echo "${OUTPUT}"
 	OUTPUT=$(echo "${OUTPUT}" | grep -c -e 'Error' -e 'error' -e 'dependency' -e 'dependent' -e 'DependencyViolation')
 
@@ -21,7 +21,7 @@ function clean_sequence() {
 			echo "Trial: ${c}. Sleep 5 before retry sshKey: Delete"
 			dozing 5
 			# retry sshKey: Delete
-			OUTPUT2=$(../5.sshKey/delete-sshKey.sh $CSP $REGION $POSTFIX $TestSetFile)
+			OUTPUT2=$(../5.sshKey/delete-sshKey.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile)
 			echo "${OUTPUT2}"
 			OUTPUT2=$(echo "${OUTPUT2}" | grep -c -e 'Error' -e 'error' -e 'dependency' -e 'dependent' -e 'DependencyViolation')
 			echo "${OUTPUT2}"
@@ -40,7 +40,7 @@ function clean_sequence() {
 	fi
 
 	echo '## 4. SecurityGroup: Delete'
-	OUTPUT=$(../4.securityGroup/delete-securityGroup.sh $CSP $REGION $POSTFIX $TestSetFile)
+	OUTPUT=$(../4.securityGroup/delete-securityGroup.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile)
 	echo "${OUTPUT}"
 	OUTPUT=$(echo "${OUTPUT}" | grep -c -e 'Error' -e 'error' -e 'dependency' -e 'dependent' -e 'DependencyViolation')
 	echo "${OUTPUT}"
@@ -51,7 +51,7 @@ function clean_sequence() {
 			echo "Trial: ${c}. Sleep 5 before retry SecurityGroup: Delete"
 			dozing 5
 			# retry SecurityGroup: Delete
-			OUTPUT2=$(../4.securityGroup/delete-securityGroup.sh $CSP $REGION $POSTFIX $TestSetFile)
+			OUTPUT2=$(../4.securityGroup/delete-securityGroup.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile)
 			echo "${OUTPUT2}"
 			OUTPUT2=$(echo "${OUTPUT2}" | grep -c -e 'Error' -e 'error' -e 'dependency' -e 'dependent' -e 'DependencyViolation')
 			echo "${OUTPUT2}"
@@ -70,7 +70,7 @@ function clean_sequence() {
 	fi
 
 	echo '## 3. vNet: Delete'
-	OUTPUT=$(../3.vNet/delete-vNet.sh $CSP $REGION $POSTFIX $TestSetFile)
+	OUTPUT=$(../3.vNet/delete-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile)
 	echo "${OUTPUT}"
 	OUTPUT=$(echo "${OUTPUT}" | grep -c -e 'Error' -e 'error' -e 'dependency' -e 'dependent' -e 'DependencyViolation')
 	echo "${OUTPUT}"
@@ -81,7 +81,7 @@ function clean_sequence() {
 			echo "Trial: ${c}. Sleep 5 before retry delete-vNet"
 			dozing 5
 			# retry delete-vNet
-			OUTPUT2=$(../3.vNet/delete-vNet.sh $CSP $REGION $POSTFIX $TestSetFile)
+			OUTPUT2=$(../3.vNet/delete-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile)
 			echo "${OUTPUT2}"
 			OUTPUT2=$(echo "${OUTPUT2}" | grep -c -e 'Error' -e 'error' -e 'dependency' -e 'dependent' -e 'DependencyViolation')
 			echo "${OUTPUT2}"
@@ -133,7 +133,7 @@ source ../init.sh
 if [ "${INDEX}" == "0" ]; then
 	echo "[Parallel excution for all CSP regions]"
 
-	../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+	../8.mcis/status-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 	INDEXX=${NumCSP}
 	for ((cspi = 1; cspi <= INDEXX; cspi++)); do

--- a/src/testclient/scripts/sequentialFullTest/clean-mcis-only.sh
+++ b/src/testclient/scripts/sequentialFullTest/clean-mcis-only.sh
@@ -7,7 +7,7 @@ function clean_mcis_sequence() {
 	local TestSetFile=$4
 
 	echo '## 8. MCIS: Terminate'
-	OUTPUT=$(../8.mcis/terminate-mcis.sh $CSP $REGION $POSTFIX $TestSetFile)
+	OUTPUT=$(../8.mcis/terminate-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile)
 	echo "${OUTPUT}"
 	OUTPUT1=$(echo "${OUTPUT}" | grep -c 'No VM to terminate')
 	OUTPUT2=$(echo "${OUTPUT}" | grep -c 'Terminate is not allowed')
@@ -18,7 +18,7 @@ function clean_mcis_sequence() {
 		dozing 30
 	fi
 
-	../8.mcis/delete-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+	../8.mcis/delete-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 }
 
 SECONDS=0

--- a/src/testclient/scripts/sequentialFullTest/conf-ansible-env.sh
+++ b/src/testclient/scripts/sequentialFullTest/conf-ansible-env.sh
@@ -48,7 +48,7 @@ echo ""
 echo "[CHECK REMOTE COMMAND BY CB-TB API]"
 echo " This will retrieve verified SSH username"
 
-./command-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+./command-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=status)
 VMARRAY=$(jq '.status.vm' <<<"$MCISINFO")

--- a/src/testclient/scripts/sequentialFullTest/create-mcir-ns-cloud.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcir-ns-cloud.sh
@@ -10,22 +10,22 @@ function test_sequence() {
 
 	local CMDPATH=$6
 
-	../1.configureSpider/register-cloud.sh $CSP $REGION $POSTFIX $TestSetFile
-	../2.configureTumblebug/create-ns.sh $CSP $REGION $POSTFIX $TestSetFile
-	../3.vNet/create-vNet.sh $CSP $REGION $POSTFIX $TestSetFile
+	../1.configureSpider/register-cloud.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../2.configureTumblebug/create-ns.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../3.vNet/create-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
 	if [ "${CSP}" == "gcp" ]; then
 		echo "[Test for GCP needs more preparation time]"
 		dozing 20
 	fi
-	../4.securityGroup/create-securityGroup.sh $CSP $REGION $POSTFIX $TestSetFile
+	../4.securityGroup/create-securityGroup.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
-	../5.sshKey/create-sshKey.sh $CSP $REGION $POSTFIX $TestSetFile
-	../6.image/registerImageWithId.sh $CSP $REGION $POSTFIX $TestSetFile
-	../7.spec/register-spec.sh $CSP $REGION $POSTFIX $TestSetFile
+	../5.sshKey/create-sshKey.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../6.image/registerImageWithId.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../7.spec/register-spec.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	# ../8.mcis/create-mcis.sh $CSP $REGION $POSTFIX $NUMVM $TestSetFile
 	# dozing 1
-	# ../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+	# ../8.mcis/status-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 	_self=$CMDPATH
 
@@ -47,19 +47,19 @@ function test_sequence_allcsp_mcir() {
 	local TestSetFile=$4
 	local CMDPATH=$5
 
-	../1.configureSpider/register-cloud.sh $CSP $REGION $POSTFIX $TestSetFile
-	../2.configureTumblebug/create-ns.sh $CSP $REGION $POSTFIX $TestSetFile
-	../3.vNet/create-vNet.sh $CSP $REGION $POSTFIX $TestSetFile
+	../1.configureSpider/register-cloud.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../2.configureTumblebug/create-ns.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../3.vNet/create-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
 	if [ "${CSP}" == "gcp" ]; then
 		echo "[Test for GCP needs more preparation time]"
 		dozing 20
 	fi
-	../4.securityGroup/create-securityGroup.sh $CSP $REGION $POSTFIX $TestSetFile
+	../4.securityGroup/create-securityGroup.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
-	../5.sshKey/create-sshKey.sh $CSP $REGION $POSTFIX $TestSetFile
-	../6.image/registerImageWithId.sh $CSP $REGION $POSTFIX $TestSetFile
-	../7.spec/register-spec.sh $CSP $REGION $POSTFIX $TestSetFile
+	../5.sshKey/create-sshKey.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../6.image/registerImageWithId.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../7.spec/register-spec.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 	_self=$CMDPATH
 

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
@@ -9,22 +9,22 @@ function test_sequence()
 	local TestSetFile=$4
 	local CMDPATH=$5
 
-	../1.configureSpider/register-cloud.sh $CSP $REGION $POSTFIX $TestSetFile
-	../2.configureTumblebug/create-ns.sh $CSP $REGION $POSTFIX $TestSetFile
-	../3.vNet/create-vNet.sh $CSP $REGION $POSTFIX $TestSetFile
+	../1.configureSpider/register-cloud.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../2.configureTumblebug/create-ns.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../3.vNet/create-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
 	if [ "${CSP}" == "gcp" ]; then
 		echo "[Test for GCP needs more preparation time]"
 		dozing 20
 	fi
-	../4.securityGroup/create-securityGroup.sh $CSP $REGION $POSTFIX $TestSetFile
+	../4.securityGroup/create-securityGroup.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
-	../5.sshKey/create-sshKey.sh $CSP $REGION $POSTFIX $TestSetFile
-	../6.image/registerImageWithId.sh $CSP $REGION $POSTFIX $TestSetFile
-	../7.spec/register-spec.sh $CSP $REGION $POSTFIX $TestSetFile
-	../8.mcis/create-mcis-no-agent.sh $CSP $REGION $POSTFIX $TestSetFile
+	../5.sshKey/create-sshKey.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../6.image/registerImageWithId.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../7.spec/register-spec.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../8.mcis/create-mcis-no-agent.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 1
-	../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+	../8.mcis/status-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 	_self=$CMDPATH
 
@@ -73,7 +73,7 @@ function test_sequence()
 
 	echo "[Deploy CB-Dragonfly Docker]"
 	dozing 60
-	./deploy-dragonfly-docker.sh $CSP $REGION $POSTFIX $TestSetFile
+	./deploy-dragonfly-docker.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 #}
 

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-for-ws.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-for-ws.sh
@@ -8,22 +8,22 @@ function test_sequence() {
 	local TestSetFile=$4
 	local CMDPATH=$5
 
-	../1.configureSpider/register-cloud.sh $CSP $REGION $POSTFIX $TestSetFile
-	../2.configureTumblebug/create-ns.sh $CSP $REGION $POSTFIX $TestSetFile
-	../3.vNet/create-vNet.sh $CSP $REGION $POSTFIX $TestSetFile
+	../1.configureSpider/register-cloud.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../2.configureTumblebug/create-ns.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../3.vNet/create-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
 	if [ "${CSP}" == "gcp" ]; then
 		echo "[Test for GCP needs more preparation time]"
 		dozing 20
 	fi
-	../4.securityGroup/create-securityGroup.sh $CSP $REGION $POSTFIX $TestSetFile
+	../4.securityGroup/create-securityGroup.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
-	../5.sshKey/create-sshKey.sh $CSP $REGION $POSTFIX $TestSetFile
-	../6.image/registerImageWithId.sh $CSP $REGION $POSTFIX $TestSetFile
-	../7.spec/register-spec.sh $CSP $REGION $POSTFIX $TestSetFile
-	../8.mcis/create-mcis-no-agent.sh $CSP $REGION $POSTFIX $TestSetFile
+	../5.sshKey/create-sshKey.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../6.image/registerImageWithId.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../7.spec/register-spec.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../8.mcis/create-mcis-no-agent.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 1
-	../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+	../8.mcis/status-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 	_self=$CMDPATH
 
@@ -68,7 +68,7 @@ test_sequence $CSP $REGION $POSTFIX $TestSetFile ${0##*/}
 
 echo "[Deploy WeaveScope]"
 dozing 60
-./deploy-weavescope-to-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+./deploy-weavescope-to-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 #}
 

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-only.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-only.sh
@@ -9,9 +9,9 @@ function test_sequence() {
 	local NUMVM=$5
 	local CMDPATH=$6
 
-	../8.mcis/create-mcis.sh $CSP $REGION $POSTFIX $TestSetFile $NUMVM 
+	../8.mcis/create-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile -x $NUMVM 
 	dozing 1
-	../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+	../8.mcis/status-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 	_self=$CMDPATH
 
@@ -37,9 +37,9 @@ function test_sequence_allcsp_mcis() {
 
 	_self=$CMDPATH
 
-	../8.mcis/create-single-vm-mcis.sh $CSP $REGION $POSTFIX $TestSetFile $NUMVM
+	../8.mcis/create-single-vm-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile -x $NUMVM
 	#dozing 1
-	#../8.mcis/status-mcis.sh $CSP $REGION $POSTFIX $TestSetFile $MCISPREFIX
+	#../8.mcis/status-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile $MCISPREFIX
 	echo ""
 	echo "[Logging to notify latest command history]"
 	echo "[MCIS:${MCISID}(${SECONDS}s+More)] ${_self} (MCIS) all 1 ${POSTFIX} ${TestSetFile}" >>./executionStatus
@@ -58,7 +58,7 @@ function test_sequence_allcsp_mcis_vm() {
 	local TestSetFile=$4
 	local NUMVM=$5
 
-	../8.mcis/add-vmgroup-to-mcis.sh $CSP $REGION $POSTFIX $TestSetFile $NUMVM 
+	../8.mcis/add-vmgroup-to-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile -x $NUMVM 
 
 }
 SECONDS=0
@@ -129,7 +129,7 @@ if [ "${INDEX}" == "0" ]; then
 	done
 	wait
 
-	../8.mcis/status-mcis.sh "$@"
+	../8.mcis/status-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 else
 	echo ""

--- a/src/testclient/scripts/sequentialFullTest/gen-sshKey.sh
+++ b/src/testclient/scripts/sequentialFullTest/gen-sshKey.sh
@@ -39,7 +39,7 @@ echo ""
 echo "[CHECK REMOTE COMMAND BY CB-TB API]"
 echo " This will retrieve verified SSH username"
 
-./command-mcis.sh $CSP $REGION $POSTFIX $TestSetFile
+./command-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 
 MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=status)
 VMARRAY=$(jq '.status.vm' <<<"$MCISINFO")


### PR DESCRIPTION
- Separate `ControlMCIS` REST API
  - Closes https://github.com/cloud-barista/cb-tumblebug/issues/23#issuecomment-901796330
  - `GET("/:nsId/control/mcis/:mcisId", rest_mcis.RestGetControlMcis)`
  - `GET("/:nsId/control/mcis/:mcisId/vm/:vmId", rest_mcis.RestGetControlMcisVm)`
  - 호출 예시: `http://localhost:1323/tumblebug/ns/:nsId/control/mcis/:mcisId/vm/:vmId?action=suspend`
- Update test scripts
  - Related PR: 
    #677
    #688
  - `create/register-*.sh`, `delete/unregister-*.sh` 스크립트가
    `-n myname01 -f ../testSet.env` 형식의 인자도 받을 수 있도록 수정
  - `create-all.sh`, `clean-all.sh` 스크립트가 정상적으로 동작하도록 수정
    (AWS Singapore + AWS Canada Central + GCP Taiwan + GCP Frankfurt (Germany) 로 구성되는 단일 MCIS 생성/삭제 테스트 완료)
  - TODO: 이 변경사항을 나머지 (`get-*.sh`, ...) 스크립트에도 반영