### PR TITLE
Add overview to inspect resources and registerCspResources for all connectionConfigs

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -388,7 +388,7 @@ type RestRegisterCspNativeResourcesRequest struct {
 // @Accept  json
 // @Produce  json
 // @Param Request body RestRegisterCspNativeResourcesRequest true "Specify connectionName and NS Id"
-// @Success 200 {object} common.IdList
+// @Success 200 {object} mcis.RegisterResourceResult
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /registerCspResources [post]
@@ -400,6 +400,36 @@ func RestRegisterCspNativeResources(c echo.Context) error {
 	}
 
 	content, err := mcis.RegisterCspNativeResources(u.NsId, u.ConnectionName, u.McisName)
+
+	if err != nil {
+		common.CBLog.Error(err)
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(http.StatusInternalServerError, &mapA)
+	}
+
+	return c.JSON(http.StatusOK, &content)
+
+}
+
+// RestRegisterCspNativeResourcesAll godoc
+// @Summary Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug
+// @Description Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug
+// @Tags [Admin] System management
+// @Accept  json
+// @Produce  json
+// @Param Request body RestRegisterCspNativeResourcesRequest true "Specify NS Id and MCIS Name"
+// @Success 200 {object} mcis.RegisterResourceAllResult
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /registerCspResourcesAll [post]
+func RestRegisterCspNativeResourcesAll(c echo.Context) error {
+
+	u := &RestRegisterCspNativeResourcesRequest{}
+	if err := c.Bind(u); err != nil {
+		return err
+	}
+
+	content, err := mcis.RegisterCspNativeResourcesAll(u.NsId, u.McisName)
 
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -130,6 +130,7 @@ func RunServer(port string) {
 
 	e.POST("/tumblebug/inspectResources", rest_common.RestInspectResources)
 	e.POST("/tumblebug/registerCspResources", rest_common.RestRegisterCspNativeResources)
+	e.POST("/tumblebug/registerCspResourcesAll", rest_common.RestRegisterCspNativeResourcesAll)
 
 	// @Tags [Admin] System environment
 	e.POST("/tumblebug/config", rest_common.RestPostConfig)

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -279,26 +279,53 @@ type InspectResource struct {
 	// ResourcesOnSpider    interface{} `json:"resourcesOnSpider"`
 	// ResourcesOnTumblebug interface{} `json:"resourcesOnTumblebug"`
 
-	ConnectionName       string                `json:"connectionName"`
-	ResourceType         string                `json:"resourceType"`
-	SystemMessage        string                `json:"systemMessage"`
-	ResourcesOnTumblebug []resourceOnTumblebug `json:"resourcesOnTumblebug"`
-	ResourcesOnSpider    []resourceOnSpider    `json:"resourcesOnSpider"`
-	ResourcesOnCsp       []resourceOnCsp       `json:"resourcesOnCsp"`
-	ResourcesOnCspOnly   []resourceOnCsp       `json:"resourcesOnCspOnly"`
+	ConnectionName   string                `json:"connectionName"`
+	ResourceType     string                `json:"resourceType"`
+	SystemMessage    string                `json:"systemMessage"`
+	ResourceOverview resourceCountOverview `json:"resourceOverview"`
+	Resources        resourcesByManageType `json:"resources"`
+}
+
+type resourceCountOverview struct {
+	OnTumblebug int `json:"onTumblebug"`
+	OnSpider    int `json:"onSpider"`
+	OnCspTotal  int `json:"onCspTotal"`
+	OnCspOnly   int `json:"onCspOnly"`
+}
+
+type resourcesByManageType struct {
+	OnTumblebug resourceOnTumblebug `json:"onTumblebug"`
+	OnSpider    resourceOnSpider    `json:"onSpider"`
+	OnCspTotal  resourceOnCsp       `json:"onCspTotal"`
+	OnCspOnly   resourceOnCsp       `json:"onCspOnly"`
 }
 
 type resourceOnSpider struct {
+	Count int                    `json:"count"`
+	Info  []resourceOnSpiderInfo `json:"info"`
+}
+
+type resourceOnSpiderInfo struct {
 	IdBySp  string `json:"idBySp"`
 	IdByCsp string `json:"idByCsp"`
 }
 
 type resourceOnCsp struct {
+	Count int                 `json:"count"`
+	Info  []resourceOnCspInfo `json:"info"`
+}
+
+type resourceOnCspInfo struct {
 	IdByCsp     string `json:"idByCsp"`
 	RefNameOrId string `json:"refNameOrId"`
 }
 
 type resourceOnTumblebug struct {
+	Count int                       `json:"count"`
+	Info  []resourceOnTumblebugInfo `json:"info"`
+}
+
+type resourceOnTumblebugInfo struct {
 	IdByTb    string `json:"idByTb"`
 	IdByCsp   string `json:"idByCsp"`
 	NsId      string `json:"nsId"`
@@ -317,7 +344,7 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 		return nullObj, err
 	}
 	// var TbResourceList []string
-	var TbResourceList []resourceOnTumblebug
+	TbResourceList := resourceOnTumblebug{}
 	for _, ns := range nsList {
 
 		// Bring TB resources
@@ -337,6 +364,7 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 				if vmListInMcis == nil {
 					continue
 				}
+
 				for _, vmId := range vmListInMcis {
 					vm, err := GetVmObject(ns, mcis, vmId)
 					if err != nil {
@@ -346,14 +374,14 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 					}
 
 					if vm.ConnectionName == connConfig { // filtering
-						temp := resourceOnTumblebug{}
+						temp := resourceOnTumblebugInfo{}
 						temp.IdByTb = vm.Id
 						temp.IdByCsp = vm.CspViewVmDetail.IId.SystemId
 						temp.NsId = ns
 						temp.McisId = mcis
 						temp.ObjectKey = common.GenMcisKey(ns, mcis, vm.Id)
 
-						TbResourceList = append(TbResourceList, temp)
+						TbResourceList.Info = append(TbResourceList.Info, temp)
 					}
 				}
 			}
@@ -370,13 +398,13 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 			resourcesInNs := resourceListInNs.([]mcir.TbVNetInfo) // type assertion
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
-					temp := resourceOnTumblebug{}
+					temp := resourceOnTumblebugInfo{}
 					temp.IdByTb = resource.Id
 					temp.IdByCsp = resource.CspVNetId
 					temp.NsId = ns
 					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
-					TbResourceList = append(TbResourceList, temp)
+					TbResourceList.Info = append(TbResourceList.Info, temp)
 				}
 			}
 		case common.StrSecurityGroup:
@@ -392,13 +420,13 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 			resourcesInNs := resourceListInNs.([]mcir.TbSecurityGroupInfo) // type assertion
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
-					temp := resourceOnTumblebug{}
+					temp := resourceOnTumblebugInfo{}
 					temp.IdByTb = resource.Id
 					temp.IdByCsp = resource.CspSecurityGroupId
 					temp.NsId = ns
 					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
-					TbResourceList = append(TbResourceList, temp)
+					TbResourceList.Info = append(TbResourceList.Info, temp)
 				}
 			}
 		case common.StrSSHKey:
@@ -414,13 +442,13 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 			resourcesInNs := resourceListInNs.([]mcir.TbSshKeyInfo) // type assertion
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
-					temp := resourceOnTumblebug{}
+					temp := resourceOnTumblebugInfo{}
 					temp.IdByTb = resource.Id
 					temp.IdByCsp = resource.CspSshKeyName
 					temp.NsId = ns
 					temp.ObjectKey = common.GenResourceKey(ns, resourceType, resource.Id)
 
-					TbResourceList = append(TbResourceList, temp)
+					TbResourceList.Info = append(TbResourceList.Info, temp)
 				}
 			}
 		}
@@ -486,41 +514,51 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 	result.ConnectionName = connConfig
 	result.ResourceType = resourceType
 
-	result.ResourcesOnTumblebug = []resourceOnTumblebug{}
-	result.ResourcesOnTumblebug = append(result.ResourcesOnTumblebug, TbResourceList...)
+	result.Resources.OnTumblebug = TbResourceList
+	//result.ResourcesOnTumblebug.Info = append(result.ResourcesOnTumblebug.Info, TbResourceList...)
 
 	// result.ResourcesOnCsp = append((*temp).AllList.MappedList, (*temp).AllList.OnlyCSPList...)
 	// result.ResourcesOnSpider = append((*temp).AllList.MappedList, (*temp).AllList.OnlySpiderList...)
-	result.ResourcesOnSpider = []resourceOnSpider{}
-	result.ResourcesOnCsp = []resourceOnCsp{}
-	result.ResourcesOnCspOnly = []resourceOnCsp{}
+	result.Resources.OnSpider = resourceOnSpider{}
+	result.Resources.OnCspTotal = resourceOnCsp{}
+	result.Resources.OnCspOnly = resourceOnCsp{}
 
-	tmpResourceOnSpider := resourceOnSpider{}
-	tmpResourceOnCsp := resourceOnCsp{}
+	tmpResourceOnSpider := resourceOnSpiderInfo{}
+	tmpResourceOnCsp := resourceOnCspInfo{}
 
 	for _, v := range (*temp).AllList.MappedList {
 		tmpResourceOnSpider.IdBySp = v.NameId
 		tmpResourceOnSpider.IdByCsp = v.SystemId
-		result.ResourcesOnSpider = append(result.ResourcesOnSpider, tmpResourceOnSpider)
+		result.Resources.OnSpider.Info = append(result.Resources.OnSpider.Info, tmpResourceOnSpider)
 
 		tmpResourceOnCsp.IdByCsp = v.SystemId
 		tmpResourceOnCsp.RefNameOrId = v.NameId
-		result.ResourcesOnCsp = append(result.ResourcesOnCsp, tmpResourceOnCsp)
+		result.Resources.OnCspTotal.Info = append(result.Resources.OnCspTotal.Info, tmpResourceOnCsp)
 	}
 
 	for _, v := range (*temp).AllList.OnlySpiderList {
 		tmpResourceOnSpider.IdBySp = v.NameId
 		tmpResourceOnSpider.IdByCsp = v.SystemId
-		result.ResourcesOnSpider = append(result.ResourcesOnSpider, tmpResourceOnSpider)
+		result.Resources.OnSpider.Info = append(result.Resources.OnSpider.Info, tmpResourceOnSpider)
 	}
 
 	for _, v := range (*temp).AllList.OnlyCSPList {
 		tmpResourceOnCsp.IdByCsp = v.SystemId
 		tmpResourceOnCsp.RefNameOrId = v.NameId
 
-		result.ResourcesOnCsp = append(result.ResourcesOnCsp, tmpResourceOnCsp)
-		result.ResourcesOnCspOnly = append(result.ResourcesOnCspOnly, tmpResourceOnCsp)
+		result.Resources.OnCspTotal.Info = append(result.Resources.OnCspTotal.Info, tmpResourceOnCsp)
+		result.Resources.OnCspOnly.Info = append(result.Resources.OnCspOnly.Info, tmpResourceOnCsp)
 	}
+
+	// Count resources
+	result.Resources.OnTumblebug.Count = len(result.Resources.OnTumblebug.Info)
+	result.Resources.OnSpider.Count = len(result.Resources.OnSpider.Info)
+	result.Resources.OnCspTotal.Count = len(result.Resources.OnCspTotal.Info)
+	result.Resources.OnCspOnly.Count = len(result.Resources.OnCspOnly.Info)
+	result.ResourceOverview.OnTumblebug = result.Resources.OnTumblebug.Count
+	result.ResourceOverview.OnSpider = result.Resources.OnSpider.Count
+	result.ResourceOverview.OnCspTotal = result.Resources.OnCspTotal.Count
+	result.ResourceOverview.OnCspOnly = result.Resources.OnCspOnly.Count
 
 	return result, nil
 }
@@ -538,7 +576,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 		common.CBLog.Error(err)
 		return common.IdList{}, err
 	}
-	for _, r := range inspectedResources.ResourcesOnCspOnly {
+	for _, r := range inspectedResources.Resources.OnCspOnly.Info {
 		req := mcir.TbVNetReq{}
 		req.ConnectionName = connConfig
 		req.CspVNetId = r.IdByCsp
@@ -562,7 +600,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 		common.CBLog.Error(err)
 		return common.IdList{}, err
 	}
-	for _, r := range inspectedResources.ResourcesOnCspOnly {
+	for _, r := range inspectedResources.Resources.OnCspOnly.Info {
 		req := mcir.TbSecurityGroupReq{}
 		req.ConnectionName = connConfig
 		req.VNetId = "not defined"
@@ -587,7 +625,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 		common.CBLog.Error(err)
 		return common.IdList{}, err
 	}
-	for _, r := range inspectedResources.ResourcesOnCspOnly {
+	for _, r := range inspectedResources.Resources.OnCspOnly.Info {
 		req := mcir.TbSshKeyReq{}
 		req.ConnectionName = connConfig
 		req.CspSshKeyId = r.IdByCsp
@@ -616,7 +654,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string) (
 		common.CBLog.Error(err)
 		return common.IdList{}, err
 	}
-	for _, r := range inspectedResources.ResourcesOnCspOnly {
+	for _, r := range inspectedResources.Resources.OnCspOnly.Info {
 		req := TbMcisReq{}
 		req.Description = "MCIS for CSP managed VMs (registered to CB-TB)"
 		req.InstallMonAgent = "no"


### PR DESCRIPTION
1. inspect resources 에 대략적인 리소스 현황을 표시

POST ​/inspectResources
Inspect Resources (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug, CB-Spider, CSP


```
{
  "connectionName": "aws-ap-southeast-1",
  "resourceType": "vm",
  "systemMessage": "",
  "resourceOverview": {
    "onTumblebug": 0,
    "onSpider": 0,
    "onCspTotal": 3,
    "onCspOnly": 3
  },
  "resources": {
    "onTumblebug": {
      "count": 0,
      "info": null
    },
    "onSpider": {
      "count": 0,
      "info": null
    },
    "onCspTotal": {
      "count": 3,
      "info": [
        {
          "idByCsp": "i-014fa6ede6ada0b2c",
          "refNameOrId": "kimy-etcd-host-aws"
        },
        {
          "idByCsp": "i-0c2d783dd905dd372",
          "refNameOrId": "kimy-agent-ubuntu"
        },
        {
          "idByCsp": "i-06ea9ba67b3bcff93",
          "refNameOrId": "kimy-agent-centos"
        }
      ]
    },
    "onCspOnly": {
      "count": 3,
      "info": [
        {
          "idByCsp": "i-014fa6ede6ada0b2c",
          "refNameOrId": "kimy-etcd-host-aws"
        },
        {
          "idByCsp": "i-0c2d783dd905dd372",
          "refNameOrId": "kimy-agent-ubuntu"
        },
        {
          "idByCsp": "i-06ea9ba67b3bcff93",
          "refNameOrId": "kimy-agent-centos"
        }
      ]
    }
  }
}
```


2. 모든 클라우드 커넥션에 대해서, CSP 자원을 모두 등록하는 기능 추가

POST ​/registerCspResourcesAll
Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug


```
   },
    {
      "connectionName": "aws-eu-south-1",
      "systemMessage": "",
      "elapsedTime": 1538,
      "registerationOverview": {
        "vNet": 12,
        "securityGroup": 18,
        "sshKey": 3,
        "vm": 0,
        "failed": 0
      },
      "registerationOutputs": {
        "output": [
          "vNet: aws-eu-south-1-vpc-05fd63dc5dca4aae1",
          "vNet: aws-eu-south-1-vpc-0998031131f31d682",
          "vNet: aws-eu-south-1-vpc-01ee3d069699fe0d7",
          "vNet: aws-eu-south-1-vpc-1bec0172",
          "vNet: aws-eu-south-1-vpc-06e407ee1cdc74b35",
          "vNet: aws-eu-south-1-vpc-0e90cfea0f0964edd",
          "vNet: aws-eu-south-1-vpc-07cd9e106c9067e15",
          "securityGroup: aws-eu-south-1-sg-56077e3c",
          "sshKey: aws-eu-south-1-aws-eu-south-1",
          "sshKey: aws-eu-south-1-e1-aws-eu-c5psc4l43424jhjo3ag0",
          "sshKey: aws-eu-south-1-e1-aws-eu-c6au9e5434207t772kf0"
        ]
      }
    },
    {
      "connectionName": "aws-eu-central-1",
      "systemMessage": "",
      "elapsedTime": 1540,
      "registerationOverview": {
        "vNet": 12,
        "securityGroup": 19,
        "sshKey": 5,
        "vm": 0,
        "failed": 0
      },
      "registerationOutputs": {
        "output": [
          "vNet: aws-eu-central-1-vpc-053ccfb275c97d6e6",
          "vNet: aws-eu-central-1-vpc-0cac065746b693ef9",
          "vNet: aws-eu-central-1-vpc-03810f258156bb099",
          "vNet: aws-eu-central-1-vpc-079e10d25decc3fa2",
          "vNet: aws-eu-central-1-vpc-0ecc657f4f569b35d",
          "vNet: aws-eu-central-1-vpc-20b8594a",
          "vNet: aws-eu-central-1-vpc-0d67e4ac902dafede",
          "vNet: aws-eu-central-1-vpc-0edec5f27ce092b5a",
          "vNet: aws-eu-central-1-vpc-028bf39924a38fe39",
          "vNet: aws-eu-central-1-vpc-08ee123e98458acb3",
          "vNet: aws-eu-central-1-vpc-07a7e0c3c248456e0",
          "vNet: aws-eu-central-1-vpc-0121a7471d4a223ad",
          "securityGroup: aws-eu-central-1-sg-00bb69ef24d2f30c0",
          "securityGroup: aws-eu-central-1-sg-0efc5ca9bfe518458",
          "securityGroup: aws-eu-central-1-sg-b044b9d3",
          "sshKey: aws-eu-central-1-aws-eu-central-1",
          "sshKey: aws-eu-central-1-aws-eu-central-1-game04",
          "sshKey: aws-eu-central-1-e1-aws-eu-c5psbmt43424jhjo39u0",
          "sshKey: aws-eu-central-1-e1-aws-eu-c6au905434207t772jt0",
          "sshKey: aws-eu-central-1-kimy-frankfurt"
        ]
      }
    },
    {
      "connectionName": "aws-ap-south-1",
      "systemMessage": "",
      "elapsedTime": 1554,
      "registerationOverview": {
        "vNet": 12,
        "securityGroup": 19,
        "sshKey": 6,
        "vm": 0,
        "failed": 0
      },
      "registerationOutputs": {
        "output": [
          "vNet: aws-ap-south-1-vpc-08aa59286ec8a2e14",
          "vNet: aws-ap-south-1-vpc-056b88dcb156a99ae",
          "vNet: aws-ap-south-1-vpc-091314877113d5241",
          "vNet: aws-ap-south-1-vpc-013f9340e12d83df4",
          "vNet: aws-ap-south-1-vpc-03c33ab81cc2f5b75",
          "vNet: aws-ap-south-1-vpc-00380b63192395b59",
          "vNet: aws-ap-south-1-vpc-0f0332cfcf271e272",
          "vNet: aws-ap-south-1-vpc-012e028a7554fffd3",
          "vNet: aws-ap-south-1-vpc-04dd6efad93e23c5f",
          "vNet: aws-ap-south-1-vpc-0fa475bbada93761c",
          "vNet: aws-ap-south-1-vpc-0c170475a7f5c4b96",
```