### PR TITLE
Rename CoreGetAllBenchmark function to RunAllBenchmarks

### DIFF
--- a/src/api/grpc/server/mcis/control.go
+++ b/src/api/grpc/server/mcis/control.go
@@ -513,7 +513,7 @@ func (s *MCISService) GetAllBenchmark(ctx context.Context, req *pb.BmQryAllReque
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.GetAllBenchmark()")
 	}
 
-	result, err := mcis.CoreGetAllBenchmark(req.NsId, req.McisId, mcisObj.Host)
+	result, err := mcis.RunAllBenchmarks(req.NsId, req.McisId, mcisObj.Host)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.GetAllBenchmark()")
 	}

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -807,7 +807,7 @@ func RestGetAllBenchmark(c echo.Context) error {
 		return err
 	}
 
-	result, err := mcis.CoreGetAllBenchmark(nsId, mcisId, req.Host)
+	result, err := mcis.RunAllBenchmarks(nsId, mcisId, req.Host)
 	if err != nil {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)

--- a/src/core/mcis/benchmark.go
+++ b/src/core/mcis/benchmark.go
@@ -192,8 +192,8 @@ func CallMilkyway(wg *sync.WaitGroup, vmList []string, nsId string, mcisId strin
 	results.ResultArray = append(results.ResultArray, resultTmp)
 }
 
-// CoreGetAllBenchmark is func to get alls Benchmarks
-func CoreGetAllBenchmark(nsId string, mcisId string, host string) (*BenchmarkInfoArray, error) {
+// RunAllBenchmarks is func to get all Benchmarks
+func RunAllBenchmarks(nsId string, mcisId string, host string) (*BenchmarkInfoArray, error) {
 
 	var err error
 


### PR DESCRIPTION
안녕하세요.
관련 이슈: #834
- src/core/mcis/benchmark.go 의 CoreGetAllBenchmark 함수명을 RunAllBenchmarks 로 수정했습니다.
- src/api/grpc/server/mcis/control.go, src/api/rest/server/mcis/control.go 에서 
함수 사용 중이어서 함수명을 RunAllBenchmarks 로 수정했습니다.

감사합니다!