### PR TITLE
add dynamic port conf for restapiserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ A sub-system of Cloud-Barista Platform to Deploy and Manage Multi-Cloud Infrastr
 ### Development stage of Cloud-Barista
 ```
 Cloud-Barista is currently under development. (not v1.0 yet)
-We welcome any new suggestions, issues, opinions, and controbutors !
+We welcome any new suggestions, issues, opinions, and contributors !
 Please note that the functionalities of Cloud-Barista are not stable and secure yet.
-Becareful if you plan to use the current release in production.
+Be careful if you plan to use the current release in production.
 If you have any difficulties in using Cloud-Barista, please let us know.
 (Open an issue or Join the Cloud-Barista Slack)
 ```

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -50,11 +50,15 @@ const (
  ██║  ██║███████╗██║  ██║██████╔╝   ██║   
  ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝    ╚═╝   
 
- Multi-cloud infrastructure managemenet framework
+ Multi-cloud infrastructure management framework
  ________________________________________________`
 )
 
-func ApiServer() {
+/*
+	port is the port that the ApiServer will listen to.
+	port is passed without a ':' (colon).
+*/
+func ApiServer(port string) {
 
 	e := echo.New()
 
@@ -258,5 +262,6 @@ func ApiServer() {
 	fmt.Printf(noticeColor, apidashboard)
 	fmt.Println("\n ")
 
-	e.Logger.Fatal(e.Start(":1323"))
+	port = fmt.Sprintf(":%s", port)
+	e.Logger.Fatal(e.Start(port))
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strconv"
@@ -39,8 +40,11 @@ import (
 
 // @securityDefinitions.basic BasicAuth
 func main() {
-
 	fmt.Println("")
+
+	// giving a default value of "1323"
+	port := flag.String("port", "1323", "port number for the restapiserver to listen to")
+	flag.Parse()
 
 	common.SpiderRestUrl = common.NVL(os.Getenv("SPIDER_REST_URL"), "http://localhost:1024/spider")
 	common.DragonflyRestUrl = common.NVL(os.Getenv("DRAGONFLY_REST_URL"), "http://localhost:9090/dragonfly")
@@ -131,7 +135,7 @@ func main() {
 
 	// Start REST Server
 	go func() {
-		restapiserver.ApiServer()
+		restapiserver.ApiServer(*port)
 		wg.Done()
 	}()
 


### PR DESCRIPTION
we can now pass port number as a command-line argument when running the application.

`--port 5000`, `-port 5000`, `--port=5000`, `-port=5000`, etc. are all valid arguments.

if a given port is not present, the server will start listening on `1323` by default.