### PR TITLE
Add usecase for FPS Game Xonotic

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/deploy-fps-game.sh
+++ b/src/testclient/scripts/sequentialFullTest/deploy-fps-game.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+
+echo "####################################################################"
+echo "## Deploy-Xonotic-FPS-Game-to-mcis "
+echo "####################################################################"
+
+SECONDS=0
+source ../init.sh
+
+
+MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?option=status)
+VMARRAY=$(jq -r '.status.vm' <<<"$MCISINFO")
+MASTERIP=$(jq -r '.status.masterIp' <<<"$MCISINFO")
+MASTERVM=$(jq -r '.status.masterVmId' <<<"$MCISINFO")
+
+echo "MASTERIP: $MASTERIP"
+
+LAUNCHCMD="sudo scope launch $IPLIST $PRIVIPLIST"
+#echo $LAUNCHCMD
+
+echo ""
+echo "Installing Xonotic to MCIS..."
+#InstallFilePath="https://.../xonotic-0.8.2.zip"
+InstallFilePath="https://z.xnz.me/xonotic/builds/xonotic-0.8.2.zip"
+INSTALLCMD="sudo apt-get update > /dev/null; wget $InstallFilePath ; sudo apt install unzip -y; unzip xonotic-0.8.2.zip"
+echo ""
+
+VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${INSTALLCMD}"
+	}
+EOF
+)
+echo "${VAR1}" | jq ''
+echo ""
+
+LAUNCHCMD="cd Xonotic/; ./xonotic-linux64-dedicated &"
+
+echo "Launching Xonotic for master node..."
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID/vm/$MASTERVM -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${LAUNCHCMD}"
+	}
+EOF
+
+
+echo "Done!"
+duration=$SECONDS
+
+printElapsed $@
+echo ""
+
+echo "[MCIS Xonotic: complete] Access to"
+echo " $MASTERIP:26000"
+echo ""


### PR DESCRIPTION

Add script to deploy FPS Game Xonotic server to MC-Infra.

What is Xonotic.
https://xonotic.org/


How to use (example)
```bash
./create-all.sh -n shson2 -f ../testSet01.env
./deploy-fps-game.sh -n shson2 -f ../testSet01.env
```
```
shson@dev:~/go/src/github.com/cloud-barista/cb-tumblebug/src/testclient/scripts/sequentialFullTest$ ./deploy-fps-game.sh -n shson2 -f ../testSet01.env 
####################################################################
## Deploy-Xonotic-FPS-Game-to-mcis 
####################################################################

MASTERIP: 13.213.58.171

Installing Xonotic to MCIS...

...

[DATE: 22/12/2021 03:50:48] [ElapsedTime: 100s (1m:40s)] [Command: ./deploy-fps-game.sh all 1 shson2 ../testSet01.env]

[MCIS Xonotic: complete] Access to
 13.213.58.171:26000

```

To access the game server,
- download Xonotic game client : https://z.xnz.me/xonotic/builds/xonotic-0.8.2.zip
- execute xonotic.exe
- select Multiplayer Game
- input Address for the dedicated server with port number (ex: 13.213.58.171:26000)
![image](https://user-images.githubusercontent.com/5966944/146984188-c46f822c-4613-4e6c-9b01-21dd78692f9d.png)

- enjoy the game with your friends !!
![image](https://user-images.githubusercontent.com/5966944/146983925-fa78bef6-fa5a-4ce2-b580-ffb75e26275b.png)

