### PR TITLE
Change workflow for Cloud connection info registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,9 @@ container-volume/
 # Config file for test
 src/testclient/scripts/sequentialFullTest/executionStatus*
 src/testclient/scripts/sequentialFullTest/ansibleAutoConf/*
-src/testclient/scripts/credentials.conf
+src/testclient/scripts/credentials*
 src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/executionStatus*
-src/api/grpc/cbadm/testclient/scripts/credentials.conf
+src/api/grpc/cbadm/testclient/scripts/credentials*
 
 # Swagger docs for REST APIs
 src/api/rest/docs/docs.go

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ src/api/rest/docs/swagger.yaml
 
 # Config file for mcism
 conf/
+conf/credentials.conf
 
 # Runtime files
 src/benchmarking.csv

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ container-volume/
 
 # Config file for test
 src/testclient/scripts/sequentialFullTest/executionStatus*
+src/testclient/scripts/sequentialFullTest/ansibleAutoConf/*
 src/testclient/scripts/credentials.conf
 src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/executionStatus*
 src/api/grpc/cbadm/testclient/scripts/credentials.conf

--- a/README.md
+++ b/README.md
@@ -272,6 +272,31 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
   make
   ```
 
+### (4) CB-Tumblebug 멀티클라우드 환경 설정
+
+- 멀티클라우드 credential 등록을 위한 `credentials.conf` 생성 
+   - 개요
+     - `credentials.conf` 는 CB-TB가 지원하는 클라우드 타입 (AWS, GCP, AZURE, ALIBABA 등)에 대해 사용자 인증 정보를 입력 및 보관하는 파일
+     - [`conf/template.credentials.conf`](https://github.com/cloud-barista/cb-tumblebug/blob/main/src/conf/template.credentials.conf)를 참조하여 `credentials.conf` 파일 생성 및 내용 입력 필요
+   - 생성 방법: CB-TB 스크립트를 통해 `credentials.conf` 기본 파일 자동 생성
+    ```bash
+    cd ~/go/src/github.com/cloud-barista/cb-tumblebug
+    ./scripts/generateCredencialFile.sh
+    ```
+   - [참고: CSP별 인증 정보 획득 방법](https://github.com/cloud-barista/cb-tumblebug/wiki/How-to-get-public-cloud-credentials)을 참고하여, `credentials.conf`에 사용자 정보 입력
+
+- 모든 멀티클라우드 연결 정보 등록 
+   - 개요
+     - CB-TB의 멀티클라우드 인프라를 생성하기 위해서, 클라우드에 대한 연결 정보 (크리덴셜, 클라우드 종류, 클라우드 리젼 등) 등록이 필요
+     - [`conf.env`](https://github.com/cloud-barista/cb-tumblebug/blob/main/src/testclient/scripts/conf.env): 클라우드 리젼 등 기본 정보 제공
+     - 이미 많은 클라우드 타입에 대한 정보가 조사 및 입력되어 있으므로, 수정없이 사용 가능
+   - 설정 방법: CB-TB 스크립트를 통해 [`conf.env`](https://github.com/cloud-barista/cb-tumblebug/blob/main/src/testclient/scripts/conf.env)의 연결 정보 자동 등록
+    ```bash
+    cd ~/go/src/github.com/cloud-barista/cb-tumblebug
+    ./scripts/registerCloudInfo.sh
+    ```
+
+
 ***
 ***
 
@@ -291,23 +316,12 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
 
 #### 클라우드 인증 정보 및 테스트 기본 정보 입력
 1. [`src/testclient/scripts/`](https://github.com/cloud-barista/cb-tumblebug/tree/main/src/testclient/scripts) 이동
-
-2. `credentials.conf` 생성 
-   - `credentials.conf` 는 기본적인 클라우드 타입 (AWS, GCP, AZURE, ALIBABA 등)에 대해 인증 정보 템플릿 제공
-   - [`credentials.conf.example`](https://github.com/cloud-barista/cb-tumblebug/blob/main/src/testclient/scripts/credentials.conf.example)를 참조하여 항목에 사용자의 클라우드 인증 정보 입력
-    ```bash
-    cd ~/go/src/github.com/cloud-barista/cb-tumblebug/src/testclient/scripts
-    cp ./credentials.conf.example credentials.conf
-    ls credentials.conf
-    ```
-   - [CSP별 인증 정보 획득 방법 참고](https://github.com/cloud-barista/cb-tumblebug/wiki/How-to-get-public-cloud-credentials)
-
-3. [`conf.env`](https://github.com/cloud-barista/cb-tumblebug/blob/main/src/testclient/scripts/conf.env) 설정
+2. [`conf.env`](https://github.com/cloud-barista/cb-tumblebug/blob/main/src/testclient/scripts/conf.env) 설정
    - CB-Spider 및 CB-Tumblebug 서버 엔드포인트, 클라우드 리젼, 테스트용 이미지명, 테스트용 스팩명 등 테스트 기본 정보 제공
    - 이미 많은 클라우드 타입에 대한 정보가 조사 및 입력되어 있으므로, 수정없이 사용 가능. (단, 지정된 Spec에 따라 과금이 발생할 수 있으므로 확인 필요)
      - 테스트용 VM 이미지 수정 방식: [`IMAGE_NAME[$IX,$IY]=ami-061eb2b23f9f8839c`](https://github.com/cloud-barista/cb-tumblebug/blob/553c4884943916b3287ec17501c6f639e8667897/src/testclient/scripts/conf.env#L49)
      - 테스트용 VM 스펙 수정 방식: [`SPEC_NAME[$IX,$IY]=m4.4xlarge`](https://github.com/cloud-barista/cb-tumblebug/blob/553c4884943916b3287ec17501c6f639e8667897/src/testclient/scripts/conf.env#L50)   
-4. [`testSet.env`](https://github.com/cloud-barista/cb-tumblebug/blob/main/src/testclient/scripts/testSet.env) 설정
+3. [`testSet.env`](https://github.com/cloud-barista/cb-tumblebug/blob/main/src/testclient/scripts/testSet.env) 설정
    - MCIS 프로비저닝에 사용될, 클라우드 및 리전 구성을 파일로 설정 (기존의 `testSet.env` 를 변경해도 되고, 복사하여 활용도 가능)
    - 조합할 CSP 종류 지정
      - 조합할 총 CSP 개수 지정 ([NumCSP=](https://github.com/cloud-barista/cb-tumblebug/blob/553c4884943916b3287ec17501c6f639e8667897/src/testclient/scripts/testSet.env#L9) 에 숫자를 변경)

--- a/conf/template.credentials.conf
+++ b/conf/template.credentials.conf
@@ -1,4 +1,4 @@
-### Cloud credentials for auto testing
+### Cloud API Credentials
 
 
 

--- a/scripts/generateCredencialFile.sh
+++ b/scripts/generateCredencialFile.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+LGREEN='\033[1;32m'
+PURPLE='\033[0;35m'
+NC='\033[0m' # No Color
+
+if [ -z "$CBTUMBLEBUG_ROOT" ]; then
+    SCRIPT_DIR=`dirname ${BASH_SOURCE[0]-$0}`
+    export CBTUMBLEBUG_ROOT=`cd $SCRIPT_DIR && cd .. && pwd`
+fi
+
+CONF_PATH="$CBTUMBLEBUG_ROOT/conf"
+TEMPLATE_FILE_NAME="template.credentials.conf"
+CRED_FILE_NAME="credentials.conf"
+
+echo
+echo ==========================================================
+echo "[Info]"
+echo ==========================================================
+echo -e "This script genrete ${RED}${CRED_FILE_NAME}${NC} file for Cloud credentials"
+echo
+echo -e "- Copy ${CONF_PATH}/${LGREEN}${TEMPLATE_FILE_NAME} ${NC} file"
+echo -e "-   to ${CONF_PATH}/${RED}${CRED_FILE_NAME} ${NC}"
+echo
+
+while true; do
+    read -p 'Do you want to proceed ? (y/n) : ' CHECKPROCEED
+    case $CHECKPROCEED in
+    [Yy]*)
+        break
+        ;;
+    [Nn]*)
+        echo
+        echo "Stop $0 See you soon :)"
+        exit 1
+        ;;
+    *)
+        echo "Please answer yes or no."
+        ;;
+    esac
+done
+
+echo
+echo -e "Copying.. (if you don't want overwrite, type ${RED}[n] or [no]${NC}) ${RED}"
+cp -i ${CONF_PATH}/${TEMPLATE_FILE_NAME} ${CONF_PATH}/${CRED_FILE_NAME}
+echo -e "${NC}"
+echo -e "Current contents of ${CONF_PATH}/${RED}${CRED_FILE_NAME} ${PURPLE}"
+cat ${CONF_PATH}/${CRED_FILE_NAME}
+echo -e "${NC}"
+
+echo
+echo ==========================================================
+echo "[What's next]"
+echo ==========================================================
+echo -e "Edit ${RED}${CRED_FILE_NAME} file to add your Cloud credentials"
+echo
+echo -e "Ex) vi ${CONF_PATH}/${RED}${CRED_FILE_NAME} ${NC}"
+echo

--- a/scripts/registerCloudInfo.sh
+++ b/scripts/registerCloudInfo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -z "$CBTUMBLEBUG_ROOT" ]; then
+    SCRIPT_DIR=`dirname ${BASH_SOURCE[0]-$0}`
+    export CBTUMBLEBUG_ROOT=`cd $SCRIPT_DIR && cd .. && pwd`
+fi
+
+$CBTUMBLEBUG_ROOT/src/testclient/scripts/1.configureSpider/register-cloud-interactive.sh -n tb

--- a/src/api/grpc/cbadm/testclient/scripts/1.configureSpider/get-cloud.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/1.configureSpider/get-cloud.sh
@@ -3,7 +3,7 @@
 #function get_cloud() {
 
 
-    FILE=../credentials.conf
+    FILE=../../../../conf/credentials.conf
     if [ ! -f "$FILE" ]; then
         echo "$FILE does not exist."
         exit
@@ -17,7 +17,7 @@
     fi
 	source $TestSetFile
     source ../conf.env
-    source ../credentials.conf
+    source ../../../../conf/credentials.conf
     
     echo "####################################################################"
     echo "## 0. Get Cloud Connction Config"

--- a/src/api/grpc/cbadm/testclient/scripts/1.configureSpider/list-cloud.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/1.configureSpider/list-cloud.sh
@@ -10,7 +10,7 @@
     fi
 	source $TestSetFile
     source ../conf.env
-    #source ../credentials.conf
+    #source ../../../../conf/credentials.conf
     
     echo "####################################################################"
     echo "## 0. List Cloud Connction Config(s)"

--- a/src/api/grpc/cbadm/testclient/scripts/1.configureSpider/register-cloud.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/1.configureSpider/register-cloud.sh
@@ -3,7 +3,7 @@
 #function register_cloud() {
 
 
-    FILE=../credentials.conf
+    FILE=../../../../conf/credentials.conf
     if [ ! -f "$FILE" ]; then
         echo "$FILE does not exist."
         exit
@@ -16,7 +16,7 @@
     fi
 	source $TestSetFile
     source ../conf.env
-    source ../credentials.conf
+    source ../../../../conf/credentials.conf
     
     echo "####################################################################"
     echo "## 1. Create Cloud Connction Config"

--- a/src/api/grpc/cbadm/testclient/scripts/1.configureSpider/unregister-cloud.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/1.configureSpider/unregister-cloud.sh
@@ -3,7 +3,7 @@
 #function unregister_cloud() {
 
 
-    FILE=../credentials.conf
+    FILE=../../../../conf/credentials.conf
     if [ ! -f "$FILE" ]; then
         echo "$FILE does not exist."
         exit
@@ -17,7 +17,7 @@
     fi
 	source $TestSetFile
     source ../conf.env
-	source ../credentials.conf
+	source ../../../../conf/credentials.conf
 	
 	echo "####################################################################"
 	echo "## 1. Remove All Cloud Connction Config(s)"

--- a/src/api/grpc/cbadm/testclient/scripts/misc/get-conn-config.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/misc/get-conn-config.sh
@@ -3,7 +3,7 @@
 #function get_cloud() {
 
 
-    FILE=../credentials.conf
+    FILE=../../../../conf/credentials.conf
     if [ ! -f "$FILE" ]; then
         echo "$FILE does not exist."
         exit
@@ -16,7 +16,7 @@
     fi
 	source $TestSetFile
     source ../conf.env
-    source ../credentials.conf
+    source ../../../../conf/credentials.conf
     
     echo "####################################################################"
     echo "## 0. Get Cloud Connction Config"

--- a/src/api/grpc/cbadm/testclient/scripts/misc/get-region.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/misc/get-region.sh
@@ -3,7 +3,7 @@
 #function get_cloud() {
 
 
-    FILE=../credentials.conf
+    FILE=../../../../conf/credentials.conf
     if [ ! -f "$FILE" ]; then
         echo "$FILE does not exist."
         exit
@@ -16,7 +16,7 @@
     fi
 	source $TestSetFile
     source ../conf.env
-    source ../credentials.conf
+    source ../../../../conf/credentials.conf
     
     echo "####################################################################"
     echo "## 0. Get Cloud Connction Config"

--- a/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud.sh
@@ -123,7 +123,7 @@ function clean_sequence() {
 
 SECONDS=0
 
-FILE=../credentials.conf
+FILE=../../../../conf/credentials.conf
 if [ ! -f "$FILE" ]; then
 	echo "$FILE does not exist."
 	exit
@@ -136,7 +136,7 @@ if [ ! -f "$TestSetFile" ]; then
 fi
 source $TestSetFile
 source ../conf.env
-source ../credentials.conf
+source ../../../../conf/credentials.conf
 
 echo "####################################################################"
 echo "## Remove mcir-ns-cloud"

--- a/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/clean-mcis-only.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/clean-mcis-only.sh
@@ -23,7 +23,7 @@ function clean_mcis_sequence() {
 
 SECONDS=0
 
-FILE=../credentials.conf
+FILE=../../../../conf/credentials.conf
 if [ ! -f "$FILE" ]; then
 	echo "$FILE does not exist."
 	exit
@@ -36,7 +36,7 @@ if [ ! -f "$TestSetFile" ]; then
 fi
 source $TestSetFile
 source ../conf.env
-source ../credentials.conf
+source ../../../../conf/credentials.conf
 
 echo "####################################################################"
 echo "## Remove MCIS only"

--- a/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/create-mcir-ns-cloud.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/create-mcir-ns-cloud.sh
@@ -79,7 +79,7 @@ function test_sequence_allcsp_mcir() {
 
 SECONDS=0
 
-FILE=../credentials.conf
+FILE=../../../../conf/credentials.conf
 if [ ! -f "$FILE" ]; then
 	echo "$FILE does not exist."
 	exit
@@ -92,7 +92,7 @@ if [ ! -f "$TestSetFile" ]; then
 fi
 source $TestSetFile
 source ../conf.env
-source ../credentials.conf
+source ../../../../conf/credentials.conf
 
 echo "####################################################################"
 echo "## Create MCIS from Zero Base"

--- a/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
@@ -41,7 +41,7 @@ function test_sequence()
 
 
 
-	FILE=../credentials.conf
+	FILE=../../../../conf/credentials.conf
     if [ ! -f "$FILE" ]; then
         echo "$FILE does not exist."
         exit
@@ -54,7 +54,7 @@ function test_sequence()
     fi
 	source $TestSetFile
     source ../conf.env
-		source ../credentials.conf
+		source ../../../../conf/credentials.conf
 
 	echo "####################################################################"
 	echo "## Create MCIS from Zero Base"

--- a/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/create-mcis-only.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/create-mcis-only.sh
@@ -63,7 +63,7 @@ function test_sequence_allcsp_mcis_vm() {
 }
 SECONDS=0
 
-FILE=../credentials.conf
+FILE=../../../../conf/credentials.conf
 if [ ! -f "$FILE" ]; then
 	echo "$FILE does not exist."
 	exit
@@ -76,7 +76,7 @@ if [ ! -f "$TestSetFile" ]; then
 fi
 source $TestSetFile
 source ../conf.env
-source ../credentials.conf
+source ../../../../conf/credentials.conf
 
 echo "####################################################################"
 echo "## Create MCIS from Zero Base"

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -201,7 +201,7 @@ type TbVmDynamicReq struct {
 	Description string `json:"description" example:"Description"`
 
 	// CommonSpec is field for id of a spec in common namespace
-	CommonSpec string `json:"commonSpec" validate:"required" example:"aws-ap-southeast-1-m1-small"`
+	CommonSpec string `json:"commonSpec" validate:"required" example:"aws-ap-northeast-2-t2-small"`
 	// CommonImage is field for id of a image in common namespace
 	CommonImage string `json:"commonImage" validate:"required" example:"ubuntu18.04"`
 }

--- a/src/testclient/scripts/1.configureSpider/register-cloud-interactive.sh
+++ b/src/testclient/scripts/1.configureSpider/register-cloud-interactive.sh
@@ -133,6 +133,8 @@ echo "####################################################################"
 echo "## 1. Register Cloud Inforation"
 echo "####################################################################"
 
+SCRIPT_DIR=`dirname ${BASH_SOURCE[0]-$0}`
+cd $SCRIPT_DIR
 
 source ../init.sh
 echo ""

--- a/src/testclient/scripts/init.sh
+++ b/src/testclient/scripts/init.sh
@@ -4,7 +4,7 @@ source ../common-functions.sh
 readParametersByName "$@"
 set -- "$CSP" "$REGION" "$POSTFIX" "$TestSetFile" "$OPTION01" "$OPTION02" "$OPTION03"
 
-FILE=../credentials.conf
+FILE=../../../../conf/credentials.conf
 if [ ! -f "$FILE" ]; then
 	echo "$FILE does not exist."
 	exit
@@ -16,7 +16,7 @@ if [ ! -f "$TestSetFile" ]; then
 fi
 source $TestSetFile
 source ../conf.env
-source ../credentials.conf
+source ../../../../conf/credentials.conf
 
 getCloudIndex $CSP
 MCISID=${POSTFIX}

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
@@ -41,7 +41,7 @@ function test_sequence()
 
 
 
-	FILE=../credentials.conf
+	FILE=../../../../conf/credentials.conf
     if [ ! -f "$FILE" ]; then
         echo "$FILE does not exist."
         exit
@@ -54,7 +54,7 @@ function test_sequence()
     fi
 	source $TestSetFile
     source ../conf.env
-		source ../credentials.conf
+		source ../../../../conf/credentials.conf
 
 	echo "####################################################################"
 	echo "## Create MCIS from Zero Base"

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-for-ws.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-for-ws.sh
@@ -37,7 +37,7 @@ function test_sequence() {
 	echo ""
 }
 
-FILE=../credentials.conf
+FILE=../../../../conf/credentials.conf
 if [ ! -f "$FILE" ]; then
 	echo "$FILE does not exist."
 	exit
@@ -50,7 +50,7 @@ if [ ! -f "$TestSetFile" ]; then
 fi
 source $TestSetFile
 source ../conf.env
-source ../credentials.conf
+source ../../../../conf/credentials.conf
 
 echo "####################################################################"
 echo "## Create MCIS from Zero Base"


### PR DESCRIPTION
Fix #650

 - 클라우드 연결 정보 등록 절차 (크리덴셜 및 리전 등) 를 **CB-TB 시스템 환경 설정**의 형태로 변경 
 - 클라우드 크리덴셜 파일 기본 위치 변경 (conf/credential.conf)
 - 스크립트를 통한 자동화
   - 크리덴셜 기본 파일 생성 스크립트 추가
   - 조사된 모든 리전 등록 스크립트 추가
 - 리드미 업데이트
 - 기타: .gitignore 보완