### PR TITLE
Fix error message tag for validation from 'NotObeyingNamingConvention' to err.Error()

### DIFF
--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -64,7 +64,7 @@ func TbImageReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.Name)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
 

--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -69,7 +69,7 @@ func TbSecurityGroupReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.Name)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
 

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -72,7 +72,7 @@ func TbSpecReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.Name)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
 

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -57,7 +57,7 @@ func TbSshKeyReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.Name)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
 

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -79,7 +79,7 @@ func TbVNetReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.Name)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
 
@@ -119,7 +119,7 @@ func TbSubnetReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.Name)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
 

--- a/src/core/mcis/monitoring.go
+++ b/src/core/mcis/monitoring.go
@@ -71,19 +71,19 @@ func DFMonAgentInstallReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.NsId)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.NsId, "nsId", "NsId", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.NsId, "nsId", "NsId", err.Error(), "")
 	}
 
 	err = common.CheckString(u.McisId)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.McisId, "mcisId", "McisId", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.McisId, "mcisId", "McisId", err.Error(), "")
 	}
 
 	err = common.CheckString(u.VmId)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.VmId, "vmId", "VmId", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.VmId, "vmId", "VmId", err.Error(), "")
 	}
 }
 

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -151,7 +151,7 @@ func TbMcisReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.Name)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
 
@@ -268,7 +268,7 @@ func TbVmReqStructLevelValidation(sl validator.StructLevel) {
 	err := common.CheckString(u.Name)
 	if err != nil {
 		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-		sl.ReportError(u.Name, "name", "Name", "NotObeyingNamingConvention", "")
+		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
 

--- a/src/core/mcis/remoteCommand.go
+++ b/src/core/mcis/remoteCommand.go
@@ -51,7 +51,7 @@ func TbMcisCmdReqStructLevelValidation(sl validator.StructLevel) {
 	// err := common.CheckString(u.Command)
 	// if err != nil {
 	// 	// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
-	// 	sl.ReportError(u.Command, "command", "Command", "NotObeyingNamingConvention", "")
+	// 	sl.ReportError(u.Command, "command", "Command", err.Error(), "")
 	// }
 }
 


### PR DESCRIPTION
- error 메시지 태그를 `NotObeyingNamingConvention`에서 err.Error()로 변경했습니다.

fix #950 