### PR TITLE
Initial codes to register existing CSP VM

### DIFF
--- a/src/api/grpc/server/mcis/control.go
+++ b/src/api/grpc/server/mcis/control.go
@@ -30,7 +30,7 @@ func (s *MCISService) CreateMcis(ctx context.Context, req *pb.TbMcisCreateReques
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.CreateMcis()")
 	}
 
-	result, err := mcis.CreateMcis(req.NsId, &mcisObj)
+	result, err := mcis.CreateMcis(req.NsId, &mcisObj, "create")
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.CreateMcis()")
 	}

--- a/src/api/rest/server/mcis/provisioning.go
+++ b/src/api/rest/server/mcis/provisioning.go
@@ -43,7 +43,42 @@ func RestPostMcis(c echo.Context) error {
 		return err
 	}
 
-	result, err := mcis.CreateMcis(nsId, req)
+	option := "create"
+	result, err := mcis.CreateMcis(nsId, req, option)
+	if err != nil {
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(http.StatusInternalServerError, &mapA)
+	}
+
+	//fmt.Printf("%+v\n", *result)
+	common.PrintJsonPretty(*result)
+
+	return c.JSON(http.StatusCreated, result)
+}
+
+// RestPostRegisterCSPNativeVM godoc
+// @Summary Register existing VM in a CSP to Cloud-Barista MCIS
+// @Description Register existing VM in a CSP to Cloud-Barista MCIS
+// @Tags [Infra service] MCIS Provisioning management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Param mcisReq body TbMcisReq true "Details for an MCIS object with existing CSP VM ID"
+// @Success 200 {object} TbMcisInfo
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /ns/{nsId}/registerCspVm [post]
+func RestPostRegisterCSPNativeVM(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+
+	req := &mcis.TbMcisReq{}
+	if err := c.Bind(req); err != nil {
+		return err
+	}
+
+	option := "register"
+	result, err := mcis.CreateMcis(nsId, req, option)
 	if err != nil {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -158,6 +158,8 @@ func RunServer(port string) {
 
 	//MCIS Management
 	g.POST("/:nsId/mcis", rest_mcis.RestPostMcis)
+	g.POST("/:nsId/registerCspVm", rest_mcis.RestPostRegisterCSPNativeVM)
+
 	g.POST("/:nsId/mcisDynamic", rest_mcis.RestPostMcisDynamic)
 	g.GET("/:nsId/mcis/:mcisId", rest_mcis.RestGetMcis)
 	g.GET("/:nsId/mcis", rest_mcis.RestGetAllMcis)


### PR DESCRIPTION

MCIS 생성과 유사한 형태로 CSP 기존 VM을 등록합니다.

VM 등록을 요청할 때,
MCIS 명칭을 입력하게 되고, 해당 명칭이 없는 경우 신규 MCIS를 생성하게 되어 있습니다. 
(동일 명칭의 MCIS가 기존에 있는 경우, 기존 MCIS에 추가하도록 만들어 두었으나, 정상 동작 여부의 검증은 필요)

MCIS 프로비저닝 플로우에 관련된 코드들을 함께 사용하고, 
option=register 인 경우 create에서 필요한 절차들을 생략하는 형태로 코드를 구성하였습니다.

사용 방법은 아래와 같습니다.

우선, VM에 관련된 자원(vNet, SG, SSHKEY)이 미리 등록되어 있어야 합니다. (향후 개선 방안 마련 필요)

그리고 아래 API를 통해서 VM을 등록하면 됩니다.

POST ​/ns​/{nsId}​/registerCspVm

request body는 MCIS create와 거의 유사하며,
`name`, vm.`connectionName`, vm.`idByCsp`, vm.`name` 은 필수로 지정해야 하고, vmgroup 항목은 제외하여야 합니다.

나머지는 임의의 값을 넣어도 동작합니다.

요청 예시
```
{
  "description": "Made in CB-TB",
  "installMonAgent": "no",
  "label": "custom tag",
  "name": "mcis-test",
  "vm": [
    {
      "connectionName": "aws-ap-southeast-1",
      "description": "Description",
      "idByCsp": "i-095afa0a0b8525fa6",
      "imageId": "string",
      "label": "string",
      "name": "vm01",
      "securityGroupIds": [
        "string"
      ],
      "specId": "string",
      "sshKeyId": "string",
      "subnetId": "string",
      "vNetId": "string",
      "vmUserAccount": "string",
      "vmUserPassword": "string"
    }
  ]
}
```

등록된 이후, 라이프사이클 제어는 확인 완료하였습니다. (suspend, resume, reboot, terminate)


1. POST [​/ns​/{nsId}​/resources​/sshKey]
```
{
  "connectionName": "aws-ap-southeast-1",
  "cspSshKeyId": "ns01-aws--c6d37c67p30lpq4g91r0",
  "description": "test",
  "fingerprint": "test",
  "name": "string",
  "privateKey": "test",
  "publicKey": "test",
  "username": "test",
  "verifiedUsername": "test"
}
```

2. POST [​/ns​/{nsId}​/resources​/vNet]
```
{
  "connectionName": "aws-ap-southeast-1",
  "cspVNetId": "vpc-e4f4d483",
  "name": "vpc-test"
}
```

3. POST [​/ns​/{nsId}​/resources​/securityGroup]
```
{
  "connectionName": "aws-ap-southeast-1",
  "cspSecurityGroupId": "sg-08d70e351cd3c22dd",
  "description": "string",
  "name": "test",
  "vNetId": "vpc-test"
}
```