### PR TITLE
Add Swagger doc files to gitignore

### DIFF
--- a/.github/workflows/make-swagger.yaml
+++ b/.github/workflows/make-swagger.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Update Swagger doc
         run: |
-          cd src
+          cd src/
           make swag
 
       # - name: Commit generated Swagger docs
@@ -38,6 +38,11 @@ jobs:
       #   with:
       #     file_pattern: src/api/rest/docs/**
       #     commit_message: Update Swagger docs
+
+      - name: Force-Add Swagger doc files
+        run: |
+          cd api/rest/docs/
+          git add -f -v docs.go swagger.json swagger.yaml
 
       - name: Create Pull Request
         id: create-pull-request

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,11 @@ src/testclient/scripts/credentials.conf
 src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/executionStatus*
 src/api/grpc/cbadm/testclient/scripts/credentials.conf
 
+# Swagger docs for REST APIs
+src/api/rest/docs/docs.go
+src/api/rest/docs/swagger.json
+src/api/rest/docs/swagger.yaml
+
 # Config file for mcism
 conf/
 

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -59,7 +59,7 @@ func RandomSleep(t int) {
 func CheckString(name string) error {
 
 	if name == "" {
-		err := fmt.Errorf("The provided name is empty")
+		err := fmt.Errorf("The provided string is empty")
 		return err
 	}
 


### PR DESCRIPTION
Idea from @seokho-son 😊

- Swagger doc file들을 `.gitignore`에 추가하여,
  기여자가 기여 시 Swagger doc file들을 신경쓰지 않아도 되도록 변경
- `.gitignore`에 Swagger doc file들이 들어가 있어서
  ["Update Swagger doc" workflow](https://github.com/cloud-barista/cb-tumblebug/blob/main/.github/workflows/make-swagger.yaml) 가 실행될 때 Swagger doc file들이 ignore 될 것 같으므로
  `git add -f -v` 명령을 이용하여 강제로 추가
  (이후, added but uncommitted change를 `peter-evans/create-pull-request` 가 잘 처리해 주리라 기대 😊)
