### PR TITLE
Set CBTUMBLEBUG_ROOT based on a project directory

### DIFF
--- a/conf/setup.env
+++ b/conf/setup.env
@@ -1,4 +1,6 @@
-export CBTUMBLEBUG_ROOT=$HOME/go/src/github.com/cloud-barista/cb-tumblebug
+SCRIPT_DIR=`dirname ${BASH_SOURCE[0]-$0}`
+export CBTUMBLEBUG_ROOT=`cd $SCRIPT_DIR && cd .. && pwd`
+# export CBTUMBLEBUG_ROOT=$HOME/go/src/github.com/cloud-barista/cb-tumblebug
 export CBSTORE_ROOT=$CBTUMBLEBUG_ROOT
 export CBLOG_ROOT=$CBTUMBLEBUG_ROOT
 export SPIDER_CALL_METHOD=REST


### PR DESCRIPTION
Resolve #815

[`setup.env` to test]
```
SCRIPT_DIR=`dirname ${BASH_SOURCE[0]-$0}`
export CBTUMBLEBUG_ROOT=`cd $SCRIPT_DIR && cd .. && pwd`

echo $SCRIPT_DIR;
echo $CBTUMBLEBUG_ROOT;
```

[Test cases and result] 
Case 1 - Based on current CB-Tumblebug README
```
ubuntu@DESKTOP-DP4QPL8:~/go/src/github.com/cloud-barista/cb-tumblebug$ source conf/setup.env
conf
/home/ubuntu/go/src/github.com/cloud-barista/cb-tumblebug
```

Case 2 - Based on current CB-Tumblebug README
```
ubuntu@DESKTOP-DP4QPL8:~/go/src/github.com/cloud-barista/cb-tumblebug/conf$ source setup.env
.
/home/ubuntu/go/src/github.com/cloud-barista/cb-tumblebug
```

Case 3 - Based on VSCode with WLS2
```
ubuntu@DESKTOP-DP4QPL8:/mnt/c/Dev/Cloud-Barista/cb-tumblebug$ source conf/setup.env
conf
/mnt/c/Dev/Cloud-Barista/cb-tumblebug
```

Case 4 - Based on a random directory
```
ubuntu@DESKTOP-DP4QPL8:~$ source mydir/cb-tumblebug/conf/setup.env
mydir/cb-tumblebug/conf
/home/ubuntu/mydir/cb-tumblebug
```

**In all cases, `make` and `make run` work.** 😃 