### PR TITLE
Add support for IBM-VPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ vendor/
 
 # Binaries
 src/src
-src/mcism
 src/cb-tumblebug
 src/cb-tumblebug-arm
 src/cli/tbctl
@@ -46,7 +45,7 @@ src/api/rest/docs/docs.go
 src/api/rest/docs/swagger.json
 src/api/rest/docs/swagger.yaml
 
-# Config file for mcism
+# Config file for CB-Tumblebug
 conf/
 conf/credentials.conf
 

--- a/assets/cloudlocation.csv
+++ b/assets/cloudlocation.csv
@@ -139,6 +139,18 @@ tencent,ap-beijing,North China (Beijing),39.9042,116.407396
 tencent,ap-chengdu,Southwest China (Chengdu),30.572815,104.066801
 tencent,ap-chongqing,Southwest China (Chongqing),29.431586,106.912251
 tencent,ap-hongkong,Hong Kong,22.396428,114.109497
+ktcloud,KOR-Cheonan,Cheon-an - South Korea,36.812583,127.107005
+ktcloud,KOR-Seoul,Seoul - South Korea,37.566535,126.977969
+ktcloud,US,LA - US,34.052234,-118.243685
+ibm,us-south,Dallas (US South),32.776664,-96.796988
+ibm,br-sao,Sao Paulo (Brazil),-23.55052,-46.633309
+ibm,ca-tor,Toronto (Canada),43.653226,-79.383184
+ibm,us-east,Washington DC (US East),38.907192,-77.036871
+ibm,eu-de,Frankfurt (Germany),50.110922,8.682127
+ibm,eu-gb,London (United Kingdom),51.507351,-0.127758
+ibm,jp-osa,Osaka (Japan),34.693738,135.502165
+ibm,au-syd,Sydney (Australia),-33.86882,151.209296
+ibm,jp-tok,Tokyo (Japan),35.689488,139.691706
 cloudtwin,default,South Korea (Daejeon),36.3804,127.3650
 mock,default,South Korea (Seoul),37.0000,126.0000
 ufc,ufc,South Korea (Seoul),37.4767,126.8841

--- a/conf/template.credentials.conf
+++ b/conf/template.credentials.conf
@@ -187,3 +187,14 @@ CredentialVal01[$IndexKTcloud]=       #{{YOURS}}
 CredentialKey02[$IndexKTcloud]=ClientSecret
 #Fill in {{YOUR-KTcloud-Credentidal-Secret}} Ex:fsfdlkfjselSDfjlejklsj/LFJSDLKfjleJKLDJ0
 CredentialVal02[$IndexKTcloud]=       #{{YOURS}}
+
+
+
+
+## IBM-VPC
+CredentialName[$IndexIBMVPC]=ibmvpc-credential01
+
+CredentialKey01[$IndexIBMVPC]=ApiKey
+#Fill in {{YOUR-IBMcloud-ApiKey}} Ex:SFLEKJEFLJIEIVJOLJSEOIV
+CredentialVal01[$IndexIBMVPC]=       #{{YOURS}}
+

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -2098,6 +2098,161 @@ SPEC_NAME[$IX,$IY]=
 
 
 
+###########################################
+## IBM-VPC (9 Regions)
+IX=$IndexIBMVPC
+ProviderName[$IX]=IBM
+DriverLibFileName[$IX]=ibmvpc-driver-v1.0.so
+DriverName[$IX]=ibmvpc-driver01
+CommonImageType[$IX]="Ubuntu 18.04"
+CommonSpec[$IX]=bx2-2x8
+
+
+# region01
+IY=$IbmVpcUsSouth
+# Location: Dallas (US South)
+RegionLocation[$IX,$IY]="Dallas (US South)"
+RegionName[$IX,$IY]=ibm-us-south
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=us-south
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=us-south-1
+CONN_CONFIG[$IX,$IY]=ibm-us-south
+IMAGE_NAME[$IX,$IY]=r006-9de77234-3189-42f8-982d-f2266477cfe0
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
+# region02
+IY=$IbmVpcBrSaoPaulo
+# Location: Sao Paulo (Brazil)
+RegionLocation[$IX,$IY]="Sao Paulo (Brazil)"
+RegionName[$IX,$IY]=ibm-br-sao
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=br-sao
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=br-sao-1
+CONN_CONFIG[$IX,$IY]=ibm-br-sao
+IMAGE_NAME[$IX,$IY]=r042-92d1cd12-f014-4b9a-abf8-c5ca6494a9e5
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
+# region03
+IY=$IbmVpcCaToronto
+# Location: Toronto (Canada)
+RegionLocation[$IX,$IY]="Toronto (Canada)"
+RegionName[$IX,$IY]=ibm-ca-tor
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=ca-tor
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=ca-tor-1
+CONN_CONFIG[$IX,$IY]=ibm-ca-tor
+IMAGE_NAME[$IX,$IY]=r038-e92647cf-8be9-438a-b94c-251cc86bc99a
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
+# region04
+IY=$IbmVpcUsEast
+# Location: Washington DC (US East)
+RegionLocation[$IX,$IY]="Washington DC (US East)"
+RegionName[$IX,$IY]=ibm-us-east
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=us-east
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=us-east-1
+CONN_CONFIG[$IX,$IY]=ibm-us-east
+IMAGE_NAME[$IX,$IY]=r014-dc446598-a1b5-41c3-a1d6-add3afaf264e
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
+
+
+# region05
+IY=$IbmVpcEuFrankfurt
+# Location: Frankfurt (Germany)
+RegionLocation[$IX,$IY]="Frankfurt (Germany)"
+RegionName[$IX,$IY]=ibm-eu-de
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=eu-de
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=eu-de-1
+CONN_CONFIG[$IX,$IY]=ibm-eu-de
+IMAGE_NAME[$IX,$IY]=r010-1f68eb2d-f35c-4959-8f4b-2b2f9cf78102
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
+
+
+# region06
+IY=$IbmVpcEuLondon
+# Location: London (United Kingdom)
+RegionLocation[$IX,$IY]="London (United Kingdom)"
+RegionName[$IX,$IY]=ibm-eu-gb
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=eu-gb
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=eu-gb-1
+CONN_CONFIG[$IX,$IY]=ibm-eu-gb
+IMAGE_NAME[$IX,$IY]=r018-1d7417c6-893e-49d4-b14d-9643d6b29812
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
+
+
+# region07
+IY=$IbmVpcJpOsaka
+# Location: Osaka (Japan)
+RegionLocation[$IX,$IY]="Osaka (Japan)"
+RegionName[$IX,$IY]=ibm-jp-osa
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=jp-osa
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=jp-osa-1
+CONN_CONFIG[$IX,$IY]=ibm-jp-osa
+IMAGE_NAME[$IX,$IY]=r034-522c639c-52e1-4cab-8dfb-bc0fb9f6f577
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
+
+
+# region08
+IY=$IbmVpcAuSydney
+# Location: Sydney (Australia)
+RegionLocation[$IX,$IY]="Sydney (Australia)"
+RegionName[$IX,$IY]=ibm-au-syd
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=au-syd
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=au-syd-1
+CONN_CONFIG[$IX,$IY]=ibm-au-syd
+IMAGE_NAME[$IX,$IY]=r026-a8c25ce6-0ca1-43e9-9b41-411c6217b8b8
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
+
+
+# region09
+IY=$IbmVpcJpTokyo
+# Location: Tokyo (Japan)
+RegionLocation[$IX,$IY]="Tokyo (Japan)"
+RegionName[$IX,$IY]=ibm-jp-tok
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=jp-tok
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=jp-tok-1
+CONN_CONFIG[$IX,$IY]=ibm-jp-tok
+IMAGE_NAME[$IX,$IY]=r022-61fdadec-6b03-4bd2-bfca-62cd16f5673f
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
+
+
 
 ###########################################
 ## Openstack (1 Regions)
@@ -2282,6 +2437,9 @@ function getCloudIndex()
 	elif [ "${CSP}" == "ktcloud" ]; then
 		# echo "[KTcloud driver]"
 		CSPIndex=$IndexKTcloud
+	elif [ "${CSP}" == "ibm" ]; then
+		# echo "[IBM-VPC driver]"
+		CSPIndex=$IndexIBMVPC
 	else
 		echo "[No acceptable argument was provided (all, aws, azure, gcp, alibaba, mock, openstack, ...).]"
 		exit
@@ -2341,6 +2499,9 @@ function getCloudIndexGeneral()
 	elif [ "${CSP}" == "ktcloud" ]; then
 		# echo "[KTcloud driver]"
 		CSPIndex=o
+	elif [ "${CSP}" == "ibm" ]; then
+		# echo "[IBM-VPC driver]"
+		CSPIndex=p
 	else
 		echo "[No acceptable argument was provided (all, aws, azure, gcp, alibaba, mock, openstack, ...).]"
 		exit

--- a/src/testclient/scripts/testSet.env
+++ b/src/testclient/scripts/testSet.env
@@ -9,7 +9,7 @@ AgentInstallOn=no
 ## Number of CSP types and corresponding regions
 NumCSP=3
 
-TotalNumCSP=14
+TotalNumCSP=15
 
 ## Define sequential test order for cloud types 
 # Note: you can change order by replacing lines (automatically assign continuous numbers starting from 1)
@@ -27,6 +27,7 @@ IndexNCP=$((++IX))
 IndexCloudit=$((++IX))
 IndexTencent=$((++IX))
 IndexKTcloud=$((++IX))
+IndexIBMVPC=$((++IX))
 
 IndexCloudTwin=$((++IX))
 IndexMock=$((++IX))
@@ -45,6 +46,7 @@ CSPType[$IndexCloudTwin]=cloudtwin
 CSPType[$IndexCloudit]=cloudit
 CSPType[$IndexTencent]=tencent
 CSPType[$IndexKTcloud]=ktcloud
+CSPType[$IndexIBMVPC]=ibm
 CSPType[$IndexTestCloud01]=testcloud01
 CSPType[$IndexTestCloud02]=testcloud02
 CSPType[$IndexTestCloud03]=testcloud03
@@ -271,6 +273,25 @@ KTcloudKRSeoulM=$((++IY))			# Location: Seoul, South Korea
 KTcloudKRSeoulM2=$((++IY))			# Location: Seoul, South Korea
 KTcloudUSwest=$((++IY))		    	# Location: LA, US
 
+
+
+
+
+# IBM-VPC (Total: n Regions / Recommend: n Regions)
+NumRegion[$IndexIBMVPC]=1
+
+TotalNumRegion[$IndexIBMVPC]=9
+
+IY=0
+IbmVpcUsSouth=$((++IY))			# Location: Dallas (US South)
+IbmVpcBrSaoPaulo=$((++IY))      # Location: Sao Paulo (Brazil)
+IbmVpcCaToronto=$((++IY))       # Location: Toronto (Canada)
+IbmVpcUsEast=$((++IY))          # Location: Washington DC (US East)
+IbmVpcEuFrankfurt=$((++IY))     # Location: Frankfurt (Germany)
+IbmVpcEuLondon=$((++IY))        # Location: London (United Kingdom)
+IbmVpcJpOsaka=$((++IY))         # Location: Osaka (Japan)
+IbmVpcAuSydney=$((++IY))        # Location: Sydney (Australia)
+IbmVpcJpTokyo=$((++IY))         # Location: Tokyo (Japan)
 
 
 # Cloud-Twin (Total: 1 Regions / Recommend: 1 Regions)


### PR DESCRIPTION
VM 생성 및 삭제까지 되는 것을 확인했습니다.

다만, VM terminate가 다른 CSP에 비해 오래 걸려서 (2~3분)
`clean-all.sh` 스크립트로 테스트 시
SSH key, SG, vNet 삭제에 실패합니다. (resources in use)

[Related]
- #910
- https://github.com/cloud-barista/cb-spider/issues/513
- https://github.com/cloud-barista/cb-spider/pull/514
- https://cloud-barista.slack.com/archives/CJQ7575PU/p1636090717074000
- https://cloud-barista.slack.com/archives/CLFCLNFTJ/p1636088609079200
- https://cloud-barista.slack.com/archives/CJQ7575PU/p1636091079077200
- ...
