### PR TITLE
Change Ubuntu18.04 image ID of Alibaba Cloud

### DIFF
--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -340,7 +340,7 @@ IY=0
 ProviderName[$IX]=ALIBABA
 DriverLibFileName[$IX]=alibaba-driver-v1.0.so
 DriverName[$IX]=alibaba-driver01
-CommonImage[$IX]=ubuntu_18_04_x64_20G_alibase_20210824.vhd
+CommonImage[$IX]=ubuntu_18_04_x64_20G_alibase_20210927.vhd
 CommonImageType[$IX]="Ubuntu 18.04" #Ubuntu 18.04
 CommonSpec[$IX]=ecs.t5-lc1m2.large
 


### PR DESCRIPTION
Minor update to resolve #450

- Change `ubuntu_18_04_x64_20G_alibase_20210824.vhd` to `ubuntu_18_04_x64_20G_alibase_20210927.vhd`

[Info from a VM]
![image](https://user-images.githubusercontent.com/7975459/138051989-8e471b78-4281-48a9-b298-e2ed60867bcb.png)
