### PR TITLE
Add script for local DNS mapping for MCIS

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/check-network-performance.sh
+++ b/src/testclient/scripts/sequentialFullTest/check-network-performance.sh
@@ -125,8 +125,9 @@ done
 
 echo ""
 
+LAUNCHCMD="fping -e $VMLIST"
 #LAUNCHCMD="fping -e $PRIVIPLIST"
-LAUNCHCMD="fping -e $IPLIST"
+#LAUNCHCMD="fping -e $IPLIST"
 #LAUNCHCMD="fping -e $IPCOMBLIST"
 # LAUNCHCMD="fping $PRIVIPLIST -q -n -c 10"
 

--- a/src/testclient/scripts/sequentialFullTest/set-mcis-hosts.sh
+++ b/src/testclient/scripts/sequentialFullTest/set-mcis-hosts.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+echo "####################################################################"
+echo "## Set Local MCIS DNS (/etc/hosts of each VM in MC-Infra)"
+echo "####################################################################"
+
+source ../init.sh
+
+echo ""
+
+MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID})
+VMARRAY=$(jq '.vm' <<<"$MCISINFO")
+
+echo ""
+echo "[GENERATED PRIVATE KEY (PEM, PPK) first]"
+
+echo ""
+
+echo "[MCIS INFO: $MCISID]"
+# for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+# 	_jq() {
+# 		echo ${row} | base64 --decode | jq -r ${1}
+# 	}
+
+# 	VMKEYID=$(jq '.sshKeyId')
+# 	KEYFILENAME="${VMKEYID}"
+
+# 	curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey/$VMKEYID -H 'Content-Type: application/json' | jq '.privateKey' | sed -e 's/\\n/\n/g' -e 's/\"//g' >./sshkey-tmp/$KEYFILENAME.pem
+# 	chmod 600 ./sshkey-tmp/$KEYFILENAME.pem
+# 	puttygen ./sshkey-tmp/$KEYFILENAME.pem -o ./sshkey-tmp/$KEYFILENAME.ppk -O private
+# done
+
+for rowi in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+	_jq() {
+		echo ${rowi} | base64 --decode | jq -r ${1}
+	}
+
+	VMID=$(_jq '.id')
+	publicIP=$(_jq '.publicIP')
+	vNetId=$(_jq '.vNetId')
+
+	echo "VMID: $VMID"
+
+	VMKEYID=$(_jq '.sshKeyId')
+	KEYINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/${NSID}/resources/sshKey/${VMKEYID})
+	USERNAME=$(jq -r '.verifiedUsername' <<<"$KEYINFO")
+	KEYFILENAME="${VMKEYID}"
+
+	for rowj in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+		_jq() {
+			echo ${rowj} | base64 --decode | jq -r ${1}
+		}
+
+		Bid=$(_jq '.id')
+		BpublicIP=$(_jq '.publicIP')
+		BprivateIP=$(_jq '.privateIP')
+		BvNetId=$(_jq '.vNetId')
+
+		CommandToAddHosts=""
+
+		if [ "${VMID}" != "${Bid}" ]; then
+			CommandToAddHosts="sudo sed -i '2i127.0.0.1 ${Bid}' /etc/hosts"
+		elif [ "${vNetId}" == "${BvNetId}" ]; then
+			CommandToAddHosts="sudo sed -i '2i${BprivateIP} ${Bid}' /etc/hosts"
+		else
+			CommandToAddHosts="sudo sed -i '2i${BpublicIP} ${Bid}' /etc/hosts"
+		fi
+
+		echo "${CommandToAddHosts}"
+
+		VAR1=$(ssh -i ./sshkey-tmp/$KEYFILENAME.pem $USERNAME@$publicIP -o StrictHostKeyChecking=no "$CommandToAddHosts")
+		echo "${VAR1}" | jq ''
+
+	done
+done
+
+CMD="cat /etc/hosts"
+VAR1=$(
+	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${CMD}"
+	}
+EOF
+)
+echo "${VAR1}" | jq . | sed 's/\\n/\n/g'


### PR DESCRIPTION
이슈
- MCIS의 모든 VM에는 퍼블릭 IP가 할당되어 있고, 이를 활용하는 것으로만 가이드되고 있습니다.
- Private 네트워크를 활용하지 못하고 있습니다.
- 내부적으로는 동일한 vNet에 있는 VM들은 Private IP로 상호 통신이 가능합니다.
- 빠른 Private 네트워크를 사용하지 못해서 아깝습니다.

PR
- Public IP와 Private IP를 동시에 활용할 수 있도록 로컬 DNS 사용
  - Private network 로 상호 연결 가능한 VM은 Private IP로 통신하고, 네트워크가 공유가 되지 않는 VM들에 대해서만 Public IP로 통신할 수 있도록 Name으로 이를 해석할 수 있도록 하였습니다. 
  - 이를 위한 PoC로, /etc/hosts 를 업데이트하는 스크립트를 개발하였습니다.
  - 이를 실행하면, MCIS 내부의 각 VM에 대해서 /etc/hosts 를 추가하게 됩니다. (아래 예시와 같이. 동적 업데이트는 아닙니다.)

```diff
cb-user@ip-192-168-2-241:~$ cat /etc/hosts
127.0.0.1 localhost

+ 127.0.0.1 gcp-as-east1-0
+ 192.168.2.241 aws-ap-se-1-1
+ 35.229.192.26 gcp-as-east1-1

# The following lines are desirable for IPv6 capable hosts
::1 ip6-localhost ip6-loopback
fe00::0 ip6-localnet
ff00::0 ip6-mcastprefix
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
ff02::3 ip6-allhosts
```

check-network-performance.sh 으로 Ping 테스트를 해볼 수 있으며,

Public IP나 Private IP를 지정하지 않고, VM ID 로 MCIS 내부에서 상호 Ping을 시험할 수 있습니다. 
```
VMID:            aws-ap-se-1-1  aws-ap-se-1-0 gcp-as-east1-0 gcp-as-east1-1
-------                -------        -------        -------        -------
aws-ap-se-1-1            0.167          0.222         49.499         46.089
aws-ap-se-1-0            0.269          0.179         46.190         46.202
gcp-as-east1-0          49.734         45.923          1.156          2.116
gcp-as-east1-1          46.102         46.379          2.355          0.905
```
