### PR TITLE
Add check test config script

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ cb-operator/src$ ./operator
 - `src/testclient/scripts/sequentialFullTest/` 에 포함된 `create-all.sh` 및 `clean-all.sh` 을 수행하면 전체 과정을 한번에 테스트 가능
 ```
 └── sequentialFullTest  # Cloud 정보 등록, NS 생성, MCIR 생성, MCIS 생성까지 한번에 자동 테스트
+    ├── check-test-config.sh  # 현재 testSet에 지정된 멀티 클라우드 인프라 구성을 확인
     ├── create-all.sh  # Cloud 정보 등록, NS 생성, MCIR 생성, MCIS 생성까지 한번에 자동 테스트
     ├── gen-sshKey.sh  # 수행이 진행된 테스트 로그 (MCIS에 접속 가능한 SSH키 파일 생성)  
     ├── command-mcis.sh  # 생성된 MCIS(다중VM)에 원격 명령 수행
@@ -274,6 +275,8 @@ cb-operator/src$ ./operator
 
 ```
 - 사용 예시
+  - 테스트 형상 확인
+    - `./check-test-config.sh -n shson -f ../testSetCustom.env`   # ../testSetCustom.env 에 구성된 조합을 미리 확인 (사용되는 CSP, region, image, spec 등)
   - 생성 테스트
     - `./create-all.sh -n shson -f ../testSetCustom.env`   # ../testSetCustom.env 에 구성된 클라우드 조합으로 MCIS 생성 수행
   - 제거 테스트 (생성에서 활용한 입력 파라미터로 삭제 필요)

--- a/src/testclient/scripts/sequentialFullTest/check-test-config.sh
+++ b/src/testclient/scripts/sequentialFullTest/check-test-config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+echo "####################################################################"
+echo "## Check test config file (-n deveoperPrefix -f ../testSetCustom.env)"
+echo "####################################################################"
+
+source ../init.sh
+
+NUMVM=${OPTION01:-1}
+
+echo ""
+echo "[Configuration in ($TestSetFile) & (../conf.env) files]"
+echo "1) TumblebugServer : $TumblebugServer // SpiderServer : $SpiderServer"
+echo "2) NameSpace ID : $NSID // MCIS ID : $MCISID"
+
+INDEXX=${NumCSP}
+echo "3) Enabled CSPs for $MCISID"
+for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+	CSP=${CSPType[$cspi]}
+	INDEXY=${NumRegion[$cspi]}
+	echo "[$cspi] $CSP (enabled regions : $INDEXY)"
+done
+echo ""
+for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+	INDEXY=${NumRegion[$cspi]}
+	CSP=${CSPType[$cspi]}
+	echo "[$cspi] $CSP details"
+	for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+		echo "[$cspi,$cspj] ${RegionName[$cspi,$cspj]}" 
+		echo "- VM SPEC : ${SPEC_NAME[$cspi,$cspj]}"
+		echo "- VM IMAGE : ${IMAGE_NAME[$cspi,$cspj]}"
+	done
+	echo ""
+done
+
+
+echo ""


### PR DESCRIPTION
This PR adds a new script to check the test configuration from given configuration file. 
This script can be used to verify a current setting before execute `./create-all.sh`

input example
```
~ cb-tumblebug/src/testclient/scripts/sequentialFullTest$ 

./check-test-config.sh -n shson01 -f ../testSet-tmp.env 

```

output example
```
####################################################################
## Check test config file (-n deveoperPrefix -f ../testSetCustom.env)
####################################################################

Input parameters
// POSTFIX:shson01 // TestSetFile:../testSet-tmp.env // CSP:all // REGION:1 // OPTION01: // OPTION02: // OPTION03:

[Configuration in (../testSet-tmp.env) & (../conf.env) files]
1) TumblebugServer : localhost:1323 // SpiderServer : localhost:1024
2) NameSpace ID : tb01 // MCIS ID : cb-shson01
3) Enabled CSPs for cb-shson01
[1] aws (enabled regions : 3)
[2] gcp (enabled regions : 1)

[1] aws details
[1,1] aws-ap-southeast-1
- VM SPEC : m4.4xlarge
- VM IMAGE : ami-061eb2b23f9f8839c
[1,2] aws-ca-central-1
- VM SPEC : t2.micro
- VM IMAGE : ami-0d0eaed20348a3389
[1,3] aws-us-west-1
- VM SPEC : t2.micro
- VM IMAGE : ami-0dd655843c87b6930

[2] gcp details
[2,1] gcp-asia-east1
- VM SPEC : e2-small
- VM IMAGE : https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-minimal-1804-bionic-v20191024
```