### PR TITLE
Display output of MCIS status script in a table

### DIFF
--- a/src/testclient/scripts/8.mcis/status-mcis.sh
+++ b/src/testclient/scripts/8.mcis/status-mcis.sh
@@ -19,6 +19,13 @@ echo "${MCISID}"
 ControlCmd=status
 curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=${ControlCmd} | jq ''
 
+echo "Table: All VMs in the MCIS : ${MCISID}"
+echo ""
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=${ControlCmd} |
+    jq '.status | .vm' |
+    jq -r '(["ID","Status","PublicIP","PrivateIP","CloudType","CloudRegion","CreatedTime"] | (., map(length*"-"))), (.[] | [.id, .status, .publicIp, .privateIp, .location.cloudType, .location.nativeRegion, .createdTime]) | @tsv' |
+    column -t
+
 #HTTP_CODE=$(curl -o /dev/null -w "%{http_code}\n" -H "${AUTH}" "http://${TumblebugServer}/tumblebug/ns/$NSID/mcis/${MCISID}?action=status" --silent)
 #echo "Status: $HTTP_CODE"
 


### PR DESCRIPTION
JSON array output is hard to understand at a glance.

So, convert output of MCIS status to a table.

```
Table: All VMs in the MCIS : cb-shson01

ID                       Status   PublicIP  PrivateIP  CloudType  CloudRegion  CreatedTime
--                       ------   --------  ---------  ---------  -----------  -----------
testcloud03-frankfurt-1  Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:53
testcloud02-canada-0     Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:47
testcloud03-frankfurt-0  Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:53
testcloud01-seoul-1      Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:37
testcloud02-canada-1     Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:47
testcloud01-seoul-0      Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:36
```


### Command
```
cb-tumblebug/src/testclient/scripts/sequentialFullTest$ ../8.mcis/status-mcis.sh -n shson01 -x 2
```

### Output
```
####################################################################
## 8. VM: Status MCIS
####################################################################

Input parameters
// POSTFIX:shson01 // TestSetFile:../testSet.env // CSP:all // REGION:1 // OPTION01:2 // OPTION02: // OPTION03:
cb-shson01
{
  "status": {
    "id": "cb-shson01",
    "name": "cb-shson01",
    "status": "Running-6(6/6)",
    "statusCount": {
      "countTotal": 6,
      "countCreating": 0,
      "countRunning": 6,
      "countFailed": 0,
      "countSuspended": 0,
      "countRebooting": 0,
      "countTerminated": 0,
      "countSuspending": 0,
      "countResuming": 0,
      "countTerminating": 0,
      "countUndefined": 0
    },
    "targetStatus": "None",
    "targetAction": "None",
    "installMonAgent": "no",
    "masterVmId": "testcloud01-seoul-0",
    "masterIp": "4.3.2.1",
    "masterSSHPort": "22",
    "vm": [
      {
        "id": "testcloud03-frankfurt-0",
        "name": "testcloud03-frankfurt-0",
        "cspVmId": "tb01-cb-shson01-testcloud03-frankfurt-0",
        "status": "Running",
        "targetStatus": "None",
        "targetAction": "None",
        "nativeStatus": "Running",
        "monAgentStatus": "notInstalled",
        "systemMessage": "",
        "createdTime": "2021-09-14 22:43:53",
        "publicIp": "4.3.2.1",
        "privateIp": "1.2.3.4",
        "sshPort": "22",
        "location": {
          "latitude": "37.0000",
          "longitude": "126.0000",
          "briefAddr": "South Korea (Seoul)",
          "cloudType": "mock",
          "nativeRegion": "default"
        }
      },
      {
        "id": "testcloud03-frankfurt-1",
        "name": "testcloud03-frankfurt-1",
        "cspVmId": "tb01-cb-shson01-testcloud03-frankfurt-1",
        "status": "Running",
        "targetStatus": "None",
        "targetAction": "None",
        "nativeStatus": "Running",
        "monAgentStatus": "notInstalled",
        "systemMessage": "",
        "createdTime": "2021-09-14 22:43:53",
        "publicIp": "4.3.2.1",
        "privateIp": "1.2.3.4",
        "sshPort": "22",
        "location": {
          "latitude": "37.0000",
          "longitude": "126.0000",
          "briefAddr": "South Korea (Seoul)",
          "cloudType": "mock",
          "nativeRegion": "default"
        }
      },
      {
        "id": "testcloud01-seoul-1",
        "name": "testcloud01-seoul-1",
        "cspVmId": "tb01-cb-shson01-testcloud01-seoul-1",
        "status": "Running",
        "targetStatus": "None",
        "targetAction": "None",
        "nativeStatus": "Running",
        "monAgentStatus": "notInstalled",
        "systemMessage": "",
        "createdTime": "2021-09-14 22:43:37",
        "publicIp": "4.3.2.1",
        "privateIp": "1.2.3.4",
        "sshPort": "22",
        "location": {
          "latitude": "37.0000",
          "longitude": "126.0000",
          "briefAddr": "South Korea (Seoul)",
          "cloudType": "mock",
          "nativeRegion": "default"
        }
      },
...
      {
        "id": "testcloud01-seoul-0",
        "name": "testcloud01-seoul-0",
        "cspVmId": "tb01-cb-shson01-testcloud01-seoul-0",
        "status": "Running",
        "targetStatus": "None",
        "targetAction": "None",
        "nativeStatus": "Running",
        "monAgentStatus": "notInstalled",
        "systemMessage": "",
        "createdTime": "2021-09-14 22:43:36",
        "publicIp": "4.3.2.1",
        "privateIp": "1.2.3.4",
        "sshPort": "22",
        "location": {
          "latitude": "37.0000",
          "longitude": "126.0000",
          "briefAddr": "South Korea (Seoul)",
          "cloudType": "mock",
          "nativeRegion": "default"
        }
      },
      {
        "id": "testcloud02-canada-1",
        "name": "testcloud02-canada-1",
        "cspVmId": "tb01-cb-shson01-testcloud02-canada-1",
        "status": "Running",
        "targetStatus": "None",
...
          "briefAddr": "South Korea (Seoul)",
          "cloudType": "mock",
          "nativeRegion": "default"
        }
      }
    ]
  }
}
Table: All VMs in the MCIS : cb-shson01

ID                       Status   PublicIP  PrivateIP  CloudType  CloudRegion  CreatedTime
--                       ------   --------  ---------  ---------  -----------  -----------
testcloud03-frankfurt-1  Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:53
testcloud02-canada-0     Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:47
testcloud03-frankfurt-0  Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:53
testcloud01-seoul-1      Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:37
testcloud02-canada-1     Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:47
testcloud01-seoul-0      Running  4.3.2.1   1.2.3.4    mock       default      2021-09-14   22:43:36
```

