### PR TITLE
Add UML image link in design readme

### DIFF
--- a/docs/designUML/README.md
+++ b/docs/designUML/README.md
@@ -11,7 +11,7 @@ http://www.plantuml.com to visualized UMLs.
 ## Sequence Diagram
 
 * [Basic sequence to create MCIS](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/docs/designUML/seq-create-mcis.puml)
-
+  ![image](https://user-images.githubusercontent.com/5966944/134637428-c3cbb328-7035-4380-8ea7-4e059baf6a72.png)
 
 ## Object Diagram
 


### PR DESCRIPTION
docs/designUML/README.md uses http://www.plantuml.com to visualized UMLs.

However, it seems there is an error with rendering from the site.

So, I added image link directly to readme.md (for this moment)

The image link is from PR #767