### PR TITLE
Update README-EN.md

### DIFF
--- a/i18n/README-EN.md
+++ b/i18n/README-EN.md
@@ -202,7 +202,10 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
   ⇨ grpc server started on [::]:50252
   ```
 
-- Known Errors and Troubleshooting
+<details>
+<summary>Known Errors and Troubleshooting</summary>
+
+- Errors related to `golang.org/x/net/trace`
   ``` 
   panic: /debug/requests is already registered. 
   You may have two independent copies of golang.org/x/net/trace in your binary, 
@@ -210,11 +213,12 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
   This may involve a vendor copy of golang.org/x/net/trace.
   ```
 
-  run following to resolve if error occurs.
+  Solution: Run following to resolve this issue by removing duplicated files.
   ```Shell
   # rm -rf $GOPATH/src/go.etcd.io/etcd/vendor/golang.org/x/net/trace
   # make
   ```
+</details>
 
 ***
 ***


### PR DESCRIPTION
- Resolves #837
- Closes #855

#855 에서는 OS에 따른 CR/LF 차이 때문인지
파일 전체가 변경된 것으로 표시됩니다.

GitHub diff 에서 whitespace 변경을 숨기면
해당 PR의 순 제안사항을 볼 수 있는데,

conflict가 있어 제가 rebase 시도를 해 보니
rebase가 쉽지 않습니다.
이에, 해당 내용을 반영하는 PR을 새로 올립니다.

참고: https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab
> Two important rules:
> 1. Make sure you have an **empty line** after the closing `</summary>` tag, otherwise the markdown/code blocks won't show correctly.
> 2. Make sure you have an **empty line** after the closing `</details>` tag if you have multiple collapsible sections.