### PR TITLE
Add 'Update Swagger doc' workflow

### DIFF
--- a/.github/workflows/make-swagger.yaml
+++ b/.github/workflows/make-swagger.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   update-swagger-doc:
     name: Update Swagger doc
+    if: github.repository == 'cloud-barista/cb-tumblebug'
     runs-on: ubuntu-18.04
     strategy:
       matrix:

--- a/.github/workflows/make-swagger.yaml
+++ b/.github/workflows/make-swagger.yaml
@@ -1,0 +1,39 @@
+name: Apply make swagger
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/core/**/**.go'
+      - 'src/api/rest/server/**/**.go'
+jobs:
+  update-swagger-doc:
+    name: Update Swagger doc
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        go-version: [ '1.17' ]
+
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout source code
+        uses: actions/checkout@v2.3.4
+        
+      - name: Install swag
+        run: |
+          go install github.com/swaggo/swag/cmd/swag@latest
+
+      - name: Update Swagger doc
+        run: |
+          cd src
+          make swag
+
+      - name: Commit generated Swagger docs
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: src/api/rest/docs/**
+          commit_message: Update Swagger docs


### PR DESCRIPTION
make swagger 를 자동으로 실행해 추가 커밋을 만드는 workflow를 추가하였습니다.

이 action은 core나 rest api쪽 코드에 변화가 있을 때에만 실행됩니다.

```yaml
    paths:
      - 'src/core/**/**.go'
      - 'src/api/rest/server/**/**.go'
```

문서 디렉토리의 파일 중 추가된 것이 있으면 자동으로 커밋합니다. 커밋 메세지는 "Update Swagger Docs" 입니다.

```yaml
      - name: Commit generated Swagger docs
        uses: stefanzweifel/git-auto-commit-action@v4
        with:
          file_pattern: src/api/rest/docs/**
          commit_message: Update Swagger docs
```

author는 원 커밋 저자로, committer는 'actions-user'로 기록됩니다.

![image](https://user-images.githubusercontent.com/26251856/138914373-7fe8e861-8cb8-4e7f-9dfe-82d257d36fdb.png)
