### PR TITLE
Hot fix vm status list mismatch bug

### DIFF
--- a/src/core/mcis/manageInfo.go
+++ b/src/core/mcis/manageInfo.go
@@ -30,6 +30,7 @@ import (
 	"os"
 
 	"math/rand"
+	"sort"
 
 	// REST API (echo)
 	"net/http"
@@ -247,14 +248,20 @@ func GetMcisInfo(nsId string, mcisId string) (*TbMcisInfo, error) {
 		common.CBLog.Error(err)
 		return nil, err
 	}
-	for num := range vmList {
-		//fmt.Println("[GetMcisInfo compare two VMs]")
-		//common.PrintJsonPretty(mcisObj.Vm[num])
-		//common.PrintJsonPretty(mcisStatus.Vm[num])
 
-		mcisObj.Vm[num].Status = mcisStatus.Vm[num].Status
-		mcisObj.Vm[num].TargetStatus = mcisStatus.Vm[num].TargetStatus
-		mcisObj.Vm[num].TargetAction = mcisStatus.Vm[num].TargetAction
+	sort.Slice(mcisObj.Vm, func(i, j int) bool {
+		return mcisObj.Vm[i].Id < mcisObj.Vm[j].Id
+	})
+
+	for vmInfoIndex := range vmList {
+		for vmStatusInfoIndex := range mcisStatus.Vm {
+			if mcisObj.Vm[vmInfoIndex].Id == mcisStatus.Vm[vmStatusInfoIndex].Id {
+				mcisObj.Vm[vmInfoIndex].Status = mcisStatus.Vm[vmStatusInfoIndex].Status
+				mcisObj.Vm[vmInfoIndex].TargetStatus = mcisStatus.Vm[vmStatusInfoIndex].TargetStatus
+				mcisObj.Vm[vmInfoIndex].TargetAction = mcisStatus.Vm[vmStatusInfoIndex].TargetAction
+				break
+			}
+		}
 	}
 
 	return &mcisObj, nil
@@ -557,6 +564,10 @@ func GetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 			break
 		}
 	}
+
+	sort.Slice(mcisStatus.Vm, func(i, j int) bool {
+		return mcisStatus.Vm[i].Id < mcisStatus.Vm[j].Id
+	})
 
 	statusFlag := []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 	statusFlagStr := []string{StatusFailed, StatusSuspended, StatusRunning, StatusTerminated, StatusCreating, StatusSuspending, StatusResuming, StatusRebooting, StatusTerminating, StatusUndefined}
@@ -1257,8 +1268,7 @@ func CoreGetMcisVmStatus(nsId string, mcisId string, vmId string) (*TbVmStatusIn
 	//fmt.Println(vmKey)
 	vmKeyValue, err := common.CBStore.Get(vmKey)
 	if err != nil {
-		common.CBLog.Error(err)
-		err = fmt.Errorf("In CoreGetMcisVmStatus(); CBStore.Get() returned an error.")
+		err = fmt.Errorf("in CoreGetMcisVmStatus(); CBStore.Get() returned an error")
 		common.CBLog.Error(err)
 		// return nil, err
 	}

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -326,7 +326,7 @@ type TbVmInfo struct {
 	VmUserAccount    string   `json:"vmUserAccount,omitempty"`
 	VmUserPassword   string   `json:"vmUserPassword,omitempty"`
 
-	CspViewVmDetail SpiderVMInfo `json:"cspViewVmDetail"`
+	CspViewVmDetail SpiderVMInfo `json:"cspViewVmDetail,omitempty"`
 }
 
 // StatusCountInfo is struct to count the number of VMs in each status. ex: Running=4, Suspended=8.


### PR DESCRIPTION

 - VM 오브젝트 리스트와 VM 상태 오브젝트 리스트 간 순서의 미스매치로 인한 오류 수정
 - 각자 소팅을 적용하고, 동일한 VM ID인 경우에만 값을 대입하도록 보완 
   - 다소 계산량이 추가(ID가 동일한지 확인)되지만, 안정성 향상
   - 향후 계산량은 개선 필요