### PR TITLE
Change struct for inspectResources and registerCspResources with Err fix

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -331,7 +331,7 @@ func RestDeleteObjects(c echo.Context) error {
 // Request struct for RestInspectResources
 type RestInspectResourcesRequest struct {
 	ConnectionName string `json:"connectionName" example:"aws-ap-southeast-1"`
-	Type           string `json:"type" example:"vNet" enums:"vNet,securityGroup,sshKey,vm"`
+	ResourceType   string `json:"resourceType" example:"vNet" enums:"vNet,securityGroup,sshKey,vm"`
 }
 
 // RestInspectResources godoc
@@ -354,7 +354,7 @@ func RestInspectResources(c echo.Context) error {
 		return err
 	}
 
-	fmt.Printf("[List Resource Status: %s]", u.Type)
+	fmt.Printf("[List Resource Status: %s]", u.ResourceType)
 	var content interface{}
 	var err error
 	// if u.Type == common.StrVNet || u.Type == common.StrSecurityGroup || u.Type == common.StrSSHKey {
@@ -362,7 +362,7 @@ func RestInspectResources(c echo.Context) error {
 	// } else if u.Type == "vm" {
 	// 	content, err = mcis.InspectVMs(u.ConnectionName)
 	// }
-	content, err = mcis.InspectResources(u.ConnectionName, u.Type)
+	content, err = mcis.InspectResources(u.ConnectionName, u.ResourceType)
 
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -388,7 +388,7 @@ type RestRegisterCspNativeResourcesRequest struct {
 // @Accept  json
 // @Produce  json
 // @Param Request body RestRegisterCspNativeResourcesRequest true "Specify connectionName and NS Id"
-// @Success 200 {object} mcis.InspectResource
+// @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /registerCspResources [post]

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -565,7 +565,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 	for _, r := range inspectedResources.ResourcesOnCspOnly {
 		req := mcir.TbSecurityGroupReq{}
 		req.ConnectionName = connConfig
-		req.VNetId = "not-defined-yet"
+		req.VNetId = "not defined"
 		req.CspSecurityGroupId = r.IdByCsp
 		req.Description = "Ref name: " + r.RefNameOrId + ". CSP managed resource (registered to CB-TB)"
 		req.Name = req.ConnectionName + "-" + req.CspSecurityGroupId

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -279,26 +279,31 @@ type InspectResource struct {
 	// ResourcesOnSpider    interface{} `json:"resourcesOnSpider"`
 	// ResourcesOnTumblebug interface{} `json:"resourcesOnTumblebug"`
 
-	ConnectionName       string                  `json:"connectionName"`
-	SystemMessage        string                  `json:"systemMessage"`
-	ResourcesOnTumblebug []resourceOnTumblebug   `json:"resourcesOnTumblebug"`
-	ResourcesOnSpider    []resourceOnCspOrSpider `json:"resourcesOnSpider"`
-	ResourcesOnCsp       []resourceOnCspOrSpider `json:"resourcesOnCsp"`
-	ResourcesOnCspOnly   []resourceOnCspOrSpider `json:"resourcesOnCspOnly"`
+	ConnectionName       string                `json:"connectionName"`
+	ResourceType         string                `json:"resourceType"`
+	SystemMessage        string                `json:"systemMessage"`
+	ResourcesOnTumblebug []resourceOnTumblebug `json:"resourcesOnTumblebug"`
+	ResourcesOnSpider    []resourceOnSpider    `json:"resourcesOnSpider"`
+	ResourcesOnCsp       []resourceOnCsp       `json:"resourcesOnCsp"`
+	ResourcesOnCspOnly   []resourceOnCsp       `json:"resourcesOnCspOnly"`
 }
 
-type resourceOnCspOrSpider struct {
-	Id          string `json:"id"`
-	CspNativeId string `json:"cspNativeId"`
+type resourceOnSpider struct {
+	IdBySp  string `json:"idBySp"`
+	IdByCsp string `json:"idByCsp"`
+}
+
+type resourceOnCsp struct {
+	IdByCsp     string `json:"idByCsp"`
+	RefNameOrId string `json:"refNameOrId"`
 }
 
 type resourceOnTumblebug struct {
-	Id          string `json:"id"`
-	CspNativeId string `json:"cspNativeId"`
-	NsId        string `json:"nsId"`
-	McisId      string `json:"mcisId"`
-	Type        string `json:"type"`
-	ObjectKey   string `json:"objectKey"`
+	IdByTb    string `json:"idByTb"`
+	IdByCsp   string `json:"idByCsp"`
+	NsId      string `json:"nsId"`
+	McisId    string `json:"mcisId,omitempty"`
+	ObjectKey string `json:"objectKey"`
 }
 
 // InspectResources returns the state list of TB MCIR objects of given connConfig and resourceType
@@ -342,11 +347,10 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 
 					if vm.ConnectionName == connConfig { // filtering
 						temp := resourceOnTumblebug{}
-						temp.Id = vm.Id
-						temp.CspNativeId = vm.CspViewVmDetail.IId.SystemId
+						temp.IdByTb = vm.Id
+						temp.IdByCsp = vm.CspViewVmDetail.IId.SystemId
 						temp.NsId = ns
 						temp.McisId = mcis
-						temp.Type = "vm"
 						temp.ObjectKey = common.GenMcisKey(ns, mcis, vm.Id)
 
 						TbResourceList = append(TbResourceList, temp)
@@ -367,11 +371,9 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
 					temp := resourceOnTumblebug{}
-					temp.Id = resource.Id
-					temp.CspNativeId = resource.CspVNetId
+					temp.IdByTb = resource.Id
+					temp.IdByCsp = resource.CspVNetId
 					temp.NsId = ns
-					//temp.McisId = ""
-					temp.Type = resourceType
 					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
 					TbResourceList = append(TbResourceList, temp)
@@ -391,11 +393,9 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
 					temp := resourceOnTumblebug{}
-					temp.Id = resource.Id
-					temp.CspNativeId = resource.CspSecurityGroupId
+					temp.IdByTb = resource.Id
+					temp.IdByCsp = resource.CspSecurityGroupId
 					temp.NsId = ns
-					//temp.McisId = ""
-					temp.Type = resourceType
 					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
 					TbResourceList = append(TbResourceList, temp)
@@ -415,11 +415,9 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
 					temp := resourceOnTumblebug{}
-					temp.Id = resource.Id
-					temp.CspNativeId = resource.CspSshKeyName
+					temp.IdByTb = resource.Id
+					temp.IdByCsp = resource.CspSshKeyName
 					temp.NsId = ns
-					//temp.McisId = ""
-					temp.Type = resourceType
 					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
 					TbResourceList = append(TbResourceList, temp)
@@ -486,40 +484,42 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 	*/
 	// Implementation style 2
 	result.ConnectionName = connConfig
+	result.ResourceType = resourceType
 
 	result.ResourcesOnTumblebug = []resourceOnTumblebug{}
 	result.ResourcesOnTumblebug = append(result.ResourcesOnTumblebug, TbResourceList...)
 
 	// result.ResourcesOnCsp = append((*temp).AllList.MappedList, (*temp).AllList.OnlyCSPList...)
 	// result.ResourcesOnSpider = append((*temp).AllList.MappedList, (*temp).AllList.OnlySpiderList...)
-	result.ResourcesOnSpider = []resourceOnCspOrSpider{}
-	result.ResourcesOnCsp = []resourceOnCspOrSpider{}
-	result.ResourcesOnCspOnly = []resourceOnCspOrSpider{}
+	result.ResourcesOnSpider = []resourceOnSpider{}
+	result.ResourcesOnCsp = []resourceOnCsp{}
+	result.ResourcesOnCspOnly = []resourceOnCsp{}
+
+	tmpResourceOnSpider := resourceOnSpider{}
+	tmpResourceOnCsp := resourceOnCsp{}
 
 	for _, v := range (*temp).AllList.MappedList {
-		tmpObj := resourceOnCspOrSpider{}
-		tmpObj.Id = v.NameId
-		tmpObj.CspNativeId = v.SystemId
+		tmpResourceOnSpider.IdBySp = v.NameId
+		tmpResourceOnSpider.IdByCsp = v.SystemId
+		result.ResourcesOnSpider = append(result.ResourcesOnSpider, tmpResourceOnSpider)
 
-		result.ResourcesOnCsp = append(result.ResourcesOnCsp, tmpObj)
-		result.ResourcesOnSpider = append(result.ResourcesOnSpider, tmpObj)
+		tmpResourceOnCsp.IdByCsp = v.SystemId
+		tmpResourceOnCsp.RefNameOrId = v.NameId
+		result.ResourcesOnCsp = append(result.ResourcesOnCsp, tmpResourceOnCsp)
 	}
 
 	for _, v := range (*temp).AllList.OnlySpiderList {
-		tmpObj := resourceOnCspOrSpider{}
-		tmpObj.Id = v.NameId
-		tmpObj.CspNativeId = v.SystemId
-
-		result.ResourcesOnSpider = append(result.ResourcesOnSpider, tmpObj)
+		tmpResourceOnSpider.IdBySp = v.NameId
+		tmpResourceOnSpider.IdByCsp = v.SystemId
+		result.ResourcesOnSpider = append(result.ResourcesOnSpider, tmpResourceOnSpider)
 	}
 
 	for _, v := range (*temp).AllList.OnlyCSPList {
-		tmpObj := resourceOnCspOrSpider{}
-		tmpObj.Id = v.NameId
-		tmpObj.CspNativeId = v.SystemId
+		tmpResourceOnCsp.IdByCsp = v.SystemId
+		tmpResourceOnCsp.RefNameOrId = v.NameId
 
-		result.ResourcesOnCsp = append(result.ResourcesOnCsp, tmpObj)
-		result.ResourcesOnCspOnly = append(result.ResourcesOnCspOnly, tmpObj)
+		result.ResourcesOnCsp = append(result.ResourcesOnCsp, tmpResourceOnCsp)
+		result.ResourcesOnCspOnly = append(result.ResourcesOnCspOnly, tmpResourceOnCsp)
 	}
 
 	return result, nil
@@ -539,8 +539,8 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 	for _, r := range inspectedResources.ResourcesOnCspOnly {
 		req := mcir.TbVNetReq{}
 		req.ConnectionName = connConfig
-		req.CspVNetId = r.CspNativeId
-		req.Description = "CSP managed resource (registered to CB-TB)"
+		req.CspVNetId = r.IdByCsp
+		req.Description = "Ref name: " + r.RefNameOrId + ". CSP managed resource (registered to CB-TB)"
 		req.Name = req.ConnectionName + "-" + req.CspVNetId
 
 		_, err = mcir.CreateVNet(nsId, &req, optionFlag)
@@ -559,8 +559,8 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 		req := mcir.TbSecurityGroupReq{}
 		req.ConnectionName = connConfig
 		req.VNetId = "not-defined-yet"
-		req.CspSecurityGroupId = r.CspNativeId
-		req.Description = "CSP managed resource (registered to CB-TB)"
+		req.CspSecurityGroupId = r.IdByCsp
+		req.Description = "Ref name: " + r.RefNameOrId + ". CSP managed resource (registered to CB-TB)"
 		req.Name = req.ConnectionName + "-" + req.CspSecurityGroupId
 		_, err = mcir.CreateSecurityGroup(nsId, &req, optionFlag)
 		if err != nil {
@@ -577,8 +577,8 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 	for _, r := range inspectedResources.ResourcesOnCspOnly {
 		req := mcir.TbSshKeyReq{}
 		req.ConnectionName = connConfig
-		req.CspSshKeyId = r.CspNativeId
-		req.Description = "CSP managed resource (registered to CB-TB)"
+		req.CspSshKeyId = r.IdByCsp
+		req.Description = "Ref name: " + r.RefNameOrId + ". CSP managed resource (registered to CB-TB)"
 		req.Name = req.ConnectionName + "-" + req.CspSshKeyId
 
 		req.Fingerprint = "cannot retrieve"
@@ -606,8 +606,8 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 
 		vm := TbVmReq{}
 		vm.ConnectionName = connConfig
-		vm.Description = "CSP managed resource (registered to CB-TB)"
-		vm.IdByCSP = r.CspNativeId
+		vm.IdByCSP = r.IdByCsp
+		vm.Description = "Ref name: " + r.RefNameOrId + ". CSP managed VM (registered to CB-TB)"
 		vm.Name = vm.ConnectionName + "-" + vm.IdByCSP
 		vm.Label = "not defined"
 


### PR DESCRIPTION
## 1. 출력 구조 개선 (inspectResources)

idByTb, idBySp, idByCsp, refNameOrId 등으로 id 표기 명확화.

[요청]
POST ​/inspectResources
(Inspect Resources (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug, CB-Spider, CSP)

```
{
  "connectionName": "aws-ap-southeast-1",
  "resourceType": "vNet"
}
```

[출력] 등록된 리로스 아이디 리스트 (등록 실패한 리소스가 있는 경우, 해당 항목의 스트링에 실패 메시지가 포함)
```
{
  "connectionName": "aws-ap-southeast-1",
  "resourceType": "vNet",
  "systemMessage": "",
  "resourcesOnTumblebug": [
    {
      "idByTb": "aws-ap-southeast-1-shson",
      "idByCsp": "vpc-0a3291546ba7bc123",
      "nsId": "ns01",
      "objectKey": "/ns/ns01/resources/vNet/aws-ap-southeast-1-shson"
    }
  ],
  "resourcesOnSpider": [
    {
      "idBySp": "ns01-aws-ap-southeast-1-shson",
      "idByCsp": "vpc-0a3291546ba7bc123"
    }
  ],
  "resourcesOnCsp": [
    {
      "idByCsp": "vpc-0a3291546ba7bc123",
      "refNameOrId": "ns01-aws-ap-southeast-1-shson"
    },
    {
      "idByCsp": "vpc-0d66c5d1321877a3b",
      "refNameOrId": "aws-ap-southeast-1"
    },
    {
      "idByCsp": "vpc-0757c665436c8f276",
      "refNameOrId": "e1-aws-ap-c6au8hd434207t772j5g"
    },
...
    {
      "idByCsp": "vpc-0dbc2796370f73912",
      "refNameOrId": "e1-aws-ap-c5psb8543424jhjo396g"
    }
  ],
  "resourcesOnCspOnly": [
    {
      "idByCsp": "vpc-0d66c5d1321877a3b",
      "refNameOrId": "aws-ap-southeast-1"
    },
    {
      "idByCsp": "vpc-0757c665436c8f276",
      "refNameOrId": "e1-aws-ap-c6au8hd434207t772j5g"
    },
    {
      "idByCsp": "vpc-0c5ac338023c4108d",
      "refNameOrId": "ns01-aws--c6ff8o8vn0pcottrcho0"
    },
...
    {
      "idByCsp": "vpc-0adb418b3b621b080",
      "refNameOrId": "ns01-aws--c8t761g9ih7nmfkhocr0"
    },
    {
      "idByCsp": "vpc-0f5c4a299ef3e63ee",
      "refNameOrId": "aws-ap-southeast-1"
    },
    {
      "idByCsp": "vpc-0dbc2796370f73912",
      "refNameOrId": "e1-aws-ap-c5psb8543424jhjo396g"
    }
  ]
}
```

## 2. 출력 구조 개선 (registerCspResources)

출력값으로 등록된 리소스 아이디 리스트 및 등록 상태 정보 제공

[요청]
POST ​/registerCspResources
(Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to CB-Tumblebug)

```
{
  "connectionName": "aws-ap-southeast-1",
  "mcisName": "mcis-csp-native",
  "nsId": "ns01"
}
```

[출력] 등록된 리소스 아이디 리스트 (등록 실패한 리소스가 있는 경우, 해당 항목의 스트링에 실패 메시지가 포함)
```
{
  "output": [
    "vNet: aws-ap-southeast-1-vpc-0d66c5d1321877a3b",
    "vNet: aws-ap-southeast-1-vpc-0757c665436c8f276",
    "vNet: aws-ap-southeast-1-vpc-0c5ac338023c4108d",
    "vNet: aws-ap-southeast-1-vpc-01898d54949ed51eb",
    "vNet: aws-ap-southeast-1-vpc-03e4610d8a4e151e7",
...
    "vNet: aws-ap-southeast-1-vpc-049e173cfe142322e",
    "vNet: aws-ap-southeast-1-vpc-031f3b02839cfdcaf",
    "vNet: aws-ap-southeast-1-vpc-e4f4d483",
    "vNet: aws-ap-southeast-1-vpc-0adb418b3b621b080",
    "vNet: aws-ap-southeast-1-vpc-0f5c4a299ef3e63ee",
    "vNet: aws-ap-southeast-1-vpc-0dbc2796370f73912",
    "securityGroup: aws-ap-southeast-1-sg-0058aa4f3572d7c7a",
    "securityGroup: aws-ap-southeast-1-sg-00a7a86a694c84f67",
    "securityGroup: aws-ap-southeast-1-sg-0133a3f9272db6ccf",
    "securityGroup: aws-ap-southeast-1-sg-0240cf26a5f9fdf4a",
    "securityGroup: aws-ap-southeast-1-sg-02a85f75655e96494",
    "securityGroup: aws-ap-southeast-1-sg-034618cf40232dee6",
    "securityGroup: aws-ap-southeast-1-sg-03d318e3ef10a9e68",
...
    "securityGroup: aws-ap-southeast-1-sg-0f5fb44e63da68a2f",
    "securityGroup: aws-ap-southeast-1-sg-0feffc5f6d0254c6e",
    "securityGroup: aws-ap-southeast-1-sg-b0c220cb",
    "sshKey: aws-ap-southeast-1-etcd-host-aws",
    "sshKey: aws-ap-southeast-1-k8s-test-kimy-aws",
    "sshKey: aws-ap-southeast-1-aws-ap-southeast-1",
    "sshKey: aws-ap-southeast-1-e1-aws-ap-c5psb8t43424jhjo3980",
...
    "sshKey: aws-ap-southeast-1-ns01-aws-ap-southeast-1-jhseo-c90o97t6qs8c0lm7ori0",
    "sshKey: aws-ap-southeast-1-ns01-aws-ap-southeast-1-yk0-c91rqbatiahu4g621ju0",
    "sshKey: aws-ap-southeast-1-ns01-aws--c9fsnmcdss6vnm1747s0",
    "sshKey: aws-ap-southeast-1-ns01-aws-ap-southeast-1-yk1net-c9kiqgkb8khu9chfogn0",
    "vm: aws-ap-southeast-1-i-014fa6ede6ada0b2c",
    "vm: aws-ap-southeast-1-i-0c2d783dd905dd372",
    "vm: aws-ap-southeast-1-i-06ea9ba67b3bcff93"
  ]
}
```

## 3. SG 전체 등록 오류 수정

SG 등록시, vNet ID가 필요함. 기존에는 임의의 vNet ID를 지정하였으나, 

적어도 connection이 동일한 vNet의 ID를 지정해야 하는 것을 확인함.

임의의 vNet 지정시 동일한 등록할 SG와 동일한 connection을 가진 vNet을 지정하도록 코드 수정.

