### PR TITLE
Add 'paths to ignore' to auto-build GitHub workflows

### DIFF
--- a/.github/workflows/build-amd64-container-image.yaml
+++ b/.github/workflows/build-amd64-container-image.yaml
@@ -15,6 +15,7 @@ on:
       - 'assets/**'
       - 'scripts/**'
       - 'src/testclient/scripts/**'
+      - 'docs/**'
 
 jobs:
   # The job key is "building"

--- a/.github/workflows/publish-multi-arch-container-images.yaml
+++ b/.github/workflows/publish-multi-arch-container-images.yaml
@@ -23,6 +23,7 @@ on:
       - 'assets/**'
       - 'scripts/**'
       - 'src/testclient/scripts/**'
+      - 'docs/**'
 
 jobs:
   # The job key is "publishing"


### PR DESCRIPTION
#797 이슈입니다.

docs/ 디렉토리 아래 파일들을 업데이트시 별도의 빌드테스트 X, 컨테이너 이미지 업데이트 불필요하여
paths-ignore에 docs 디렉토리의 모든 하위폴더에 대해 무시하도록 경로 설정하였습니다.

이렇게 경로 설정된 파일은 2개입니다.
build-amd64-container-image.yaml
publish-multi-arch-container-images.yaml
