### PR TITLE
Update Swagger serving URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
 
 
    Access to API dashboard (username: default / password: default)
-   http://xxx.xxx.xxx.xxx:1323/tumblebug/swagger/index.html?url=http://xxx.xxx.xxx.xxx:1323/tumblebug/swaggerActive
+   http://xxx.xxx.xxx.xxx:1323/tumblebug/swagger/index.html
 
   ⇨ http server started on [::]:1323
   ⇨ grpc server started on [::]:50252

--- a/i18n/README-EN.md
+++ b/i18n/README-EN.md
@@ -196,7 +196,7 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
 
 
    Access to API dashboard (username: default / password: default)
-   http://xxx.xxx.xxx.xxx:1323/tumblebug/swagger/index.html?url=http://xxx.xxx.xxx.xxx:1323/tumblebug/swaggerActive
+   http://xxx.xxx.xxx.xxx:1323/tumblebug/swagger/index.html
 
   ⇨ http server started on [::]:1323
   ⇨ grpc server started on [::]:50252

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
@@ -87,6 +86,7 @@ func RestGetHealth(c echo.Context) error {
 	return c.JSON(http.StatusOK, &okMessage)
 }
 
+/*
 // RestGetSwagger func is to get API document web.
 // RestGetSwagger godoc
 // @Summary Get API document web
@@ -115,6 +115,7 @@ func RestGetSwagger(c echo.Context) error {
 	data["host"] = os.Getenv("SELF_ENDPOINT")
 	return c.JSON(http.StatusOK, data)
 }
+*/
 
 // RestGetConnConfig func is a rest api wrapper for GetConnConfig.
 // RestGetConnConfig godoc

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -82,7 +82,7 @@ func RunServer(port string) {
 
 	// Route for system management
 	e.GET("/tumblebug/swagger/*", echoSwagger.WrapHandler)
-	e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
+	// e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
 	e.GET("/tumblebug/health", rest_common.RestGetHealth)
 
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
@@ -276,7 +276,7 @@ func RunServer(port string) {
 	g.GET("/:nsId/testGetAssociatedObjectCount/:resourceType/:resourceId", rest_mcir.RestTestGetAssociatedObjectCount)
 
 	selfEndpoint := os.Getenv("SELF_ENDPOINT")
-	apidashboard := " http://" + selfEndpoint + "/tumblebug/swagger/index.html?url=http://" + selfEndpoint + "/tumblebug/swaggerActive"
+	apidashboard := " http://" + selfEndpoint + "/tumblebug/swagger/index.html"
 
 	fmt.Println(" Access to API dashboard" + " (username: " + API_USERNAME + " / password: " + API_PASSWORD + ")")
 	fmt.Printf(noticeColor, apidashboard)

--- a/src/main.go
+++ b/src/main.go
@@ -49,7 +49,6 @@ import (
 // @license.name Apache 2.0
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 
-// @host localhost:1323
 // @BasePath /tumblebug
 
 // @securityDefinitions.basic BasicAuth


### PR DESCRIPTION
- Update Swagger serving URL
- Remove `/tumblebug/swaggerActive` REST API
- Remove `@host` option from Swagger conf

['Update Swagger doc' workflow](https://github.com/cloud-barista/cb-tumblebug/actions/workflows/make-swagger.yaml)가 잘 되는지 확인하기 위해, Swagger doc 을 일부러 업데이트하지 않았습니다. 😊