### PR TITLE
Expedite scripts by applying parallel execution with minor changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/bramvdbogaerde/go-scp v1.0.0
 	github.com/cloud-barista/cb-dragonfly v0.4.3
 	github.com/cloud-barista/cb-log v0.4.0
-	github.com/cloud-barista/cb-spider v0.4.17
+	github.com/cloud-barista/cb-spider v0.4.18
 	github.com/cloud-barista/cb-store v0.4.1
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/go-resty/resty/v2 v2.6.0

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/cloud-barista/cb-spider v0.4.13 h1:SFH20EH1/6hqtx5VBY1LlfL+3pgnUMXgie
 github.com/cloud-barista/cb-spider v0.4.13/go.mod h1:PfVT0TTR8kgpH5DGJkyqa6nsEsb8rp/Y/KIwFw4TcvA=
 github.com/cloud-barista/cb-spider v0.4.17 h1:q+B/S9/xNe+iA/qjk2mnKIkibmZ/PTof8Bz6/GUMTIM=
 github.com/cloud-barista/cb-spider v0.4.17/go.mod h1:QhEE8dYh0xUvi4tSyxrbIZn1TzCwpDfFQTVTYIGlS6s=
+github.com/cloud-barista/cb-spider v0.4.18 h1:XzPuKWA7EdZKWsZOCLZEr5Kl1oSTjYKAdb0zinat4jU=
+github.com/cloud-barista/cb-spider v0.4.18/go.mod h1:QhEE8dYh0xUvi4tSyxrbIZn1TzCwpDfFQTVTYIGlS6s=
 github.com/cloud-barista/cb-store v0.4.1 h1:/4Y8SWO3QAvQU2YUc8i72aBp+W5X8rvgk5w4yMt0MQg=
 github.com/cloud-barista/cb-store v0.4.1/go.mod h1:d3mwxDF2gC4lc7a+DFc2eo1OqqS9sHygLGUrU94hhj0=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=

--- a/scripts/runSpider.sh
+++ b/scripts/runSpider.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CONTAINER_NAME_READ="CB-Spider"
-CONTAINER_VERSION="0.4.17"
+CONTAINER_VERSION="0.4.18"
 CONTAINER_PORT="-p 1024:1024 -p 2048:2048"
 CONTAINER_DATA_PATH="/root/go/src/github.com/cloud-barista/cb-spider/meta_db"
 

--- a/scripts/setcbsp.sh
+++ b/scripts/setcbsp.sh
@@ -6,7 +6,7 @@ sudo apt-key fingerprint 0EBFCD88
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get update > /dev/null
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io > /dev/null
-sudo docker run --rm -p 1024:1024 -p 2048:2048 -v /root/go/src/github.com/cloud-barista/cb-spider/meta_db:/root/go/src/github.com/cloud-barista/cb-spider/meta_db --name cb-spider cloudbaristaorg/cb-spider:0.4.17
+sudo docker run --rm -p 1024:1024 -p 2048:2048 -v /root/go/src/github.com/cloud-barista/cb-spider/meta_db:/root/go/src/github.com/cloud-barista/cb-spider/meta_db --name cb-spider cloudbaristaorg/cb-spider:0.4.18
 
 # Print a message (IP address)
 str=$(curl https://api.ipify.org)

--- a/src/api/grpc/cbadm/testclient/scripts/9.monitoring/install-agent.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/9.monitoring/install-agent.sh
@@ -34,7 +34,7 @@
 		\"nsId\":  \"${NSID}\",
 		\"mcisId\": \"${MCISID}\",
 		\"cmd\": {
-			\"command\": \"echo -n [CMD] Works! [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname ; echo -n ]\"
+			\"command\": \"echo -n [CMD] Works! [Hostname: ; hostname ; echo -n ]\"
 		}
 	}" | jq '' #|| return 1
 #}

--- a/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/command-mcis.sh
+++ b/src/api/grpc/cbadm/testclient/scripts/sequentialFullTest/command-mcis.sh
@@ -35,7 +35,7 @@
 		\"nsId\":  \"${NSID}\",
 		\"mcisId\": \"${MCISID}\",
 		\"cmd\": {
-			\"command\": \"echo -n [CMD] Works! [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname ; echo -n ]\"
+			\"command\": \"echo -n [CMD] Works! [Hostname: ; hostname ; echo -n ]\"
 		}
 	}" | jq '' #|| return 1
 

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -1681,7 +1681,7 @@ func LoadCommonResource() (common.IdList, error) {
 			go func(i int, row []string) {
 				defer wait.Done()
 				// RandomSleep for safe parallel executions
-				common.RandomSleep(5)
+				common.RandomSleep(20)
 				specReqTmp := TbSpecReq{}
 				// [0]connectionName, [1]cspSpecName, [2]CostPerHour
 				specReqTmp.ConnectionName = row[0]
@@ -1768,7 +1768,7 @@ func LoadCommonResource() (common.IdList, error) {
 			go func(i int, row []string) {
 				defer wait.Done()
 				// RandomSleep for safe parallel executions
-				common.RandomSleep(5)
+				common.RandomSleep(20)
 				imageReqTmp := TbImageReq{}
 				// row0: ProviderName
 				// row1: connectionName

--- a/src/testclient/scripts/9.monitoring/install-agent.sh
+++ b/src/testclient/scripts/9.monitoring/install-agent.sh
@@ -31,7 +31,7 @@
 
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/monitoring/install/mcis/$MCISID -H 'Content-Type: application/json' -d \
 		'{
-			"command": "echo -n [CMD] Works! [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname ; echo -n ]"
+			"command": "echo -n [CMD] Works! [Hostname: ; hostname ; echo -n ]"
 		}' | jq '' #|| return 1
 #}
 

--- a/src/testclient/scripts/sequentialFullTest/change-mcis-hostname.sh
+++ b/src/testclient/scripts/sequentialFullTest/change-mcis-hostname.sh
@@ -33,7 +33,7 @@ for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
     getCloudIndexGeneral $cloudType
 
     # ChangeHostCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${connectionName}-${publicIP}; sudo hostname -f"
-    USERCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${VMID}; echo -n [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname -f; echo -n ]"
+    USERCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${VMID}; echo -n [Hostname: ; hostname -f; echo -n ]"
 	VAR1=$(
 		curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d @- <<EOF
 	{

--- a/src/testclient/scripts/sequentialFullTest/command-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/command-mcis.sh
@@ -10,7 +10,7 @@ USERCMD=$OPTION01
 VMID=$OPTION02
 
 if [ -z "$USERCMD" ]; then
-	USERCMD="echo -n [Public IP: ; curl https://api.ipify.org ; echo -n ], [Hostname: ; hostname ; echo -n ]"
+	USERCMD="echo -n [Hostname: ; hostname ; echo -n ]"
 fi
 
 if [ -z "$VMID" ]; then

--- a/src/testclient/scripts/sequentialFullTest/config-hybridIP-withHosts.sh
+++ b/src/testclient/scripts/sequentialFullTest/config-hybridIP-withHosts.sh
@@ -31,48 +31,51 @@ echo "[MCIS INFO: $MCISID]"
 # done
 
 for rowi in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
-	_jq() {
-		echo ${rowi} | base64 --decode | jq -r ${1}
-	}
-
-	VMID=$(_jq '.id')
-	publicIP=$(_jq '.publicIP')
-	vNetId=$(_jq '.vNetId')
-
-	echo "VMID: $VMID"
-
-	VMKEYID=$(_jq '.sshKeyId')
-	KEYINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/${NSID}/resources/sshKey/${VMKEYID})
-	USERNAME=$(jq -r '.verifiedUsername' <<<"$KEYINFO")
-	KEYFILENAME="${VMKEYID}"
-
-	for rowj in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+	{
 		_jq() {
-			echo ${rowj} | base64 --decode | jq -r ${1}
+			echo ${rowi} | base64 --decode | jq -r ${1}
 		}
 
-		Bid=$(_jq '.id')
-		BpublicIP=$(_jq '.publicIP')
-		BprivateIP=$(_jq '.privateIP')
-		BvNetId=$(_jq '.vNetId')
+		VMID=$(_jq '.id')
+		publicIP=$(_jq '.publicIP')
+		vNetId=$(_jq '.vNetId')
 
-		CommandToAddHosts=""
+		echo "VMID: $VMID"
 
-		if [ "${VMID}" == "${Bid}" ]; then
-			CommandToAddHosts="sudo sed -i '2i127.0.0.1 ${Bid}' /etc/hosts"
-		elif [ "${vNetId}" == "${BvNetId}" ]; then
-			CommandToAddHosts="sudo sed -i '2i${BprivateIP} ${Bid}' /etc/hosts"
-		else
-			CommandToAddHosts="sudo sed -i '2i${BpublicIP} ${Bid}' /etc/hosts"
-		fi
+		VMKEYID=$(_jq '.sshKeyId')
+		KEYINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/${NSID}/resources/sshKey/${VMKEYID})
+		USERNAME=$(jq -r '.verifiedUsername' <<<"$KEYINFO")
+		KEYFILENAME="${VMKEYID}"
 
-		echo "${CommandToAddHosts}"
+		for rowj in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+			_jq() {
+				echo ${rowj} | base64 --decode | jq -r ${1}
+			}
 
-		VAR1=$(ssh -i ./sshkey-tmp/$KEYFILENAME.pem $USERNAME@$publicIP -o StrictHostKeyChecking=no "$CommandToAddHosts")
-		echo "${VAR1}" | jq ''
+			Bid=$(_jq '.id')
+			BpublicIP=$(_jq '.publicIP')
+			BprivateIP=$(_jq '.privateIP')
+			BvNetId=$(_jq '.vNetId')
 
-	done
+			CommandToAddHosts=""
+
+			if [ "${VMID}" == "${Bid}" ]; then
+				CommandToAddHosts="sudo sed -i '2i127.0.0.1 ${Bid}' /etc/hosts"
+			elif [ "${vNetId}" == "${BvNetId}" ]; then
+				CommandToAddHosts="sudo sed -i '2i${BprivateIP} ${Bid}' /etc/hosts"
+			else
+				CommandToAddHosts="sudo sed -i '2i${BpublicIP} ${Bid}' /etc/hosts"
+			fi
+
+			echo "${CommandToAddHosts}"
+
+			VAR1=$(ssh -i ./sshkey-tmp/$KEYFILENAME.pem $USERNAME@$publicIP -o StrictHostKeyChecking=no "$CommandToAddHosts")
+			echo "${VAR1}" | jq ''
+
+		done
+	} &
 done
+wait
 
 CMD="cat /etc/hosts"
 VAR1=$(


### PR DESCRIPTION

1. 
 - Expedite config-hybridIP script
 - Expedite gen sshkey script
 - Avoid using 3rd ip retrieving service in scripts

2.
 - Update CB-Spider version to v0.4.18

3.
 - Increase random sleep duration for safe api call