### PR TITLE
Add MCIS status count feature and update MCIS response field

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -5509,6 +5509,9 @@ var doc = `{
                 "status": {
                     "type": "string"
                 },
+                "statusCount": {
+                    "$ref": "#/definitions/mcis.StatusCountInfo"
+                },
                 "targetAction": {
                     "type": "string"
                 },
@@ -5883,6 +5886,55 @@ var doc = `{
                 }
             }
         },
+        "mcis.StatusCountInfo": {
+            "type": "object",
+            "properties": {
+                "countCreating": {
+                    "description": "CountCreating is for counting Creating",
+                    "type": "integer"
+                },
+                "countFailed": {
+                    "description": "CountFailed is for counting Failed",
+                    "type": "integer"
+                },
+                "countRebooting": {
+                    "description": "CountRebooting is for counting Rebooting",
+                    "type": "integer"
+                },
+                "countResuming": {
+                    "description": "CountResuming is for counting Resuming",
+                    "type": "integer"
+                },
+                "countRunning": {
+                    "description": "CountRunning is for counting Running",
+                    "type": "integer"
+                },
+                "countSuspended": {
+                    "description": "CountSuspended is for counting Suspended",
+                    "type": "integer"
+                },
+                "countSuspending": {
+                    "description": "CountSuspending is for counting Suspending",
+                    "type": "integer"
+                },
+                "countTerminated": {
+                    "description": "CountTerminated is for counting Terminated",
+                    "type": "integer"
+                },
+                "countTerminating": {
+                    "description": "CountTerminating is for counting Terminating",
+                    "type": "integer"
+                },
+                "countTotal": {
+                    "description": "CountTotal is for Total VMs",
+                    "type": "integer"
+                },
+                "countUndefined": {
+                    "description": "CountUndefined is for counting Undefined",
+                    "type": "integer"
+                }
+            }
+        },
         "mcis.TbInspectResourcesResponse": {
             "type": "object",
             "properties": {
@@ -5938,6 +5990,9 @@ var doc = `{
                 },
                 "status": {
                     "type": "string"
+                },
+                "statusCount": {
+                    "$ref": "#/definitions/mcis.StatusCountInfo"
                 },
                 "targetAction": {
                     "type": "string"

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -5494,6 +5494,9 @@
                 "status": {
                     "type": "string"
                 },
+                "statusCount": {
+                    "$ref": "#/definitions/mcis.StatusCountInfo"
+                },
                 "targetAction": {
                     "type": "string"
                 },
@@ -5868,6 +5871,55 @@
                 }
             }
         },
+        "mcis.StatusCountInfo": {
+            "type": "object",
+            "properties": {
+                "countCreating": {
+                    "description": "CountCreating is for counting Creating",
+                    "type": "integer"
+                },
+                "countFailed": {
+                    "description": "CountFailed is for counting Failed",
+                    "type": "integer"
+                },
+                "countRebooting": {
+                    "description": "CountRebooting is for counting Rebooting",
+                    "type": "integer"
+                },
+                "countResuming": {
+                    "description": "CountResuming is for counting Resuming",
+                    "type": "integer"
+                },
+                "countRunning": {
+                    "description": "CountRunning is for counting Running",
+                    "type": "integer"
+                },
+                "countSuspended": {
+                    "description": "CountSuspended is for counting Suspended",
+                    "type": "integer"
+                },
+                "countSuspending": {
+                    "description": "CountSuspending is for counting Suspending",
+                    "type": "integer"
+                },
+                "countTerminated": {
+                    "description": "CountTerminated is for counting Terminated",
+                    "type": "integer"
+                },
+                "countTerminating": {
+                    "description": "CountTerminating is for counting Terminating",
+                    "type": "integer"
+                },
+                "countTotal": {
+                    "description": "CountTotal is for Total VMs",
+                    "type": "integer"
+                },
+                "countUndefined": {
+                    "description": "CountUndefined is for counting Undefined",
+                    "type": "integer"
+                }
+            }
+        },
         "mcis.TbInspectResourcesResponse": {
             "type": "object",
             "properties": {
@@ -5923,6 +5975,9 @@
                 },
                 "status": {
                     "type": "string"
+                },
+                "statusCount": {
+                    "$ref": "#/definitions/mcis.StatusCountInfo"
                 },
                 "targetAction": {
                     "type": "string"

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -871,6 +871,8 @@ definitions:
         type: string
       status:
         type: string
+      statusCount:
+        $ref: '#/definitions/mcis.StatusCountInfo'
       targetAction:
         type: string
       targetStatus:
@@ -1125,6 +1127,42 @@ definitions:
       vpcname:
         type: string
     type: object
+  mcis.StatusCountInfo:
+    properties:
+      countCreating:
+        description: CountCreating is for counting Creating
+        type: integer
+      countFailed:
+        description: CountFailed is for counting Failed
+        type: integer
+      countRebooting:
+        description: CountRebooting is for counting Rebooting
+        type: integer
+      countResuming:
+        description: CountResuming is for counting Resuming
+        type: integer
+      countRunning:
+        description: CountRunning is for counting Running
+        type: integer
+      countSuspended:
+        description: CountSuspended is for counting Suspended
+        type: integer
+      countSuspending:
+        description: CountSuspending is for counting Suspending
+        type: integer
+      countTerminated:
+        description: CountTerminated is for counting Terminated
+        type: integer
+      countTerminating:
+        description: CountTerminating is for counting Terminating
+        type: integer
+      countTotal:
+        description: CountTotal is for Total VMs
+        type: integer
+      countUndefined:
+        description: CountUndefined is for counting Undefined
+        type: integer
+    type: object
   mcis.TbInspectResourcesResponse:
     properties:
       resourcesOnCsp:
@@ -1169,6 +1207,8 @@ definitions:
         type: string
       status:
         type: string
+      statusCount:
+        $ref: '#/definitions/mcis.StatusCountInfo'
       targetAction:
         type: string
       targetStatus:

--- a/src/api/rest/docs/v0.4.7.yaml
+++ b/src/api/rest/docs/v0.4.7.yaml
@@ -871,6 +871,8 @@ definitions:
         type: string
       status:
         type: string
+      statusCount:
+        $ref: '#/definitions/mcis.StatusCountInfo'
       targetAction:
         type: string
       targetStatus:
@@ -1125,6 +1127,42 @@ definitions:
       vpcname:
         type: string
     type: object
+  mcis.StatusCountInfo:
+    properties:
+      countCreating:
+        description: CountCreating is for counting Creating
+        type: integer
+      countFailed:
+        description: CountFailed is for counting Failed
+        type: integer
+      countRebooting:
+        description: CountRebooting is for counting Rebooting
+        type: integer
+      countResuming:
+        description: CountResuming is for counting Resuming
+        type: integer
+      countRunning:
+        description: CountRunning is for counting Running
+        type: integer
+      countSuspended:
+        description: CountSuspended is for counting Suspended
+        type: integer
+      countSuspending:
+        description: CountSuspending is for counting Suspending
+        type: integer
+      countTerminated:
+        description: CountTerminated is for counting Terminated
+        type: integer
+      countTerminating:
+        description: CountTerminating is for counting Terminating
+        type: integer
+      countTotal:
+        description: CountTotal is for Total VMs
+        type: integer
+      countUndefined:
+        description: CountUndefined is for counting Undefined
+        type: integer
+    type: object
   mcis.TbInspectResourcesResponse:
     properties:
       resourcesOnCsp:
@@ -1169,6 +1207,8 @@ definitions:
         type: string
       status:
         type: string
+      statusCount:
+        $ref: '#/definitions/mcis.StatusCountInfo'
       targetAction:
         type: string
       targetStatus:

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -171,11 +171,12 @@ func TbMcisReqStructLevelValidation(sl validator.StructLevel) {
 
 // TbMcisInfo is struct for MCIS info
 type TbMcisInfo struct {
-	Id           string `json:"id"`
-	Name         string `json:"name"`
-	Status       string `json:"status"`
-	TargetStatus string `json:"targetStatus"`
-	TargetAction string `json:"targetAction"`
+	Id           string          `json:"id"`
+	Name         string          `json:"name"`
+	Status       string          `json:"status"`
+	StatusCount  StatusCountInfo `json:"statusCount"`
+	TargetStatus string          `json:"targetStatus"`
+	TargetAction string          `json:"targetAction"`
 
 	// InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
 	InstallMonAgent string `json:"installMonAgent" example:"yes" default:"yes" enums:"yes,no"` // yes or no
@@ -289,14 +290,52 @@ type GeoLocation struct {
 	NativeRegion string `json:"nativeRegion"`
 }
 
+// StatusCountInfo is struct to count the number of VMs in each status. ex: Running=4, Suspended=8.
+type StatusCountInfo struct {
+
+	// CountTotal is for Total VMs
+	CountTotal int `json:"countTotal"`
+
+	// CountCreating is for counting Creating
+	CountCreating int `json:"countCreating"`
+
+	// CountRunning is for counting Running
+	CountRunning int `json:"countRunning"`
+
+	// CountFailed is for counting Failed
+	CountFailed int `json:"countFailed"`
+
+	// CountSuspended is for counting Suspended
+	CountSuspended int `json:"countSuspended"`
+
+	// CountRebooting is for counting Rebooting
+	CountRebooting int `json:"countRebooting"`
+
+	// CountTerminated is for counting Terminated
+	CountTerminated int `json:"countTerminated"`
+
+	// CountSuspending is for counting Suspending
+	CountSuspending int `json:"countSuspending"`
+
+	// CountResuming is for counting Resuming
+	CountResuming int `json:"countResuming"`
+
+	// CountTerminating is for counting Terminating
+	CountTerminating int `json:"countTerminating"`
+
+	// CountUndefined is for counting Undefined
+	CountUndefined int `json:"countUndefined"`
+}
+
 // McisStatusInfo is struct to define simple information of MCIS with updated status of all VMs
 type McisStatusInfo struct {
 	Id   string `json:"id"`
 	Name string `json:"name"`
 
-	Status       string `json:"status"`
-	TargetStatus string `json:"targetStatus"`
-	TargetAction string `json:"targetAction"`
+	Status       string          `json:"status"`
+	StatusCount  StatusCountInfo `json:"statusCount"`
+	TargetStatus string          `json:"targetStatus"`
+	TargetAction string          `json:"targetAction"`
 
 	// InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
 	InstallMonAgent string `json:"installMonAgent" example:"[yes, no]"` // yes or no
@@ -1671,6 +1710,7 @@ func GetMcisInfo(nsId string, mcisId string) (*TbMcisInfo, error) {
 	// common.PrintJsonPretty(mcisStatus)
 
 	mcisObj.Status = mcisStatus.Status
+	mcisObj.StatusCount = mcisStatus.StatusCount
 
 	vmList, err := ListVmId(nsId, mcisId)
 	if err != nil {
@@ -4022,6 +4062,19 @@ func GetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 	// 	mcisStatus.Status = statusFlagStr[9] + proportionStr
 	// }
 
+	// Set mcisStatus.StatusCount
+	mcisStatus.StatusCount.CountTotal = numVm
+	mcisStatus.StatusCount.CountFailed = statusFlag[0]
+	mcisStatus.StatusCount.CountSuspended = statusFlag[1]
+	mcisStatus.StatusCount.CountRunning = statusFlag[2]
+	mcisStatus.StatusCount.CountTerminated = statusFlag[3]
+	mcisStatus.StatusCount.CountCreating = statusFlag[4]
+	mcisStatus.StatusCount.CountSuspending = statusFlag[5]
+	mcisStatus.StatusCount.CountResuming = statusFlag[6]
+	mcisStatus.StatusCount.CountRebooting = statusFlag[7]
+	mcisStatus.StatusCount.CountTerminating = statusFlag[8]
+	mcisStatus.StatusCount.CountUndefined = statusFlag[9]
+
 	var isDone bool
 	isDone = true
 	for _, v := range mcisStatus.Vm {
@@ -4034,6 +4087,7 @@ func GetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 		mcisStatus.TargetStatus = StatusComplete
 		mcisTmp.TargetAction = ActionComplete
 		mcisTmp.TargetStatus = StatusComplete
+		mcisTmp.StatusCount = mcisStatus.StatusCount
 		UpdateMcisInfo(nsId, mcisTmp)
 	}
 


### PR DESCRIPTION

Add a field to MCIS object to count VM status by status types.

This feature will support cb-webtool.

```
  "statusCount": {
    "countTotal": 7,
    "countCreating": 0,
    "countRunning": 0,
    "countFailed": 0,
    "countSuspended": 6,
    "countRebooting": 0,
    "countTerminated": 0,
    "countSuspending": 1,
    "countResuming": 0,
    "countTerminating": 0,
    "countUndefined": 0
  },
```

### EX
```
####################################################################
## 8. Get MCIS
####################################################################

Input parameters
// POSTFIX:shson02 // TestSetFile:../testSet01.env // CSP:all // REGION:1 // OPTION01: // OPTION02: // OPTION03:
{
  "id": "cb-shson02",
  "name": "cb-shson02",
  "status": "Partial-Suspended-6(7/7)",
  "statusCount": {
    "countTotal": 7,
    "countCreating": 0,
    "countRunning": 0,
    "countFailed": 0,
    "countSuspended": 6,
    "countRebooting": 0,
    "countTerminated": 0,
    "countSuspending": 1,
    "countResuming": 0,
    "countTerminating": 0,
    "countUndefined": 0
  },
  "targetStatus": "Suspended",
  "targetAction": "Suspend",
  "installMonAgent": "no",
  "label": "generated by script",
  "placementAlgo": "",
  "description": "Tumblebug Demo",
  "vm": [
    {
      "id": "aws-ap-se-1-0",
      "name": "aws-ap-se-1-0",
      "vmGroupId": "aws-ap-se-1",
      "location": {
        "latitude": "1.3700",
        "longitude": "103.8000",
        "briefAddr": "Singapore",
```