### PR TITLE
Add comment to exported SpiderNameIdSystemId

### DIFF
--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -428,6 +428,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	}
 }
 
+// SpiderNameIdSystemId is struct for mapping NameID and System ID from CB-Spider response
 type SpiderNameIdSystemId struct {
 	NameId   string
 	SystemId string


### PR DESCRIPTION
Fix #783 partially. 

Task 1

 Line 431: warning: exported type SpiderNameIdSystemId should have comment or be unexported (golint)
