### PR TITLE
Adopt struct validator more

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -4916,6 +4916,12 @@ var doc = `{
         },
         "mcir.TbSecurityGroupReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "firewallRules",
+                "name",
+                "vNetId"
+            ],
             "properties": {
                 "connectionName": {
                     "type": "string"
@@ -5053,6 +5059,11 @@ var doc = `{
         },
         "mcir.TbSpecReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "cspSpecName",
+                "name"
+            ],
             "properties": {
                 "connectionName": {
                     "type": "string"
@@ -5120,6 +5131,10 @@ var doc = `{
         },
         "mcir.TbSshKeyReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "name"
+            ],
             "properties": {
                 "connectionName": {
                     "type": "string"
@@ -5184,6 +5199,10 @@ var doc = `{
         },
         "mcir.TbVNetReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "name"
+            ],
             "properties": {
                 "cidrBlock": {
                     "type": "string"
@@ -5392,6 +5411,9 @@ var doc = `{
         },
         "mcis.McisCmdReq": {
             "type": "object",
+            "required": [
+                "command"
+            ],
             "properties": {
                 "command": {
                     "type": "string",
@@ -5914,6 +5936,10 @@ var doc = `{
         },
         "mcis.TbMcisReq": {
             "type": "object",
+            "required": [
+                "name",
+                "vm"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -6121,6 +6147,15 @@ var doc = `{
         },
         "mcis.TbVmReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "imageId",
+                "name",
+                "securityGroupIds",
+                "specId",
+                "sshKeyId",
+                "vNetId"
+            ],
             "properties": {
                 "connectionName": {
                     "type": "string"

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -4901,6 +4901,12 @@
         },
         "mcir.TbSecurityGroupReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "firewallRules",
+                "name",
+                "vNetId"
+            ],
             "properties": {
                 "connectionName": {
                     "type": "string"
@@ -5038,6 +5044,11 @@
         },
         "mcir.TbSpecReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "cspSpecName",
+                "name"
+            ],
             "properties": {
                 "connectionName": {
                     "type": "string"
@@ -5105,6 +5116,10 @@
         },
         "mcir.TbSshKeyReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "name"
+            ],
             "properties": {
                 "connectionName": {
                     "type": "string"
@@ -5169,6 +5184,10 @@
         },
         "mcir.TbVNetReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "name"
+            ],
             "properties": {
                 "cidrBlock": {
                     "type": "string"
@@ -5377,6 +5396,9 @@
         },
         "mcis.McisCmdReq": {
             "type": "object",
+            "required": [
+                "command"
+            ],
             "properties": {
                 "command": {
                     "type": "string",
@@ -5899,6 +5921,10 @@
         },
         "mcis.TbMcisReq": {
             "type": "object",
+            "required": [
+                "name",
+                "vm"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -6106,6 +6132,15 @@
         },
         "mcis.TbVmReq": {
             "type": "object",
+            "required": [
+                "connectionName",
+                "imageId",
+                "name",
+                "securityGroupIds",
+                "specId",
+                "sshKeyId",
+                "vNetId"
+            ],
             "properties": {
                 "connectionName": {
                     "type": "string"

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -490,6 +490,11 @@ definitions:
         type: string
       vNetId:
         type: string
+    required:
+    - connectionName
+    - firewallRules
+    - name
+    - vNetId
     type: object
   mcir.TbSpecInfo:
     properties:
@@ -577,6 +582,10 @@ definitions:
         type: string
       name:
         type: string
+    required:
+    - connectionName
+    - cspSpecName
+    - name
     type: object
   mcir.TbSshKeyInfo:
     properties:
@@ -619,6 +628,9 @@ definitions:
         type: string
       name:
         type: string
+    required:
+    - connectionName
+    - name
     type: object
   mcir.TbVNetInfo:
     properties:
@@ -667,6 +679,9 @@ definitions:
         items:
           $ref: '#/definitions/mcir.SpiderSubnetReqInfo'
         type: array
+    required:
+    - connectionName
+    - name
     type: object
   mcis.AgentInstallContent:
     properties:
@@ -800,6 +815,8 @@ definitions:
       userName:
         example: cb-user
         type: string
+    required:
+    - command
     type: object
   mcis.McisPolicyInfo:
     properties:
@@ -1181,6 +1198,9 @@ definitions:
         items:
           $ref: '#/definitions/mcis.TbVmReq'
         type: array
+    required:
+    - name
+    - vm
     type: object
   mcis.TbVmInfo:
     properties:
@@ -1333,6 +1353,14 @@ definitions:
         type: string
       vmUserPassword:
         type: string
+    required:
+    - connectionName
+    - imageId
+    - name
+    - securityGroupIds
+    - specId
+    - sshKeyId
+    - vNetId
     type: object
   mcis.TbVmStatusInfo:
     properties:

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -47,10 +47,14 @@ func init() {
 		return name
 	})
 
-	// register validation for 'TbImageReq'
-	// NOTE: only have to register a non-pointer type for 'TbImageReq', validator
+	// register validation for 'Tb*Req'
+	// NOTE: only have to register a non-pointer type for 'Tb*Req', validator
 	// internally dereferences during it's type checks.
 	validate.RegisterStructValidation(TbImageReqStructLevelValidation, TbImageReq{})
+	validate.RegisterStructValidation(TbSecurityGroupReqStructLevelValidation, TbSecurityGroupReq{})
+	validate.RegisterStructValidation(TbSpecReqStructLevelValidation, TbSpecReq{})
+	validate.RegisterStructValidation(TbSshKeyReqStructLevelValidation, TbSshKeyReq{})
+	validate.RegisterStructValidation(TbVNetReqStructLevelValidation, TbVNetReq{})
 }
 
 // DelAllResources deletes all TB MCIR object of given resourceType

--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -117,13 +117,6 @@ func RegisterImageWithId(nsId string, u *TbImageReq) (TbImageInfo, error) {
 		return temp, err
 	}
 
-	// err = common.CheckString(u.Name)
-	// if err != nil {
-	// 	temp := TbImageInfo{}
-	// 	common.CBLog.Error(err)
-	// 	return temp, err
-	// }
-
 	// returns InvalidValidationError for bad validation input, nil or ValidationErrors ( []FieldError )
 	err = validate.Struct(u)
 	if err != nil {

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cloud-barista/cb-spider/interface/api"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
+	validator "github.com/go-playground/validator/v10"
 	"github.com/go-resty/resty/v2"
 
 	//"github.com/cloud-barista/cb-tumblebug/src/core/mcis"
@@ -44,10 +45,21 @@ type SpiderGpuInfo struct { // Spider
 }
 
 type TbSpecReq struct { // Tumblebug
-	Name           string `json:"name"`
-	ConnectionName string `json:"connectionName"`
-	CspSpecName    string `json:"cspSpecName"`
+	Name           string `json:"name" validate:"required"`
+	ConnectionName string `json:"connectionName" validate:"required"`
+	CspSpecName    string `json:"cspSpecName" validate:"required"`
 	Description    string `json:"description"`
+}
+
+func TbSpecReqStructLevelValidation(sl validator.StructLevel) {
+
+	u := sl.Current().Interface().(TbSpecReq)
+
+	err := common.CheckString(u.Name)
+	if err != nil {
+		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
+		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+	}
 }
 
 type TbSpecInfo struct { // Tumblebug
@@ -367,12 +379,39 @@ func RegisterSpecWithCspSpecName(nsId string, u *TbSpecReq) (TbSpecInfo, error) 
 		common.CBLog.Error(err)
 		return temp, err
 	}
-	err = common.CheckString(u.Name)
+
+	// returns InvalidValidationError for bad validation input, nil or ValidationErrors ( []FieldError )
+	err = validate.Struct(u)
 	if err != nil {
+
+		// this check is only needed when your code could produce
+		// an invalid value for validation such as interface with nil
+		// value most including myself do not usually have code like this.
+		if _, ok := err.(*validator.InvalidValidationError); ok {
+			fmt.Println(err)
+			temp := TbSpecInfo{}
+			return temp, err
+		}
+
+		// for _, err := range err.(validator.ValidationErrors) {
+
+		// 	fmt.Println(err.Namespace()) // can differ when a custom TagNameFunc is registered or
+		// 	fmt.Println(err.Field())     // by passing alt name to ReportError like below
+		// 	fmt.Println(err.StructNamespace())
+		// 	fmt.Println(err.StructField())
+		// 	fmt.Println(err.Tag())
+		// 	fmt.Println(err.ActualTag())
+		// 	fmt.Println(err.Kind())
+		// 	fmt.Println(err.Type())
+		// 	fmt.Println(err.Value())
+		// 	fmt.Println(err.Param())
+		// 	fmt.Println()
+		// }
+
 		temp := TbSpecInfo{}
-		common.CBLog.Error(err)
 		return temp, err
 	}
+
 	check, _ := CheckResource(nsId, resourceType, u.Name)
 
 	if check {

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cloud-barista/cb-spider/interface/api"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
+	validator "github.com/go-playground/validator/v10"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -38,9 +39,20 @@ type SpiderKeyPairInfo struct { // Spider
 }
 
 type TbSshKeyReq struct {
-	Name           string `json:"name"`
-	ConnectionName string `json:"connectionName"`
+	Name           string `json:"name" validate:"required"`
+	ConnectionName string `json:"connectionName" validate:"required"`
 	Description    string `json:"description"`
+}
+
+func TbSshKeyReqStructLevelValidation(sl validator.StructLevel) {
+
+	u := sl.Current().Interface().(TbSshKeyReq)
+
+	err := common.CheckString(u.Name)
+	if err != nil {
+		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
+		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+	}
 }
 
 type TbSshKeyInfo struct {
@@ -70,12 +82,39 @@ func CreateSshKey(nsId string, u *TbSshKeyReq) (TbSshKeyInfo, error) {
 		common.CBLog.Error(err)
 		return temp, err
 	}
-	err = common.CheckString(u.Name)
+
+	// returns InvalidValidationError for bad validation input, nil or ValidationErrors ( []FieldError )
+	err = validate.Struct(u)
 	if err != nil {
+
+		// this check is only needed when your code could produce
+		// an invalid value for validation such as interface with nil
+		// value most including myself do not usually have code like this.
+		if _, ok := err.(*validator.InvalidValidationError); ok {
+			fmt.Println(err)
+			temp := TbSshKeyInfo{}
+			return temp, err
+		}
+
+		// for _, err := range err.(validator.ValidationErrors) {
+
+		// 	fmt.Println(err.Namespace()) // can differ when a custom TagNameFunc is registered or
+		// 	fmt.Println(err.Field())     // by passing alt name to ReportError like below
+		// 	fmt.Println(err.StructNamespace())
+		// 	fmt.Println(err.StructField())
+		// 	fmt.Println(err.Tag())
+		// 	fmt.Println(err.ActualTag())
+		// 	fmt.Println(err.Kind())
+		// 	fmt.Println(err.Type())
+		// 	fmt.Println(err.Value())
+		// 	fmt.Println(err.Param())
+		// 	fmt.Println()
+		// }
+
 		temp := TbSshKeyInfo{}
-		common.CBLog.Error(err)
 		return temp, err
 	}
+
 	check, err := CheckResource(nsId, resourceType, u.Name)
 
 	if check {

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cloud-barista/cb-spider/interface/api"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
+	validator "github.com/go-playground/validator/v10"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -45,11 +46,22 @@ type SpiderSubnetInfo struct { // Spider
 }
 
 type TbVNetReq struct { // Tumblebug
-	Name           string                `json:"name"`
-	ConnectionName string                `json:"connectionName"`
+	Name           string                `json:"name" validate:"required"`
+	ConnectionName string                `json:"connectionName" validate:"required"`
 	CidrBlock      string                `json:"cidrBlock"`
 	SubnetInfoList []SpiderSubnetReqInfo `json:"subnetInfoList"`
 	Description    string                `json:"description"`
+}
+
+func TbVNetReqStructLevelValidation(sl validator.StructLevel) {
+
+	u := sl.Current().Interface().(TbVNetReq)
+
+	err := common.CheckString(u.Name)
+	if err != nil {
+		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
+		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+	}
 }
 
 type TbVNetInfo struct { // Tumblebug
@@ -82,12 +94,39 @@ func CreateVNet(nsId string, u *TbVNetReq) (TbVNetInfo, error) {
 		common.CBLog.Error(err)
 		return temp, err
 	}
-	err = common.CheckString(u.Name)
+
+	// returns InvalidValidationError for bad validation input, nil or ValidationErrors ( []FieldError )
+	err = validate.Struct(u)
 	if err != nil {
+
+		// this check is only needed when your code could produce
+		// an invalid value for validation such as interface with nil
+		// value most including myself do not usually have code like this.
+		if _, ok := err.(*validator.InvalidValidationError); ok {
+			fmt.Println(err)
+			temp := TbVNetInfo{}
+			return temp, err
+		}
+
+		// for _, err := range err.(validator.ValidationErrors) {
+
+		// 	fmt.Println(err.Namespace()) // can differ when a custom TagNameFunc is registered or
+		// 	fmt.Println(err.Field())     // by passing alt name to ReportError like below
+		// 	fmt.Println(err.StructNamespace())
+		// 	fmt.Println(err.StructField())
+		// 	fmt.Println(err.Tag())
+		// 	fmt.Println(err.ActualTag())
+		// 	fmt.Println(err.Kind())
+		// 	fmt.Println(err.Type())
+		// 	fmt.Println(err.Value())
+		// 	fmt.Println(err.Param())
+		// 	fmt.Println()
+		// }
+
 		temp := TbVNetInfo{}
-		common.CBLog.Error(err)
 		return temp, err
 	}
+
 	check, err := CheckResource(nsId, resourceType, u.Name)
 
 	if check {

--- a/src/core/mcis/monitor.go
+++ b/src/core/mcis/monitor.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	validator "github.com/go-playground/validator/v10"
 	"github.com/tidwall/gjson"
 
 	"fmt"
@@ -52,6 +53,29 @@ type MonAgentInstallReq struct {
 	UserName string `json:"userName,omitempty"`
 	SshKey   string `json:"sshKey,omitempty"`
 	CspType  string `json:"cspType,omitempty"`
+}
+
+func DFMonAgentInstallReqStructLevelValidation(sl validator.StructLevel) {
+
+	u := sl.Current().Interface().(MonAgentInstallReq)
+
+	err := common.CheckString(u.NsId)
+	if err != nil {
+		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
+		sl.ReportError(u.NsId, "nsId", "NsId", "NotObeyingNamingConvention", "")
+	}
+
+	err = common.CheckString(u.McisId)
+	if err != nil {
+		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
+		sl.ReportError(u.McisId, "mcisId", "McisId", "NotObeyingNamingConvention", "")
+	}
+
+	err = common.CheckString(u.VmId)
+	if err != nil {
+		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
+		sl.ReportError(u.VmId, "vmId", "VmId", "NotObeyingNamingConvention", "")
+	}
 }
 
 /*

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -21,6 +21,10 @@ import (
 	//"github.com/cloud-barista/cb-tumblebug/src/core/common"
 
 	"github.com/go-resty/resty/v2"
+
+	"reflect"
+
+	validator "github.com/go-playground/validator/v10"
 )
 
 // CB-Store
@@ -29,10 +33,39 @@ import (
 
 //var SPIDER_REST_URL string
 
+// use a single instance of Validate, it caches struct info
+var validate *validator.Validate
+
 func init() {
 	//cblog = config.Cblogger
 	//store = cbstore.GetStore()
 	//SPIDER_REST_URL = os.Getenv("SPIDER_REST_URL")
+
+	validate = validator.New()
+
+	// register function to get tag name from json tags.
+	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+		if name == "-" {
+			return ""
+		}
+		return name
+	})
+
+	// register validation for 'Tb*Req'
+	// NOTE: only have to register a non-pointer type for 'Tb*Req', validator
+	// internally dereferences during it's type checks.
+
+	validate.RegisterStructValidation(TbMcisReqStructLevelValidation, TbMcisReq{})
+	validate.RegisterStructValidation(TbVmReqStructLevelValidation, TbVmReq{})
+	validate.RegisterStructValidation(TbMcisCmdReqStructLevelValidation, McisCmdReq{})
+	// validate.RegisterStructValidation(TbMcisRecommendReqStructLevelValidation, McisRecommendReq{})
+	// validate.RegisterStructValidation(TbVmRecommendReqStructLevelValidation, TbVmRecommendReq{})
+	// validate.RegisterStructValidation(TbBenchmarkReqStructLevelValidation, BenchmarkReq{})
+	// validate.RegisterStructValidation(TbMultihostBenchmarkReqStructLevelValidation, MultihostBenchmarkReq{})
+
+	validate.RegisterStructValidation(DFMonAgentInstallReqStructLevelValidation, MonAgentInstallReq{})
+
 }
 
 /*


### PR DESCRIPTION
- 나머지 MCIR (SecurityGroup, Spec, SSHKey, vNet) 에 대해서도 validator를 도입했습니다.
  - 잘 적용되었는지 (struct tag, validation 함수, 빠진 필드가 없는지 등) 검토가 이루어지면 좋습니다.
- MCIS의 `*Req` struct 중, `TbMcisReq`, `TbVmReq`, `McisCmdReq`, `MonAgentInstallReq` 에 대해서도 validator를 도입했습니다.
  - 잘 적용되었는지 (struct tag, validation 함수, 빠진 필드가 없는지 등) 검토가 이루어지면 좋습니다.
  - MCIS의 `*Req` struct 중, 나머지 struct에도 적용이 필요한지 검토가 이루어지면 좋습니다.
