### PR TITLE
Update 'registerExistingSG' function

### DIFF
--- a/src/api/grpc/server/mcir/securitygroup.go
+++ b/src/api/grpc/server/mcir/securitygroup.go
@@ -28,7 +28,7 @@ func (s *MCIRService) CreateSecurityGroup(ctx context.Context, req *pb.TbSecurit
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.CreateSecurityGroup()")
 	}
 
-	content, err := mcir.CreateSecurityGroup(req.NsId, &mcirObj)
+	content, err := mcir.CreateSecurityGroup(req.NsId, &mcirObj, "")
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.CreateSecurityGroup()")
 	}

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -5320,7 +5320,6 @@ var doc = `{
             "type": "object",
             "required": [
                 "connectionName",
-                "firewallRules",
                 "name",
                 "vNetId"
             ],
@@ -5332,6 +5331,7 @@ var doc = `{
                     "type": "string"
                 },
                 "firewallRules": {
+                    "description": "validate:\"required\"` + "`" + `",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcir.SpiderSecurityRuleInfo"

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -5306,7 +5306,6 @@
             "type": "object",
             "required": [
                 "connectionName",
-                "firewallRules",
                 "name",
                 "vNetId"
             ],
@@ -5318,6 +5317,7 @@
                     "type": "string"
                 },
                 "firewallRules": {
+                    "description": "validate:\"required\"`",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcir.SpiderSecurityRuleInfo"

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -482,6 +482,7 @@ definitions:
       description:
         type: string
       firewallRules:
+        description: validate:"required"`
         items:
           $ref: '#/definitions/mcir.SpiderSecurityRuleInfo'
         type: array
@@ -491,7 +492,6 @@ definitions:
         type: string
     required:
     - connectionName
-    - firewallRules
     - name
     - vNetId
     type: object

--- a/src/api/rest/server/mcir/securitygroup.go
+++ b/src/api/rest/server/mcir/securitygroup.go
@@ -37,27 +37,18 @@ import (
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/securityGroup [post]
 func RestPostSecurityGroup(c echo.Context) error {
-	fmt.Println("[POST SecurityGroup")
+	fmt.Println("[POST SecurityGroup]")
 
 	nsId := c.Param("nsId")
 
 	optionFlag := c.QueryParam("option")
 
-	var content mcir.TbSecurityGroupInfo
-	var err error
-	if optionFlag == "register" {
-		u := &mcir.TbSecurityGroupRegReq{}
-		if err := c.Bind(u); err != nil {
-			return err
-		}
-		content, err = mcir.RegisterSecurityGroup(nsId, u)
-	} else {
-		u := &mcir.TbSecurityGroupReq{}
-		if err := c.Bind(u); err != nil {
-			return err
-		}
-		content, err = mcir.CreateSecurityGroup(nsId, u)
+	u := &mcir.TbSecurityGroupReq{}
+	if err := c.Bind(u); err != nil {
+		return err
 	}
+
+	content, err := mcir.CreateSecurityGroup(nsId, u, optionFlag)
 	if err != nil {
 		common.CBLog.Error(err)
 		mapA := map[string]string{"message": err.Error()}

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -1969,7 +1969,7 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 
 				common.PrintJsonPretty(reqTmp)
 
-				resultInfo, err := CreateSecurityGroup(nsId, &reqTmp)
+				resultInfo, err := CreateSecurityGroup(nsId, &reqTmp, "")
 				if err != nil {
 					common.CBLog.Error(err)
 					// If already exist, error will occur


### PR DESCRIPTION
- https://github.com/cloud-barista/cb-tumblebug/pull/990#pullrequestreview-821924918 에서 제안된 대로,
  별도로 추가했던 `RegisterSecurityGroup` 함수를
  `CreateSecurityGroup` 에 통합했습니다.
- 다만, https://github.com/cloud-barista/cb-tumblebug/pull/990#issuecomment-986435758 의 내용대로
  'firewallRules 필드에 임의의 기본값을 넣고 struct validate' 하려고 했으나
  `*u.FirewallRules = append(*u.FirewallRules, mockFirewallRule)` 부분에서 Internal Server Error 가 발생하여
  - TB 코드 중에 `*returnResult = append(*returnResult, sshResultTmp)` 와 같은 코드가 있는데..
    왜 여기서는 안되는걸까요.. ㅠㅠ
- 다음과 같이 하였습니다.
  - `TbSecurityGroupReq` struct의 `FirewallRules` 필드의 `required` 태그 해제
  - 대신, `option != "register"` 이면 `FirewallRules` 필드에 대해 따로 `required` validate 수행