### PR TITLE
Add `registerExistingSSHKey` feature

### DIFF
--- a/src/api/grpc/server/mcir/sshkey.go
+++ b/src/api/grpc/server/mcir/sshkey.go
@@ -29,7 +29,7 @@ func (s *MCIRService) CreateSshKey(ctx context.Context, req *pb.TbSshKeyCreateRe
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.CreateSshKey()")
 	}
 
-	content, err := mcir.CreateSshKey(req.NsId, &mcirObj)
+	content, err := mcir.CreateSshKey(req.NsId, &mcirObj, "")
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCIRService.CreateSshKey()")
 	}

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -5541,10 +5541,29 @@ var doc = `{
                 "connectionName": {
                     "type": "string"
                 },
+                "cspSshKeyName": {
+                    "description": "Fields for \"Register existing SSH keys\" feature",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
+                "fingerprint": {
+                    "type": "string"
+                },
                 "name": {
+                    "type": "string"
+                },
+                "privateKey": {
+                    "type": "string"
+                },
+                "publicKey": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "verifiedUsername": {
                     "type": "string"
                 }
             }

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -5527,10 +5527,29 @@
                 "connectionName": {
                     "type": "string"
                 },
+                "cspSshKeyName": {
+                    "description": "Fields for \"Register existing SSH keys\" feature",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
+                "fingerprint": {
+                    "type": "string"
+                },
                 "name": {
+                    "type": "string"
+                },
+                "privateKey": {
+                    "type": "string"
+                },
+                "publicKey": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "verifiedUsername": {
                     "type": "string"
                 }
             }

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -623,9 +623,22 @@ definitions:
     properties:
       connectionName:
         type: string
+      cspSshKeyName:
+        description: Fields for "Register existing SSH keys" feature
+        type: string
       description:
         type: string
+      fingerprint:
+        type: string
       name:
+        type: string
+      privateKey:
+        type: string
+      publicKey:
+        type: string
+      username:
+        type: string
+      verifiedUsername:
         type: string
     required:
     - connectionName

--- a/src/api/rest/server/mcir/sshkey.go
+++ b/src/api/rest/server/mcir/sshkey.go
@@ -36,18 +36,18 @@ import (
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/resources/sshKey [post]
 func RestPostSshKey(c echo.Context) error {
+	fmt.Println("[POST SshKey]")
 
 	nsId := c.Param("nsId")
+
+	optionFlag := c.QueryParam("option")
 
 	u := &mcir.TbSshKeyReq{}
 	if err := c.Bind(u); err != nil {
 		return err
 	}
 
-	fmt.Println("[POST SshKey")
-	//fmt.Println("[Creating SshKey]")
-	//content, responseCode, _, err := CreateSshKey(nsId, u)
-	content, err := mcir.CreateSshKey(nsId, u)
+	content, err := mcir.CreateSshKey(nsId, u, optionFlag)
 	if err != nil {
 		common.CBLog.Error(err)
 		mapA := map[string]string{"message": err.Error()}

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -1990,7 +1990,7 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 
 				common.PrintJsonPretty(reqTmp)
 
-				resultInfo, err := CreateSshKey(nsId, &reqTmp)
+				resultInfo, err := CreateSshKey(nsId, &reqTmp, "")
 				if err != nil {
 					common.CBLog.Error(err)
 					// If already exist, error will occur

--- a/src/testclient/scripts/5.sshKey/spider-get-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/spider-get-sshKey.sh
@@ -4,7 +4,7 @@ function CallSpider() {
     echo "- Get sshKey in ${MCIRRegionName}"
 
     resp=$(
-        curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d @- <<EOF
+        curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/keypair/${NSID}-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d @- <<EOF
         { 
 			"ConnectionName": "${CONN_CONFIG[$INDEX,$REGION]}"
 		}

--- a/src/testclient/scripts/5.sshKey/test-register-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/test-register-sshKey.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+function CallTB() {
+	echo "- Register sshKey in ${MCIRRegionName}"
+
+	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/resources/sshKey?option=register -H 'Content-Type: application/json' -d \
+		'{ 
+			"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
+			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'", 
+			"cspSshKeyName": "'${NSID}-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}'",
+			"fingerprint": "xx:c4:5a:ea:7f:c4:db:d5:80:80:92:47:7e:43:c9:2c:01:d3:ee:xx",
+			"username": "cb-user",
+			"publicKey": "",
+			"privateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIE....Kplg==\n-----END RSA PRIVATE KEY-----"
+		}' | jq '.message'
+}
+
+#function register_sshKey() {
+
+	echo "####################################################################"
+	echo "## 5. sshKey: Register"
+	echo "####################################################################"
+
+	source ../init.sh
+
+	if [ "${INDEX}" == "0" ]; then
+        echo "[Parallel execution for all CSP regions]"
+        INDEXX=${NumCSP}
+        for ((cspi = 1; cspi <= INDEXX; cspi++)); do
+            INDEXY=${NumRegion[$cspi]}
+            CSP=${CSPType[$cspi]}
+            echo "[$cspi] $CSP details"
+            for ((cspj = 1; cspj <= INDEXY; cspj++)); do
+                echo "[$cspi,$cspj] ${RegionName[$cspi,$cspj]}"
+
+				MCIRRegionName=${RegionName[$cspi,$cspj]}
+
+				CallTB
+
+			done
+
+		done
+		wait
+
+	else
+		echo ""
+		
+		MCIRRegionName=${CONN_CONFIG[$INDEX,$REGION]}
+
+		CallTB
+
+	fi
+	
+#}
+
+#register_sshKey


### PR DESCRIPTION
앞선
- #983
- #990

에서는
`option=register` 이면 Spider 에 Get 하고 그 결과를 이용하여 TB object를 생성했지만,

SSH Key는 Spider에 Get 해도 Spider가 Private key 등을 리턴하지 않기 때문에

사용자가 TB에 registerExistingSSHKey 할 때 모든 정보를 제공하도록 하였습니다.

---

[특이사항]
- 사용자가 TB에 registerExistingSSHKey 할 때 SSH Key 정보를 제공할 수 있도록, `TbSshKeyReq` struct에 field 추가
  (사용자가 모든 필드를 채워야 하는 것은 아니며, 일부만 채워도 되지만, 
  register 시 `Username` 과 `PrivateKey` 는 필수 필드로 지정했음)
  - `CspSshKeyName`
  - `Fingerprint`
  - `Username`
  - `VerifiedUsername`
  - `PublicKey`
  - `PrivateKey`

---

기존의 "Create SSH Key"

[Request]
```JSON
{ 
	"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
	"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'", 
	"username": "ubuntu"
}
```

[Response]
```JSON
{
  "id": "aws-ap-southeast-1-sjhtest",
  "name": "aws-ap-southeast-1-sjhtest",
  "connectionName": "aws-ap-southeast-1",
  "description": "",
  "cspSshKeyName": "ns01-aws-ap-southeast-1-sjhtest",
  "fingerprint": "xx:c4:5a:ea:7f:c4:db:d5:80:80:92:47:7e:43:c9:2c:01:d3:ee:xx",
  "username": "",
  "verifiedUsername": "",
  "publicKey": "",
  "privateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIE....Kplg==\n-----END RSA PRIVATE KEY-----",
  "keyValueList": [
    {
      "Key": "KeyMaterial",
      "Value": "-----BEGIN RSA PRIVATE KEY-----\nMIIE....Kplg==\n-----END RSA PRIVATE KEY-----"
    }
  ],
  "associatedObjectList": [],
  "isAutoGenerated": false
}
```

(@powerkimhub : Spider에서 `VMUserID` 필드에 `cb-user`로 채워서 주면 좋을 것 같은데, 지금은 빈 값으로 주는 것 같습니다. 😊)

---

TB object만 삭제하고, `registerExistingSSHKey` 시도

[Request]
```JSON
{ 
	"connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'", 
	"name": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'", 
	"cspSshKeyName": "'${NSID}-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}'",
	"fingerprint": "xx:c4:5a:ea:7f:c4:db:d5:80:80:92:47:7e:43:c9:2c:01:d3:ee:xx",
	"username": "cb-user",
	"publicKey": "",
	"privateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIE....Kplg==\n-----END RSA PRIVATE KEY-----"
}
```

[Response]
```JSON
{
  "id": "aws-ap-southeast-1-sjhtest",
  "name": "aws-ap-southeast-1-sjhtest",
  "connectionName": "aws-ap-southeast-1",
  "description": "",
  "cspSshKeyName": "ns01-aws-ap-southeast-1-sjhtest",
  "fingerprint": "xx:c4:5a:ea:7f:c4:db:d5:80:80:92:47:7e:43:c9:2c:01:d3:ee:xx",
  "username": "cb-user",
  "verifiedUsername": "",
  "publicKey": "",
  "privateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIE....Kplg==\n-----END RSA PRIVATE KEY-----",
  "keyValueList": null,
  "associatedObjectList": [],
  "isAutoGenerated": false
}
```
