### PR TITLE
Prevent deletion of obj in use

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -4741,7 +4741,7 @@ var doc = `{
         "common.IdList": {
             "type": "object",
             "properties": {
-                "ouput": {
+                "output": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -4727,7 +4727,7 @@
         "common.IdList": {
             "type": "object",
             "properties": {
-                "ouput": {
+                "output": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -67,7 +67,7 @@ definitions:
     type: object
   common.IdList:
     properties:
-      ouput:
+      output:
         items:
           type: string
         type: array

--- a/src/core/common/common.go
+++ b/src/core/common/common.go
@@ -31,7 +31,7 @@ type KeyValue struct {
 }
 
 type IdList struct {
-	IdList []string `json:"ouput"`
+	IdList []string `json:"output"`
 }
 
 // CB-Store

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -161,6 +161,16 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	// In CheckResource() above, calling 'CBStore.Get()' and checking err parts exist.
 	// So, in here, we don't need to check whether keyValue == nil or err != nil.
 
+	associatedList, _ := GetAssociatedObjectList(nsId, resourceType, resourceId)
+	if len(associatedList) == 0 {
+		// continue
+	} else {
+		errString := "  [FAILED]" + " in use by [" + strings.Join(associatedList[:], ", "+"]")
+		err := fmt.Errorf(errString)
+		common.CBLog.Error(err)
+		return err
+	}
+
 	//cspType := common.GetResourcesCspType(nsId, resourceType, resourceId)
 
 	var childResources interface{}

--- a/src/testclient/scripts/3.vNet/delete-all-vNet.sh
+++ b/src/testclient/scripts/3.vNet/delete-all-vNet.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+function CallTB() {
+	echo "- Delete all vNets"
+
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet | jq ''
+}
+
+#function delete_vNet() {
+	
+	echo "####################################################################"
+	echo "## 3. vNet: Delete"
+	echo "####################################################################"
+
+	source ../init.sh
+
+	CallTB
+
+#}
+
+#delete_vNet


### PR DESCRIPTION
- Resolves #945
- Related PR: #944

이 PR로 인해, `DelAllResources` 호출 시 다음과 같이 동작합니다.

1. `resourceType` (예: vNet) 에 대해 `resourceIdList` 추출
2. `resourceIdList` 의 각 `v` (예: `vnet-01`) 에 대해, 
3. `GetAssociatedObjectList` 조회하고, 
   1. 없으면 `DelResource` 호출
      1. `DelResource` 함수 안에서 `GetAssociatedObjectList` 조회

즉, `DelAllResources` 함수에서 `3. GetAssociatedObjectList 조회하고,` 와 
`a. DelResource 함수 안에서 GetAssociatedObjectList 조회` 가 중복입니다.

Optional: `DelAllResources` 함수에서 `3. GetAssociatedObjectList 조회하고,` 를 삭제할 수도 있겠습니다. 😊
