### PR TITLE
Add sorting for VMs from status-mcis

### DIFF
--- a/src/testclient/scripts/8.mcis/status-mcis.sh
+++ b/src/testclient/scripts/8.mcis/status-mcis.sh
@@ -22,7 +22,7 @@ curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCIS
 echo "Table: All VMs in the MCIS : ${MCISID}"
 echo ""
 curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?action=${ControlCmd} |
-    jq '.status | .vm' |
+    jq '.status | .vm | sort_by(.id)' |
     jq -r '(["ID","Status","PublicIP","PrivateIP","CloudType","CloudRegion","CreatedTime"] | (., map(length*"-"))), (.[] | [.id, .status, .publicIp, .privateIp, .location.cloudType, .location.nativeRegion, .createdTime]) | @tsv' |
     column -t
 


### PR DESCRIPTION

Sorting VM list by ID to enhance readability.

```
Table: All VMs in the MCIS : cb-shson01

ID                       Status   PublicIP  PrivateIP  CloudType  CloudRegion  CreatedTime
--                       ------   --------  ---------  ---------  -----------  -----------
testcloud01-seoul-0      Running  4.3.2.1   1.2.3.4    mock       default      2021-09-24   00:47:40
testcloud02-canada-0     Running  4.3.2.1   1.2.3.4    mock       default      2021-09-24   00:47:51
testcloud03-frankfurt-0  Running  4.3.2.1   1.2.3.4    mock       default      2021-09-24   00:47:57
```