### PR TITLE
Add script for remote copy file to MCIS VMs

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/change-mcis-hostname.sh
+++ b/src/testclient/scripts/sequentialFullTest/change-mcis-hostname.sh
@@ -33,7 +33,8 @@ for row in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
     getCloudIndexGeneral $cloudType
 
     # ChangeHostCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${connectionName}-${publicIP}; sudo hostname -f"
-    USERCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${VMID}; echo -n [Hostname: ; hostname -f; echo -n ]"
+    # USERCMD="sudo hostnamectl set-hostname ${GeneralINDEX}-${VMID}; echo -n [Hostname: ; hostname -f; echo -n ]"
+    USERCMD="sudo hostnamectl set-hostname ${VMID}; echo -n [Hostname: ; hostname -f; echo -n ]"
 	VAR1=$(
 		curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID/vm/$VMID -H 'Content-Type: application/json' -d @- <<EOF
 	{

--- a/src/testclient/scripts/sequentialFullTest/conf-ansible-env.sh
+++ b/src/testclient/scripts/sequentialFullTest/conf-ansible-env.sh
@@ -1,35 +1,17 @@
 #!/bin/bash
 
-TestSetFile=${4:-../testSet.env}
-if [ ! -f "$TestSetFile" ]; then
-	echo "$TestSetFile does not exist."
-	exit
-fi
-source $TestSetFile
-source ../conf.env
-
 echo "####################################################################"
 echo "## Config Ansible environment (generate host file)"
 echo "####################################################################"
 
-CSP=${1}
-REGION=${2:-1}
-POSTFIX=${3:-developer}
+SECONDS=0
 
-source ../common-functions.sh
-getCloudIndex $CSP
-
-MCISID=${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}
+source ../init.sh
 
 if [ "${INDEX}" == "0" ]; then
-	# MCISPREFIX=avengers
 	MCISID=${POSTFIX}
 fi
 
-#install jq and puttygen
-echo "[Check jq and putty-tools package (if not, install)]"
-if ! dpkg-query -W -f='${Status}' jq | grep "ok installed"; then sudo apt install -y jq; fi
-if ! dpkg-query -W -f='${Status}' putty-tools | grep "ok installed"; then sudo apt install -y putty-tools; fi
 
 echo "[Check Ansible (if not, Exit)]"
 
@@ -48,7 +30,7 @@ echo ""
 echo "[CHECK REMOTE COMMAND BY CB-TB API]"
 echo " This will retrieve verified SSH username"
 
-./command-mcis.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+./command-mcis.sh -n $POSTFIX -f $TestSetFile
 
 MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}?option=status)
 VMARRAY=$(jq '.status.vm' <<<"$MCISINFO")

--- a/src/testclient/scripts/sequentialFullTest/copy-file-to-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/copy-file-to-mcis.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+echo "####################################################################"
+echo "## Copy a local file to all VMs in the MCIS (-x source-file-path / -y destination-file-path)"
+echo "####################################################################"
+
+source ../init.sh
+
+SOURCEPATH=$OPTION01
+DESTPATH=$OPTION02
+
+echo ""
+
+MCISINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID})
+VMARRAY=$(jq '.vm' <<<"$MCISINFO")
+
+echo ""
+echo "[MCIS INFO: $MCISID]"
+
+for rowi in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
+	{
+		_jq() {
+			echo ${rowi} | base64 --decode | jq -r ${1}
+		}
+
+		publicIP=$(_jq '.publicIP')
+		vNetId=$(_jq '.vNetId')
+
+		VMKEYID=$(_jq '.sshKeyId')
+		KEYINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/${NSID}/resources/sshKey/${VMKEYID})
+		USERNAME=$(jq -r '.verifiedUsername' <<<"$KEYINFO")
+		KEYFILENAME="${VMKEYID}"
+
+
+		VAR1=$(scp -i ./sshkey-tmp/$KEYFILENAME.pem ${SOURCEPATH} $USERNAME@$publicIP:${DESTPATH})
+		echo "${VAR1}" 
+
+	} &
+done
+wait
+
+CMD="ls ${DESTPATH}"
+VAR1=$(
+	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/cmd/mcis/$MCISID -H 'Content-Type: application/json' -d @- <<EOF
+	{
+	"command"        : "${CMD}"
+	}
+EOF
+)
+echo "${VAR1}" | jq . | sed 's/\\n/\n/g'


### PR DESCRIPTION

1) Add script for remote copy file to MCIS VMs (src/testclient/scripts/sequentialFullTest/copy-file-to-mcis.sh)

- How to use: Copy a local file to all VMs in the MCIS (-x source-file-path / -y destination-file-path)

- Ex) `./copy-file-to-mcis.sh` -n mcis02 -f ../testSet-kubespray.env -x `./sshkey-tmp/aws-ap-southeast-1-mcis02.pem` -y `/home/cb-user/`

---

2) Minor updates for scripts
