### PR TITLE
Add comment for exported type SpiderAllListWrapper

### DIFF
--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -433,6 +433,7 @@ type SpiderNameIdSystemId struct {
 	SystemId string
 }
 
+// SpiderAllListWrapper is struct for wrapping SpiderAllList struct from CB-Spider response.
 type SpiderAllListWrapper struct {
 	AllList SpiderAllList
 }


### PR DESCRIPTION

Add comment for exported type SpiderAllListWrapper.

To fix task-2 of #783.
