### PR TITLE
Update KTcloud metadata [skip ci]

### DIFF
--- a/assets/cloudlocation.csv
+++ b/assets/cloudlocation.csv
@@ -141,6 +141,7 @@ tencent,ap-chongqing,Southwest China (Chongqing),29.431586,106.912251
 tencent,ap-hongkong,Hong Kong,22.396428,114.109497
 ktcloud,KOR-Cheonan,Cheon-an - South Korea,36.812583,127.107005
 ktcloud,KOR-Seoul,Seoul - South Korea,37.566535,126.977969
+ktcloud,KOR-Kimhae,Kimhae - South Korea,35.228545,128.889352
 ktcloud,US,LA - US,34.052234,-118.243685
 ibm,us-south,Dallas (US South),32.776664,-96.796988
 ibm,br-sao,Sao Paulo (Brazil),-23.55052,-46.633309

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -2015,7 +2015,7 @@ SPEC_NAME[$IX,$IY]=${CommonSpec[$IX]}
 
 
 ###########################################
-## KTcloud (5 Regions)
+## KTcloud (6 Regions)
 IX=$IndexKTcloud
 ProviderName[$IX]=KTCLOUD
 DriverLibFileName[$IX]=ktcloud-driver-v1.0.so
@@ -2033,9 +2033,9 @@ RegionVal01[$IX,$IY]=KOR-Cheonan
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=eceb5d65-6571-4696-875f-5a17949f3317
 CONN_CONFIG[$IX,$IY]=kt-kr-central-a
-IMAGE_NAME[$IX,$IY]=
+IMAGE_NAME[$IX,$IY]=45e20478-6c24-4c32-a5e5-2ba2d464a8d1
 IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
-SPEC_NAME[$IX,$IY]=
+SPEC_NAME[$IX,$IY]=385df834-6cf7-485b-bca8-de4d4f59b0b0 # 1vCore 1GB
 
 # region02
 IY=$KTcloudKRcentralB
@@ -2047,9 +2047,9 @@ RegionVal01[$IX,$IY]=KOR-Cheonan
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=9845bd17-d438-4bde-816d-1b12f37d5080
 CONN_CONFIG[$IX,$IY]=kt-kr-central-b
-IMAGE_NAME[$IX,$IY]=
+IMAGE_NAME[$IX,$IY]=45e20478-6c24-4c32-a5e5-2ba2d464a8d1
 IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
-SPEC_NAME[$IX,$IY]=
+SPEC_NAME[$IX,$IY]=385df834-6cf7-485b-bca8-de4d4f59b0b0 # 1vCore 1GB
 
 # region03
 IY=$KTcloudKRSeoulM
@@ -2061,9 +2061,9 @@ RegionVal01[$IX,$IY]=KOR-Seoul
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=95e2f517-d64a-4866-8585-5177c256f7c7
 CONN_CONFIG[$IX,$IY]=kt-kr-seoul-m
-IMAGE_NAME[$IX,$IY]=
+IMAGE_NAME[$IX,$IY]=45e20478-6c24-4c32-a5e5-2ba2d464a8d1
 IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
-SPEC_NAME[$IX,$IY]=
+SPEC_NAME[$IX,$IY]=385df834-6cf7-485b-bca8-de4d4f59b0b0 # 1vCore 1GB
 
 # region04
 IY=$KTcloudKRSeoulM2
@@ -2075,9 +2075,9 @@ RegionVal01[$IX,$IY]=KOR-Seoul
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=d7d0177e-6cda-404a-a46f-a5b356d2874e
 CONN_CONFIG[$IX,$IY]=kt-kr-seoul-m2
-IMAGE_NAME[$IX,$IY]=
+IMAGE_NAME[$IX,$IY]=63de6d04-7f1b-4924-8e95-1acd6581ca0c
 IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
-SPEC_NAME[$IX,$IY]=
+SPEC_NAME[$IX,$IY]=753c80b0-b03f-4a91-98a7-6b11233f85a8 # 1vCore 1GB
 
 # region05
 IY=$KTcloudUSwest
@@ -2089,9 +2089,23 @@ RegionVal01[$IX,$IY]=US
 RegionKey02[$IX,$IY]=Zone
 RegionVal02[$IX,$IY]=b7eb18c8-876d-4dc6-9215-3bd455bb05be
 CONN_CONFIG[$IX,$IY]=kt-us-west
-IMAGE_NAME[$IX,$IY]=
+IMAGE_NAME[$IX,$IY]=45e20478-6c24-4c32-a5e5-2ba2d464a8d1
 IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
-SPEC_NAME[$IX,$IY]=
+SPEC_NAME[$IX,$IY]=385df834-6cf7-485b-bca8-de4d4f59b0b0 # 1vCore 1GB
+
+# region06
+IY=$KTcloudKRKimhae
+# Location: Kimhae - South Korea
+RegionLocation[$IX,$IY]="Kimhae - South Korea"
+RegionName[$IX,$IY]=kt-kr-kimhae
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=KOR-Kimhae
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=dfd6f03d-dae5-458e-a2ea-cb6a55d0d994
+CONN_CONFIG[$IX,$IY]=kt-kr-kimhae
+IMAGE_NAME[$IX,$IY]=45e20478-6c24-4c32-a5e5-2ba2d464a8d1
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=385df834-6cf7-485b-bca8-de4d4f59b0b0 # 1vCore 1GB
 
 
 

--- a/src/testclient/scripts/testSet.env
+++ b/src/testclient/scripts/testSet.env
@@ -261,10 +261,10 @@ TencentApHongKong=$((++IY))		    	# Location: Hong Kong
 
 
 
-# KT cloud (Total: 5 Regions / Recommend: n Regions)
+# KT cloud (Total: 6 Regions / Recommend: n Regions)
 NumRegion[$IndexKTcloud]=1
 
-TotalNumRegion[$IndexKTcloud]=5
+TotalNumRegion[$IndexKTcloud]=6
 
 IY=0
 KTcloudKRcentralA=$((++IY))			# Location: Cheon-an, South Korea
@@ -272,7 +272,7 @@ KTcloudKRcentralB=$((++IY))			# Location: Cheon-an, South Korea
 KTcloudKRSeoulM=$((++IY))			# Location: Seoul, South Korea
 KTcloudKRSeoulM2=$((++IY))			# Location: Seoul, South Korea
 KTcloudUSwest=$((++IY))		    	# Location: LA, US
-
+KTcloudKRKimhae=$((++IY))			# Location: Kimhae, South Korea
 
 
 


### PR DESCRIPTION

For everyone's information:
https://github.com/cloud-barista/ktcloud/blob/main/ktcloud/main/config/config.yaml
> 주의 : KT Cloud CSP에서는 Region 단위가 없이 Zone 단위로 구분되어 서비스되나, 편의를 위해 Region 정보를 기입했음.

---

- 참고: KT Cloud는 Zone ID, Image ID, Spec ID 가 UUID 형태로 되어 있습니다.
- 모든 존의 Image ID가 `45e20478-6c24-4c32-a5e5-2ba2d464a8d1` 으로 동일한데,
  - 'Seoul M2' 만 `63de6d04-7f1b-4924-8e95-1acd6581ca0c` 로 다릅니다.
  - Spec ID 도 마찬가지 입니다.
  - [안] 동일한 것들은 `CommonImage`, `CommonSpec` 으로 묶을 수도 있겠습니다.
- 이 PR에서 '김해' 존을 추가했는데, KT Cloud 에서는 'KOR-HA' 라는 이름으로 부르고 있습니다.
  - 이전 PR에서 추가하지 않아 이 PR에서 새롭게 추가하는 것이기도 하고,
    이름처럼 HA용으로 사용하는 것을 가정하고 있을까 하여
    `conf.env` 에서 맨 마지막 순서로 넣었습니다.
  - [안] 김해도 한국이므로, 다른 한국 존 직후에 오도록 US West 위쪽으로 순서를 바꿀 수도 있겠습니다.

[KT Cloud 웹 콘솔]
![image](https://user-images.githubusercontent.com/46767780/141064158-226aaa9e-0adf-4a68-b2d4-b2759b381900.png)
