### PR TITLE
Fix bug on NS prefix of SG name

### DIFF
--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -1290,7 +1290,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo, option string) e
 
 		var SecurityGroupIdsTmp []string
 		for _, v := range vmInfoData.SecurityGroupIds {
-			CspSgId := v //common.GetCspResourceId(nsId, common.StrSecurityGroup, v)
+			CspSgId, err := common.GetCspResourceId(nsId, common.StrSecurityGroup, v)
 			if CspSgId == "" {
 				common.CBLog.Error(err)
 				return err

--- a/src/testclient/scripts/3.vNet/spider-delete-vNet.sh
+++ b/src/testclient/scripts/3.vNet/spider-delete-vNet.sh
@@ -4,7 +4,7 @@ function CallSpider() {
     echo "- Delete vNet in ${MCIRRegionName}"
 
     resp=$(
-        curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' 
+        curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/vpc/$NSID-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' 
     ); echo ${resp} | jq ''
     echo ""
 }

--- a/src/testclient/scripts/3.vNet/spider-get-vNet.sh
+++ b/src/testclient/scripts/3.vNet/spider-get-vNet.sh
@@ -4,7 +4,7 @@ function CallSpider() {
     echo "- Get vNet in ${MCIRRegionName}"
 
     resp=$(
-        curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vpc/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' 
+        curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/vpc/$NSID-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' 
     ); echo ${resp} | jq ''
     echo ""
 }

--- a/src/testclient/scripts/4.securityGroup/spider-delete-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/spider-delete-securityGroup.sh
@@ -3,7 +3,7 @@
 function CallSpider() {
 	echo "- Delete securityGroup in ${MCIRRegionName}"
 
-	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/securitygroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | jq ''
+	curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/securitygroup/$NSID-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | jq ''
 }
 
 #function spider_get_securityGroup() {

--- a/src/testclient/scripts/4.securityGroup/spider-get-securityGroup.sh
+++ b/src/testclient/scripts/4.securityGroup/spider-get-securityGroup.sh
@@ -3,7 +3,7 @@
 function CallSpider() {
 	echo "- Get securityGroup in ${MCIRRegionName}"
 
-	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/securitygroup/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | jq ''
+	curl -H "${AUTH}" -sX GET http://$SpiderServer/spider/securitygroup/$NSID-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} -H 'Content-Type: application/json' -d '{ "ConnectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'"}' | jq ''
 }
 
 #function spider_get_securityGroup() {

--- a/src/testclient/scripts/5.sshKey/spider-delete-sshKey.sh
+++ b/src/testclient/scripts/5.sshKey/spider-delete-sshKey.sh
@@ -4,7 +4,7 @@ function CallSpider() {
     echo "- Delete sshKey in ${MCIRRegionName}"
 
     resp=$(
-        curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/keypair/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d @- <<EOF
+        curl -H "${AUTH}" -sX DELETE http://$SpiderServer/spider/keypair/$NSID-${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true -H 'Content-Type: application/json' -d @- <<EOF
         { 
 			"ConnectionName": "${CONN_CONFIG[$INDEX,$REGION]}"
 		}

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -340,7 +340,7 @@ IY=0
 ProviderName[$IX]=ALIBABA
 DriverLibFileName[$IX]=alibaba-driver-v1.0.so
 DriverName[$IX]=alibaba-driver01
-CommonImage[$IX]=ubuntu_18_04_x64_20G_alibase_20211027.vhd
+CommonImage[$IX]=ubuntu_18_04_x64_20G_alibase_20220208.vhd
 CommonImageType[$IX]="Ubuntu 18.04"
 CommonSpec[$IX]=ecs.t5-lc1m2.large
 


### PR DESCRIPTION
Closes #1051

TB가 SP에 VM 생성을 요청할 때
SG 칸에는 'Spider가 관리하는 SG name' 을 적어야 하는데
이 값은 TB SG object의 `cspSecurityGroupName` 필드에 있습니다.
이 필드의 값을 활용하도록 수정하는 PR입니다.

AWS는 VM 생성 되는 것을 확인했고,

Alibaba에서는 기존에 발생하던 `[aws-ap-southeast-1:aws-ap-southeast-1-jhseo:aws-ap-southeast-1-jhseo]` 와 같은 에러는 발생하지 않는 것을 확인했습니다.
(다만, 다른 에러인 `The resource in the specified zone is no longer available for sale. Please try other regions and zones.` 에러가 발생하여 VM 생성까지는 가지 못했음) (https://github.com/cloud-barista/cb-tumblebug/pull/974#issuecomment-1080115907)