### PR TITLE
Move MCIS refine feature's REST API: from GET /mcis to GET /control/mcis

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -1082,7 +1082,8 @@ var doc = `{
                             "suspend",
                             "resume",
                             "reboot",
-                            "terminate"
+                            "terminate",
+                            "refine"
                         ],
                         "type": "string",
                         "description": "Action to MCIS",
@@ -1471,7 +1472,7 @@ var doc = `{
         },
         "/ns/{nsId}/mcis/{mcisId}": {
             "get": {
-                "description": "Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate, refine), or Get VMs' ID",
+                "description": "Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate), or Get VMs' ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -1481,7 +1482,7 @@ var doc = `{
                 "tags": [
                     "[MCIS] Provisioning management"
                 ],
-                "summary": "Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate, refine), or Get VMs' ID",
+                "summary": "Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate), or Get VMs' ID",
                 "parameters": [
                     {
                         "type": "string",
@@ -1503,8 +1504,7 @@ var doc = `{
                             "suspend",
                             "resume",
                             "reboot",
-                            "terminate",
-                            "refine"
+                            "terminate"
                         ],
                         "type": "string",
                         "description": "Action to MCIS",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -1068,7 +1068,8 @@
                             "suspend",
                             "resume",
                             "reboot",
-                            "terminate"
+                            "terminate",
+                            "refine"
                         ],
                         "type": "string",
                         "description": "Action to MCIS",
@@ -1457,7 +1458,7 @@
         },
         "/ns/{nsId}/mcis/{mcisId}": {
             "get": {
-                "description": "Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate, refine), or Get VMs' ID",
+                "description": "Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate), or Get VMs' ID",
                 "consumes": [
                     "application/json"
                 ],
@@ -1467,7 +1468,7 @@
                 "tags": [
                     "[MCIS] Provisioning management"
                 ],
-                "summary": "Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate, refine), or Get VMs' ID",
+                "summary": "Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate), or Get VMs' ID",
                 "parameters": [
                     {
                         "type": "string",
@@ -1489,8 +1490,7 @@
                             "suspend",
                             "resume",
                             "reboot",
-                            "terminate",
-                            "refine"
+                            "terminate"
                         ],
                         "type": "string",
                         "description": "Action to MCIS",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -2214,6 +2214,7 @@ paths:
         - resume
         - reboot
         - terminate
+        - refine
         in: query
         name: action
         type: string
@@ -2475,8 +2476,8 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate,
-        refine), or Get VMs' ID
+      description: Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate),
+        or Get VMs' ID
       parameters:
       - description: Namespace ID
         in: path
@@ -2495,7 +2496,6 @@ paths:
         - resume
         - reboot
         - terminate
-        - refine
         in: query
         name: action
         type: string
@@ -2531,8 +2531,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/common.SimpleMsg'
-      summary: Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate,
-        refine), or Get VMs' ID
+      summary: Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate),
+        or Get VMs' ID
       tags:
       - '[MCIS] Provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vm:

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -53,14 +53,14 @@ type JSONResult struct {
 // Annotation for API documention Need to be revised.
 
 // RestGetMcis godoc
-// @Summary Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate, refine), or Get VMs' ID
-// @Description Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate, refine), or Get VMs' ID
+// @Summary Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate), or Get VMs' ID
+// @Description Get MCIS, Action to MCIS (status, suspend, resume, reboot, terminate), or Get VMs' ID
 // @Tags [MCIS] Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
 // @Param mcisId path string true "MCIS ID"
-// @Param action query string false "Action to MCIS" Enums(status, suspend, resume, reboot, terminate, refine)
+// @Param action query string false "Action to MCIS" Enums(status, suspend, resume, reboot, terminate)
 // @Param option query string false "Option" Enums(id)
 // @success 200 {object} JSONResult{[DEFAULT]=mcis.TbMcisInfo,[STATUS]=mcis.McisStatusInfo,[CONTROL]=common.SimpleMsg,[ID]=common.IdList} "Different return structures by the given action param"
 // @Failure 404 {object} common.SimpleMsg
@@ -84,7 +84,7 @@ func RestGetMcis(c echo.Context) error {
 		}
 
 		return c.JSON(http.StatusOK, &content)
-	} else if action == "suspend" || action == "resume" || action == "reboot" || action == "terminate" || action == "refine" {
+	} else if action == "suspend" || action == "resume" || action == "reboot" || action == "terminate" {
 
 		result, err := mcis.HandleMcisAction(nsId, mcisId, action)
 		if err != nil {
@@ -331,7 +331,7 @@ func RestPostMcisRecommend(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID"
 // @Param mcisId path string true "MCIS ID"
-// @Param action query string false "Action to MCIS" Enums(status, suspend, resume, reboot, terminate)
+// @Param action query string false "Action to MCIS" Enums(status, suspend, resume, reboot, terminate, refine)
 // @Success 200 {object} common.SimpleMsg
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -342,7 +342,7 @@ func RestGetControlMcis(c echo.Context) error {
 
 	action := c.QueryParam("action")
 
-	if action == "suspend" || action == "resume" || action == "reboot" || action == "terminate" {
+	if action == "suspend" || action == "resume" || action == "reboot" || action == "terminate" || action == "refine" {
 
 		result, err := mcis.HandleMcisAction(nsId, mcisId, action)
 		if err != nil {
@@ -354,7 +354,7 @@ func RestGetControlMcis(c echo.Context) error {
 		return c.JSON(http.StatusOK, &mapA)
 
 	} else {
-		mapA := map[string]string{"message": "'action' should be one of these: suspend, resume, reboot, terminate"}
+		mapA := map[string]string{"message": "'action' should be one of these: suspend, resume, reboot, terminate, refine"}
 		return c.JSON(http.StatusBadRequest, &mapA)
 	}
 }

--- a/src/testclient/scripts/8.mcis/refine-mcis.sh
+++ b/src/testclient/scripts/8.mcis/refine-mcis.sh
@@ -15,4 +15,4 @@ fi
 echo "${MCISID}"
 
 ControlCmd=refine
-curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=${ControlCmd} | jq ''
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/control/mcis/${MCISID}?action=${ControlCmd} | jq ''


### PR DESCRIPTION
fix #755 

* src/api/rest/server/mcis/control.go에서 `RestGetMcis(c echo.Context) error` 함수의 `action == "refine"` 조건 삭제 및 `RestGetControlMcis(c echo.Context) error` 함수에 `action == "refine"` 조건 추가
* 위 두 함수의 annotations 수정
* Swagger doc 업데이트
* src/testclient/scripts/8.mcis/refine-mcis.sh 스크립트 REST API path 수정