### PR TITLE
Register all CSP resources to CB-TB objs

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -330,7 +330,7 @@ func RestDeleteObjects(c echo.Context) error {
 
 // Request struct for RestInspectResources
 type RestInspectResourcesRequest struct {
-	ConnectionName string `json:"connectionName"`
+	ConnectionName string `json:"connectionName" example:"aws-ap-southeast-1"`
 	Type           string `json:"type" example:"vNet" enums:"vNet,securityGroup,sshKey,vm"`
 }
 
@@ -363,6 +363,43 @@ func RestInspectResources(c echo.Context) error {
 	// 	content, err = mcis.InspectVMs(u.ConnectionName)
 	// }
 	content, err = mcis.InspectResources(u.ConnectionName, u.Type)
+
+	if err != nil {
+		common.CBLog.Error(err)
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(http.StatusInternalServerError, &mapA)
+	}
+
+	return c.JSON(http.StatusOK, &content)
+
+}
+
+// Request struct for RestRegisterCspNativeResources
+type RestRegisterCspNativeResourcesRequest struct {
+	ConnectionName string `json:"connectionName" example:"aws-ap-southeast-1"`
+	NsId           string `json:"nsId" example:"ns01"`
+	McisName       string `json:"mcisName" example:"mcis-csp-native"`
+}
+
+// RestRegisterCspNativeResources godoc
+// @Summary Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to CB-Tumblebug
+// @Description Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to CB-Tumblebug
+// @Tags [Admin] System management
+// @Accept  json
+// @Produce  json
+// @Param Request body RestRegisterCspNativeResourcesRequest true "Specify connectionName and NS Id"
+// @Success 200 {object} mcis.InspectResource
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /registerCspResources [post]
+func RestRegisterCspNativeResources(c echo.Context) error {
+
+	u := &RestRegisterCspNativeResourcesRequest{}
+	if err := c.Bind(u); err != nil {
+		return err
+	}
+
+	content, err := mcis.RegisterCspNativeResources(u.NsId, u.ConnectionName, u.McisName)
 
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -129,6 +129,7 @@ func RunServer(port string) {
 	e.POST("/tumblebug/lookupImage", rest_mcir.RestLookupImage)
 
 	e.POST("/tumblebug/inspectResources", rest_common.RestInspectResources)
+	e.POST("/tumblebug/registerCspResources", rest_common.RestRegisterCspNativeResources)
 
 	// @Tags [Admin] System environment
 	e.POST("/tumblebug/config", rest_common.RestPostConfig)

--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -165,12 +165,31 @@ func CreateSecurityGroup(nsId string, u *TbSecurityGroupReq, option string) (TbS
 		return content, err
 	}
 
+	// TODO: Need to be improved
+	// Avoid retrieving vNet info if option == register
+	// Assign random temporal ID to u.VNetId
+	if option == "register" {
+		resourceIdList, err := ListResourceId(nsId, common.StrVNet)
+		if err != nil {
+			common.CBLog.Error(err)
+			err := fmt.Errorf("Cannot ListResourceId securityGroup")
+			return TbSecurityGroupInfo{}, err
+		}
+		if len(resourceIdList) == 0 {
+			errString := "There is no " + common.StrVNet + " resource in " + nsId
+			err := fmt.Errorf(errString)
+			common.CBLog.Error(err)
+			return TbSecurityGroupInfo{}, err
+		}
+		u.VNetId = resourceIdList[0]
+	}
+
+	vNetInfo := TbVNetInfo{}
 	tempInterface, err := GetResource(nsId, common.StrVNet, u.VNetId)
 	if err != nil {
 		err := fmt.Errorf("Failed to get the TbVNetInfo " + u.VNetId + ".")
 		return TbSecurityGroupInfo{}, err
 	}
-	vNetInfo := TbVNetInfo{}
 	err = common.CopySrcToDest(&tempInterface, &vNetInfo)
 	if err != nil {
 		err := fmt.Errorf("Failed to get the TbVNetInfo-CopySrcToDest() " + u.VNetId + ".")


### PR DESCRIPTION
Foundation for #1055

POST ​`/registerCspResources` 
> Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to CB-Tumblebug

Request body ex

> {
>   "connectionName": "aws-ap-northeast-2",
>   "mcisName": "mcis-csp-native",
>   "nsId": "ns01"
> }

해당 클라우드 리전에 포함된 리소스를
vNet -> SG -> SSHKey -> VM 순서로 CB-TB의 오브젝트로 등록시킴.

[보완 필요 부분]
 - API return body 구조 개선
 - 자원간 연관관계 및 자원 정보 재구축 필요 (일부 가능한 항목만)
 - SG 등록 관련 임의의 값 임시 지정한 항목 개선 필요 (https://github.com/cloud-barista/cb-tumblebug/issues/1055#issuecomment-1112540552)
 - 모든 connectionConfig 를 기준으로 등록하는 스크립트 추가 (아마도 기능으로 개발할 필요는 없을 듯..)
