### PR TITLE
Add list MCIS simple option

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -1267,7 +1267,9 @@ var doc = `{
                     },
                     {
                         "enum": [
-                            "id"
+                            "id",
+                            "simple",
+                            "status"
                         ],
                         "type": "string",
                         "description": "Option",
@@ -1291,6 +1293,12 @@ var doc = `{
                                         },
                                         "[ID]": {
                                             "$ref": "#/definitions/common.IdList"
+                                        },
+                                        "[SIMPLE]": {
+                                            "$ref": "#/definitions/mcis.RestGetAllMcisResponse"
+                                        },
+                                        "[STATUS]": {
+                                            "$ref": "#/definitions/mcis.RestGetAllMcisStatusResponse"
                                         }
                                     }
                                 }
@@ -5692,6 +5700,17 @@ var doc = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcis.TbMcisInfo"
+                    }
+                }
+            }
+        },
+        "mcis.RestGetAllMcisStatusResponse": {
+            "type": "object",
+            "properties": {
+                "mcis": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.McisStatusInfo"
                     }
                 }
             }

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -1252,7 +1252,9 @@
                     },
                     {
                         "enum": [
-                            "id"
+                            "id",
+                            "simple",
+                            "status"
                         ],
                         "type": "string",
                         "description": "Option",
@@ -1276,6 +1278,12 @@
                                         },
                                         "[ID]": {
                                             "$ref": "#/definitions/common.IdList"
+                                        },
+                                        "[SIMPLE]": {
+                                            "$ref": "#/definitions/mcis.RestGetAllMcisResponse"
+                                        },
+                                        "[STATUS]": {
+                                            "$ref": "#/definitions/mcis.RestGetAllMcisStatusResponse"
                                         }
                                     }
                                 }
@@ -5677,6 +5685,17 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcis.TbMcisInfo"
+                    }
+                }
+            }
+        },
+        "mcis.RestGetAllMcisStatusResponse": {
+            "type": "object",
+            "properties": {
+                "mcis": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.McisStatusInfo"
                     }
                 }
             }

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1004,6 +1004,13 @@ definitions:
           $ref: '#/definitions/mcis.TbMcisInfo'
         type: array
     type: object
+  mcis.RestGetAllMcisStatusResponse:
+    properties:
+      mcis:
+        items:
+          $ref: '#/definitions/mcis.McisStatusInfo'
+        type: array
+    type: object
   mcis.RestGetBenchmarkRequest:
     properties:
       host:
@@ -2321,6 +2328,8 @@ paths:
       - description: Option
         enum:
         - id
+        - simple
+        - status
         in: query
         name: option
         type: string
@@ -2337,6 +2346,10 @@ paths:
                   $ref: '#/definitions/mcis.RestGetAllMcisResponse'
                 '[ID]':
                   $ref: '#/definitions/common.IdList'
+                '[SIMPLE]':
+                  $ref: '#/definitions/mcis.RestGetAllMcisResponse'
+                '[STATUS]':
+                  $ref: '#/definitions/mcis.RestGetAllMcisStatusResponse'
               type: object
         "404":
           description: Not Found

--- a/src/api/rest/docs/v0.4.7.yaml
+++ b/src/api/rest/docs/v0.4.7.yaml
@@ -1,0 +1,4209 @@
+basePath: /tumblebug
+definitions:
+  common.ConfigInfo:
+    properties:
+      id:
+        example: SPIDER_REST_URL
+        type: string
+      name:
+        example: SPIDER_REST_URL
+        type: string
+      value:
+        example: http://localhost:1024/spider
+        type: string
+    type: object
+  common.ConfigReq:
+    properties:
+      name:
+        example: SPIDER_REST_URL
+        type: string
+      value:
+        example: http://localhost:1024/spider
+        type: string
+    type: object
+  common.ConnConfig:
+    properties:
+      configName:
+        type: string
+      credentialName:
+        type: string
+      driverName:
+        type: string
+      providerName:
+        type: string
+      regionName:
+        type: string
+    type: object
+  common.ConnConfigList:
+    properties:
+      connectionconfig:
+        items:
+          $ref: '#/definitions/common.ConnConfig'
+        type: array
+    type: object
+  common.IID:
+    properties:
+      nameId:
+        description: NameID by user
+        type: string
+      systemId:
+        description: SystemID by CloudOS
+        type: string
+    type: object
+  common.IdList:
+    properties:
+      idList:
+        items:
+          type: string
+        type: array
+    type: object
+  common.JSONResult:
+    type: object
+  common.KeyValue:
+    properties:
+      key:
+        type: string
+      value:
+        type: string
+    type: object
+  common.NsInfo:
+    properties:
+      description:
+        example: Description for this namespace
+        type: string
+      id:
+        example: namespaceid01
+        type: string
+      name:
+        example: namespacename01
+        type: string
+    type: object
+  common.NsReq:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+    type: object
+  common.Region:
+    properties:
+      keyValueInfoList:
+        description: ex) { {region, us-east1}, {zone, us-east1-c} }
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      providerName:
+        description: ex) "GCP"
+        type: string
+      regionName:
+        description: ex) "region01"
+        type: string
+    type: object
+  common.RegionList:
+    properties:
+      region:
+        items:
+          $ref: '#/definitions/common.Region'
+        type: array
+    type: object
+  common.RestGetAllConfigResponse:
+    properties:
+      config:
+        description: Name string     `json:"name"`
+        items:
+          $ref: '#/definitions/common.ConfigInfo'
+        type: array
+    type: object
+  common.RestGetAllNsResponse:
+    properties:
+      ns:
+        description: Name string     `json:"name"`
+        items:
+          $ref: '#/definitions/common.NsInfo'
+        type: array
+    type: object
+  common.RestInspectResourcesRequest:
+    properties:
+      connectionName:
+        type: string
+      type:
+        enum:
+        - vNet
+        - securityGroup
+        - sshKey
+        - vm
+        example: vNet
+        type: string
+    type: object
+  common.SimpleMsg:
+    properties:
+      message:
+        example: Any message
+        type: string
+    type: object
+  common.TbConnectionName:
+    properties:
+      connectionName:
+        type: string
+    type: object
+  mcir.FilterSpecsByRangeRequest:
+    properties:
+      connectionName:
+        type: string
+      costPerHour:
+        $ref: '#/definitions/mcir.Range'
+      cspSpecName:
+        type: string
+      description:
+        type: string
+      ebsBwMbps:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore01:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore02:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore03:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore04:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore05:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore06:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore07:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore08:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore09:
+        $ref: '#/definitions/mcir.Range'
+      evaluationScore10:
+        $ref: '#/definitions/mcir.Range'
+      evaluationStatus:
+        type: string
+      gpuMemGiB:
+        $ref: '#/definitions/mcir.Range'
+      gpuModel:
+        type: string
+      gpuP2p:
+        type: string
+      id:
+        type: string
+      maxNumStorage:
+        $ref: '#/definitions/mcir.Range'
+      maxTotalStorageTiB:
+        $ref: '#/definitions/mcir.Range'
+      memGiB:
+        $ref: '#/definitions/mcir.Range'
+      name:
+        type: string
+      netBwGbps:
+        $ref: '#/definitions/mcir.Range'
+      numGpu:
+        $ref: '#/definitions/mcir.Range'
+      numStorage:
+        $ref: '#/definitions/mcir.Range'
+      numcore:
+        $ref: '#/definitions/mcir.Range'
+      numvCPU:
+        $ref: '#/definitions/mcir.Range'
+      osType:
+        type: string
+      storageGiB:
+        $ref: '#/definitions/mcir.Range'
+    type: object
+  mcir.JSONResult:
+    type: object
+  mcir.Range:
+    properties:
+      max:
+        type: number
+      min:
+        type: number
+    type: object
+  mcir.RestFilterSpecsResponse:
+    properties:
+      spec:
+        items:
+          $ref: '#/definitions/mcir.TbSpecInfo'
+        type: array
+    type: object
+  mcir.RestGetAllImageResponse:
+    properties:
+      image:
+        items:
+          $ref: '#/definitions/mcir.TbImageInfo'
+        type: array
+    type: object
+  mcir.RestGetAllSecurityGroupResponse:
+    properties:
+      securityGroup:
+        items:
+          $ref: '#/definitions/mcir.TbSecurityGroupInfo'
+        type: array
+    type: object
+  mcir.RestGetAllSpecResponse:
+    properties:
+      spec:
+        items:
+          $ref: '#/definitions/mcir.TbSpecInfo'
+        type: array
+    type: object
+  mcir.RestGetAllSshKeyResponse:
+    properties:
+      sshKey:
+        items:
+          $ref: '#/definitions/mcir.TbSshKeyInfo'
+        type: array
+    type: object
+  mcir.RestGetAllVNetResponse:
+    properties:
+      vNet:
+        items:
+          $ref: '#/definitions/mcir.TbVNetInfo'
+        type: array
+    type: object
+  mcir.RestLookupImageRequest:
+    properties:
+      connectionName:
+        type: string
+      cspImageId:
+        type: string
+    type: object
+  mcir.RestLookupSpecRequest:
+    properties:
+      connectionName:
+        type: string
+      cspSpecName:
+        type: string
+    type: object
+  mcir.RestSearchImageRequest:
+    properties:
+      keywords:
+        items:
+          type: string
+        type: array
+    type: object
+  mcir.SpiderGpuInfo:
+    properties:
+      count:
+        type: string
+      mem:
+        type: string
+      mfr:
+        type: string
+      model:
+        type: string
+    type: object
+  mcir.SpiderImageInfo:
+    properties:
+      guestOS:
+        description: Windows7, Ubuntu etc.
+        type: string
+      iid:
+        $ref: '#/definitions/common.IID'
+        description: Fields for response
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      name:
+        description: Fields for request
+        type: string
+      status:
+        description: available, unavailable
+        type: string
+    type: object
+  mcir.SpiderImageList:
+    properties:
+      image:
+        items:
+          $ref: '#/definitions/mcir.SpiderImageInfo'
+        type: array
+    type: object
+  mcir.SpiderSecurityRuleInfo:
+    properties:
+      cidr:
+        type: string
+      direction:
+        description: '`json:"direction"`'
+        type: string
+      fromPort:
+        description: '`json:"fromPort"`'
+        type: string
+      ipprotocol:
+        description: '`json:"ipProtocol"`'
+        type: string
+      toPort:
+        description: '`json:"toPort"`'
+        type: string
+    type: object
+  mcir.SpiderSpecInfo:
+    properties:
+      gpu:
+        items:
+          $ref: '#/definitions/mcir.SpiderGpuInfo'
+        type: array
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      mem:
+        type: string
+      name:
+        type: string
+      region:
+        type: string
+      vcpu:
+        $ref: '#/definitions/mcir.SpiderVCpuInfo'
+    type: object
+  mcir.SpiderSpecList:
+    properties:
+      vmspec:
+        items:
+          $ref: '#/definitions/mcir.SpiderSpecInfo'
+        type: array
+    type: object
+  mcir.SpiderSubnetInfo:
+    properties:
+      iid:
+        $ref: '#/definitions/common.IID'
+        description: '{NameId, SystemId}'
+      ipv4_CIDR:
+        type: string
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+    type: object
+  mcir.SpiderSubnetReqInfo:
+    properties:
+      ipv4_CIDR:
+        type: string
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      name:
+        type: string
+    type: object
+  mcir.SpiderVCpuInfo:
+    properties:
+      clock:
+        description: GHz
+        type: string
+      count:
+        type: string
+    type: object
+  mcir.TbImageInfo:
+    properties:
+      associatedObjectList:
+        items:
+          type: string
+        type: array
+      connectionName:
+        type: string
+      creationDate:
+        type: string
+      cspImageId:
+        type: string
+      cspImageName:
+        type: string
+      description:
+        type: string
+      guestOS:
+        description: Windows7, Ubuntu etc.
+        type: string
+      id:
+        type: string
+      isAutoGenerated:
+        type: boolean
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      name:
+        type: string
+      namespace:
+        description: required to save in RDB
+        type: string
+      status:
+        description: available, unavailable
+        type: string
+    type: object
+  mcir.TbImageReq:
+    properties:
+      connectionName:
+        type: string
+      cspImageId:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+    required:
+    - connectionName
+    - cspImageId
+    - name
+    type: object
+  mcir.TbSecurityGroupInfo:
+    properties:
+      associatedObjectList:
+        items:
+          type: string
+        type: array
+      connectionName:
+        type: string
+      cspSecurityGroupId:
+        type: string
+      cspSecurityGroupName:
+        type: string
+      description:
+        type: string
+      firewallRules:
+        items:
+          $ref: '#/definitions/mcir.SpiderSecurityRuleInfo'
+        type: array
+      id:
+        type: string
+      isAutoGenerated:
+        type: boolean
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      name:
+        type: string
+      vNetId:
+        type: string
+    type: object
+  mcir.TbSecurityGroupReq:
+    properties:
+      connectionName:
+        type: string
+      description:
+        type: string
+      firewallRules:
+        items:
+          $ref: '#/definitions/mcir.SpiderSecurityRuleInfo'
+        type: array
+      name:
+        type: string
+      vNetId:
+        type: string
+    required:
+    - connectionName
+    - firewallRules
+    - name
+    - vNetId
+    type: object
+  mcir.TbSpecInfo:
+    properties:
+      associatedObjectList:
+        items:
+          type: string
+        type: array
+      connectionName:
+        type: string
+      costPerHour:
+        type: number
+      cspSpecName:
+        type: string
+      description:
+        type: string
+      ebsBwMbps:
+        type: integer
+      evaluationScore01:
+        type: number
+      evaluationScore02:
+        type: number
+      evaluationScore03:
+        type: number
+      evaluationScore04:
+        type: number
+      evaluationScore05:
+        type: number
+      evaluationScore06:
+        type: number
+      evaluationScore07:
+        type: number
+      evaluationScore08:
+        type: number
+      evaluationScore09:
+        type: number
+      evaluationScore10:
+        type: number
+      evaluationStatus:
+        type: string
+      gpuMemGiB:
+        type: integer
+      gpuModel:
+        type: string
+      gpuP2p:
+        type: string
+      id:
+        type: string
+      isAutoGenerated:
+        type: boolean
+      maxNumStorage:
+        type: integer
+      maxTotalStorageTiB:
+        type: integer
+      memGiB:
+        type: integer
+      name:
+        type: string
+      namespace:
+        description: required to save in RDB
+        type: string
+      netBwGbps:
+        type: integer
+      numCore:
+        type: integer
+      numGpu:
+        type: integer
+      numStorage:
+        type: integer
+      numvCPU:
+        type: integer
+      orderInFilteredResult:
+        type: integer
+      osType:
+        type: string
+      storageGiB:
+        type: integer
+    type: object
+  mcir.TbSpecReq:
+    properties:
+      connectionName:
+        type: string
+      cspSpecName:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+    required:
+    - connectionName
+    - cspSpecName
+    - name
+    type: object
+  mcir.TbSshKeyInfo:
+    properties:
+      associatedObjectList:
+        items:
+          type: string
+        type: array
+      connectionName:
+        type: string
+      cspSshKeyName:
+        type: string
+      description:
+        type: string
+      fingerprint:
+        type: string
+      id:
+        type: string
+      isAutoGenerated:
+        type: boolean
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      name:
+        type: string
+      privateKey:
+        type: string
+      publicKey:
+        type: string
+      username:
+        type: string
+      verifiedUsername:
+        type: string
+    type: object
+  mcir.TbSshKeyReq:
+    properties:
+      connectionName:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+    required:
+    - connectionName
+    - name
+    type: object
+  mcir.TbVNetInfo:
+    properties:
+      associatedObjectList:
+        items:
+          type: string
+        type: array
+      cidrBlock:
+        type: string
+      connectionName:
+        type: string
+      cspVNetId:
+        type: string
+      cspVNetName:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      isAutoGenerated:
+        type: boolean
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      name:
+        type: string
+      status:
+        type: string
+      subnetInfoList:
+        items:
+          $ref: '#/definitions/mcir.SpiderSubnetInfo'
+        type: array
+    type: object
+  mcir.TbVNetReq:
+    properties:
+      cidrBlock:
+        type: string
+      connectionName:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+      subnetInfoList:
+        items:
+          $ref: '#/definitions/mcir.SpiderSubnetReqInfo'
+        type: array
+    required:
+    - connectionName
+    - name
+    type: object
+  mcis.AgentInstallContent:
+    properties:
+      mcisId:
+        type: string
+      result:
+        type: string
+      vmId:
+        type: string
+      vmIp:
+        type: string
+    type: object
+  mcis.AgentInstallContentWrapper:
+    properties:
+      resultArray:
+        items:
+          $ref: '#/definitions/mcis.AgentInstallContent'
+        type: array
+    type: object
+  mcis.AutoAction:
+    properties:
+      actionType:
+        type: string
+      placementAlgo:
+        type: string
+      postCommand:
+        $ref: '#/definitions/mcis.McisCmdReq'
+      vm:
+        $ref: '#/definitions/mcis.TbVmInfo'
+    type: object
+  mcis.AutoCondition:
+    properties:
+      evaluationPeriod:
+        description: evaluationPeriod
+        type: string
+      evaluationValue:
+        items:
+          type: string
+        type: array
+      metric:
+        type: string
+      operand:
+        description: 10, 70, 80, 98, ...
+        type: string
+      operator:
+        description: <, <=, >, >=, ...
+        type: string
+    type: object
+  mcis.BenchmarkInfo:
+    properties:
+      desc:
+        type: string
+      elapsed:
+        type: string
+      result:
+        type: string
+      resultarray:
+        description: struct-element cycle ?
+        items:
+          $ref: '#/definitions/mcis.BenchmarkInfo'
+        type: array
+      specid:
+        type: string
+      unit:
+        type: string
+    type: object
+  mcis.BenchmarkInfoArray:
+    properties:
+      resultarray:
+        items:
+          $ref: '#/definitions/mcis.BenchmarkInfo'
+        type: array
+    type: object
+  mcis.DeploymentPlan:
+    properties:
+      filter:
+        $ref: '#/definitions/mcis.FilterInfo'
+      limit:
+        enum:
+        - "1"
+        - "2"
+        - '...'
+        - "30"
+        - '...'
+        example: "5"
+        type: string
+      priority:
+        $ref: '#/definitions/mcis.PriorityInfo'
+    type: object
+  mcis.FilterCondition:
+    properties:
+      condition:
+        items:
+          $ref: '#/definitions/mcis.Operation'
+        type: array
+      metric:
+        enum:
+        - numvCPU
+        - memGiB
+        - CostPerHour
+        example: numvCPU
+        type: string
+    type: object
+  mcis.FilterInfo:
+    properties:
+      policy:
+        items:
+          $ref: '#/definitions/mcis.FilterCondition'
+        type: array
+    type: object
+  mcis.GeoLocation:
+    properties:
+      briefAddr:
+        type: string
+      cloudType:
+        type: string
+      latitude:
+        type: string
+      longitude:
+        type: string
+      nativeRegion:
+        type: string
+    type: object
+  mcis.JSONResult:
+    type: object
+  mcis.McisCmdReq:
+    properties:
+      command:
+        example: sudo apt-get install ...
+        type: string
+      userName:
+        example: cb-user
+        type: string
+    required:
+    - command
+    type: object
+  mcis.McisPolicyInfo:
+    properties:
+      Id:
+        description: MCIS Id (generated ID by the Name)
+        type: string
+      Name:
+        description: MCIS Name (for request)
+        type: string
+      actionLog:
+        type: string
+      description:
+        type: string
+      policy:
+        items:
+          $ref: '#/definitions/mcis.Policy'
+        type: array
+    type: object
+  mcis.McisRecommendReq:
+    properties:
+      maxResultNum:
+        type: string
+      placementAlgo:
+        type: string
+      placementParam:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      vmReq:
+        items:
+          $ref: '#/definitions/mcis.TbVmRecommendReq'
+        type: array
+    type: object
+  mcis.McisStatusInfo:
+    properties:
+      id:
+        type: string
+      installMonAgent:
+        description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no]
+          default:yes)
+        example: '[yes, no]'
+        type: string
+      masterIp:
+        example: 32.201.134.113
+        type: string
+      masterSSHPort:
+        type: string
+      masterVmId:
+        example: vm-asiaeast1-cb-01
+        type: string
+      name:
+        type: string
+      status:
+        type: string
+      targetAction:
+        type: string
+      targetStatus:
+        type: string
+      vm:
+        items:
+          $ref: '#/definitions/mcis.TbVmStatusInfo'
+        type: array
+    type: object
+  mcis.MonResultSimple:
+    properties:
+      err:
+        type: string
+      metric:
+        type: string
+      value:
+        type: string
+      vmId:
+        type: string
+    type: object
+  mcis.MonResultSimpleResponse:
+    properties:
+      mcisId:
+        type: string
+      mcisMonitoring:
+        items:
+          $ref: '#/definitions/mcis.MonResultSimple'
+        type: array
+      nsId:
+        type: string
+    type: object
+  mcis.Operation:
+    properties:
+      operand:
+        description: 10, 70, 80, 98, ...
+        enum:
+        - "4"
+        - "8"
+        - ..
+        example: "4"
+        type: string
+      operator:
+        description: '>=, <=, =='
+        enum:
+        - '>='
+        - <=
+        - ==
+        example: '>='
+        type: string
+    type: object
+  mcis.ParameterKeyVal:
+    properties:
+      key:
+        description: coordinate
+        enum:
+        - coordinateClose
+        - coordinateWithin
+        - coordinateFair
+        example: coordinateClose
+        type: string
+      val:
+        description: '["Latitude,Longitude","12,543",..,"31,433"]'
+        example:
+        - 46.3772/2.3730
+        items:
+          type: string
+        type: array
+    type: object
+  mcis.Policy:
+    properties:
+      autoAction:
+        $ref: '#/definitions/mcis.AutoAction'
+      autoCondition:
+        $ref: '#/definitions/mcis.AutoCondition'
+      status:
+        type: string
+    type: object
+  mcis.PriorityCondition:
+    properties:
+      metric:
+        description: location,latency,cost
+        enum:
+        - location
+        - latency
+        - cost
+        example: location
+        type: string
+      parameter:
+        items:
+          $ref: '#/definitions/mcis.ParameterKeyVal'
+        type: array
+      weight:
+        description: "0.3"
+        enum:
+        - "0.1"
+        - "0.2"
+        - '...'
+        example: "0.3"
+        type: string
+    type: object
+  mcis.PriorityInfo:
+    properties:
+      policy:
+        items:
+          $ref: '#/definitions/mcis.PriorityCondition'
+        type: array
+    type: object
+  mcis.RegionInfo:
+    properties:
+      region:
+        type: string
+      zone:
+        type: string
+    type: object
+  mcis.RestGetAllBenchmarkRequest:
+    properties:
+      host:
+        type: string
+    type: object
+  mcis.RestGetAllMcisPolicyResponse:
+    properties:
+      mcisPolicy:
+        items:
+          $ref: '#/definitions/mcis.McisPolicyInfo'
+        type: array
+    type: object
+  mcis.RestGetAllMcisResponse:
+    properties:
+      mcis:
+        items:
+          $ref: '#/definitions/mcis.TbMcisInfo'
+        type: array
+    type: object
+  mcis.RestGetAllMcisStatusResponse:
+    properties:
+      mcis:
+        items:
+          $ref: '#/definitions/mcis.McisStatusInfo'
+        type: array
+    type: object
+  mcis.RestGetBenchmarkRequest:
+    properties:
+      host:
+        type: string
+    type: object
+  mcis.RestPostCmdMcisResponse:
+    properties:
+      mcisId:
+        type: string
+      result:
+        type: string
+      vmId:
+        type: string
+      vmIp:
+        type: string
+    type: object
+  mcis.RestPostCmdMcisResponseWrapper:
+    properties:
+      resultArray:
+        items:
+          $ref: '#/definitions/mcis.RestPostCmdMcisResponse'
+        type: array
+    type: object
+  mcis.RestPostCmdMcisVmResponse:
+    properties:
+      result:
+        type: string
+    type: object
+  mcis.RestPostMcisRecommendResponse:
+    properties:
+      placementAlgo:
+        type: string
+      placementParam:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      vmRecommend:
+        description: VmReq          []TbVmRecommendReq    `json:"vmReq"`
+        items:
+          $ref: '#/definitions/mcis.TbVmRecommendInfo'
+        type: array
+    type: object
+  mcis.SpiderVMInfo:
+    properties:
+      iid:
+        $ref: '#/definitions/common.IID'
+        description: Fields for response
+      imageIId:
+        $ref: '#/definitions/common.IID'
+      imageName:
+        type: string
+      keyPairIId:
+        $ref: '#/definitions/common.IID'
+      keyPairName:
+        type: string
+      keyValueList:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      name:
+        description: Fields for request
+        type: string
+      networkInterface:
+        description: ex) eth0
+        type: string
+      privateDNS:
+        type: string
+      privateIP:
+        type: string
+      publicDNS:
+        type: string
+      publicIP:
+        type: string
+      region:
+        $ref: '#/definitions/mcis.RegionInfo'
+        description: ex) {us-east1, us-east1-c} or {ap-northeast-2}
+      securityGroupIIds:
+        description: AWS, ex) sg-0b7452563e1121bb6
+        items:
+          $ref: '#/definitions/common.IID'
+        type: array
+      securityGroupNames:
+        items:
+          type: string
+        type: array
+      sshaccessPoint:
+        type: string
+      startTime:
+        description: 'Timezone: based on cloud-barista server location.'
+        type: string
+      subnetIID:
+        $ref: '#/definitions/common.IID'
+        description: AWS, ex) subnet-8c4a53e4
+      subnetName:
+        type: string
+      vmblockDisk:
+        description: ex)
+        type: string
+      vmbootDisk:
+        description: ex) /dev/sda1
+        type: string
+      vmspecName:
+        description: Fields for both request and response
+        type: string
+      vmuserId:
+        description: ex) user1
+        type: string
+      vmuserPasswd:
+        type: string
+      vpcIID:
+        $ref: '#/definitions/common.IID'
+      vpcname:
+        type: string
+    type: object
+  mcis.TbInspectResourcesResponse:
+    properties:
+      resourcesOnCsp:
+        description: |-
+          ResourcesOnCsp       interface{} `json:"resourcesOnCsp"`
+          ResourcesOnSpider    interface{} `json:"resourcesOnSpider"`
+          ResourcesOnTumblebug interface{} `json:"resourcesOnTumblebug"`
+        items:
+          $ref: '#/definitions/mcis.resourceOnCspOrSpider'
+        type: array
+      resourcesOnSpider:
+        items:
+          $ref: '#/definitions/mcis.resourceOnCspOrSpider'
+        type: array
+      resourcesOnTumblebug:
+        items:
+          $ref: '#/definitions/mcis.resourceOnTumblebug'
+        type: array
+    type: object
+  mcis.TbMcisInfo:
+    properties:
+      description:
+        type: string
+      id:
+        type: string
+      installMonAgent:
+        default: "yes"
+        description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no]
+          default:yes)
+        enum:
+        - "yes"
+        - "no"
+        example: "yes"
+        type: string
+      label:
+        description: Label is for describing the mcis in a keyword (any string can
+          be used)
+        type: string
+      name:
+        type: string
+      placementAlgo:
+        type: string
+      status:
+        type: string
+      targetAction:
+        type: string
+      targetStatus:
+        type: string
+      vm:
+        items:
+          $ref: '#/definitions/mcis.TbVmInfo'
+        type: array
+    type: object
+  mcis.TbMcisReq:
+    properties:
+      description:
+        type: string
+      installMonAgent:
+        default: "yes"
+        description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no]
+          default:yes)
+        enum:
+        - "yes"
+        - "no"
+        example: "yes"
+        type: string
+      label:
+        default: "no"
+        description: Label is for describing the mcis in a keyword (any string can
+          be used)
+        example: custom tag
+        type: string
+      name:
+        type: string
+      placementAlgo:
+        type: string
+      vm:
+        items:
+          $ref: '#/definitions/mcis.TbVmReq'
+        type: array
+    required:
+    - name
+    - vm
+    type: object
+  mcis.TbVmInfo:
+    properties:
+      connectionName:
+        type: string
+      createdTime:
+        description: Created time
+        example: "2022-11-10 23:00:00"
+        type: string
+      cspViewVmDetail:
+        $ref: '#/definitions/mcis.SpiderVMInfo'
+      description:
+        type: string
+      id:
+        type: string
+      imageId:
+        type: string
+      label:
+        type: string
+      location:
+        $ref: '#/definitions/mcis.GeoLocation'
+      monAgentStatus:
+        description: Montoring agent status
+        example: '[installed, notInstalled, failed]'
+        type: string
+      name:
+        type: string
+      privateDNS:
+        type: string
+      privateIP:
+        type: string
+      publicDNS:
+        type: string
+      publicIP:
+        type: string
+      region:
+        $ref: '#/definitions/mcis.RegionInfo'
+        description: AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
+      securityGroupIds:
+        items:
+          type: string
+        type: array
+      specId:
+        type: string
+      sshKeyId:
+        type: string
+      sshPort:
+        type: string
+      status:
+        description: Required by CB-Tumblebug
+        type: string
+      subnetId:
+        type: string
+      systemMessage:
+        description: Latest system message such as error message
+        example: Failed because ...
+        type: string
+      targetAction:
+        type: string
+      targetStatus:
+        type: string
+      vNetId:
+        type: string
+      vmBlockDisk:
+        type: string
+      vmBootDisk:
+        description: ex) /dev/sda1
+        type: string
+      vmGroupId:
+        description: defined if the VM is in a group
+        type: string
+      vmUserAccount:
+        type: string
+      vmUserPassword:
+        type: string
+    type: object
+  mcis.TbVmPriority:
+    properties:
+      priority:
+        type: string
+      vmSpec:
+        $ref: '#/definitions/mcir.TbSpecInfo'
+    type: object
+  mcis.TbVmRecommendInfo:
+    properties:
+      placementAlgo:
+        type: string
+      placementParam:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      vmPriority:
+        items:
+          $ref: '#/definitions/mcis.TbVmPriority'
+        type: array
+      vmReq:
+        $ref: '#/definitions/mcis.TbVmRecommendReq'
+    type: object
+  mcis.TbVmRecommendReq:
+    properties:
+      diskSize:
+        type: string
+      maxResultNum:
+        type: string
+      memorySize:
+        type: string
+      placementAlgo:
+        type: string
+      placementParam:
+        items:
+          $ref: '#/definitions/common.KeyValue'
+        type: array
+      requestName:
+        type: string
+      vcpuSize:
+        type: string
+    type: object
+  mcis.TbVmReq:
+    properties:
+      connectionName:
+        type: string
+      description:
+        type: string
+      imageId:
+        type: string
+      label:
+        type: string
+      name:
+        description: VM name or VM group name if is (not empty) && (> 0). If it is
+          a group, actual VM name will be generated with -N postfix.
+        type: string
+      securityGroupIds:
+        items:
+          type: string
+        type: array
+      specId:
+        type: string
+      sshKeyId:
+        type: string
+      subnetId:
+        type: string
+      vNetId:
+        type: string
+      vmGroupSize:
+        description: if vmGroupSize is (not empty) && (> 0), VM group will be gernetad.
+          VMs will be created accordingly.
+        example: "3"
+        type: string
+      vmUserAccount:
+        type: string
+      vmUserPassword:
+        type: string
+    required:
+    - connectionName
+    - imageId
+    - name
+    - securityGroupIds
+    - specId
+    - sshKeyId
+    - vNetId
+    type: object
+  mcis.TbVmStatusInfo:
+    properties:
+      createdTime:
+        description: Created time
+        example: "2022-11-10 23:00:00"
+        type: string
+      cspVmId:
+        type: string
+      id:
+        type: string
+      location:
+        $ref: '#/definitions/mcis.GeoLocation'
+      monAgentStatus:
+        description: Montoring agent status
+        example: '[installed, notInstalled, failed]'
+        type: string
+      name:
+        type: string
+      nativeStatus:
+        type: string
+      privateIp:
+        type: string
+      publicIp:
+        type: string
+      sshPort:
+        type: string
+      status:
+        type: string
+      systemMessage:
+        description: Latest system message such as error message
+        example: Failed because ...
+        type: string
+      targetAction:
+        type: string
+      targetStatus:
+        type: string
+    type: object
+  mcis.resourceOnCspOrSpider:
+    properties:
+      cspNativeId:
+        type: string
+      id:
+        type: string
+    type: object
+  mcis.resourceOnTumblebug:
+    properties:
+      cspNativeId:
+        type: string
+      id:
+        type: string
+      mcisId:
+        type: string
+      nsId:
+        type: string
+      objectKey:
+        type: string
+      type:
+        type: string
+    type: object
+host: localhost:1323
+info:
+  contact:
+    email: contact-to-cloud-barista@googlegroups.com
+    name: API Support
+    url: http://cloud-barista.github.io
+  description: CB-Tumblebug REST API
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  title: CB-Tumblebug REST API
+  version: latest
+paths:
+  /{nsId}/checkResource/{resourceType}/{resourceId}:
+    get:
+      consumes:
+      - application/json
+      description: Check resources' existence
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Resource Type
+        in: path
+        name: resourceType
+        required: true
+        type: string
+      - description: Resource ID
+        in: path
+        name: resourceId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Check resources' existence
+      tags:
+      - '[Admin] System management'
+  /config:
+    delete:
+      consumes:
+      - application/json
+      description: Init all configs
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Init all configs
+      tags:
+      - '[Admin] System environment'
+    get:
+      consumes:
+      - application/json
+      description: List all configs
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.RestGetAllConfigResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all configs
+      tags:
+      - '[Admin] System environment'
+    post:
+      consumes:
+      - application/json
+      description: Create or Update config (SPIDER_REST_URL, DRAGONFLY_REST_URL, ...)
+      parameters:
+      - description: Key and Value for configuration
+        in: body
+        name: config
+        required: true
+        schema:
+          $ref: '#/definitions/common.ConfigReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.ConfigInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create or Update config
+      tags:
+      - '[Admin] System environment'
+  /config/{configId}:
+    delete:
+      consumes:
+      - application/json
+      description: Init config
+      parameters:
+      - description: Config ID
+        in: path
+        name: configId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.ConfigInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Init config
+      tags:
+      - '[Admin] System environment'
+    get:
+      consumes:
+      - application/json
+      description: Get config
+      parameters:
+      - description: Config ID
+        in: path
+        name: configId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.ConfigInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get config
+      tags:
+      - '[Admin] System environment'
+  /connConfig:
+    get:
+      consumes:
+      - application/json
+      description: List all registered ConnConfig
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.ConnConfigList'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all registered ConnConfig
+      tags:
+      - '[Admin] Cloud environment management'
+  /connConfig/{connConfigName}:
+    get:
+      consumes:
+      - application/json
+      description: Get registered ConnConfig info
+      parameters:
+      - description: Name of connection config (cloud config)
+        in: path
+        name: connConfigName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.ConnConfig'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get registered ConnConfig info
+      tags:
+      - '[Admin] Cloud environment management'
+  /health:
+    get:
+      consumes:
+      - application/json
+      description: Check Tumblebug is alive
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Check Tumblebug is alive
+      tags:
+      - '[Admin] System management'
+  /inspectResources:
+    post:
+      consumes:
+      - application/json
+      description: Inspect Resources (vNet, securityGroup, sshKey, vm) registered
+        in CB-Tumblebug, CB-Spider, CSP
+      parameters:
+      - description: Specify connectionName and resource type
+        in: body
+        name: connectionName
+        required: true
+        schema:
+          $ref: '#/definitions/common.RestInspectResourcesRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.TbInspectResourcesResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Inspect Resources (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug,
+        CB-Spider, CSP
+      tags:
+      - '[Admin] Cloud environment management'
+  /lookupImage:
+    get:
+      consumes:
+      - application/json
+      description: Lookup image
+      parameters:
+      - description: Specify connectionName & cspImageId
+        in: body
+        name: lookupImageReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.RestLookupImageRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.SpiderImageInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Lookup image
+      tags:
+      - '[Admin] Cloud environment management'
+  /lookupImages:
+    get:
+      consumes:
+      - application/json
+      description: Lookup image list
+      parameters:
+      - description: Specify connectionName
+        in: body
+        name: lookupImagesReq
+        required: true
+        schema:
+          $ref: '#/definitions/common.TbConnectionName'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.SpiderImageList'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Lookup image list
+      tags:
+      - '[Admin] Cloud environment management'
+  /lookupSpec:
+    get:
+      consumes:
+      - application/json
+      description: Lookup spec
+      parameters:
+      - description: Specify connectionName & cspSpecName
+        in: body
+        name: lookupSpecReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.RestLookupSpecRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.SpiderSpecInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Lookup spec
+      tags:
+      - '[Admin] Cloud environment management'
+  /lookupSpecs:
+    get:
+      consumes:
+      - application/json
+      description: Lookup spec list
+      parameters:
+      - description: Specify connectionName
+        in: body
+        name: lookupSpecsReq
+        required: true
+        schema:
+          $ref: '#/definitions/common.TbConnectionName'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.SpiderSpecList'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Lookup spec list
+      tags:
+      - '[Admin] Cloud environment management'
+  /ns:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all namespaces
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all namespaces
+      tags:
+      - '[Namespace] Namespace management'
+    get:
+      consumes:
+      - application/json
+      description: List all namespaces or namespaces' ID
+      parameters:
+      - description: Option
+        enum:
+        - id
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given option param
+          schema:
+            allOf:
+            - $ref: '#/definitions/common.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/common.RestGetAllNsResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all namespaces or namespaces' ID
+      tags:
+      - '[Namespace] Namespace management'
+    post:
+      consumes:
+      - application/json
+      description: Create namespace
+      parameters:
+      - description: Details for a new namespace
+        in: body
+        name: nsReq
+        required: true
+        schema:
+          $ref: '#/definitions/common.NsReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.NsInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create namespace
+      tags:
+      - '[Namespace] Namespace management'
+  /ns/{nsId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete namespace
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete namespace
+      tags:
+      - '[Namespace] Namespace management'
+    get:
+      consumes:
+      - application/json
+      description: Get namespace
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.NsInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get namespace
+      tags:
+      - '[Namespace] Namespace management'
+  /ns/{nsId}/benchmark/mcis/{mcisId}:
+    post:
+      consumes:
+      - application/json
+      description: Run MCIS benchmark for a single performance metric and return results
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Host IP address to benchmark
+        in: body
+        name: hostIP
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.RestGetBenchmarkRequest'
+      - description: Benchmark Action to MCIS
+        enum:
+        - install
+        - init
+        - cpus
+        - cpum
+        - memR
+        - memW
+        - fioR
+        - fioW
+        - dbR
+        - dbW
+        - rtt
+        - mrtt
+        - clean
+        in: query
+        name: action
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.BenchmarkInfoArray'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Run MCIS benchmark for a single performance metric and return results
+      tags:
+      - '[MCIS] Performance benchmarking (WIP)'
+  /ns/{nsId}/benchmarkall/mcis/{mcisId}:
+    post:
+      consumes:
+      - application/json
+      description: Run MCIS benchmark for all performance metrics and return results
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Host IP address to benchmark
+        in: body
+        name: hostIP
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.RestGetAllBenchmarkRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.BenchmarkInfoArray'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Run MCIS benchmark for all performance metrics and return results
+      tags:
+      - '[MCIS] Performance benchmarking (WIP)'
+  /ns/{nsId}/cmd/mcis/{mcisId}:
+    post:
+      consumes:
+      - application/json
+      description: Send a command to specified MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: MCIS Command Request
+        in: body
+        name: mcisCmdReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.McisCmdReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.RestPostCmdMcisResponseWrapper'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Send a command to specified MCIS
+      tags:
+      - '[MCIS] Remote command'
+  /ns/{nsId}/cmd/mcis/{mcisId}/vm/{vmId}:
+    post:
+      consumes:
+      - application/json
+      description: Send a command to specified VM
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
+      - description: MCIS Command Request
+        in: body
+        name: mcisCmdReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.McisCmdReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.RestPostCmdMcisVmResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Send a command to specified VM
+      tags:
+      - '[MCIS] Remote command'
+  /ns/{nsId}/control/mcis/{mcisId}:
+    get:
+      consumes:
+      - application/json
+      description: Control the lifecycle of MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Action to MCIS
+        enum:
+        - status
+        - suspend
+        - resume
+        - reboot
+        - terminate
+        in: query
+        name: action
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Control the lifecycle of MCIS
+      tags:
+      - '[MCIS] Control lifecycle'
+  /ns/{nsId}/control/mcis/{mcisId}/vm/{vmId}:
+    get:
+      consumes:
+      - application/json
+      description: Control the lifecycle of VM
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
+      - description: Action to MCIS
+        enum:
+        - status
+        - suspend
+        - resume
+        - reboot
+        - terminate
+        in: query
+        name: action
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Control the lifecycle of VM
+      tags:
+      - '[MCIS] Control lifecycle'
+  /ns/{nsId}/install/mcis/{mcisId}:
+    post:
+      consumes:
+      - application/json
+      description: Install the benchmark agent to specified MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: MCIS Command Request
+        in: body
+        name: mcisCmdReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.McisCmdReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.AgentInstallContentWrapper'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Install the benchmark agent to specified MCIS
+      tags:
+      - '[MCIS] Performance benchmarking (WIP)'
+  /ns/{nsId}/mcis:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all MCISs
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Option for delete MCIS (support force delete)
+        enum:
+        - force
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all MCISs
+      tags:
+      - '[MCIS] Provisioning management'
+    get:
+      consumes:
+      - application/json
+      description: List all MCISs or MCISs' ID
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Option
+        enum:
+        - id
+        - simple
+        - status
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given option param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcis.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcis.RestGetAllMcisResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+                '[SIMPLE]':
+                  $ref: '#/definitions/mcis.RestGetAllMcisResponse'
+                '[STATUS]':
+                  $ref: '#/definitions/mcis.RestGetAllMcisStatusResponse'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all MCISs or MCISs' ID
+      tags:
+      - '[MCIS] Provisioning management'
+    post:
+      consumes:
+      - application/json
+      description: Create MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Details for an MCIS object
+        in: body
+        name: mcisReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.TbMcisReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.TbMcisInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create MCIS
+      tags:
+      - '[MCIS] Provisioning management'
+  /ns/{nsId}/mcis/{mcisId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Option for delete MCIS (support force delete)
+        enum:
+        - force
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete MCIS
+      tags:
+      - '[MCIS] Provisioning management'
+    get:
+      consumes:
+      - application/json
+      description: Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate,
+        refine), or Get VMs' ID
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Action to MCIS
+        enum:
+        - status
+        - suspend
+        - resume
+        - reboot
+        - terminate
+        - refine
+        in: query
+        name: action
+        type: string
+      - description: Option
+        enum:
+        - id
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given action param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcis.JSONResult'
+            - properties:
+                '[CONTROL]':
+                  $ref: '#/definitions/common.SimpleMsg'
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcis.TbMcisInfo'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+                '[STATUS]':
+                  $ref: '#/definitions/mcis.McisStatusInfo'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate,
+        refine), or Get VMs' ID
+      tags:
+      - '[MCIS] Provisioning management'
+  /ns/{nsId}/mcis/{mcisId}/vm:
+    post:
+      consumes:
+      - application/json
+      description: Create VM in specified MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Details for an VM object
+        in: body
+        name: vmReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.TbVmReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.TbVmInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create VM in specified MCIS
+      tags:
+      - '[MCIS] Provisioning management'
+  /ns/{nsId}/mcis/{mcisId}/vm/{vmId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete VM in specified MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
+      - description: Option for delete VM (support force delete)
+        enum:
+        - force
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete VM in specified MCIS
+      tags:
+      - '[MCIS] Provisioning management'
+    get:
+      consumes:
+      - application/json
+      description: Get VM in specified MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
+      - description: Action to MCIS
+        enum:
+        - status
+        - suspend
+        - resume
+        - reboot
+        - terminate
+        in: query
+        name: action
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given action param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcis.JSONResult'
+            - properties:
+                '[CONTROL]':
+                  $ref: '#/definitions/common.SimpleMsg'
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcis.TbVmInfo'
+                '[STATUS]':
+                  $ref: '#/definitions/mcis.TbVmStatusInfo'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get VM in specified MCIS
+      tags:
+      - '[MCIS] Provisioning management'
+  /ns/{nsId}/mcis/{mcisId}/vmgroup:
+    post:
+      consumes:
+      - application/json
+      description: Create multiple VMs by VM group in specified MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Details for VM Group
+        in: body
+        name: vmReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.TbVmReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.TbMcisInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create multiple VMs by VM group in specified MCIS
+      tags:
+      - '[MCIS] Provisioning management'
+  /ns/{nsId}/mcis/recommend:
+    post:
+      consumes:
+      - application/json
+      deprecated: true
+      description: Get MCIS recommendation
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Details for an MCIS object
+        in: body
+        name: mcisRecommendReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.McisRecommendReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.RestPostMcisRecommendResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get MCIS recommendation
+      tags:
+      - '[MCIS] Provisioning management'
+  /ns/{nsId}/monitoring/install/mcis/{mcisId}:
+    post:
+      consumes:
+      - application/json
+      description: Install monitoring agent (CB-Dragonfly agent) to MCIS
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Details for an MCIS object
+        in: body
+        name: mcisInfo
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.McisCmdReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.AgentInstallContentWrapper'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Install monitoring agent (CB-Dragonfly agent) to MCIS
+      tags:
+      - '[MCIS] Resource monitor (Developer)'
+  /ns/{nsId}/monitoring/mcis/{mcisId}/metric/{metric}:
+    get:
+      consumes:
+      - application/json
+      description: Get monitoring data of specified MCIS for specified monitoring
+        metric (cpu, memory, disk, network)
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: 'Metric type: cpu, memory, disk, network'
+        in: path
+        name: metric
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.MonResultSimpleResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get monitoring data of specified MCIS for specified monitoring metric
+        (cpu, memory, disk, network)
+      tags:
+      - '[MCIS] Resource monitor (Developer)'
+  /ns/{nsId}/policy/mcis:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all MCIS policies
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all MCIS policies
+      tags:
+      - '[MCIS] Auto control policy management (WIP)'
+    get:
+      consumes:
+      - application/json
+      description: List all MCIS policies
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.RestGetAllMcisPolicyResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all MCIS policies
+      tags:
+      - '[MCIS] Auto control policy management (WIP)'
+  /ns/{nsId}/policy/mcis/{mcisId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete MCIS Policy
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete MCIS Policy
+      tags:
+      - '[MCIS] Auto control policy management (WIP)'
+    get:
+      consumes:
+      - application/json
+      description: Get MCIS Policy
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.McisPolicyInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get MCIS Policy
+      tags:
+      - '[MCIS] Auto control policy management (WIP)'
+    post:
+      consumes:
+      - application/json
+      description: Create MCIS Automation policy
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - description: Details for an MCIS object
+        in: body
+        name: mcisInfo
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.McisPolicyInfo'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.McisPolicyInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create MCIS Automation policy
+      tags:
+      - '[MCIS] Auto control policy management (WIP)'
+  /ns/{nsId}/resources/fetchImages:
+    post:
+      consumes:
+      - application/json
+      description: Fetch images
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Fetch images
+      tags:
+      - '[MCIR] Image management'
+  /ns/{nsId}/resources/fetchSpecs:
+    post:
+      consumes:
+      - application/json
+      description: Fetch specs
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Fetch specs
+      tags:
+      - '[MCIR] Spec management'
+  /ns/{nsId}/resources/filterSpecs:
+    post:
+      consumes:
+      - application/json
+      description: Filter specs
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Filter for filtering specs
+        in: body
+        name: specFilter
+        schema:
+          $ref: '#/definitions/mcir.TbSpecInfo'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.RestFilterSpecsResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Filter specs
+      tags:
+      - '[MCIR] Spec management'
+  /ns/{nsId}/resources/filterSpecsByRange:
+    post:
+      consumes:
+      - application/json
+      description: Filter specs by range
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Filter for range-filtering specs
+        in: body
+        name: specRangeFilter
+        schema:
+          $ref: '#/definitions/mcir.FilterSpecsByRangeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.RestFilterSpecsResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Filter specs by range
+      tags:
+      - '[MCIR] Spec management'
+  /ns/{nsId}/resources/image:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all images
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all images
+      tags:
+      - '[MCIR] Image management'
+    get:
+      consumes:
+      - application/json
+      description: List all images or images' ID
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Option
+        enum:
+        - id
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given option param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcir.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcir.RestGetAllImageResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all images or images' ID
+      tags:
+      - '[MCIR] Image management'
+    post:
+      consumes:
+      - application/json
+      description: Register image
+      parameters:
+      - description: registerWithInfo or registerWithId
+        in: query
+        name: registeringMethod
+        required: true
+        type: string
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Details for an image object
+        in: body
+        name: imageInfo
+        schema:
+          $ref: '#/definitions/mcir.TbImageInfo'
+      - description: name, connectionName and cspImageId
+        in: body
+        name: imageId
+        schema:
+          $ref: '#/definitions/mcir.TbImageReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbImageInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Register image
+      tags:
+      - '[MCIR] Image management'
+  /ns/{nsId}/resources/image/{imageId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete image
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Image ID
+        in: path
+        name: imageId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete image
+      tags:
+      - '[MCIR] Image management'
+    get:
+      consumes:
+      - application/json
+      description: Get image
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Image ID
+        in: path
+        name: imageId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbImageInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get image
+      tags:
+      - '[MCIR] Image management'
+  /ns/{nsId}/resources/searchImage:
+    post:
+      consumes:
+      - application/json
+      description: Search image
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Keywords
+        in: body
+        name: keywords
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.RestSearchImageRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.RestGetAllImageResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Search image
+      tags:
+      - '[MCIR] Image management'
+  /ns/{nsId}/resources/securityGroup:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all Security Groups
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all Security Groups
+      tags:
+      - '[MCIR] Security group management'
+    get:
+      consumes:
+      - application/json
+      description: List all Security Groups or Security Groups' ID
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Option
+        enum:
+        - id
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given option param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcir.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcir.RestGetAllSecurityGroupResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all Security Groups or Security Groups' ID
+      tags:
+      - '[MCIR] Security group management'
+    post:
+      consumes:
+      - application/json
+      description: Create Security Group
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Details for an securityGroup object
+        in: body
+        name: securityGroupReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.TbSecurityGroupReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbSecurityGroupInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create Security Group
+      tags:
+      - '[MCIR] Security group management'
+  /ns/{nsId}/resources/securityGroup/{securityGroupId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete Security Group
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Security Group ID
+        in: path
+        name: securityGroupId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete Security Group
+      tags:
+      - '[MCIR] Security group management'
+    get:
+      consumes:
+      - application/json
+      description: Get Security Group
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Security Group ID
+        in: path
+        name: securityGroupId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbSecurityGroupInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get Security Group
+      tags:
+      - '[MCIR] Security group management'
+  /ns/{nsId}/resources/spec:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all specs
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all specs
+      tags:
+      - '[MCIR] Spec management'
+    get:
+      consumes:
+      - application/json
+      description: List all specs or specs' ID
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Option
+        enum:
+        - id
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given option param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcir.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcir.RestGetAllSpecResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all specs or specs' ID
+      tags:
+      - '[MCIR] Spec management'
+    post:
+      consumes:
+      - application/json
+      description: Register spec
+      parameters:
+      - description: registerWithInfo or else
+        in: query
+        name: registeringMethod
+        required: true
+        type: string
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Details for an spec object
+        in: body
+        name: specInfo
+        schema:
+          $ref: '#/definitions/mcir.TbSpecInfo'
+      - description: name, connectionName and cspSpecName
+        in: body
+        name: specName
+        schema:
+          $ref: '#/definitions/mcir.TbSpecReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbSpecInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Register spec
+      tags:
+      - '[MCIR] Spec management'
+  /ns/{nsId}/resources/spec/{specId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete spec
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Spec ID
+        in: path
+        name: specId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete spec
+      tags:
+      - '[MCIR] Spec management'
+    get:
+      consumes:
+      - application/json
+      description: Get spec
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Spec ID
+        in: path
+        name: specId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbSpecInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get spec
+      tags:
+      - '[MCIR] Spec management'
+    put:
+      consumes:
+      - application/json
+      description: Update spec
+      parameters:
+      - description: Details for an spec object
+        in: body
+        name: specInfo
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.TbSpecInfo'
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Spec ID
+        in: path
+        name: specId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbSpecInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Update spec
+      tags:
+      - '[MCIR] Spec management'
+  /ns/{nsId}/resources/sshKey:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all SSH Keys
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all SSH Keys
+      tags:
+      - '[MCIR] Access key management'
+    get:
+      consumes:
+      - application/json
+      description: List all SSH Keys or SSH Keys' ID
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Option
+        enum:
+        - id
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given option param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcir.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcir.RestGetAllSshKeyResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all SSH Keys or SSH Keys' ID
+      tags:
+      - '[MCIR] Access key management'
+    post:
+      consumes:
+      - application/json
+      description: Create SSH Key
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Details for an SSH Key object
+        in: body
+        name: sshKeyInfo
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.TbSshKeyReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbSshKeyInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create SSH Key
+      tags:
+      - '[MCIR] Access key management'
+  /ns/{nsId}/resources/sshKey/{sshKeyId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete SSH Key
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: SSH Key ID
+        in: path
+        name: sshKeyId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete SSH Key
+      tags:
+      - '[MCIR] Access key management'
+    get:
+      consumes:
+      - application/json
+      description: Get SSH Key
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: SSH Key ID
+        in: path
+        name: sshKeyId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbSshKeyInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get SSH Key
+      tags:
+      - '[MCIR] Access key management'
+  /ns/{nsId}/resources/vNet:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all VNets
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all VNets
+      tags:
+      - '[MCIR] Network management'
+    get:
+      consumes:
+      - application/json
+      description: List all VNets or VNets' ID
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Option
+        enum:
+        - id
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given option param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcir.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcir.RestGetAllVNetResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all VNets or VNets' ID
+      tags:
+      - '[MCIR] Network management'
+    post:
+      consumes:
+      - application/json
+      description: Create VNet
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Details for an VNet object
+        in: body
+        name: vNetReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.TbVNetReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbVNetInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create VNet
+      tags:
+      - '[MCIR] Network management'
+  /ns/{nsId}/resources/vNet/{vNetId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete VNet
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: VNet ID
+        in: path
+        name: vNetId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete VNet
+      tags:
+      - '[MCIR] Network management'
+    get:
+      consumes:
+      - application/json
+      description: Get VNet
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: VNet ID
+        in: path
+        name: vNetId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbVNetInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get VNet
+      tags:
+      - '[MCIR] Network management'
+  /ns/{nsId}/testRecommendVm:
+    post:
+      consumes:
+      - application/json
+      description: Recommend MCIS plan (filter and priority)
+      parameters:
+      - description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Recommend MCIS plan (filter and priority)
+        in: body
+        name: deploymentPlan
+        schema:
+          $ref: '#/definitions/mcis.DeploymentPlan'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/mcir.TbSpecInfo'
+            type: array
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Recommend MCIS plan (filter and priority)
+      tags:
+      - '[MCIS] Provisioning management'
+  /object:
+    delete:
+      consumes:
+      - application/json
+      description: Delete an object
+      parameters:
+      - description: delete object value by key
+        in: query
+        name: key
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete an object
+      tags:
+      - '[Admin] System management'
+    get:
+      consumes:
+      - application/json
+      description: Get value of an object
+      parameters:
+      - description: get object value by key
+        in: query
+        name: key
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get value of an object
+      tags:
+      - '[Admin] System management'
+  /objects:
+    delete:
+      consumes:
+      - application/json
+      description: Delete child objects along with the given object
+      parameters:
+      - description: Delete child objects based on the given key string
+        in: query
+        name: key
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete child objects along with the given object
+      tags:
+      - '[Admin] System management'
+    get:
+      consumes:
+      - application/json
+      description: List all objects for a given key
+      parameters:
+      - description: retrieve objects by key
+        in: query
+        name: key
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all objects for a given key
+      tags:
+      - '[Admin] System management'
+  /region:
+    get:
+      consumes:
+      - application/json
+      description: List all registered regions
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.RegionList'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all registered regions
+      tags:
+      - '[Admin] Cloud environment management'
+  /region/{regionName}:
+    get:
+      consumes:
+      - application/json
+      description: Get registered region info
+      parameters:
+      - description: Name of region to retrieve
+        in: path
+        name: regionName
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.Region'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get registered region info
+      tags:
+      - '[Admin] Cloud environment management'
+  /swaggerActive:
+    get:
+      consumes:
+      - application/json
+      description: Get API document web
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get API document web
+      tags:
+      - '[Admin] System management'
+securityDefinitions:
+  BasicAuth:
+    type: basic
+swagger: "2.0"

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -159,6 +159,7 @@ func RestGetAllMcis(c echo.Context) error {
 	fmt.Println("[Get MCIS List requested with option: " + option)
 
 	if option == "id" {
+		// return MCIS IDs
 		content := common.IdList{}
 		var err error
 		content.IdList, err = mcis.ListMcisId(nsId)
@@ -169,6 +170,7 @@ func RestGetAllMcis(c echo.Context) error {
 
 		return c.JSON(http.StatusOK, &content)
 	} else if option == "status" {
+		// return MCIS Status objects (diffent with MCIS objects)
 		result, err := mcis.GetMcisStatusAll(nsId)
 		if err != nil {
 			mapA := map[string]string{"message": err.Error()}
@@ -179,10 +181,8 @@ func RestGetAllMcis(c echo.Context) error {
 		common.PrintJsonPretty(content)
 		return c.JSON(http.StatusOK, &content)
 	} else if option == "simple" {
-		// mcis in detail (with status information)
-		detail := "simple"
-
-		result, err := mcis.CoreGetAllMcis(nsId, detail)
+		// MCIS in simple (without VM information)
+		result, err := mcis.CoreGetAllMcis(nsId, option)
 		if err != nil {
 			mapA := map[string]string{"message": err.Error()}
 			return c.JSON(http.StatusNotFound, &mapA)
@@ -192,10 +192,8 @@ func RestGetAllMcis(c echo.Context) error {
 		common.PrintJsonPretty(content)
 		return c.JSON(http.StatusOK, &content)
 	} else {
-		// mcis in detail (with status information)
-		detail := "status"
-
-		result, err := mcis.CoreGetAllMcis(nsId, detail)
+		// MCIS in detail (with status information)
+		result, err := mcis.CoreGetAllMcis(nsId, "status")
 		if err != nil {
 			mapA := map[string]string{"message": err.Error()}
 			return c.JSON(http.StatusNotFound, &mapA)
@@ -205,6 +203,7 @@ func RestGetAllMcis(c echo.Context) error {
 		common.PrintJsonPretty(content)
 		return c.JSON(http.StatusOK, &content)
 	}
+
 }
 
 /* function RestPutMcis not yet implemented

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -147,8 +147,8 @@ type RestGetAllMcisStatusResponse struct {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
-// @Param option query string false "Option" Enums(id)
-// @Success 200 {object} JSONResult{[DEFAULT]=RestGetAllMcisResponse,[ID]=common.IdList} "Different return structures by the given option param"
+// @Param option query string false "Option" Enums(id, simple, status)
+// @Success 200 {object} JSONResult{[DEFAULT]=RestGetAllMcisResponse,[SIMPLE]=RestGetAllMcisResponse,[ID]=common.IdList,[STATUS]=RestGetAllMcisStatusResponse} "Different return structures by the given option param"
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis [get]
@@ -175,6 +175,19 @@ func RestGetAllMcis(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, &mapA)
 		}
 		content := RestGetAllMcisStatusResponse{}
+		content.Mcis = result
+		common.PrintJsonPretty(content)
+		return c.JSON(http.StatusOK, &content)
+	} else if option == "simple" {
+		// mcis in detail (with status information)
+		detail := "simple"
+
+		result, err := mcis.CoreGetAllMcis(nsId, detail)
+		if err != nil {
+			mapA := map[string]string{"message": err.Error()}
+			return c.JSON(http.StatusNotFound, &mapA)
+		}
+		content := RestGetAllMcisResponse{}
 		content.Mcis = result
 		common.PrintJsonPretty(content)
 		return c.JSON(http.StatusOK, &content)

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -1744,6 +1744,7 @@ func CoreGetAllMcis(nsId string, option string) ([]TbMcisInfo, error) {
 			mcisTmp.Status = ""
 		}
 
+		// The cases with id, status, or others. except simple
 		if option != "simple" {
 			vmList, err := ListVmId(nsId, mcisId)
 			if err != nil {


### PR DESCRIPTION
Feature request from cb-webtool. @MZC-CSC

> MCIS 목록 조회에서
> 협의 내용대로 최초 ID 목록 조회 후 각 MCID ID 별로 상세조회하여 table에 data를 채우려고 했는데
> mcis 목록에 표시되는 내용이 MCIS ID, MCIS Name, MCIS Status 정도라
> option=simple 같은 것으로 최소 필수 값정도를 목록으로 가져오는게 있으면 좋겠습니다.
> 
> 가령 mcis status 를 가져올 때 vm을 바라보지 않아도 된다면 mcis 정보만 가져와도
> id 가져온 후 상세 조회를 일일이 던지는 것 보다 불필요한 트래픽이 줄어들고 표시하기도 용이할 것 같습니다.


According to request, this PR adds the feature to list MCIS with simple response option. 
With the option=simple, CB-TB doesn't include VM details in the response body.


### Test example
#### [Request URL]
GET `http://localhost:1323/tumblebug/ns/tb01/mcis?option=simple`

#### [Response body]
```
{
  "mcis": [
    {
      "id": "cb-shson01",
      "name": "cb-shson01",
      "status": "Running-3(3/3)",
      "targetStatus": "None",
      "targetAction": "None",
      "installMonAgent": "no",
      "label": "generated by script",
      "placementAlgo": "",
      "description": "Tumblebug Demo",
      "vm": null
    },
    {
      "id": "cb-shson02",
      "name": "cb-shson02",
      "status": "Running-3(3/3)",
      "targetStatus": "None",
      "targetAction": "None",
      "installMonAgent": "no",
      "label": "generated by script",
      "placementAlgo": "",
      "description": "Tumblebug Demo",
      "vm": null
    },
    {
      "id": "cb-shson03",
      "name": "cb-shson03",
      "status": "Running-3(3/3)",
      "targetStatus": "None",
      "targetAction": "None",
      "installMonAgent": "no",
      "label": "generated by script",
      "placementAlgo": "",
      "description": "Tumblebug Demo",
      "vm": null
    },
    {
      "id": "cb-shson04",
      "name": "cb-shson04",
      "status": "Running-7(7/7)",
      "targetStatus": "None",
      "targetAction": "None",
      "installMonAgent": "no",
      "label": "generated by script",
      "placementAlgo": "",
      "description": "Tumblebug Demo",
      "vm": null
    }
  ]
}
```