### PR TITLE
Add delete all default resource feature

### DIFF
--- a/src/api/grpc/server/mcir/image.go
+++ b/src/api/grpc/server/mcir/image.go
@@ -162,7 +162,7 @@ func (s *MCIRService) DeleteAllImage(ctx context.Context, req *pb.ResourceAllQry
 
 	logger.Debug("calling MCIRService.DeleteAllImage()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
+	_, err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllImage()")
 	}

--- a/src/api/grpc/server/mcir/image.go
+++ b/src/api/grpc/server/mcir/image.go
@@ -162,7 +162,7 @@ func (s *MCIRService) DeleteAllImage(ctx context.Context, req *pb.ResourceAllQry
 
 	logger.Debug("calling MCIRService.DeleteAllImage()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, req.Force)
+	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllImage()")
 	}

--- a/src/api/grpc/server/mcir/securitygroup.go
+++ b/src/api/grpc/server/mcir/securitygroup.go
@@ -131,7 +131,7 @@ func (s *MCIRService) DeleteAllSecurityGroup(ctx context.Context, req *pb.Resour
 
 	logger.Debug("calling MCIRService.DeleteAllSecurityGroup()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, req.Force)
+	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllSecurityGroup()")
 	}

--- a/src/api/grpc/server/mcir/securitygroup.go
+++ b/src/api/grpc/server/mcir/securitygroup.go
@@ -131,7 +131,7 @@ func (s *MCIRService) DeleteAllSecurityGroup(ctx context.Context, req *pb.Resour
 
 	logger.Debug("calling MCIRService.DeleteAllSecurityGroup()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
+	_, err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllSecurityGroup()")
 	}

--- a/src/api/grpc/server/mcir/spec.go
+++ b/src/api/grpc/server/mcir/spec.go
@@ -162,7 +162,7 @@ func (s *MCIRService) DeleteAllSpec(ctx context.Context, req *pb.ResourceAllQryR
 
 	logger.Debug("calling MCIRService.DeleteAllSpec()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, req.Force)
+	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllSpec()")
 	}

--- a/src/api/grpc/server/mcir/spec.go
+++ b/src/api/grpc/server/mcir/spec.go
@@ -162,7 +162,7 @@ func (s *MCIRService) DeleteAllSpec(ctx context.Context, req *pb.ResourceAllQryR
 
 	logger.Debug("calling MCIRService.DeleteAllSpec()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
+	_, err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllSpec()")
 	}

--- a/src/api/grpc/server/mcir/sshkey.go
+++ b/src/api/grpc/server/mcir/sshkey.go
@@ -132,7 +132,7 @@ func (s *MCIRService) DeleteAllSshKey(ctx context.Context, req *pb.ResourceAllQr
 
 	logger.Debug("calling MCIRService.DeleteAllSshKey()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
+	_, err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllSshKey()")
 	}

--- a/src/api/grpc/server/mcir/sshkey.go
+++ b/src/api/grpc/server/mcir/sshkey.go
@@ -132,7 +132,7 @@ func (s *MCIRService) DeleteAllSshKey(ctx context.Context, req *pb.ResourceAllQr
 
 	logger.Debug("calling MCIRService.DeleteAllSshKey()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, req.Force)
+	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllSshKey()")
 	}

--- a/src/api/grpc/server/mcir/vnet.go
+++ b/src/api/grpc/server/mcir/vnet.go
@@ -132,7 +132,7 @@ func (s *MCIRService) DeleteAllVNet(ctx context.Context, req *pb.ResourceAllQryR
 
 	logger.Debug("calling MCIRService.DeleteAllVNet()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, req.Force)
+	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllVNet()")
 	}

--- a/src/api/grpc/server/mcir/vnet.go
+++ b/src/api/grpc/server/mcir/vnet.go
@@ -132,7 +132,7 @@ func (s *MCIRService) DeleteAllVNet(ctx context.Context, req *pb.ResourceAllQryR
 
 	logger.Debug("calling MCIRService.DeleteAllVNet()")
 
-	err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
+	_, err := mcir.DelAllResources(req.NsId, req.ResourceType, "", req.Force)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.DeleteAllVNet()")
 	}

--- a/src/api/rest/server/mcir/common.go
+++ b/src/api/rest/server/mcir/common.go
@@ -378,19 +378,14 @@ func RestLoadDefaultResouce(c echo.Context) error {
 func RestDelAllDefaultResouces(c echo.Context) error {
 
 	nsId := c.Param("nsId")
-	resourceType := strings.Split(c.Path(), "/")[5]
-	// c.Path(): /tumblebug/ns/:nsId/resources/spec/:specId
 
-	forceFlag := c.QueryParam("force")
-	subString := c.QueryParam("match")
-
-	err := mcir.DelAllResources(nsId, resourceType, subString, forceFlag)
+	err := mcir.DelAllDefaultResources(nsId)
 	if err != nil {
 		common.CBLog.Error(err)
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusConflict, &mapA)
 	}
 
-	mapA := map[string]string{"message": "All " + resourceType + "s has been deleted"}
+	mapA := map[string]string{"message": "All default resources have been deleted"}
 	return c.JSON(http.StatusOK, &mapA)
 }

--- a/src/api/rest/server/mcir/common.go
+++ b/src/api/rest/server/mcir/common.go
@@ -39,8 +39,9 @@ func RestDelAllResources(c echo.Context) error {
 	// c.Path(): /tumblebug/ns/:nsId/resources/spec/:specId
 
 	forceFlag := c.QueryParam("force")
+	subString := c.QueryParam("match")
 
-	err := mcir.DelAllResources(nsId, resourceType, forceFlag)
+	err := mcir.DelAllResources(nsId, resourceType, subString, forceFlag)
 	if err != nil {
 		common.CBLog.Error(err)
 		mapA := map[string]string{"message": err.Error()}
@@ -361,5 +362,35 @@ func RestLoadDefaultResouce(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, &mapA)
 	}
 	mapA := map[string]string{"message": "Done"}
+	return c.JSON(http.StatusOK, &mapA)
+}
+
+// RestDelAllDefaultResouces godoc
+// @Summary Delete all Default Resource Objects in the given namespace
+// @Description Delete all Default Resource Objects in the given namespace
+// @Tags [Admin] Cloud environment management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Router /ns/{nsId}/defaultResouces [delete]
+func RestDelAllDefaultResouces(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+	resourceType := strings.Split(c.Path(), "/")[5]
+	// c.Path(): /tumblebug/ns/:nsId/resources/spec/:specId
+
+	forceFlag := c.QueryParam("force")
+	subString := c.QueryParam("match")
+
+	err := mcir.DelAllResources(nsId, resourceType, subString, forceFlag)
+	if err != nil {
+		common.CBLog.Error(err)
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(http.StatusConflict, &mapA)
+	}
+
+	mapA := map[string]string{"message": "All " + resourceType + "s has been deleted"}
 	return c.JSON(http.StatusOK, &mapA)
 }

--- a/src/api/rest/server/mcir/common.go
+++ b/src/api/rest/server/mcir/common.go
@@ -41,15 +41,15 @@ func RestDelAllResources(c echo.Context) error {
 	forceFlag := c.QueryParam("force")
 	subString := c.QueryParam("match")
 
-	err := mcir.DelAllResources(nsId, resourceType, subString, forceFlag)
+	output, err := mcir.DelAllResources(nsId, resourceType, subString, forceFlag)
 	if err != nil {
 		common.CBLog.Error(err)
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusConflict, &mapA)
 	}
 
-	mapA := map[string]string{"message": "All " + resourceType + "s has been deleted"}
-	return c.JSON(http.StatusOK, &mapA)
+	//mapA := map[string]string{"message": "All " + resourceType + "s has been deleted"}
+	return c.JSON(http.StatusOK, output)
 }
 
 // Dummy functions for Swagger exist in [mcir/*.go]
@@ -372,20 +372,20 @@ func RestLoadDefaultResouce(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/defaultResouces [delete]
 func RestDelAllDefaultResouces(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 
-	err := mcir.DelAllDefaultResources(nsId)
+	output, err := mcir.DelAllDefaultResources(nsId)
 	if err != nil {
 		common.CBLog.Error(err)
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusConflict, &mapA)
 	}
 
-	mapA := map[string]string{"message": "All default resources have been deleted"}
-	return c.JSON(http.StatusOK, &mapA)
+	//mapA := map[string]string{"message": "All default resources have been deleted"}
+	return c.JSON(http.StatusOK, output)
 }

--- a/src/api/rest/server/mcir/image.go
+++ b/src/api/rest/server/mcir/image.go
@@ -305,7 +305,7 @@ func RestDelImage(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param match query string false "Delete resources containing matched ID-substring only" default()
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/image [delete]
 func RestDelAllImage(c echo.Context) error {

--- a/src/api/rest/server/mcir/image.go
+++ b/src/api/rest/server/mcir/image.go
@@ -304,6 +304,7 @@ func RestDelImage(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
+// @Param match query string false "Delete resources containing matched ID-substring only" default()
 // @Success 200 {object} common.SimpleMsg
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/image [delete]

--- a/src/api/rest/server/mcir/securitygroup.go
+++ b/src/api/rest/server/mcir/securitygroup.go
@@ -141,6 +141,7 @@ func RestDelSecurityGroup(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
+// @Param match query string false "Delete resources containing matched ID-substring only" default()
 // @Success 200 {object} common.SimpleMsg
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/securityGroup [delete]

--- a/src/api/rest/server/mcir/securitygroup.go
+++ b/src/api/rest/server/mcir/securitygroup.go
@@ -142,7 +142,7 @@ func RestDelSecurityGroup(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param match query string false "Delete resources containing matched ID-substring only" default()
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/securityGroup [delete]
 func RestDelAllSecurityGroup(c echo.Context) error {

--- a/src/api/rest/server/mcir/spec.go
+++ b/src/api/rest/server/mcir/spec.go
@@ -391,6 +391,7 @@ func RestDelSpec(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
+// @Param match query string false "Delete resources containing matched ID-substring only" default()
 // @Success 200 {object} common.SimpleMsg
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/spec [delete]

--- a/src/api/rest/server/mcir/spec.go
+++ b/src/api/rest/server/mcir/spec.go
@@ -392,7 +392,7 @@ func RestDelSpec(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param match query string false "Delete resources containing matched ID-substring only" default()
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/spec [delete]
 func RestDelAllSpec(c echo.Context) error {

--- a/src/api/rest/server/mcir/sshkey.go
+++ b/src/api/rest/server/mcir/sshkey.go
@@ -138,7 +138,7 @@ func RestDelSshKey(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param match query string false "Delete resources containing matched ID-substring only" default()
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/sshKey [delete]
 func RestDelAllSshKey(c echo.Context) error {

--- a/src/api/rest/server/mcir/sshkey.go
+++ b/src/api/rest/server/mcir/sshkey.go
@@ -137,6 +137,7 @@ func RestDelSshKey(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
+// @Param match query string false "Delete resources containing matched ID-substring only" default()
 // @Success 200 {object} common.SimpleMsg
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/sshKey [delete]

--- a/src/api/rest/server/mcir/vnet.go
+++ b/src/api/rest/server/mcir/vnet.go
@@ -143,7 +143,7 @@ func RestDelVNet(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param match query string false "Delete resources containing matched ID-substring only" default()
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/vNet [delete]
 func RestDelAllVNet(c echo.Context) error {

--- a/src/api/rest/server/mcir/vnet.go
+++ b/src/api/rest/server/mcir/vnet.go
@@ -142,6 +142,7 @@ func RestDelVNet(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
+// @Param match query string false "Delete resources containing matched ID-substring only" default()
 // @Success 200 {object} common.SimpleMsg
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/vNet [delete]

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -138,6 +138,7 @@ func RunServer(port string) {
 
 	e.GET("/tumblebug/loadCommonResource", rest_mcir.RestLoadCommonResource)
 	e.GET("/tumblebug/ns/:nsId/loadDefaultResouce", rest_mcir.RestLoadDefaultResouce)
+	e.DELETE("/tumblebug/ns/:nsId/defaultResouces", rest_mcir.RestDelAllDefaultResouces)
 
 	// Route for NameSpace subgroup
 	g := e.Group("/tumblebug/ns", common.NsValidation())

--- a/src/core/common/common.go
+++ b/src/core/common/common.go
@@ -31,7 +31,7 @@ type KeyValue struct {
 }
 
 type IdList struct {
-	IdList []string `json:"idList"`
+	IdList []string `json:"ouput"`
 }
 
 // CB-Store

--- a/src/core/common/common.go
+++ b/src/core/common/common.go
@@ -66,7 +66,7 @@ const (
 	StrSpec                       string = "spec"
 	StrVNet                       string = "vNet"
 	StrSubnet                     string = "subnet"
-	StrDefaultResourceName        string = "-default-"
+	StrDefaultResourceName        string = "-systemdefault-"
 )
 
 var StartTime string

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -76,38 +76,6 @@ func init() {
 	validate.RegisterStructValidation(TbVNetReqStructLevelValidation, TbVNetReq{})
 }
 
-// DelAllDefaultResources deletes all Default securityGroup, sshKey, vNet objects
-func DelAllDefaultResources(nsId string) error {
-
-	err := common.CheckString(nsId)
-	if err != nil {
-		common.CBLog.Error(err)
-		return err
-	}
-
-	matchedSubstring := nsId + common.StrDefaultResourceName
-
-	err = DelAllResources(nsId, common.StrSecurityGroup, matchedSubstring, "false")
-	if err != nil {
-		common.CBLog.Error(err)
-		//return err
-	}
-
-	err = DelAllResources(nsId, common.StrSSHKey, matchedSubstring, "false")
-	if err != nil {
-		common.CBLog.Error(err)
-		//return err
-	}
-
-	err = DelAllResources(nsId, common.StrVNet, matchedSubstring, "false")
-	if err != nil {
-		common.CBLog.Error(err)
-		//return err
-	}
-
-	return nil
-}
-
 // DelAllResources deletes all TB MCIR object of given resourceType
 func DelAllResources(nsId string, resourceType string, subString string, forceFlag string) error {
 
@@ -1965,6 +1933,38 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 			}
 		}
 	}
+	return nil
+}
+
+// DelAllDefaultResources deletes all Default securityGroup, sshKey, vNet objects
+func DelAllDefaultResources(nsId string) error {
+
+	err := common.CheckString(nsId)
+	if err != nil {
+		common.CBLog.Error(err)
+		return err
+	}
+
+	matchedSubstring := nsId + common.StrDefaultResourceName
+
+	err = DelAllResources(nsId, common.StrSecurityGroup, matchedSubstring, "false")
+	if err != nil {
+		common.CBLog.Error(err)
+		//return err
+	}
+
+	err = DelAllResources(nsId, common.StrSSHKey, matchedSubstring, "false")
+	if err != nil {
+		common.CBLog.Error(err)
+		//return err
+	}
+
+	err = DelAllResources(nsId, common.StrVNet, matchedSubstring, "false")
+	if err != nil {
+		common.CBLog.Error(err)
+		//return err
+	}
+
 	return nil
 }
 

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -77,7 +77,7 @@ func init() {
 }
 
 // DelAllResources deletes all TB MCIR object of given resourceType
-func DelAllResources(nsId string, resourceType string, forceFlag string) error {
+func DelAllResources(nsId string, resourceType string, subString string, forceFlag string) error {
 
 	err := common.CheckString(nsId)
 	if err != nil {
@@ -95,9 +95,12 @@ func DelAllResources(nsId string, resourceType string, forceFlag string) error {
 	}
 
 	for _, v := range resourceIdList {
-		err := DelResource(nsId, resourceType, v, forceFlag)
-		if err != nil {
-			return err
+		// if subSting is provided, check the resourceId contains the subString.
+		if subString == "" || strings.Contains(v, subString) {
+			err := DelResource(nsId, resourceType, v, forceFlag)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -1832,7 +1835,7 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 
 		connectionName := row[1]
 		//resourceName := connectionName
-		// Default resource name has this pattern (nsId + "-default-" + connectionName)
+		// Default resource name has this pattern (nsId + "-systemdefault-" + connectionName)
 		resourceName := nsId + common.StrDefaultResourceName + connectionName
 		description := "Generated Default Resource"
 

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -77,33 +77,41 @@ func init() {
 }
 
 // DelAllResources deletes all TB MCIR object of given resourceType
-func DelAllResources(nsId string, resourceType string, subString string, forceFlag string) error {
+func DelAllResources(nsId string, resourceType string, subString string, forceFlag string) (common.IdList, error) {
+
+	deletedResources := common.IdList{}
+	deleteStatus := ""
 
 	err := common.CheckString(nsId)
 	if err != nil {
 		common.CBLog.Error(err)
-		return err
+		return deletedResources, err
 	}
 
 	resourceIdList, err := ListResourceId(nsId, resourceType)
 	if err != nil {
-		return err
+		return deletedResources, err
 	}
 
 	if len(resourceIdList) == 0 {
-		return nil
+		return deletedResources, nil
 	}
 
 	for _, v := range resourceIdList {
 		// if subSting is provided, check the resourceId contains the subString.
 		if subString == "" || strings.Contains(v, subString) {
 			err := DelResource(nsId, resourceType, v, forceFlag)
+			common.CBLog.Error(err)
+			deleteStatus = ""
 			if err != nil {
-				return err
+				deleteStatus = "  [FAILED]" + err.Error()
+			} else {
+				deleteStatus = "  [DELETED]"
 			}
+			deletedResources.IdList = append(deletedResources.IdList, resourceType+": "+v+deleteStatus)
 		}
 	}
-	return nil
+	return deletedResources, nil
 }
 
 // DelResource deletes the TB MCIR object
@@ -1937,35 +1945,39 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 }
 
 // DelAllDefaultResources deletes all Default securityGroup, sshKey, vNet objects
-func DelAllDefaultResources(nsId string) error {
+func DelAllDefaultResources(nsId string) (common.IdList, error) {
 
+	output := common.IdList{}
 	err := common.CheckString(nsId)
 	if err != nil {
 		common.CBLog.Error(err)
-		return err
+		return output, err
 	}
 
 	matchedSubstring := nsId + common.StrDefaultResourceName
 
-	err = DelAllResources(nsId, common.StrSecurityGroup, matchedSubstring, "false")
+	list, err := DelAllResources(nsId, common.StrSecurityGroup, matchedSubstring, "false")
 	if err != nil {
 		common.CBLog.Error(err)
 		//return err
 	}
+	output.IdList = append(output.IdList, list.IdList...)
 
-	err = DelAllResources(nsId, common.StrSSHKey, matchedSubstring, "false")
+	list, err = DelAllResources(nsId, common.StrSSHKey, matchedSubstring, "false")
 	if err != nil {
 		common.CBLog.Error(err)
 		//return err
 	}
+	output.IdList = append(output.IdList, list.IdList...)
 
-	err = DelAllResources(nsId, common.StrVNet, matchedSubstring, "false")
+	list, err = DelAllResources(nsId, common.StrVNet, matchedSubstring, "false")
 	if err != nil {
 		common.CBLog.Error(err)
 		//return err
 	}
+	output.IdList = append(output.IdList, list.IdList...)
 
-	return nil
+	return output, nil
 }
 
 // ToNamingRuleCompatible func is a tool to replace string for name to make the name follow naming convention

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -76,6 +76,38 @@ func init() {
 	validate.RegisterStructValidation(TbVNetReqStructLevelValidation, TbVNetReq{})
 }
 
+// DelAllDefaultResources deletes all Default securityGroup, sshKey, vNet objects
+func DelAllDefaultResources(nsId string) error {
+
+	err := common.CheckString(nsId)
+	if err != nil {
+		common.CBLog.Error(err)
+		return err
+	}
+
+	matchedSubstring := nsId + common.StrDefaultResourceName
+
+	err = DelAllResources(nsId, common.StrSecurityGroup, matchedSubstring, "false")
+	if err != nil {
+		common.CBLog.Error(err)
+		//return err
+	}
+
+	err = DelAllResources(nsId, common.StrSSHKey, matchedSubstring, "false")
+	if err != nil {
+		common.CBLog.Error(err)
+		//return err
+	}
+
+	err = DelAllResources(nsId, common.StrVNet, matchedSubstring, "false")
+	if err != nil {
+		common.CBLog.Error(err)
+		//return err
+	}
+
+	return nil
+}
+
 // DelAllResources deletes all TB MCIR object of given resourceType
 func DelAllResources(nsId string, resourceType string, subString string, forceFlag string) error {
 

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -1015,7 +1015,7 @@ func CreateMcisDynamic(nsId string, req *TbMcisDynamicReq) (*TbMcisInfo, error) 
 		// remake vmReqest from given input and check resource availablity
 		vmReq.ConnectionName = specInfo.ConnectionName
 
-		// Default resource name has this pattern (nsId + "-default-" + vmReq.ConnectionName)
+		// Default resource name has this pattern (nsId + "-systemdefault-" + vmReq.ConnectionName)
 		resourceName := nsId + common.StrDefaultResourceName + vmReq.ConnectionName
 
 		vmReq.SpecId = specInfo.Id


### PR DESCRIPTION

 - substring match로 delete all mcis 에 대한 조건 지원
 - default resources (sg, key, vnet) 을 순서에 맞추서 모두 삭제하는 기능 추가
 - API 출력 결과를 항목별로 제공 
 - idList JSON tag 를 output 으로 변경

`http://localhost:1323/tumblebug/ns/ns01/defaultResouces`
```
{
  "ouput": [
    "securityGroup: ns01-systemdefault-aws-ap-northeast-2  [DELETED]",
    "sshKey: ns01-systemdefault-aws-ap-northeast-2  [DELETED]",
    "vNet: ns01-systemdefault-aws-ap-northeast-2  [DELETED]"
  ]
}
```