### PR TITLE
Append error message for load common resource

### DIFF
--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -1697,9 +1697,9 @@ func LoadCommonResource() (common.IdList, error) {
 				common.PrintJsonPretty(specReqTmp)
 
 				// Register Spec object
-				_, err := RegisterSpecWithCspSpecName(commonNsId, &specReqTmp)
-				if err != nil {
-					common.CBLog.Error(err)
+				_, err1 := RegisterSpecWithCspSpecName(commonNsId, &specReqTmp)
+				if err1 != nil {
+					common.CBLog.Error(err1)
 					// If already exist, error will occur
 					// Even if error, do not return here to update information
 					// return err
@@ -1707,9 +1707,9 @@ func LoadCommonResource() (common.IdList, error) {
 				specObjId := specReqTmp.Name
 
 				// Update registered Spec object with Cost info
-				costPerHour, err := strconv.ParseFloat(strings.ReplaceAll(row[2], " ", ""), 32)
-				if err != nil {
-					common.CBLog.Error(err)
+				costPerHour, err2 := strconv.ParseFloat(strings.ReplaceAll(row[2], " ", ""), 32)
+				if err2 != nil {
+					common.CBLog.Error(err2)
 					// If already exist, error will occur
 					// Even if error, do not return here to update information
 					// return err
@@ -1717,9 +1717,9 @@ func LoadCommonResource() (common.IdList, error) {
 				costPerHour32 := float32(costPerHour)
 				specUpdateRequest := TbSpecInfo{CostPerHour: costPerHour32}
 
-				updatedSpecInfo, err := UpdateSpec(commonNsId, specObjId, specUpdateRequest)
-				if err != nil {
-					common.CBLog.Error(err)
+				updatedSpecInfo, err3 := UpdateSpec(commonNsId, specObjId, specUpdateRequest)
+				if err3 != nil {
+					common.CBLog.Error(err3)
 					// If already exist, error will occur
 					// Even if error, do not return here to update information
 					// return err
@@ -1728,8 +1728,18 @@ func LoadCommonResource() (common.IdList, error) {
 				common.PrintJsonPretty(updatedSpecInfo)
 
 				regiesteredStatus = ""
-				if updatedSpecInfo.Id == "" {
-					regiesteredStatus = "  [FAILED]"
+				if updatedSpecInfo.Id != "" {
+					if err3 != nil {
+						regiesteredStatus = "  [Failed] " + err3.Error()
+					}
+				} else {
+					if err1 != nil {
+						regiesteredStatus = "  [Failed] " + err1.Error()
+					} else if err2 != nil {
+						regiesteredStatus = "  [Failed] " + err2.Error()
+					} else if err3 != nil {
+						regiesteredStatus = "  [Failed] " + err3.Error()
+					}
 				}
 				regiesteredIds.IdList = append(regiesteredIds.IdList, common.StrSpec+": "+specObjId+regiesteredStatus)
 			}(i, row)
@@ -1777,9 +1787,9 @@ func LoadCommonResource() (common.IdList, error) {
 				common.PrintJsonPretty(imageReqTmp)
 
 				// Register Spec object
-				_, err := RegisterImageWithId(commonNsId, &imageReqTmp)
-				if err != nil {
-					common.CBLog.Error(err)
+				_, err1 := RegisterImageWithId(commonNsId, &imageReqTmp)
+				if err1 != nil {
+					common.CBLog.Error(err1)
 					// If already exist, error will occur
 					// Even if error, do not return here to update information
 					//return err
@@ -1790,17 +1800,26 @@ func LoadCommonResource() (common.IdList, error) {
 
 				imageUpdateRequest := TbImageInfo{GuestOS: osType}
 
-				updatedImageInfo, err := UpdateImage(commonNsId, imageObjId, imageUpdateRequest)
-				if err != nil {
-					common.CBLog.Error(err)
+				updatedImageInfo, err2 := UpdateImage(commonNsId, imageObjId, imageUpdateRequest)
+				if err2 != nil {
+					common.CBLog.Error(err2)
 					//return err
 				}
 				fmt.Printf("[%d] Registered Common Image\n", i)
 				common.PrintJsonPretty(updatedImageInfo)
 				regiesteredStatus = ""
-				if updatedImageInfo.Id == "" {
-					regiesteredStatus = "  [FAILED]"
+				if updatedImageInfo.Id != "" {
+					if err2 != nil {
+						regiesteredStatus = "  [Failed] " + err2.Error()
+					}
+				} else {
+					if err1 != nil {
+						regiesteredStatus = "  [Failed] " + err1.Error()
+					} else if err2 != nil {
+						regiesteredStatus = "  [Failed] " + err2.Error()
+					}
 				}
+				//regiesteredStatus = strings.Replace(regiesteredStatus, "\\", "", -1)
 				regiesteredIds.IdList = append(regiesteredIds.IdList, common.StrImage+": "+imageObjId+regiesteredStatus)
 			}(i, row)
 		}


### PR DESCRIPTION

```
Load common Specs and Images. Do you want to proceed ? (y/n) : y

####################################################################
## Load common Image and Spec from asset files (takes 5~20 seconds)
## (assets/cloudspec.csv, assets/cloudimage.csv)
####################################################################

{
  "output": [
    "image: alibaba-ap-northeast-1-ubuntu18-04",
    "image: alibaba-ap-south-1-ubuntu18-04",
    "image: alibaba-ap-southeast-1-ubuntu18-04",
    "image: alibaba-ap-southeast-2-ubuntu18-04",
    "image: alibaba-ap-southeast-3-ubuntu18-04",
    "image: alibaba-ap-southeast-5-ubuntu18-04",
    "image: alibaba-cn-beijing-ubuntu18-04",
    "image: alibaba-cn-chengdu-ubuntu18-04  [Failed] {\"message\":\"Notfound: 'ubuntu_18_04_x64_20G_alibase_20210927.vhd' Images Not found\"}\n",
    "image: alibaba-cn-guangzhou-ubuntu18-04",
    "image: alibaba-cn-hangzhou-ubuntu18-04",
    "image: alibaba-cn-heyuan-ubuntu18-04",
    "image: alibaba-cn-hongkong-ubuntu18-04",
    "image: alibaba-cn-huhehaote-ubuntu18-04",
    "image: alibaba-cn-qingdao-ubuntu18-04",
    "image: alibaba-cn-shanghai-ubuntu18-04",
    "image: alibaba-cn-shenz-ubuntu18-04",
    "image: alibaba-cn-wulanchabu-ubuntu18-04",
    "image: alibaba-cn-zhangjiakou-ubuntu18-04",
    "image: alibaba-eu-central-1-ubuntu18-04",
    "image: alibaba-eu-west-1-ubuntu18-04",
    "image: alibaba-me-east-1-ubuntu18-04",
    "image: alibaba-us-east-1-ubuntu18-04",
    "image: alibaba-us-west-1-ubuntu18-04",
    "image: aws-af-south-1-ubuntu18-04",
    "image: aws-ap-east-1-ubuntu18-04",
    "image: aws-ap-northeast-1-ubuntu18-04",
    "image: aws-ap-northeast-2-ubuntu18-04",
    "image: aws-ap-northeast-3-ubuntu18-04",
    "image: aws-ap-south-1-ubuntu18-04",
    "image: aws-ap-southeast-1-ubuntu18-04",
    "image: aws-ap-southeast-2-ubuntu18-04",
    "image: aws-ca-central-1-ubuntu18-04",
    "image: aws-eu-central-1-ubuntu18-04",
    "image: aws-eu-north-1-ubuntu18-04",
    "image: aws-eu-south-1-ubuntu18-04",
    "image: aws-eu-west-1-ubuntu18-04",
    "image: aws-eu-west-2-ubuntu18-04",
    "image: aws-eu-west-3-ubuntu18-04",
    "image: aws-me-south-1-ubuntu18-04",
    "image: aws-sa-east-1-ubuntu18-04",
    "image: aws-us-east-1-ubuntu18-04",
    "image: aws-us-east-2-ubuntu18-04",
    "image: aws-us-west-1-ubuntu18-04",
    "image: aws-us-west-2-ubuntu18-04",
    "image: azure-australiacentral-ubuntu18-04",
    "image: azure-australiacentral2-ubuntu18-04  [Failed] {\"message\":\"compute.VirtualMachineImagesClient#Get: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code=\\\"NoRegisteredProviderFound\\\" Message=\\\"No registered resource provider found for location 'australiacentral2' and API version '2021-03-01' for type 'locations/publishers'. The supported api-versions are '2015-05-01-preview, 2015-06-15, 2016-03-30, 2016-04-30-preview, 2016-08-30, 2017-03-30, 2017-12-01, 2018-04-01, 2018-06-01, 2018-10-01, 2019-03-01, 2019-07-01, 2019-12-01, 2020-06-01, 2020-09-30, 2020-12-01, 2021-03-01, 2021-04-01, 2021-07-01'. The supported locations are 'eastus, eastus2, westus, centralus, northcentralus, southcentralus, northeurope, westeurope, eastasia, southeastasia, japaneast, japanwest, australiaeast, australiasoutheast, australiacentral, brazilsouth, southindia, centralindia, westindia, canadacentral, canadaeast, westus2, westcentralus, uksouth, ukwest, koreacentral, francecentral, southafricanorth, uaenorth, switzerlandnorth, germanywestcentral, norwayeast, jioindiawest, westus3, koreasouth'.\\\"\"}\n",
    "image: azure-australiaeast-ubuntu18-04",
    "image: azure-australiasoutheast-ubuntu18-04",
    "image: azure-brazilsouth-ubuntu18-04",
    "image: azure-canadacentral-ubuntu18-04",
    "image: azure-canadaeast-ubuntu18-04",
    "image: azure-centralindia-ubuntu18-04",
    "image: azure-centralus-ubuntu18-04",
    "image: azure-eastasia-ubuntu18-04",
    "image: azure-eastus-ubuntu18-04",
    "image: azure-eastus2-ubuntu18-04",
    "image: azure-francecentral-ubuntu18-04",
    "image: azure-francesouth-ubuntu18-04  [Failed] {\"message\":\"resources.GroupsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code=\\\"LocationNotAvailableForResourceGroup\\\" Message=\\\"The provided location 'francesouth' is not available for resource group. List of available regions is 'centralus,eastasia,southeastasia,eastus,eastus2,westus,westus2,northcentralus,southcentralus,westcentralus,northeurope,westeurope,japaneast,japanwest,brazilsouth,australiasoutheast,australiaeast,westindia,southindia,centralindia,canadacentral,canadaeast,uksouth,ukwest,koreacentral,francecentral,southafricanorth,uaenorth,australiacentral,switzerlandnorth,germanywestcentral,norwayeast,jioindiawest,westus3,australiacentral2,koreasouth'.\\\"\"}\n",
    "image: azure-germanynorth-ubuntu18-04  [Failed] {\"message\":\"resources.GroupsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code=\\\"LocationNotAvailableForResourceGroup\\\" Message=\\\"The provided location 'germanynorth' is not available for resource group. List of available regions is 'centralus,eastasia,southeastasia,eastus,eastus2,westus,westus2,northcentralus,southcentralus,westcentralus,northeurope,westeurope,japaneast,japanwest,brazilsouth,australiasoutheast,australiaeast,westindia,southindia,centralindia,canadacentral,canadaeast,uksouth,ukwest,koreacentral,francecentral,southafricanorth,uaenorth,australiacentral,switzerlandnorth,germanywestcentral,norwayeast,jioindiawest,westus3,australiacentral2,koreasouth'.\\\"\"}\n",
    "image: azure-germanywestcentral-ubuntu18-04",
    "image: azure-japaneast-ubuntu18-04",
    "image: azure-japanwest-ubuntu18-04",
    "image: azure-koreacentral-ubuntu18-04",
    "image: azure-koreasouth-ubuntu18-04",
    "image: azure-northcentralus-ubuntu18-04",
    "image: azure-northeurope-ubuntu18-04",
    "image: azure-norwayeast-ubuntu18-04",
    "image: azure-norwaywestest-ubuntu18-04  [Failed] {\"message\":\"azure-norwaywestest: does not exist!\"}\n",
    "image: azure-southafricanorth-ubuntu18-04",
    "image: azure-southafricawest-ubuntu18-04  [Failed] {\"message\":\"resources.GroupsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code=\\\"LocationNotAvailableForResourceGroup\\\" Message=\\\"The provided location 'southafricawest' is not available for resource group. List of available regions is 'centralus,eastasia,southeastasia,eastus,eastus2,westus,westus2,northcentralus,southcentralus,westcentralus,northeurope,westeurope,japaneast,japanwest,brazilsouth,australiasoutheast,australiaeast,westindia,southindia,centralindia,canadacentral,canadaeast,uksouth,ukwest,koreacentral,francecentral,southafricanorth,uaenorth,australiacentral,switzerlandnorth,germanywestcentral,norwayeast,jioindiawest,westus3,australiacentral2,koreasouth'.\\\"\"}\n",
    "image: azure-southcentralus-ubuntu18-04",
    "image: azure-southeastasia-ubuntu18-04",
    "image: azure-southindia-ubuntu18-04",
    "image: azure-switzerlandnorth-ubuntu18-04",
    "image: azure-switzerlandwest-ubuntu18-04  [Failed] {\"message\":\"resources.GroupsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code=\\\"LocationNotAvailableForResourceGroup\\\" Message=\\\"The provided location 'switzerlandwest' is not available for resource group. List of available regions is 'centralus,eastasia,southeastasia,eastus,eastus2,westus,westus2,northcentralus,southcentralus,westcentralus,northeurope,westeurope,japaneast,japanwest,brazilsouth,australiasoutheast,australiaeast,westindia,southindia,centralindia,canadacentral,canadaeast,uksouth,ukwest,koreacentral,francecentral,southafricanorth,uaenorth,australiacentral,switzerlandnorth,germanywestcentral,norwayeast,jioindiawest,westus3,australiacentral2,koreasouth'.\\\"\"}\n",
    "image: azure-uaecentral-ubuntu18-04  [Failed] {\"message\":

...
```