### PR TITLE
Add user input to confirm test config

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/check-test-config.sh
+++ b/src/testclient/scripts/sequentialFullTest/check-test-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "####################################################################"
-echo "## Check test config file (-n deveoperPrefix -f ../testSetCustom.env)"
+echo "## Check test config file (-n deveoperPrefix -f ../testSetCustom.env -x numOfVMsInEachVMGroup)"
 echo "####################################################################"
 
 source ../init.sh
@@ -10,28 +10,41 @@ NUMVM=${OPTION01:-1}
 
 echo ""
 echo "[Configuration in ($TestSetFile) & (../conf.env) files]"
-echo "1) TumblebugServer : $TumblebugServer // SpiderServer : $SpiderServer"
-echo "2) NameSpace ID : $NSID // MCIS ID : $MCISID"
+echo "1) Tumblebug Server : $TumblebugServer // Spider Server : $SpiderServer"
+
 
 INDEXX=${NumCSP}
-echo "3) Enabled CSPs for $MCISID"
+echo "2) Enabled CSPs and regions in $TestSetFile"
 for ((cspi = 1; cspi <= INDEXX; cspi++)); do
 	CSP=${CSPType[$cspi]}
 	INDEXY=${NumRegion[$cspi]}
-	echo "[$cspi] $CSP (enabled regions : $INDEXY)"
+	echo " - [$cspi] $CSP (enabled regions : $INDEXY)"
 done
 echo ""
+
 for ((cspi = 1; cspi <= INDEXX; cspi++)); do
 	INDEXY=${NumRegion[$cspi]}
 	CSP=${CSPType[$cspi]}
-	echo "[$cspi] $CSP details"
+	echo "   [$cspi] $CSP details"
 	for ((cspj = 1; cspj <= INDEXY; cspj++)); do
-		echo "[$cspi,$cspj] ${RegionName[$cspi,$cspj]}" 
-		echo "- VM SPEC : ${SPEC_NAME[$cspi,$cspj]}"
-		echo "- VM IMAGE : ${IMAGE_NAME[$cspi,$cspj]}"
+		echo "   [$cspi,$cspj] ${RegionName[$cspi,$cspj]}" 
+		echo "    - VM SPEC : ${SPEC_NAME[$cspi,$cspj]}"
+		echo "    - VM IMAGE : ${IMAGE_NAME[$cspi,$cspj]}"
 	done
 	echo ""
 done
 
+echo "3) MCIS Configuration"
+echo " - NameSpace ID : $NSID"
+echo " - MCIS ID : $MCISID"
+echo " - Number of VMs"
+
+for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+	INDEXY=${NumRegion[$cspi]}
+	CSP=${CSPType[$cspi]}
+	TOTALVM=$((1 * INDEXY * NUMVM))
+	echo "   - [$cspi] VMs($TOTALVM) = $CSP(1) * Region($INDEXY) * VMgroup($NUMVM)"
+done
 
 echo ""
+

--- a/src/testclient/scripts/sequentialFullTest/create-all.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-all.sh
@@ -2,6 +2,14 @@
 
 SECONDS=0
 
+./check-test-config.sh "$@"
+
+read -p 'Confirm the above configuration. Do you want to proceed ? (y/n) : ' CHECKPROCEED
+if [ "${CHECKPROCEED}" != "y" ]; then
+	echo "[Command: $0 $@] has been cancelled. See you soon. :)"
+    exit 0
+fi
+
 ./create-mcir-ns-cloud.sh "$@"
 
 ./create-mcis-only.sh "$@"


### PR DESCRIPTION

Confirm the above configuration. Do you want to proceed ? (y/n) : n
[Command: ./create-all.sh -n shson01 -x 3] has been cancelled. See you soon. :)

```
cb-tumblebug/src/testclient/scripts/sequentialFullTest$ ./create-all.sh -n shson01 -x 3
```
```
####################################################################
## Check test config file (-n deveoperPrefix -f ../testSetCustom.env -x numOfVMsInEachVMGroup)
####################################################################

Input parameters
// POSTFIX:shson01 // TestSetFile:../testSet.env // CSP:all // REGION:1 // OPTION01:3 // OPTION02: // OPTION03:

[Configuration in (../testSet.env) & (../conf.env) files]
1) Tumblebug Server : localhost:1323 // Spider Server : localhost:1024
2) Enabled CSPs and regions in ../testSet.env
 - [1] testcloud01 (enabled regions : 1)
 - [2] testcloud02 (enabled regions : 1)
 - [3] testcloud03 (enabled regions : 1)

   [1] testcloud01 details
   [1,1] testcloud01-seoul
    - VM SPEC : mock-vmspec-01
    - VM IMAGE : mock-vmimage-01

   [2] testcloud02 details
   [2,1] testcloud02-canada
    - VM SPEC : mock-vmspec-01
    - VM IMAGE : mock-vmimage-01

   [3] testcloud03 details
   [3,1] testcloud03-frankfurt
    - VM SPEC : mock-vmspec-01
    - VM IMAGE : mock-vmimage-01

3) MCIS Configuration
 - NameSpace ID : tb01
 - MCIS ID : cb-shson01
 - Number of VMs
   - [1] VMs(3) = testcloud01(1) * Region(1) * VMgroup(3)
   - [2] VMs(3) = testcloud02(1) * Region(1) * VMgroup(3)
   - [3] VMs(3) = testcloud03(1) * Region(1) * VMgroup(3)

Confirm the above configuration. Do you want to proceed ? (y/n) : n
[Command: ./create-all.sh -n shson01 -x 3] has been cancelled. See you soon. :)
```