### PR TITLE
Add RootDiskType, RootDiskSize handling feature

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -6358,6 +6358,18 @@ const docTemplate = `{
                     "description": "ex) {us-east1, us-east1-c} or {ap-northeast-2}",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
+                "rootDeviceName": {
+                    "description": "\"/dev/sda1\", ...",
+                    "type": "string"
+                },
+                "rootDiskSize": {
+                    "description": "\"default\", \"50\", \"1000\" (GB)",
+                    "type": "string"
+                },
+                "rootDiskType": {
+                    "description": "\"SSD(gp2)\", \"Premium SSD\", ...",
+                    "type": "string"
+                },
                 "securityGroupIIds": {
                     "description": "AWS, ex) sg-0b7452563e1121bb6",
                     "type": "array",
@@ -6390,7 +6402,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "vmbootDisk": {
-                    "description": "ex) /dev/sda1",
+                    "description": "Deprecated soon // ex) /dev/sda1",
                     "type": "string"
                 },
                 "vmspecName": {
@@ -6659,6 +6671,11 @@ const docTemplate = `{
                     "type": "string",
                     "example": "vm01"
                 },
+                "rootDiskSize": {
+                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
+                    "type": "string",
+                    "example": "default, 30, 42, ..."
+                },
                 "vmGroupSize": {
                     "description": "if vmGroupSize is (not empty) \u0026\u0026 (\u003e 0), VM group will be gernetad. VMs will be created accordingly.",
                     "type": "string",
@@ -6722,6 +6739,15 @@ const docTemplate = `{
                 "region": {
                     "description": "AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}",
                     "$ref": "#/definitions/mcis.RegionInfo"
+                },
+                "rootDeviceName": {
+                    "type": "string"
+                },
+                "rootDiskSize": {
+                    "type": "string"
+                },
+                "rootDiskType": {
+                    "type": "string"
                 },
                 "securityGroupIds": {
                     "type": "array",
@@ -6787,6 +6813,7 @@ const docTemplate = `{
                 "securityGroupIds",
                 "specId",
                 "sshKeyId",
+                "subnetId",
                 "vNetId"
             ],
             "properties": {
@@ -6813,6 +6840,16 @@ const docTemplate = `{
                     "description": "VM name or VM group name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",
                     "type": "string",
                     "example": "vm01"
+                },
+                "rootDiskSize": {
+                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
+                    "type": "string",
+                    "example": "default, 30, 42, ..."
+                },
+                "rootDiskType": {
+                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHHD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
+                    "type": "string",
+                    "example": "default, TYPE1, ..."
                 },
                 "securityGroupIds": {
                     "type": "array",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -6350,6 +6350,18 @@
                     "description": "ex) {us-east1, us-east1-c} or {ap-northeast-2}",
                     "$ref": "#/definitions/mcis.RegionInfo"
                 },
+                "rootDeviceName": {
+                    "description": "\"/dev/sda1\", ...",
+                    "type": "string"
+                },
+                "rootDiskSize": {
+                    "description": "\"default\", \"50\", \"1000\" (GB)",
+                    "type": "string"
+                },
+                "rootDiskType": {
+                    "description": "\"SSD(gp2)\", \"Premium SSD\", ...",
+                    "type": "string"
+                },
                 "securityGroupIIds": {
                     "description": "AWS, ex) sg-0b7452563e1121bb6",
                     "type": "array",
@@ -6382,7 +6394,7 @@
                     "type": "string"
                 },
                 "vmbootDisk": {
-                    "description": "ex) /dev/sda1",
+                    "description": "Deprecated soon // ex) /dev/sda1",
                     "type": "string"
                 },
                 "vmspecName": {
@@ -6651,6 +6663,11 @@
                     "type": "string",
                     "example": "vm01"
                 },
+                "rootDiskSize": {
+                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
+                    "type": "string",
+                    "example": "default, 30, 42, ..."
+                },
                 "vmGroupSize": {
                     "description": "if vmGroupSize is (not empty) \u0026\u0026 (\u003e 0), VM group will be gernetad. VMs will be created accordingly.",
                     "type": "string",
@@ -6714,6 +6731,15 @@
                 "region": {
                     "description": "AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}",
                     "$ref": "#/definitions/mcis.RegionInfo"
+                },
+                "rootDeviceName": {
+                    "type": "string"
+                },
+                "rootDiskSize": {
+                    "type": "string"
+                },
+                "rootDiskType": {
+                    "type": "string"
                 },
                 "securityGroupIds": {
                     "type": "array",
@@ -6779,6 +6805,7 @@
                 "securityGroupIds",
                 "specId",
                 "sshKeyId",
+                "subnetId",
                 "vNetId"
             ],
             "properties": {
@@ -6805,6 +6832,16 @@
                     "description": "VM name or VM group name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",
                     "type": "string",
                     "example": "vm01"
+                },
+                "rootDiskSize": {
+                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
+                    "type": "string",
+                    "example": "default, 30, 42, ..."
+                },
+                "rootDiskType": {
+                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHHD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
+                    "type": "string",
+                    "example": "default, TYPE1, ..."
                 },
                 "securityGroupIds": {
                     "type": "array",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1137,6 +1137,15 @@ definitions:
       region:
         $ref: '#/definitions/mcis.RegionInfo'
         description: ex) {us-east1, us-east1-c} or {ap-northeast-2}
+      rootDeviceName:
+        description: '"/dev/sda1", ...'
+        type: string
+      rootDiskSize:
+        description: '"default", "50", "1000" (GB)'
+        type: string
+      rootDiskType:
+        description: '"SSD(gp2)", "Premium SSD", ...'
+        type: string
       securityGroupIIds:
         description: AWS, ex) sg-0b7452563e1121bb6
         items:
@@ -1160,7 +1169,7 @@ definitions:
         description: ex)
         type: string
       vmbootDisk:
-        description: ex) /dev/sda1
+        description: Deprecated soon // ex) /dev/sda1
         type: string
       vmspecName:
         description: Fields for both request and response
@@ -1365,6 +1374,10 @@ definitions:
           a group, actual VM name will be generated with -N postfix.
         example: vm01
         type: string
+      rootDiskSize:
+        description: '"default", Integer (GB): ["50", ..., "1000"]'
+        example: default, 30, 42, ...
+        type: string
       vmGroupSize:
         description: if vmGroupSize is (not empty) && (> 0), VM group will be gernetad.
           VMs will be created accordingly.
@@ -1414,6 +1427,12 @@ definitions:
       region:
         $ref: '#/definitions/mcis.RegionInfo'
         description: AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
+      rootDeviceName:
+        type: string
+      rootDiskSize:
+        type: string
+      rootDiskType:
+        type: string
       securityGroupIds:
         items:
           type: string
@@ -1473,6 +1492,17 @@ definitions:
           a group, actual VM name will be generated with -N postfix.
         example: vm01
         type: string
+      rootDiskSize:
+        description: '"default", Integer (GB): ["50", ..., "1000"]'
+        example: default, 30, 42, ...
+        type: string
+      rootDiskType:
+        description: '"", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure:
+          ["PremiumSSD", "StandardSSD", "StandardHHD"], GCP: ["pd-standard", "pd-balanced",
+          "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_ssd"],
+          TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]'
+        example: default, TYPE1, ...
+        type: string
       securityGroupIds:
         items:
           type: string
@@ -1501,6 +1531,7 @@ definitions:
     - securityGroupIds
     - specId
     - sshKeyId
+    - subnetId
     - vNetId
     type: object
   mcis.TbVmStatusInfo:

--- a/src/testclient/scripts/8.mcis/create-mcis.sh
+++ b/src/testclient/scripts/8.mcis/create-mcis.sh
@@ -37,7 +37,9 @@
 				"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 				"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 				"description": "description",
-				"vmUserPassword": ""
+				"vmUserPassword": "",
+				"rootDiskType": "",
+				"rootDiskSize": "77"
 			}
 			]
 		}' | jq '' 

--- a/src/testclient/scripts/8.mcis/create-single-vm-mcis.sh
+++ b/src/testclient/scripts/8.mcis/create-single-vm-mcis.sh
@@ -35,7 +35,9 @@
 				"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 				"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 				"description": "description",
-				"vmUserPassword": ""
+				"vmUserPassword": "",
+				"rootDiskType": "",
+				"rootDiskSize": "77"
 			}
 			]
 		}' | jq '' 


### PR DESCRIPTION
[Related links]
- https://github.com/cloud-barista/cb-spider/issues/348
- https://github.com/cloud-barista/cb-spider/blob/master/api-runtime/rest-runtime/test/each-test/vm-rootdisk-test.sh
- Resolves #960

[사용 방법]
MCIS/VM 생성 시, VM 명세에 다음과 같이 명시
```JSON
				"rootDiskType": "",
				"rootDiskSize": "77"
```

[테스트 결과]
AWS 에 대해
TB -> SP 통해서 VM 만들 때
`RootDiskSize` 를 명시하면 적용이 되는 것은 확인했습니다.
![image](https://user-images.githubusercontent.com/46767780/141749554-2dc06b6a-443a-496c-95e9-50092e8648a5.png)
(참고: https://github.com/cloud-barista/cb-spider/issues/531 )
