### PR TITLE
Tidy redundant comments & prints

### DIFF
--- a/src/api/grpc/request/mcirapi.go
+++ b/src/api/grpc/request/mcirapi.go
@@ -102,7 +102,7 @@ type TbSecurityGroupCreateRequest struct {
 // }
 
 // SpiderSecurityRuleInfo
-// type SpiderSecurityRuleInfo struct { // Spider
+// type SpiderSecurityRuleInfo struct {
 // 	FromPort   string `yaml:"fromPort" json:"fromPort"`
 // 	ToPort     string `yaml:"toPort" json:"toPort"`
 // 	IPProtocol string `yaml:"ipProtocol" json:"ipProtocol"`
@@ -198,7 +198,7 @@ type TbVNetCreateRequest struct {
 // }
 
 // SpiderSubnetReqInfo
-// type SpiderSubnetReqInfo struct { // Spider
+// type SpiderSubnetReqInfo struct {
 // 	Name         string     `yaml:"Name" json:"Name"`
 // 	IPv4_CIDR    string     `yaml:"IPv4_CIDR" json:"IPv4_CIDR"`
 // 	KeyValueList []KeyValue `yaml:"KeyValueList" json:"KeyValueList"`

--- a/src/api/grpc/request/mcisapi.go
+++ b/src/api/grpc/request/mcisapi.go
@@ -127,13 +127,13 @@ type TbVmInfo struct {
 // }
 
 // RegionInfo is for Region 정보 구조 정의
-// type RegionInfo struct { // Spider
+// type RegionInfo struct {
 // 	Region string `yaml:"Region" json:"Region"`
 // 	Zone   string `yaml:"Zone" json:"Zone"`
 // }
 
 // SpiderVMInfo is for VM 정보 구조 정의
-// type SpiderVMInfo struct { // Spider
+// type SpiderVMInfo struct {
 // 	// Fields for request
 // 	Name               string   `yaml:"Name" json:"Name"`
 // 	ImageName          string   `yaml:"ImageName" json:"ImageName"`

--- a/src/api/grpc/server/server.go
+++ b/src/api/grpc/server/server.go
@@ -103,8 +103,6 @@ func RunServer() {
 		gs.GracefulStop()
 	}(&wg)
 
-	//fmt.Printf("\n[CB-Tumblebug: Multi-Cloud Infra Service Management]")
-	//fmt.Printf("\n   Initiating GRPC API Server....__^..^__....")
 	fmt.Printf("⇨ grpc server started on [::]%s\n", tumblebugsrv.Addr)
 
 	if err := gs.Serve(conn); err != nil {

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -4758,7 +4758,53 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/common.IdList"
+                            "$ref": "#/definitions/mcis.RegisterResourceResult"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/registerCspResourcesAll": {
+            "post": {
+                "description": "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Admin] System management"
+                ],
+                "summary": "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug",
+                "parameters": [
+                    {
+                        "description": "Specify NS Id and MCIS Name",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/common.RestRegisterCspNativeResourcesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.RegisterResourceAllResult"
                         }
                     },
                     "404": {
@@ -6189,32 +6235,14 @@ const docTemplate = `{
                 "connectionName": {
                     "type": "string"
                 },
+                "resourceOverview": {
+                    "$ref": "#/definitions/mcis.resourceCountOverview"
+                },
                 "resourceType": {
                     "type": "string"
                 },
-                "resourcesOnCsp": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcis.resourceOnCsp"
-                    }
-                },
-                "resourcesOnCspOnly": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcis.resourceOnCsp"
-                    }
-                },
-                "resourcesOnSpider": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcis.resourceOnSpider"
-                    }
-                },
-                "resourcesOnTumblebug": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcis.resourceOnTumblebug"
-                    }
+                "resources": {
+                    "$ref": "#/definitions/mcis.resourcesByManageType"
                 },
                 "systemMessage": {
                     "type": "string"
@@ -6506,6 +6534,37 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.RegisterResourceAllResult": {
+            "type": "object",
+            "properties": {
+                "registerationResult": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.RegisterResourceResult"
+                    }
+                }
+            }
+        },
+        "mcis.RegisterResourceResult": {
+            "type": "object",
+            "properties": {
+                "connectionName": {
+                    "type": "string"
+                },
+                "elapsedTime": {
+                    "type": "integer"
+                },
+                "registerationOutputs": {
+                    "$ref": "#/definitions/common.IdList"
+                },
+                "registerationOverview": {
+                    "$ref": "#/definitions/mcis.registerationOverview"
+                },
+                "systemMessage": {
                     "type": "string"
                 }
             }
@@ -7220,7 +7279,58 @@ const docTemplate = `{
                 }
             }
         },
+        "mcis.registerationOverview": {
+            "type": "object",
+            "properties": {
+                "failed": {
+                    "type": "integer"
+                },
+                "securityGroup": {
+                    "type": "integer"
+                },
+                "sshKey": {
+                    "type": "integer"
+                },
+                "vNet": {
+                    "type": "integer"
+                },
+                "vm": {
+                    "type": "integer"
+                }
+            }
+        },
+        "mcis.resourceCountOverview": {
+            "type": "object",
+            "properties": {
+                "onCspOnly": {
+                    "type": "integer"
+                },
+                "onCspTotal": {
+                    "type": "integer"
+                },
+                "onSpider": {
+                    "type": "integer"
+                },
+                "onTumblebug": {
+                    "type": "integer"
+                }
+            }
+        },
         "mcis.resourceOnCsp": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "info": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnCspInfo"
+                    }
+                }
+            }
+        },
+        "mcis.resourceOnCspInfo": {
             "type": "object",
             "properties": {
                 "idByCsp": {
@@ -7234,6 +7344,20 @@ const docTemplate = `{
         "mcis.resourceOnSpider": {
             "type": "object",
             "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "info": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnSpiderInfo"
+                    }
+                }
+            }
+        },
+        "mcis.resourceOnSpiderInfo": {
+            "type": "object",
+            "properties": {
                 "idByCsp": {
                     "type": "string"
                 },
@@ -7243,6 +7367,20 @@ const docTemplate = `{
             }
         },
         "mcis.resourceOnTumblebug": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "info": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnTumblebugInfo"
+                    }
+                }
+            }
+        },
+        "mcis.resourceOnTumblebugInfo": {
             "type": "object",
             "properties": {
                 "idByCsp": {
@@ -7259,6 +7397,23 @@ const docTemplate = `{
                 },
                 "objectKey": {
                     "type": "string"
+                }
+            }
+        },
+        "mcis.resourcesByManageType": {
+            "type": "object",
+            "properties": {
+                "onCspOnly": {
+                    "$ref": "#/definitions/mcis.resourceOnCsp"
+                },
+                "onCspTotal": {
+                    "$ref": "#/definitions/mcis.resourceOnCsp"
+                },
+                "onSpider": {
+                    "$ref": "#/definitions/mcis.resourceOnSpider"
+                },
+                "onTumblebug": {
+                    "$ref": "#/definitions/mcis.resourceOnTumblebug"
                 }
             }
         }

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -4750,7 +4750,53 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/common.IdList"
+                            "$ref": "#/definitions/mcis.RegisterResourceResult"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/registerCspResourcesAll": {
+            "post": {
+                "description": "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Admin] System management"
+                ],
+                "summary": "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from all Clouds to CB-Tumblebug",
+                "parameters": [
+                    {
+                        "description": "Specify NS Id and MCIS Name",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/common.RestRegisterCspNativeResourcesRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.RegisterResourceAllResult"
                         }
                     },
                     "404": {
@@ -6181,32 +6227,14 @@
                 "connectionName": {
                     "type": "string"
                 },
+                "resourceOverview": {
+                    "$ref": "#/definitions/mcis.resourceCountOverview"
+                },
                 "resourceType": {
                     "type": "string"
                 },
-                "resourcesOnCsp": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcis.resourceOnCsp"
-                    }
-                },
-                "resourcesOnCspOnly": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcis.resourceOnCsp"
-                    }
-                },
-                "resourcesOnSpider": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcis.resourceOnSpider"
-                    }
-                },
-                "resourcesOnTumblebug": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/mcis.resourceOnTumblebug"
-                    }
+                "resources": {
+                    "$ref": "#/definitions/mcis.resourcesByManageType"
                 },
                 "systemMessage": {
                     "type": "string"
@@ -6498,6 +6526,37 @@
                     "type": "string"
                 },
                 "zone": {
+                    "type": "string"
+                }
+            }
+        },
+        "mcis.RegisterResourceAllResult": {
+            "type": "object",
+            "properties": {
+                "registerationResult": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.RegisterResourceResult"
+                    }
+                }
+            }
+        },
+        "mcis.RegisterResourceResult": {
+            "type": "object",
+            "properties": {
+                "connectionName": {
+                    "type": "string"
+                },
+                "elapsedTime": {
+                    "type": "integer"
+                },
+                "registerationOutputs": {
+                    "$ref": "#/definitions/common.IdList"
+                },
+                "registerationOverview": {
+                    "$ref": "#/definitions/mcis.registerationOverview"
+                },
+                "systemMessage": {
                     "type": "string"
                 }
             }
@@ -7212,7 +7271,58 @@
                 }
             }
         },
+        "mcis.registerationOverview": {
+            "type": "object",
+            "properties": {
+                "failed": {
+                    "type": "integer"
+                },
+                "securityGroup": {
+                    "type": "integer"
+                },
+                "sshKey": {
+                    "type": "integer"
+                },
+                "vNet": {
+                    "type": "integer"
+                },
+                "vm": {
+                    "type": "integer"
+                }
+            }
+        },
+        "mcis.resourceCountOverview": {
+            "type": "object",
+            "properties": {
+                "onCspOnly": {
+                    "type": "integer"
+                },
+                "onCspTotal": {
+                    "type": "integer"
+                },
+                "onSpider": {
+                    "type": "integer"
+                },
+                "onTumblebug": {
+                    "type": "integer"
+                }
+            }
+        },
         "mcis.resourceOnCsp": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "info": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnCspInfo"
+                    }
+                }
+            }
+        },
+        "mcis.resourceOnCspInfo": {
             "type": "object",
             "properties": {
                 "idByCsp": {
@@ -7226,6 +7336,20 @@
         "mcis.resourceOnSpider": {
             "type": "object",
             "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "info": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnSpiderInfo"
+                    }
+                }
+            }
+        },
+        "mcis.resourceOnSpiderInfo": {
+            "type": "object",
+            "properties": {
                 "idByCsp": {
                     "type": "string"
                 },
@@ -7235,6 +7359,20 @@
             }
         },
         "mcis.resourceOnTumblebug": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "info": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.resourceOnTumblebugInfo"
+                    }
+                }
+            }
+        },
+        "mcis.resourceOnTumblebugInfo": {
             "type": "object",
             "properties": {
                 "idByCsp": {
@@ -7251,6 +7389,23 @@
                 },
                 "objectKey": {
                     "type": "string"
+                }
+            }
+        },
+        "mcis.resourcesByManageType": {
+            "type": "object",
+            "properties": {
+                "onCspOnly": {
+                    "$ref": "#/definitions/mcis.resourceOnCsp"
+                },
+                "onCspTotal": {
+                    "$ref": "#/definitions/mcis.resourceOnCsp"
+                },
+                "onSpider": {
+                    "$ref": "#/definitions/mcis.resourceOnSpider"
+                },
+                "onTumblebug": {
+                    "$ref": "#/definitions/mcis.resourceOnTumblebug"
                 }
             }
         }

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -919,24 +919,12 @@ definitions:
     properties:
       connectionName:
         type: string
+      resourceOverview:
+        $ref: '#/definitions/mcis.resourceCountOverview'
       resourceType:
         type: string
-      resourcesOnCsp:
-        items:
-          $ref: '#/definitions/mcis.resourceOnCsp'
-        type: array
-      resourcesOnCspOnly:
-        items:
-          $ref: '#/definitions/mcis.resourceOnCsp'
-        type: array
-      resourcesOnSpider:
-        items:
-          $ref: '#/definitions/mcis.resourceOnSpider'
-        type: array
-      resourcesOnTumblebug:
-        items:
-          $ref: '#/definitions/mcis.resourceOnTumblebug'
-        type: array
+      resources:
+        $ref: '#/definitions/mcis.resourcesByManageType'
       systemMessage:
         type: string
     type: object
@@ -1142,6 +1130,26 @@ definitions:
       region:
         type: string
       zone:
+        type: string
+    type: object
+  mcis.RegisterResourceAllResult:
+    properties:
+      registerationResult:
+        items:
+          $ref: '#/definitions/mcis.RegisterResourceResult'
+        type: array
+    type: object
+  mcis.RegisterResourceResult:
+    properties:
+      connectionName:
+        type: string
+      elapsedTime:
+        type: integer
+      registerationOutputs:
+        $ref: '#/definitions/common.IdList'
+      registerationOverview:
+        $ref: '#/definitions/mcis.registerationOverview'
+      systemMessage:
         type: string
     type: object
   mcis.RestGetAllBenchmarkRequest:
@@ -1668,7 +1676,40 @@ definitions:
       targetStatus:
         type: string
     type: object
+  mcis.registerationOverview:
+    properties:
+      failed:
+        type: integer
+      securityGroup:
+        type: integer
+      sshKey:
+        type: integer
+      vNet:
+        type: integer
+      vm:
+        type: integer
+    type: object
+  mcis.resourceCountOverview:
+    properties:
+      onCspOnly:
+        type: integer
+      onCspTotal:
+        type: integer
+      onSpider:
+        type: integer
+      onTumblebug:
+        type: integer
+    type: object
   mcis.resourceOnCsp:
+    properties:
+      count:
+        type: integer
+      info:
+        items:
+          $ref: '#/definitions/mcis.resourceOnCspInfo'
+        type: array
+    type: object
+  mcis.resourceOnCspInfo:
     properties:
       idByCsp:
         type: string
@@ -1677,12 +1718,30 @@ definitions:
     type: object
   mcis.resourceOnSpider:
     properties:
+      count:
+        type: integer
+      info:
+        items:
+          $ref: '#/definitions/mcis.resourceOnSpiderInfo'
+        type: array
+    type: object
+  mcis.resourceOnSpiderInfo:
+    properties:
       idByCsp:
         type: string
       idBySp:
         type: string
     type: object
   mcis.resourceOnTumblebug:
+    properties:
+      count:
+        type: integer
+      info:
+        items:
+          $ref: '#/definitions/mcis.resourceOnTumblebugInfo'
+        type: array
+    type: object
+  mcis.resourceOnTumblebugInfo:
     properties:
       idByCsp:
         type: string
@@ -1694,6 +1753,17 @@ definitions:
         type: string
       objectKey:
         type: string
+    type: object
+  mcis.resourcesByManageType:
+    properties:
+      onCspOnly:
+        $ref: '#/definitions/mcis.resourceOnCsp'
+      onCspTotal:
+        $ref: '#/definitions/mcis.resourceOnCsp'
+      onSpider:
+        $ref: '#/definitions/mcis.resourceOnSpider'
+      onTumblebug:
+        $ref: '#/definitions/mcis.resourceOnTumblebug'
     type: object
 info:
   contact:
@@ -4912,7 +4982,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/common.IdList'
+            $ref: '#/definitions/mcis.RegisterResourceResult'
         "404":
           description: Not Found
           schema:
@@ -4923,6 +4993,38 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to
         CB-Tumblebug
+      tags:
+      - '[Admin] System management'
+  /registerCspResourcesAll:
+    post:
+      consumes:
+      - application/json
+      description: Register CSP Native Resources (vNet, securityGroup, sshKey, vm)
+        from all Clouds to CB-Tumblebug
+      parameters:
+      - description: Specify NS Id and MCIS Name
+        in: body
+        name: Request
+        required: true
+        schema:
+          $ref: '#/definitions/common.RestRegisterCspNativeResourcesRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.RegisterResourceAllResult'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from
+        all Clouds to CB-Tumblebug
       tags:
       - '[Admin] System management'
 securityDefinitions:

--- a/src/api/rest/server/common/config.go
+++ b/src/api/rest/server/common/config.go
@@ -43,11 +43,8 @@ func RestInitConfig(c echo.Context) error {
 
 	err := common.InitConfig(c.Param("configId"))
 	if err != nil {
-		//mapA := common.SimpleMsg{"Failed to find the config " + id}
-		//return c.JSON(http.StatusNotFound, &mapA)
 		return SendMessage(c, http.StatusOK, "Failed to init the config "+c.Param("configId"))
 	} else {
-		//return c.JSON(http.StatusOK, &res)
 		return SendMessage(c, http.StatusOK, "The config "+c.Param("configId")+" has been initialized.")
 	}
 }
@@ -72,11 +69,8 @@ func RestGetConfig(c echo.Context) error {
 
 	res, err := common.GetConfig(c.Param("configId"))
 	if err != nil {
-		//mapA := common.SimpleMsg{"Failed to find the config " + id}
-		//return c.JSON(http.StatusNotFound, &mapA)
 		return SendMessage(c, http.StatusOK, "Failed to find the config "+c.Param("configId"))
 	} else {
-		//return c.JSON(http.StatusOK, &res)
 		return Send(c, http.StatusOK, res)
 	}
 }
@@ -103,19 +97,15 @@ func RestGetAllConfig(c echo.Context) error {
 
 	configList, err := common.ListConfig()
 	if err != nil {
-		//mapA := common.SimpleMsg{"Failed to list configs."}
-		//return c.JSON(http.StatusNotFound, &mapA)
 		return SendMessage(c, http.StatusOK, "Failed to list configs.")
 	}
 
 	if configList == nil {
-		//return c.JSON(http.StatusOK, &content)
 		return Send(c, http.StatusOK, content)
 	}
 
 	// When err == nil && resourceList != nil
 	content.Config = configList
-	//return c.JSON(http.StatusOK, &content)
 	return Send(c, http.StatusOK, content)
 
 }
@@ -142,13 +132,8 @@ func RestPostConfig(c echo.Context) error {
 	fmt.Println("[Creating or Updating Config]")
 	content, err := common.UpdateConfig(u)
 	if err != nil {
-		//common.CBLog.Error(err)
-		////mapA := common.SimpleMsg{"Failed to create the config " + u.Name}
-		//mapA := common.SimpleMsg{err.Error()}
-		//return c.JSON(http.StatusFailedDependency, &mapA)
 		return SendMessage(c, http.StatusBadRequest, err.Error())
 	}
-	//return c.JSON(http.StatusCreated, content)
 	return Send(c, http.StatusOK, content)
 
 }

--- a/src/api/rest/server/common/namespace.go
+++ b/src/api/rest/server/common/namespace.go
@@ -25,27 +25,6 @@ import (
 
 func RestCheckNs(c echo.Context) error {
 
-	/*
-		nsId := c.Param("nsId")
-
-		exists, err := common.CheckNs(nsId)
-
-		type JsonTemplate struct {
-			Exists bool `json:"exists"`
-		}
-		content := JsonTemplate{}
-		content.Exists = exists
-
-		if err != nil {
-			common.CBLog.Error(err)
-			//mapA := common.SimpleMsg{err.Error()}
-			//return c.JSON(http.StatusFailedDependency, &mapA)
-			return c.JSON(http.StatusNotFound, &content)
-		}
-
-		return c.JSON(http.StatusOK, &content)
-	*/
-
 	if err := Validate(c, []string{"nsId"}); err != nil {
 		common.CBLog.Error(err)
 		return SendMessage(c, http.StatusNotFound, err.Error())
@@ -77,18 +56,6 @@ func RestCheckNs(c echo.Context) error {
 // @Router /ns [delete]
 func RestDelAllNs(c echo.Context) error {
 
-	/*
-		err := common.DelAllNs()
-		if err != nil {
-			common.CBLog.Error(err)
-			mapA := common.SimpleMsg{err.Error()}
-			return c.JSON(http.StatusConflict, &mapA)
-		}
-
-		mapA := common.SimpleMsg{"All namespaces has been deleted"}
-		return c.JSON(http.StatusOK, &mapA)
-	*/
-
 	err := common.DelAllNs()
 	if err != nil {
 		common.CBLog.Error(err)
@@ -109,20 +76,6 @@ func RestDelAllNs(c echo.Context) error {
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId} [delete]
 func RestDelNs(c echo.Context) error {
-
-	/*
-		id := c.Param("nsId")
-
-		err := common.DelNs(id)
-		if err != nil {
-			common.CBLog.Error(err)
-			mapA := common.SimpleMsg{err.Error()}
-			return c.JSON(http.StatusFailedDependency, &mapA)
-		}
-
-		mapA := common.SimpleMsg{"The ns has been deleted"}
-		return c.JSON(http.StatusOK, &mapA)
-	*/
 
 	if err := Validate(c, []string{"nsId"}); err != nil {
 		common.CBLog.Error(err)
@@ -173,8 +126,6 @@ func RestGetAllNs(c echo.Context) error {
 		var err error
 		content.IdList, err = common.ListNsId()
 		if err != nil {
-			//mapA := common.SimpleMsg{"Failed to list namespaces."}
-			//return c.JSON(http.StatusNotFound, &mapA)
 			return SendMessage(c, http.StatusOK, "Failed to list namespaces' ID: "+err.Error())
 		}
 
@@ -182,19 +133,15 @@ func RestGetAllNs(c echo.Context) error {
 	} else {
 		nsList, err := common.ListNs()
 		if err != nil {
-			//mapA := common.SimpleMsg{"Failed to list namespaces."}
-			//return c.JSON(http.StatusNotFound, &mapA)
 			return SendMessage(c, http.StatusOK, "Failed to list namespaces.")
 		}
 
 		if nsList == nil {
-			//return c.JSON(http.StatusOK, &content)
 			return Send(c, http.StatusOK, content)
 		}
 
 		// When err == nil && resourceList != nil
 		content.Ns = nsList
-		//return c.JSON(http.StatusOK, &content)
 		return Send(c, http.StatusOK, content)
 	}
 }
@@ -219,11 +166,8 @@ func RestGetNs(c echo.Context) error {
 
 	res, err := common.GetNs(c.Param("nsId"))
 	if err != nil {
-		//mapA := common.SimpleMsg{"Failed to find the namespace " + id}
-		//return c.JSON(http.StatusNotFound, &mapA)
 		return SendMessage(c, http.StatusOK, "Failed to find the namespace "+c.Param("nsId"))
 	} else {
-		//return c.JSON(http.StatusOK, &res)
 		return Send(c, http.StatusOK, res)
 	}
 }
@@ -250,13 +194,8 @@ func RestPostNs(c echo.Context) error {
 	fmt.Println("[Creating Ns]")
 	content, err := common.CreateNs(u)
 	if err != nil {
-		//common.CBLog.Error(err)
-		////mapA := common.SimpleMsg{"Failed to create the ns " + u.Name}
-		//mapA := common.SimpleMsg{err.Error()}
-		//return c.JSON(http.StatusFailedDependency, &mapA)
 		return SendMessage(c, http.StatusBadRequest, err.Error())
 	}
-	//return c.JSON(http.StatusCreated, content)
 	return Send(c, http.StatusOK, content)
 
 }

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -347,8 +347,6 @@ type RestInspectResourcesRequest struct {
 // @Router /inspectResources [post]
 func RestInspectResources(c echo.Context) error {
 
-	fmt.Println("RestInspectResources called;") // for debug
-
 	u := &RestInspectResourcesRequest{}
 	if err := c.Bind(u); err != nil {
 		return err

--- a/src/api/rest/server/mcir/common.go
+++ b/src/api/rest/server/mcir/common.go
@@ -49,7 +49,6 @@ func RestDelAllResources(c echo.Context) error {
 		return c.JSON(http.StatusConflict, &mapA)
 	}
 
-	//mapA := map[string]string{"message": "All " + resourceType + "s has been deleted"}
 	return c.JSON(http.StatusOK, output)
 }
 
@@ -248,8 +247,6 @@ func RestCheckResource(c echo.Context) error {
 
 	if err != nil {
 		common.CBLog.Error(err)
-		//mapA := map[string]string{"message": err.Error()}
-		//return c.JSON(http.StatusFailedDependency, &mapA)
 		return c.JSON(http.StatusNotFound, &content)
 	}
 
@@ -273,7 +270,6 @@ func RestTestAddObjectAssociation(c echo.Context) error {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
-	//mapA := map[string]int8{"inUseCount": inUseCount}
 	return c.JSON(http.StatusOK, vmKeyList)
 }
 
@@ -294,7 +290,6 @@ func RestTestDeleteObjectAssociation(c echo.Context) error {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
-	//mapA := map[string]int8{"inUseCount": inUseCount}
 	return c.JSON(http.StatusOK, vmKeyList)
 }
 
@@ -391,7 +386,6 @@ func RestDelAllDefaultResources(c echo.Context) error {
 		return c.JSON(http.StatusConflict, &mapA)
 	}
 
-	//mapA := map[string]string{"message": "All default resources have been deleted"}
 	return c.JSON(http.StatusOK, output)
 }
 

--- a/src/api/rest/server/mcir/image.go
+++ b/src/api/rest/server/mcir/image.go
@@ -69,12 +69,9 @@ func RestPostImage(c echo.Context) error {
 		if err := c.Bind(u); err != nil {
 			return err
 		}
-		//content, responseCode, body, err := RegisterImageWithId(nsId, u)
 		content, err := mcir.RegisterImageWithId(nsId, u)
 		if err != nil {
 			common.CBLog.Error(err)
-			//fmt.Println("body: ", string(body))
-			//return c.JSONBlob(responseCode, body)
 			mapA := map[string]string{"message": err.Error()}
 			return c.JSON(http.StatusInternalServerError, &mapA)
 		}
@@ -102,7 +99,6 @@ func RestPostImage(c echo.Context) error {
 func RestPutImage(c echo.Context) error {
 	nsId := c.Param("nsId")
 	imageId := c.Param("resourceId")
-	fmt.Printf("RestPutImage called; nsId: %s, imageId: %s \n", nsId, imageId) // for debug
 
 	u := &mcir.TbImageInfo{}
 	if err := c.Bind(u); err != nil {
@@ -167,10 +163,6 @@ func RestLookupImage(c echo.Context) error {
 // @Router /lookupImages [post]
 func RestLookupImageList(c echo.Context) error {
 
-	//type JsonTemplate struct {
-	//	ConnectionName string
-	//}
-
 	u := &RestLookupImageRequest{}
 	if err := c.Bind(u); err != nil {
 		return err
@@ -202,14 +194,6 @@ func RestFetchImages(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 
-	// connConfigCount, imageCount, err := mcir.FetchImages(nsId)
-	// if err != nil {
-	// 	common.CBLog.Error(err)
-	// 	mapA := map[string]string{
-	// 		"message": err.Error()}
-	// 	return c.JSON(http.StatusInternalServerError, &mapA)
-	// }
-
 	u := &RestLookupImageRequest{}
 	if err := c.Bind(u); err != nil {
 		return err
@@ -239,7 +223,7 @@ func RestFetchImages(c echo.Context) error {
 
 	mapA := map[string]string{
 		"message": "Fetched " + fmt.Sprint(imageCount) + " images (from " + fmt.Sprint(connConfigCount) + " connConfigs)"}
-	return c.JSON(http.StatusCreated, &mapA) //content)
+	return c.JSON(http.StatusCreated, &mapA)
 }
 
 // RestGetImage godoc
@@ -337,9 +321,6 @@ func RestSearchImage(c echo.Context) error {
 	if err := c.Bind(u); err != nil {
 		return err
 	}
-
-	//fmt.Println("RestSearchImage called; keywords: ") // for debug
-	//fmt.Println(u.Keywords) // for debug
 
 	content, err := mcir.SearchImage(nsId, u.Keywords...)
 	if err != nil {

--- a/src/api/rest/server/mcir/spec.go
+++ b/src/api/rest/server/mcir/spec.go
@@ -97,7 +97,6 @@ func RestPostSpec(c echo.Context) error {
 func RestPutSpec(c echo.Context) error {
 	nsId := c.Param("nsId")
 	specId := c.Param("resourceId")
-	fmt.Printf("RestPutSpec called; nsId: %s, specId: %s \n", nsId, specId) // for debug
 
 	u := &mcir.TbSpecInfo{}
 	if err := c.Bind(u); err != nil {
@@ -161,10 +160,6 @@ func RestLookupSpec(c echo.Context) error {
 // @Router /lookupSpecs [post]
 func RestLookupSpecList(c echo.Context) error {
 
-	//type JsonTemplate struct {
-	//	ConnectionName string
-	//}
-
 	u := &RestLookupSpecRequest{}
 	if err := c.Bind(u); err != nil {
 		return err
@@ -225,7 +220,7 @@ func RestFetchSpecs(c echo.Context) error {
 
 	mapA := map[string]string{
 		"message": "Fetched " + fmt.Sprint(specCount) + " specs (from " + fmt.Sprint(connConfigCount) + " connConfigs)"}
-	return c.JSON(http.StatusCreated, &mapA) //content)
+	return c.JSON(http.StatusCreated, &mapA)
 }
 
 // RestFilterSpecsResponse is Response structure for RestFilterSpecs

--- a/src/api/rest/server/mcir/sshkey.go
+++ b/src/api/rest/server/mcir/sshkey.go
@@ -73,7 +73,6 @@ func RestPostSshKey(c echo.Context) error {
 func RestPutSshKey(c echo.Context) error {
 	nsId := c.Param("nsId")
 	sshKeyId := c.Param("resourceId")
-	fmt.Printf("RestPutSshKey called; nsId: %s, sshKeyId: %s \n", nsId, sshKeyId) // for debug
 
 	u := &mcir.TbSshKeyInfo{}
 	if err := c.Bind(u); err != nil {

--- a/src/api/rest/server/mcir/subnet.go
+++ b/src/api/rest/server/mcir/subnet.go
@@ -46,16 +46,9 @@ func RestPostSubnet(c echo.Context) error {
 	}
 
 	fmt.Println("[POST Subnet]")
-	//fmt.Println("[Creating Subnet]")
-	//content, responseCode, body, err := CreateSubnet(nsId, u)
 	content, err := mcir.CreateSubnet(nsId, vNetId, *u, false)
 	if err != nil {
 		common.CBLog.Error(err)
-		/*
-			mapA := map[string]string{
-				"message": "Failed to create a subnet"}
-		*/
-		//return c.JSONBlob(responseCode, body)
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}

--- a/src/api/rest/server/mcis/manageInfo.go
+++ b/src/api/rest/server/mcis/manageInfo.go
@@ -141,7 +141,6 @@ func RestGetAllMcis(c echo.Context) error {
 		}
 		content := RestGetAllMcisStatusResponse{}
 		content.Mcis = result
-		//common.PrintJsonPretty(content)
 		return c.JSON(http.StatusOK, &content)
 	} else if option == "simple" {
 		// MCIS in simple (without VM information)
@@ -152,7 +151,6 @@ func RestGetAllMcis(c echo.Context) error {
 		}
 		content := RestGetAllMcisResponse{}
 		content.Mcis = result
-		//common.PrintJsonPretty(content)
 		return c.JSON(http.StatusOK, &content)
 	} else {
 		// MCIS in detail (with status information)
@@ -163,7 +161,6 @@ func RestGetAllMcis(c echo.Context) error {
 		}
 		content := RestGetAllMcisResponse{}
 		content.Mcis = result
-		//common.PrintJsonPretty(content)
 		return c.JSON(http.StatusOK, &content)
 	}
 
@@ -274,7 +271,6 @@ func RestGetMcisVm(c echo.Context) error {
 			return c.JSON(http.StatusInternalServerError, &mapA)
 		}
 
-		//fmt.Printf("%+v\n", *result)
 		common.PrintJsonPretty(*result)
 
 		return c.JSON(http.StatusOK, result)
@@ -287,11 +283,8 @@ func RestGetMcisVm(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, &mapA)
 		}
 
-		//fmt.Printf("%+v\n", *result)
 		common.PrintJsonPretty(*result)
 
-		//return by string
-		//return c.String(http.StatusOK, keyValue.Value)
 		return c.JSON(http.StatusOK, result)
 
 	}

--- a/src/api/rest/server/mcis/network.go
+++ b/src/api/rest/server/mcis/network.go
@@ -63,35 +63,37 @@ func RestPostConfigureCloudAdaptiveNetworkToMcis(c echo.Context) error {
 	return c.JSON(http.StatusOK, contents)
 }
 
-// // RestGetMonitorData godoc
-// // @Summary Get monitoring data of specified MCIS for specified monitoring metric (cpu, memory, disk, network)
-// // @Description Get monitoring data of specified MCIS for specified monitoring metric (cpu, memory, disk, network)
-// // @Tags [Infra service] MCIS Resource monitor (for developer)
-// // @Accept  json
-// // @Produce  json
-// // @Param nsId path string true "Namespace ID" default(ns01)
-// // @Param mcisId path string true "MCIS ID" default(mcis01)
-// // @Param metric path string true "Metric type: cpu, memory, disk, network"
-// // @Success 200 {object} mcis.MonResultSimpleResponse
-// // @Failure 404 {object} common.SimpleMsg
-// // @Failure 500 {object} common.SimpleMsg
-// // @Router /ns/{nsId}/monitoring/mcis/{mcisId}/metric/{metric} [get]
-// func RestGetMonitorData(c echo.Context) error {
+/*
+// RestGetMonitorData godoc
+// @Summary Get monitoring data of specified MCIS for specified monitoring metric (cpu, memory, disk, network)
+// @Description Get monitoring data of specified MCIS for specified monitoring metric (cpu, memory, disk, network)
+// @Tags [Infra service] MCIS Resource monitor (for developer)
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Param mcisId path string true "MCIS ID" default(mcis01)
+// @Param metric path string true "Metric type: cpu, memory, disk, network"
+// @Success 200 {object} mcis.MonResultSimpleResponse
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /ns/{nsId}/monitoring/mcis/{mcisId}/metric/{metric} [get]
+func RestGetMonitorData(c echo.Context) error {
 
-// 	nsId := c.Param("nsId")
-// 	mcisId := c.Param("mcisId")
-// 	metric := c.Param("metric")
+	nsId := c.Param("nsId")
+	mcisId := c.Param("mcisId")
+	metric := c.Param("metric")
 
-// 	req := &mcis.McisCmdReq{}
-// 	if err := c.Bind(req); err != nil {
-// 		return err
-// 	}
+	req := &mcis.McisCmdReq{}
+	if err := c.Bind(req); err != nil {
+		return err
+	}
 
-// 	content, err := mcis.GetMonitoringData(nsId, mcisId, metric)
-// 	if err != nil {
-// 		common.CBLog.Error(err)
-// 		return err
-// 	}
+	content, err := mcis.GetMonitoringData(nsId, mcisId, metric)
+	if err != nil {
+		common.CBLog.Error(err)
+		return err
+	}
 
-// 	return c.JSON(http.StatusOK, content)
-// }
+	return c.JSON(http.StatusOK, content)
+}
+*/

--- a/src/api/rest/server/mcis/orchestration.go
+++ b/src/api/rest/server/mcis/orchestration.go
@@ -119,7 +119,6 @@ func RestGetAllMcisPolicy(c echo.Context) error {
 	content := RestGetAllMcisPolicyResponse{}
 	content.McisPolicy = result
 
-	//fmt.Printf("content %+v\n", content)
 	common.PrintJsonPretty(content)
 
 	return c.JSON(http.StatusOK, &content)

--- a/src/api/rest/server/mcis/provisioning.go
+++ b/src/api/rest/server/mcis/provisioning.go
@@ -50,7 +50,6 @@ func RestPostMcis(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
 
-	//fmt.Printf("%+v\n", *result)
 	common.PrintJsonPretty(*result)
 
 	return c.JSON(http.StatusCreated, result)
@@ -84,7 +83,6 @@ func RestPostRegisterCSPNativeVM(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
 
-	//fmt.Printf("%+v\n", *result)
 	common.PrintJsonPretty(*result)
 
 	return c.JSON(http.StatusCreated, result)
@@ -117,7 +115,6 @@ func RestPostMcisDynamic(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
 
-	//fmt.Printf("%+v\n", *result)
 	common.PrintJsonPretty(*result)
 
 	return c.JSON(http.StatusCreated, result)
@@ -147,7 +144,6 @@ func RestPostMcisDynamicCheckRequest(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
 
-	//fmt.Printf("%+v\n", *result)
 	common.PrintJsonPretty(*result)
 
 	return c.JSON(http.StatusOK, result)

--- a/src/api/rest/server/mcis/recommendation.go
+++ b/src/api/rest/server/mcis/recommendation.go
@@ -93,7 +93,6 @@ func RestPostMcisRecommend(c echo.Context) error {
 	content.PlacementAlgo = req.PlacementAlgo
 	content.PlacementParam = req.PlacementParam
 
-	//fmt.Printf("%+v\n", content)
 	common.PrintJsonPretty(content)
 
 	return c.JSON(http.StatusCreated, content)

--- a/src/api/rest/server/mcis/remoteCommand.go
+++ b/src/api/rest/server/mcis/remoteCommand.go
@@ -111,10 +111,8 @@ func RestPostCmdMcis(c echo.Context) error {
 		resultTmp.VmIp = v.VmIp
 		resultTmp.Result = v.Result
 		content.ResultArray = append(content.ResultArray, resultTmp)
-		//fmt.Println("result from goroutin " + v)
 	}
 
-	//fmt.Printf("%+v\n", content)
 	common.PrintJsonPretty(content)
 
 	return c.JSON(http.StatusOK, content)

--- a/src/api/rest/server/mcis/utility.go
+++ b/src/api/rest/server/mcis/utility.go
@@ -37,8 +37,6 @@ func RestCheckMcis(c echo.Context) error {
 
 	if err != nil {
 		common.CBLog.Error(err)
-		//mapA := map[string]string{"message": err.Error()}
-		//return c.JSON(http.StatusFailedDependency, &mapA)
 		return c.JSON(http.StatusNotFound, &content)
 	}
 
@@ -61,8 +59,6 @@ func RestCheckVm(c echo.Context) error {
 
 	if err != nil {
 		common.CBLog.Error(err)
-		//mapA := map[string]string{"message": err.Error()}
-		//return c.JSON(http.StatusFailedDependency, &mapA)
 		return c.JSON(http.StatusNotFound, &content)
 	}
 

--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -137,7 +137,6 @@ func InitConfig(id string) error {
 	if check && err == nil {
 		fmt.Println("[Init config] " + id)
 		key := "/config/" + id
-		//fmt.Println(key)
 
 		CBStore.Delete(key)
 		// if err != nil {
@@ -169,7 +168,6 @@ func GetConfig(id string) (ConfigInfo, error) {
 
 	fmt.Println("[Get config] " + id)
 	key := "/config/" + id
-	//fmt.Println(key)
 
 	keyValue, err := CBStore.Get(key)
 	if err != nil {
@@ -178,7 +176,6 @@ func GetConfig(id string) (ConfigInfo, error) {
 	}
 
 	fmt.Println("<" + keyValue.Key + "> " + keyValue.Value)
-	//fmt.Println("===============================================")
 
 	err = json.Unmarshal([]byte(keyValue.Value), &res)
 	if err != nil {
@@ -278,7 +275,6 @@ func CheckConfig(id string) (bool, error) {
 	}
 
 	key := "/config/" + id
-	//fmt.Println(key)
 
 	keyValue, _ := CBStore.Get(key)
 	if keyValue != nil {

--- a/src/core/common/namespace.go
+++ b/src/core/common/namespace.go
@@ -197,9 +197,7 @@ func AppendIfMissing(slice []string, i string) []string {
 
 func ListNsId() ([]string, error) {
 
-	//fmt.Println("[List ns]")
 	key := "/ns"
-	//fmt.Println(key)
 
 	var nsList []string
 
@@ -241,10 +239,6 @@ func ListNsId() ([]string, error) {
 	}
 	// EOF of Implementation Option 2
 
-	//for _, v := range nsList {
-	//	fmt.Println("<" + v + "> \n")
-	//}
-	//fmt.Println("===============================================")
 	return nsList, nil
 
 }
@@ -351,10 +345,7 @@ func CheckNs(id string) (bool, error) {
 		return false, err
 	}
 
-	//fmt.Println("[Check ns] " + lowerizedId)
-
 	key := "/ns/" + id
-	//fmt.Println(key)
 
 	keyValue, _ := CBStore.Get(key)
 	if keyValue != nil {

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -363,8 +363,6 @@ func GetConnConfig(ConnConfigName string) (ConnConfig, error) {
 			return content, err
 		}
 
-		fmt.Println(string(resp.Body())) // for debug
-
 		fmt.Println("HTTP Status code: " + strconv.Itoa(resp.StatusCode()))
 		switch {
 		case resp.StatusCode() >= 400 || resp.StatusCode() < 200:
@@ -446,8 +444,6 @@ func GetConnConfigList() (ConnConfigList, error) {
 			err := fmt.Errorf("an error occurred while requesting to CB-Spider")
 			return content, err
 		}
-
-		fmt.Println(string(resp.Body())) // for debug
 
 		fmt.Println("HTTP Status code: " + strconv.Itoa(resp.StatusCode()))
 		switch {
@@ -535,8 +531,6 @@ func GetRegion(RegionName string) (Region, error) {
 			err := fmt.Errorf("an error occurred while requesting to CB-Spider")
 			return content, err
 		}
-
-		fmt.Println(string(resp.Body())) // for debug
 
 		fmt.Println("HTTP Status code: " + strconv.Itoa(resp.StatusCode()))
 		switch {
@@ -651,8 +645,6 @@ func GetRegionList() (RegionList, error) {
 			err := fmt.Errorf("an error occurred while requesting to CB-Spider")
 			return content, err
 		}
-
-		fmt.Println(string(resp.Body())) // for debug
 
 		fmt.Println("HTTP Status code: " + strconv.Itoa(resp.StatusCode()))
 		switch {

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -123,8 +123,6 @@ func DelAllResources(nsId string, resourceType string, subString string, forceFl
 // DelResource deletes the TB MCIR object
 func DelResource(nsId string, resourceType string, resourceId string, forceFlag string) error {
 
-	fmt.Printf("DelResource() called; %s %s %s %s \n", nsId, resourceType, resourceId, forceFlag) // for debug
-
 	err := common.CheckString(nsId)
 	if err != nil {
 		common.CBLog.Error(err)
@@ -145,10 +143,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
-		//mapA := map[string]string{"message": errString}
-		//mapB, _ := json.Marshal(mapA)
 		err := fmt.Errorf(errString)
-		//return http.StatusNotFound, mapB, err
 		return err
 	}
 
@@ -189,7 +184,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 			err := common.CBStore.Delete(key)
 			if err != nil {
 				common.CBLog.Error(err)
-				//return http.StatusInternalServerError, nil, err
 				return err
 			}
 
@@ -201,7 +195,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 				fmt.Println("Data deleted successfully..")
 			}
 
-			//return http.StatusOK, nil, nil
 			return nil
 		case common.StrSpec:
 			// delete spec info
@@ -229,7 +222,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 				fmt.Println("Data deleted successfully..")
 			}
 
-			//return http.StatusOK, nil, nil
 			return nil
 		case common.StrSSHKey:
 			temp := TbSshKeyInfo{}
@@ -277,7 +269,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 		*/
 		default:
 			err := fmt.Errorf("invalid resourceType")
-			//return http.StatusBadRequest, nil, err
 			return err
 		}
 
@@ -358,7 +349,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 			err := common.CBStore.Delete(key)
 			if err != nil {
 				common.CBLog.Error(err)
-				//return http.StatusInternalServerError, nil, err
 				return err
 			}
 
@@ -370,7 +360,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 				fmt.Println("Data deleted successfully..")
 			}
 
-			//return http.StatusOK, nil, nil
 			return nil
 		case common.StrSpec:
 			// delete spec info
@@ -458,12 +447,10 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 	if resourceType == common.StrVNet {
 		// var subnetKeys []string
-		fmt.Printf("childResources: %s", childResources) // for debug
 		subnets := childResources.([]TbSubnetInfo)
 		for _, v := range subnets {
 			subnetKey := common.GenChildResourceKey(nsId, common.StrSubnet, resourceId, v.Id)
 			// subnetKeys = append(subnetKeys, subnetKey)
-			fmt.Printf("subnetKey: %s", subnetKey) // for debug
 			err = common.CBStore.Delete(subnetKey)
 			if err != nil {
 				common.CBLog.Error(err)
@@ -482,8 +469,6 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 
 // DelChildResource deletes the TB MCIR object
 func DelChildResource(nsId string, resourceType string, parentResourceId string, resourceId string, forceFlag string) error {
-
-	fmt.Printf("DelChildResource() called; %s %s %s %s \n", nsId, resourceType, parentResourceId, resourceId) // for debug
 
 	var parentResourceType string
 	switch resourceType {
@@ -516,10 +501,7 @@ func DelChildResource(nsId string, resourceType string, parentResourceId string,
 
 	if !check {
 		errString := "The " + parentResourceType + " " + parentResourceId + " does not exist."
-		//mapA := map[string]string{"message": errString}
-		//mapB, _ := json.Marshal(mapA)
 		err := fmt.Errorf(errString)
-		//return http.StatusNotFound, mapB, err
 		return err
 	}
 
@@ -532,10 +514,7 @@ func DelChildResource(nsId string, resourceType string, parentResourceId string,
 
 	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
-		//mapA := map[string]string{"message": errString}
-		//mapB, _ := json.Marshal(mapA)
 		err := fmt.Errorf(errString)
-		//return http.StatusNotFound, mapB, err
 		return err
 	}
 
@@ -551,15 +530,6 @@ func DelChildResource(nsId string, resourceType string, parentResourceId string,
 	fmt.Println("childResourceKey: " + childResourceKey)
 
 	parentKeyValue, _ := common.CBStore.Get(parentResourceKey)
-	/*
-		if keyValue == nil {
-			mapA := map[string]string{"message": "Failed to find the resource with given ID."}
-			mapB, _ := json.Marshal(mapA)
-			err := fmt.Errorf("Failed to find the resource with given ID.")
-			return http.StatusNotFound, mapB, err
-		}
-	*/
-	//fmt.Println("keyValue: " + keyValue.Key + " / " + keyValue.Value)
 
 	//cspType := common.GetResourcesCspType(nsId, resourceType, resourceId)
 
@@ -582,11 +552,9 @@ func DelChildResource(nsId string, resourceType string, parentResourceId string,
 				return err
 			}
 			tempReq.ConnectionName = temp.ConnectionName
-			// url = common.SpiderRestUrl + "/vpc/" + temp.Name
 			url = fmt.Sprintf("%s/vpc/%s/subnet/%s", common.SpiderRestUrl, temp.Name, resourceId)
 		default:
 			err := fmt.Errorf("invalid resourceType")
-			//return http.StatusBadRequest, nil, err
 			return err
 		}
 
@@ -731,29 +699,6 @@ func DelEleInSlice(arr interface{}, index int) {
 	}
 }
 
-/*
-// RegisterExistingResources
-func RegisterExistingResources(nsId string, connConfig string) (interface{}, error) {
-	fmt.Println("RegisterExistingResources called;") // for debug
-
-	vpcInspectionResult, err := InspectResources(connConfig, common.StrVNet)
-	if err != nil {
-		common.CBLog.Error(err)
-		err := fmt.Errorf("in RegisterExistingResources(); an error occurred while calling InspectResources()")
-		return nil, err
-	}
-
-	vNetsInCspOnly := vpcInspectionResult.ResourcesOnCsp
-	vNetsInSpiderOnly :=
-	for _, v := range vpcInspectionResult.ResourcesOnTumblebug {
-		vNetId := v.Id
-		fmt.Println("vNetId: " + vNetId) // for debug
-	}
-
-	return nil, nil
-}
-*/
-
 // ListResourceId returns the list of TB MCIR object IDs of given resourceType
 func ListResourceId(nsId string, resourceType string) ([]string, error) {
 
@@ -805,10 +750,7 @@ func ListResourceId(nsId string, resourceType string) ([]string, error) {
 			resourceList = append(resourceList, trimmedString)
 		}
 	}
-	// for _, v := range resourceList {
-	// 	fmt.Println("<" + v + "> \n")
-	// }
-	// fmt.Println("===============================================")
+
 	return resourceList, nil
 
 }
@@ -846,17 +788,6 @@ func ListResource(nsId string, resourceType string) (interface{}, error) {
 
 	if err != nil {
 		common.CBLog.Error(err)
-		/*
-			fmt.Println("func ListResource; common.CBStore.GetList gave error")
-			var resourceList []string
-			for _, v := range keyValue {
-				resourceList = append(resourceList, strings.TrimPrefix(v.Key, "/ns/"+nsId+"/resources/"+resourceType+"/"))
-			}
-			for _, v := range resourceList {
-				fmt.Println("<" + v + "> \n")
-			}
-			fmt.Println("===============================================")
-		*/
 		return nil, err
 	}
 	if keyValue != nil {
@@ -947,8 +878,6 @@ func GetAssociatedObjectCount(nsId string, resourceType string, resourceId strin
 
 	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
-		//mapA := map[string]string{"message": errString}
-		//mapB, _ := json.Marshal(mapA)
 		err := fmt.Errorf(errString)
 		return -1, err
 	}
@@ -960,7 +889,6 @@ func GetAssociatedObjectCount(nsId string, resourceType string, resourceId strin
 	fmt.Println("[Get count] " + resourceType + ", " + resourceId)
 
 	key := common.GenResourceKey(nsId, resourceType, resourceId)
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -996,8 +924,6 @@ func GetAssociatedObjectList(nsId string, resourceType string, resourceId string
 
 	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
-		//mapA := map[string]string{"message": errString}
-		//mapB, _ := json.Marshal(mapA)
 		err := fmt.Errorf(errString)
 		return nil, err
 	}
@@ -1009,7 +935,6 @@ func GetAssociatedObjectList(nsId string, resourceType string, resourceId string
 	fmt.Println("[Get count] " + resourceType + ", " + resourceId)
 
 	key := common.GenResourceKey(nsId, resourceType, resourceId)
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -1017,38 +942,6 @@ func GetAssociatedObjectList(nsId string, resourceType string, resourceId string
 		return nil, err
 	}
 	if keyValue != nil {
-		/*
-			objList := gjson.Get(keyValue.Value, "associatedObjectList")
-			objList.ForEach(func(key, value gjson.Result) bool {
-				result = append(result, value.String())
-				return true
-			})
-		*/
-
-		/*
-			switch resourceType {
-			case common.StrImage:
-				res := TbImageInfo{}
-				json.Unmarshal([]byte(keyValue.Value), &res)
-				//result = res.
-			case common.StrSecurityGroup:
-				res := TbSecurityGroupInfo{}
-				json.Unmarshal([]byte(keyValue.Value), &res)
-
-			case common.StrSpec:
-				res := TbSpecInfo{}
-				json.Unmarshal([]byte(keyValue.Value), &res)
-
-			case common.StrSSHKey:
-				res := TbSshKeyInfo{}
-				json.Unmarshal([]byte(keyValue.Value), &res)
-				result = res.AssociatedObjectList
-			case common.StrVNet:
-				res := TbVNetInfo{}
-				json.Unmarshal([]byte(keyValue.Value), &res)
-
-			}
-		*/
 
 		type stringList struct {
 			AssociatedObjectList []string `json:"associatedObjectList"`
@@ -1087,8 +980,6 @@ func UpdateAssociatedObjectList(nsId string, resourceType string, resourceId str
 
 		if !check {
 			errString := "The " + resourceType + " " + resourceId + " does not exist."
-			//mapA := map[string]string{"message": errString}
-			//mapB, _ := json.Marshal(mapA)
 			err := fmt.Errorf(errString)
 			return -1, err
 		}
@@ -1101,7 +992,6 @@ func UpdateAssociatedObjectList(nsId string, resourceType string, resourceId str
 	fmt.Println("[Set count] " + resourceType + ", " + resourceId)
 
 	key := common.GenResourceKey(nsId, resourceType, resourceId)
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -1120,28 +1010,20 @@ func UpdateAssociatedObjectList(nsId string, resourceType string, resourceId str
 					return nil, err
 				}
 			}
-			// fmt.Println("len(objList): " + strconv.Itoa(len(objList))) // for debug
-			// fmt.Print("objList: ")                                     // for debug
-			// fmt.Println(objList)                                       // for debug
-
 			var anyJson map[string]interface{}
 			json.Unmarshal([]byte(keyValue.Value), &anyJson)
 			if anyJson["associatedObjectList"] == nil {
 				arrayToBe := []string{objectKey}
-				// fmt.Println("array_to_be: ", array_to_be) // for debug
 
 				anyJson["associatedObjectList"] = arrayToBe
 			} else { // anyJson["associatedObjectList"] != nil
 				arrayAsIs := anyJson["associatedObjectList"].([]interface{})
-				// fmt.Println("array_as_is: ", array_as_is) // for debug
 
 				arrayToBe := append(arrayAsIs, objectKey)
-				// fmt.Println("array_to_be: ", array_to_be) // for debug
 
 				anyJson["associatedObjectList"] = arrayToBe
 			}
 			updatedJson, _ := json.Marshal(anyJson)
-			// fmt.Println(string(updatedJson)) // for debug
 
 			keyValue.Value = string(updatedJson)
 		case common.StrDelete:
@@ -1207,8 +1089,6 @@ func GetResource(nsId string, resourceType string, resourceId string) (interface
 
 	if !check {
 		errString := "The " + resourceType + " " + resourceId + " does not exist."
-		//mapA := map[string]string{"message": errString}
-		//mapB, _ := json.Marshal(mapA)
 		err := fmt.Errorf(errString)
 		return nil, err
 	}
@@ -1216,7 +1096,6 @@ func GetResource(nsId string, resourceType string, resourceId string) (interface
 	fmt.Println("[Get resource] " + resourceType + ", " + resourceId)
 
 	key := common.GenResourceKey(nsId, resourceType, resourceId)
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -1319,7 +1198,6 @@ func CheckResource(nsId string, resourceType string, resourceId string) (bool, e
 	fmt.Println("[Check resource] " + resourceType + ", " + resourceId)
 
 	key := common.GenResourceKey(nsId, resourceType, resourceId)
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -1383,7 +1261,6 @@ func CheckChildResource(nsId string, resourceType string, parentResourceId strin
 
 	key := common.GenResourceKey(nsId, parentResourceType, parentResourceId)
 	key += "/" + resourceType + "/" + resourceId
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -1436,11 +1313,8 @@ type NameOnly struct {
 func GetNameFromStruct(u interface{}) string {
 	var result = ReturnValue{CustomStruct: u}
 
-	//fmt.Println(result)
-
 	msg, ok := result.CustomStruct.(NameOnly)
 	if ok {
-		//fmt.Printf("Message1 is %s\n", msg.Name)
 		return msg.Name
 	} else {
 		return ""
@@ -1822,7 +1696,6 @@ func DelAllDefaultResources(nsId string) (common.IdList, error) {
 	list, err := DelAllResources(nsId, common.StrSecurityGroup, matchedSubstring, "false")
 	if err != nil {
 		common.CBLog.Error(err)
-		//return err
 		output.IdList = append(output.IdList, err.Error())
 	}
 	output.IdList = append(output.IdList, list.IdList...)
@@ -1830,7 +1703,6 @@ func DelAllDefaultResources(nsId string) (common.IdList, error) {
 	list, err = DelAllResources(nsId, common.StrSSHKey, matchedSubstring, "false")
 	if err != nil {
 		common.CBLog.Error(err)
-		//return err
 		output.IdList = append(output.IdList, err.Error())
 	}
 	output.IdList = append(output.IdList, list.IdList...)
@@ -1838,7 +1710,6 @@ func DelAllDefaultResources(nsId string) (common.IdList, error) {
 	list, err = DelAllResources(nsId, common.StrVNet, matchedSubstring, "false")
 	if err != nil {
 		common.CBLog.Error(err)
-		//return err
 		output.IdList = append(output.IdList, err.Error())
 	}
 	output.IdList = append(output.IdList, list.IdList...)

--- a/src/core/mcir/image.go
+++ b/src/core/mcir/image.go
@@ -30,13 +30,13 @@ import (
 )
 
 // SpiderImageReqInfoWrapper is a wrapper struct to create JSON body of 'Get image request'
-type SpiderImageReqInfoWrapper struct { // Spider
+type SpiderImageReqInfoWrapper struct {
 	ConnectionName string
 	ReqInfo        SpiderImageInfo
 }
 
 // SpiderImageInfo is a struct to create JSON body of 'Get image request'
-type SpiderImageInfo struct { // Spider
+type SpiderImageInfo struct {
 	// Fields for request
 	Name string
 
@@ -431,10 +431,9 @@ func LookupImage(connConfig string, imageId string) (SpiderImageInfo, error) {
 		}
 
 		temp := SpiderImageInfo{}
-		err2 := json.Unmarshal([]byte(result), &temp)
-		if err2 != nil {
-			//fmt.Errorf("an error occurred while unmarshaling: " + err2.Error())
-			common.CBLog.Error(err2)
+		err = json.Unmarshal([]byte(result), &temp)
+		if err != nil {
+			common.CBLog.Error(err)
 		}
 		return temp, nil
 
@@ -459,7 +458,6 @@ func FetchImagesForConnConfig(connConfig string, nsId string) (imageCount uint, 
 		}
 
 		tumblebugImageId := connConfig + "-" + ToNamingRuleCompatible(tumblebugImage.Name)
-		//fmt.Println("tumblebugImageId: " + tumblebugImageId) // for debug
 
 		check, err := CheckResource(nsId, common.StrImage, tumblebugImageId)
 		if check {

--- a/src/core/mcir/spec.go
+++ b/src/core/mcir/spec.go
@@ -34,7 +34,7 @@ import (
 )
 
 // SpiderSpecInfo is a struct to create JSON body of 'Get spec request'
-type SpiderSpecInfo struct { // Spider
+type SpiderSpecInfo struct {
 	// https://github.com/cloud-barista/cb-spider/blob/master/cloud-control-manager/cloud-driver/interfaces/resources/VMSpecHandler.go
 
 	Region string
@@ -47,13 +47,13 @@ type SpiderSpecInfo struct { // Spider
 }
 
 // SpiderVCpuInfo is a struct to handle vCPU Info from CB-Spider.
-type SpiderVCpuInfo struct { // Spider
+type SpiderVCpuInfo struct {
 	Count string
 	Clock string // GHz
 }
 
 // SpiderGpuInfo is a struct to handle GPU Info from CB-Spider.
-type SpiderGpuInfo struct { // Spider
+type SpiderGpuInfo struct {
 	Count string
 	Mfr   string
 	Model string
@@ -177,7 +177,7 @@ func ConvertSpiderSpecToTumblebugSpec(spiderSpec SpiderSpecInfo) (TbSpecInfo, er
 	tempUint64, _ := strconv.ParseUint(spiderSpec.VCpu.Count, 10, 16)
 	tumblebugSpec.NumvCPU = uint16(tempUint64)
 	tempFloat64, _ := strconv.ParseFloat(spiderSpec.Mem, 32)
-	tumblebugSpec.MemGiB = float32(tempFloat64 / 1024) //fmt.Sprintf("%.0f", tempFloat64/1024)
+	tumblebugSpec.MemGiB = float32(tempFloat64 / 1024)
 
 	return tumblebugSpec, nil
 }
@@ -376,7 +376,6 @@ func FetchSpecsForConnConfig(connConfig string, nsId string) (specCount uint, er
 		}
 
 		tumblebugSpecId := connConfig + "-" + ToNamingRuleCompatible(tumblebugSpec.Name)
-		//fmt.Println("tumblebugSpecId: " + tumblebugSpecId) // for debug
 
 		check, err := CheckResource(nsId, common.StrSpec, tumblebugSpecId)
 		if check {

--- a/src/core/mcir/sshkey.go
+++ b/src/core/mcir/sshkey.go
@@ -26,13 +26,13 @@ import (
 )
 
 // SpiderKeyPairReqInfoWrapper is a wrapper struct to create JSON body of 'Create keypair request'
-type SpiderKeyPairReqInfoWrapper struct { // Spider
+type SpiderKeyPairReqInfoWrapper struct {
 	ConnectionName string
 	ReqInfo        SpiderKeyPairInfo
 }
 
 // SpiderKeyPairInfo is a struct to create JSON body of 'Create keypair request'
-type SpiderKeyPairInfo struct { // Spider
+type SpiderKeyPairInfo struct {
 	// Fields for request
 	Name  string
 	CSPId string
@@ -146,7 +146,6 @@ func CreateSshKey(nsId string, u *TbSshKeyReq, option string) (TbSshKeyInfo, err
 	if check {
 		temp := TbSshKeyInfo{}
 		err := fmt.Errorf("The sshKey %s already exists.", u.Name)
-		//return temp, http.StatusConflict, nil, err
 		return temp, err
 	}
 
@@ -280,9 +279,6 @@ func CreateSshKey(nsId string, u *TbSshKeyReq, option string) (TbSshKeyInfo, err
 		common.CBLog.Error(err)
 		return content, err
 	}
-	//keyValue, _ := common.CBStore.Get(Key)
-	//fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
-	fmt.Println("===========================")
 	return content, nil
 }
 

--- a/src/core/mcir/subnet.go
+++ b/src/core/mcir/subnet.go
@@ -43,33 +43,13 @@ func CreateSubnet(nsId string, vNetId string, req TbSubnetReq, objectOnly bool) 
 		return temp, err
 	}
 
-	// returns InvalidValidationError for bad validation input, nil or ValidationErrors ( []FieldError )
 	err = validate.Struct(req)
 	if err != nil {
-
-		// this check is only needed when your code could produce
-		// an invalid value for validation such as interface with nil
-		// value most including myself do not usually have code like this.
 		if _, ok := err.(*validator.InvalidValidationError); ok {
 			fmt.Println(err)
 			temp := TbVNetInfo{}
 			return temp, err
 		}
-
-		// for _, err := range err.(validator.ValidationErrors) {
-
-		// 	fmt.Println(err.Namespace()) // can differ when a custom TagNameFunc is registered or
-		// 	fmt.Println(err.Field())     // by passing alt name to ReportError like below
-		// 	fmt.Println(err.StructNamespace())
-		// 	fmt.Println(err.StructField())
-		// 	fmt.Println(err.Tag())
-		// 	fmt.Println(err.ActualTag())
-		// 	fmt.Println(err.Kind())
-		// 	fmt.Println(err.Type())
-		// 	fmt.Println(err.Value())
-		// 	fmt.Println(err.Param())
-		// 	fmt.Println()
-		// }
 
 		temp := TbVNetInfo{}
 		return temp, err
@@ -125,7 +105,6 @@ func CreateSubnet(nsId string, vNetId string, req TbSubnetReq, objectOnly bool) 
 
 		if os.Getenv("SPIDER_CALL_METHOD") == "REST" {
 
-			//url := common.SpiderRestUrl + "/vpc"
 			url := fmt.Sprintf("%s/vpc/%s/subnet", common.SpiderRestUrl, vNetId)
 
 			client := resty.New().SetCloseConnection(true)
@@ -172,7 +151,6 @@ func CreateSubnet(nsId string, vNetId string, req TbSubnetReq, objectOnly bool) 
 			defer ccm.Close()
 
 			payload, _ := json.MarshalIndent(tempReq, "", "  ")
-			fmt.Println("payload: " + string(payload)) // for debug
 
 			result, err := ccm.AddSubnet(string(payload))
 			if err != nil {
@@ -180,7 +158,7 @@ func CreateSubnet(nsId string, vNetId string, req TbSubnetReq, objectOnly bool) 
 				return TbVNetInfo{}, err
 			}
 
-			tempSpiderVPCInfo = &SpiderVPCInfo{} // Spider
+			tempSpiderVPCInfo = &SpiderVPCInfo{}
 			err = json.Unmarshal([]byte(result), &tempSpiderVPCInfo)
 			if err != nil {
 				common.CBLog.Error(err)
@@ -219,7 +197,7 @@ func CreateSubnet(nsId string, vNetId string, req TbSubnetReq, objectOnly bool) 
 	tbSubnetInfo.Id = req.Name
 	tbSubnetInfo.Name = req.Name
 
-	newVNet.SubnetInfoList = append(newVNet.SubnetInfoList, tbSubnetInfo) // need to be uncommented.
+	newVNet.SubnetInfoList = append(newVNet.SubnetInfoList, tbSubnetInfo)
 	Val, _ = json.Marshal(newVNet)
 
 	err = common.CBStore.Put(vNetKey, string(Val))
@@ -228,15 +206,5 @@ func CreateSubnet(nsId string, vNetId string, req TbSubnetReq, objectOnly bool) 
 		return oldVNet, err
 	}
 
-	// vNetKey := common.GenResourceKey(nsId, common.StrVNet, vNetId)
-	// keyValue, _ := common.CBStore.Get(vNetKey)
-	// fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
-	// fmt.Println("===========================")
-	// content := TbVNetInfo{}
-	// err = json.Unmarshal([]byte(keyValue.Value), &content)
-	// if err != nil {
-	// 	common.CBLog.Error(err)
-	// 	return err
-	// }
 	return newVNet, nil
 }

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -29,13 +29,13 @@ import (
 // 2020-04-09 https://github.com/cloud-barista/cb-spider/blob/master/cloud-control-manager/cloud-driver/interfaces/resources/VPCHandler.go
 
 // SpiderVPCReqInfoWrapper is a wrapper struct to create JSON body of 'Create VPC request'
-type SpiderVPCReqInfoWrapper struct { // Spider
+type SpiderVPCReqInfoWrapper struct {
 	ConnectionName string
 	ReqInfo        SpiderVPCReqInfo
 }
 
 // SpiderVPCReqInfo is a struct to create JSON body of 'Create VPC request'
-type SpiderVPCReqInfo struct { // Spider
+type SpiderVPCReqInfo struct {
 	Name           string
 	IPv4_CIDR      string
 	SubnetInfoList []SpiderSubnetReqInfo
@@ -43,20 +43,20 @@ type SpiderVPCReqInfo struct { // Spider
 }
 
 // SpiderSubnetReqInfoWrapper is a wrapper struct to create JSON body of 'Create subnet request'
-type SpiderSubnetReqInfoWrapper struct { // Spider
+type SpiderSubnetReqInfoWrapper struct {
 	ConnectionName string
 	ReqInfo        SpiderSubnetReqInfo
 }
 
 // SpiderSubnetReqInfo is a struct to create JSON body of 'Create subnet request'
-type SpiderSubnetReqInfo struct { // Spider
+type SpiderSubnetReqInfo struct {
 	Name         string `validate:"required"`
 	IPv4_CIDR    string `validate:"required"`
 	KeyValueList []common.KeyValue
 }
 
 // SpiderVPCInfo is a struct to handle VPC information from the CB-Spider's REST API response
-type SpiderVPCInfo struct { // Spider
+type SpiderVPCInfo struct {
 	IId            common.IID // {NameId, SystemId}
 	IPv4_CIDR      string
 	SubnetInfoList []SpiderSubnetInfo
@@ -64,7 +64,7 @@ type SpiderVPCInfo struct { // Spider
 }
 
 // SpiderSubnetInfo is a struct to handle subnet information from the CB-Spider's REST API response
-type SpiderSubnetInfo struct { // Spider
+type SpiderSubnetInfo struct {
 	IId          common.IID // {NameId, SystemId}
 	IPv4_CIDR    string
 	KeyValueList []common.KeyValue
@@ -268,9 +268,7 @@ func CreateVNet(nsId string, u *TbVNetReq, option string) (TbVNetInfo, error) {
 		defer ccm.Close()
 
 		payload, _ := json.MarshalIndent(tempReq, "", "  ")
-		fmt.Println("payload: " + string(payload)) // for debug
 
-		// result, err := ccm.CreateVPC(string(payload))
 		var result string
 
 		if option == "register" {
@@ -284,7 +282,7 @@ func CreateVNet(nsId string, u *TbVNetReq, option string) (TbVNetInfo, error) {
 			return TbVNetInfo{}, err
 		}
 
-		tempSpiderVPCInfo = &SpiderVPCInfo{} // Spider
+		tempSpiderVPCInfo = &SpiderVPCInfo{}
 		err = json.Unmarshal([]byte(result), &tempSpiderVPCInfo)
 		if err != nil {
 			common.CBLog.Error(err)
@@ -315,8 +313,6 @@ func CreateVNet(nsId string, u *TbVNetReq, option string) (TbVNetInfo, error) {
 	Key := common.GenResourceKey(nsId, common.StrVNet, content.Id)
 	Val, _ := json.Marshal(content)
 
-	//fmt.Println("Key: ", Key)
-	//fmt.Println("Val: ", Val)
 	err = common.CBStore.Put(Key, string(Val))
 	if err != nil {
 		common.CBLog.Error(err)
@@ -341,6 +337,7 @@ func CreateVNet(nsId string, u *TbVNetReq, option string) (TbVNetInfo, error) {
 			common.CBLog.Error(err)
 		}
 	}
+
 	keyValue, err := common.CBStore.Get(Key)
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/core/mcis/benchmark.go
+++ b/src/core/mcis/benchmark.go
@@ -343,8 +343,6 @@ func RunAllBenchmarks(nsId string, mcisId string, host string) (*BenchmarkInfoAr
 	csvWriter2.Flush()
 
 	if err != nil {
-		//mapError := map[string]string{"message": "Benchmark Error"}
-		//return c.JSON(http.StatusFailedDependency, &mapError)
 		return nil, fmt.Errorf("Benchmark Error")
 	}
 
@@ -392,14 +390,10 @@ func CoreGetBenchmark(nsId string, mcisId string, action string, host string) (*
 	if strings.Contains(vaildActions, action) {
 		content, err = BenchmarkAction(nsId, mcisId, action, option)
 	} else {
-		//mapA := map[string]string{"message": "Not available action"}
-		//return c.JSON(http.StatusFailedDependency, &mapA)
 		return nil, fmt.Errorf("Not available action")
 	}
 
 	if err != nil {
-		//mapError := map[string]string{"message": "Benchmark Error"}
-		//return c.JSON(http.StatusFailedDependency, &mapError)
 		return nil, fmt.Errorf("Benchmark Error")
 	}
 

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -81,13 +81,9 @@ func HandleMcisAction(nsId string, mcisId string, action string) (string, error)
 
 		err := ControlMcisAsync(nsId, mcisId, ActionSuspend)
 		if err != nil {
-			//mapA := map[string]string{"message": err.Error()}
-			//return c.JSON(http.StatusFailedDependency, &mapA)
 			return "", err
 		}
 
-		//mapA := map[string]string{"message": "Suspending the MCIS"}
-		//return c.JSON(http.StatusOK, &mapA)
 		return "Suspending the MCIS", nil
 
 	} else if action == "resume" {
@@ -95,13 +91,9 @@ func HandleMcisAction(nsId string, mcisId string, action string) (string, error)
 
 		err := ControlMcisAsync(nsId, mcisId, ActionResume)
 		if err != nil {
-			//mapA := map[string]string{"message": err.Error()}
-			//return c.JSON(http.StatusFailedDependency, &mapA)
 			return "", err
 		}
 
-		//mapA := map[string]string{"message": "Resuming the MCIS"}
-		//return c.JSON(http.StatusOK, &mapA)
 		return "Resuming the MCIS", nil
 
 	} else if action == "reboot" {
@@ -109,13 +101,9 @@ func HandleMcisAction(nsId string, mcisId string, action string) (string, error)
 
 		err := ControlMcisAsync(nsId, mcisId, ActionReboot)
 		if err != nil {
-			//mapA := map[string]string{"message": err.Error()}
-			//return c.JSON(http.StatusFailedDependency, &mapA)
 			return "", err
 		}
 
-		//mapA := map[string]string{"message": "Rebooting the MCIS"}
-		//return c.JSON(http.StatusOK, &mapA)
 		return "Rebooting the MCIS", nil
 
 	} else if action == "terminate" {
@@ -127,18 +115,10 @@ func HandleMcisAction(nsId string, mcisId string, action string) (string, error)
 			return "", err
 		}
 
-		//fmt.Println("len(vmList) %d ", len(vmList))
 		if len(vmList) == 0 {
-			//mapA := map[string]string{"message": "No VM to terminate in the MCIS"}
-			//return c.JSON(http.StatusOK, &mapA)
 			return "No VM to terminate in the MCIS", nil
 		}
 
-		/*
-			for _, v := range vmList {
-				ControlVm(nsId, mcisId, v, ActionTerminate)
-			}
-		*/
 		err = ControlMcisAsync(nsId, mcisId, ActionTerminate)
 		if err != nil {
 			return "", err
@@ -146,7 +126,7 @@ func HandleMcisAction(nsId string, mcisId string, action string) (string, error)
 
 		return "Terminating the MCIS", nil
 
-	} else if action == "refine" { //refine delete VMs in StatusFailed or StatusUndefined
+	} else if action == "refine" { // refine delete VMs in StatusFailed or StatusUndefined
 		fmt.Println("[refine MCIS]")
 
 		vmList, err := ListVmId(nsId, mcisId)
@@ -216,35 +196,22 @@ func CoreGetMcisVmAction(nsId string, mcisId string, vmId string, action string)
 	fmt.Println("[Get VM requested action: " + action)
 	if action == "suspend" {
 		fmt.Println("[suspend VM]")
-
 		ControlVm(nsId, mcisId, vmId, ActionSuspend)
-		//mapA := map[string]string{"message": "Suspending the VM"}
-		//return c.JSON(http.StatusOK, &mapA)
 		return "Suspending the VM", nil
 
 	} else if action == "resume" {
 		fmt.Println("[resume VM]")
-
 		ControlVm(nsId, mcisId, vmId, ActionResume)
-		//mapA := map[string]string{"message": "Resuming the VM"}
-		//return c.JSON(http.StatusOK, &mapA)
 		return "Resuming the VM", nil
 
 	} else if action == "reboot" {
 		fmt.Println("[reboot VM]")
-
 		ControlVm(nsId, mcisId, vmId, ActionReboot)
-		//mapA := map[string]string{"message": "Rebooting the VM"}
-		//return c.JSON(http.StatusOK, &mapA)
 		return "Rebooting the VM", nil
 
 	} else if action == "terminate" {
 		fmt.Println("[terminate VM]")
-
 		ControlVm(nsId, mcisId, vmId, ActionTerminate)
-
-		//mapA := map[string]string{"message": "Terminating the VM"}
-		//return c.JSON(http.StatusOK, &mapA)
 		return "Terminating the VM", nil
 	} else {
 		return "", fmt.Errorf(action + " not supported")
@@ -469,7 +436,6 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 				}
 
 				UpdateVmInfo(nsId, mcisId, temp)
-				//fmt.Println("url: " + url + " method: " + method)
 
 				type ControlVMReqInfo struct {
 					ConnectionName string
@@ -477,7 +443,6 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 				tempReq := ControlVMReqInfo{}
 				tempReq.ConnectionName = temp.ConnectionName
 				payload, _ := json.MarshalIndent(tempReq, "", "  ")
-				//fmt.Println("payload: " + string(payload)) // for debug
 
 				client := &http.Client{
 					CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -639,9 +604,6 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 
 	json.Unmarshal([]byte(keyValue.Value), &content)
 
-	//fmt.Printf("%+v\n", content.CloudId)
-	//fmt.Printf("%+v\n", content.CspVmId)
-
 	temp := TbVmInfo{}
 	unmarshalErr := json.Unmarshal([]byte(keyValue.Value), &temp)
 	if unmarshalErr != nil {
@@ -650,15 +612,6 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 
 	fmt.Println("\n[Calling SPIDER]START vmControl")
 
-	//fmt.Println("temp.CspVmId: " + temp.CspViewVmDetail.IId.NameId)
-
-	/*
-		cspType := getVMsCspType(nsId, mcisId, vmId)
-		var cspVmId string
-		if cspType == "AWS" {
-			cspVmId = temp.CspViewVmDetail.Id
-		} else {
-	*/
 	cspVmId := temp.CspViewVmDetail.IId.NameId
 	common.PrintJsonPretty(temp.CspViewVmDetail)
 
@@ -704,7 +657,6 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 		}
 
 		UpdateVmInfo(nsId, mcisId, temp)
-		//fmt.Println("url: " + url + " method: " + method)
 
 		type ControlVMReqInfo struct {
 			ConnectionName string
@@ -712,7 +664,6 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 		tempReq := ControlVMReqInfo{}
 		tempReq.ConnectionName = temp.ConnectionName
 		payload, _ := json.MarshalIndent(tempReq, "", "  ")
-		//fmt.Println("payload: " + string(payload)) // for debug
 
 		client := &http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -728,13 +679,12 @@ func ControlVm(nsId string, mcisId string, vmId string, action string) error {
 		req.Header.Add("Content-Type", "application/json")
 
 		res, err := client.Do(req)
-		//fmt.Println("Called mockAPI.")
 		defer res.Body.Close()
 		body, err := ioutil.ReadAll(res.Body)
 
 		fmt.Println(string(body))
 
-		fmt.Println("[Calling SPIDER]END vmControl\n")
+		fmt.Println("[Calling SPIDER] END vmControl\n")
 		/*
 			if strings.Compare(content.CspVmId, "Not assigned yet") == 0 {
 				return nil

--- a/src/core/mcis/manageInfo.go
+++ b/src/core/mcis/manageInfo.go
@@ -53,7 +53,6 @@ func ListMcisId(nsId string) ([]string, error) {
 		return nil, err
 	}
 
-	// fmt.Println("[ListMcisId]")
 	var mcisList []string
 
 	// Check MCIS exists
@@ -95,7 +94,6 @@ func ListVmId(nsId string, mcisId string) ([]string, error) {
 		return nil, err
 	}
 
-	// fmt.Println("[ListVmId]")
 	var vmList []string
 
 	// Check MCIS exists
@@ -154,7 +152,7 @@ func GetVmListByLabel(nsId string, mcisId string, label string) ([]string, error
 			common.CBLog.Error(err)
 			return nil, vmErr
 		}
-		//fmt.Println("vmObj.Label: "+ vmObj.Label)
+
 		if vmObj.Label == label {
 			fmt.Println("Found VM with " + vmObj.Label + ", VM ID: " + vmObj.Id)
 			vmListByLabel = append(vmListByLabel, vmObj.Id)
@@ -295,7 +293,6 @@ func CoreGetAllMcis(nsId string, option string) ([]TbMcisInfo, error) {
 	for _, v := range mcisList {
 
 		key := common.GenMcisKey(nsId, v, "")
-		//fmt.Println(key)
 		keyValue, err := common.CBStore.Get(key)
 		if err != nil {
 			common.CBLog.Error(err)
@@ -305,11 +302,8 @@ func CoreGetAllMcis(nsId string, option string) ([]TbMcisInfo, error) {
 		}
 
 		if keyValue == nil {
-			//mapA := map[string]string{"message": "Cannot find " + key}
-			//return c.JSON(http.StatusOK, &mapA)
 			return nil, fmt.Errorf("in CoreGetAllMcis() mcis loop; Cannot find " + key)
 		}
-		//fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
 		mcisTmp := TbMcisInfo{}
 		json.Unmarshal([]byte(keyValue.Value), &mcisTmp)
 		mcisId := v
@@ -338,7 +332,6 @@ func CoreGetAllMcis(nsId string, option string) ([]TbMcisInfo, error) {
 
 		for _, v1 := range vmList {
 			vmKey := common.GenMcisKey(nsId, mcisId, v1)
-			//fmt.Println(vmKey)
 			vmKeyValue, err := common.CBStore.Get(vmKey)
 			if err != nil {
 				err = fmt.Errorf("In CoreGetAllMcis(); CBStore.Get() returned an error")
@@ -347,12 +340,8 @@ func CoreGetAllMcis(nsId string, option string) ([]TbMcisInfo, error) {
 			}
 
 			if vmKeyValue == nil {
-				//mapA := map[string]string{"message": "Cannot find " + key}
-				//return c.JSON(http.StatusOK, &mapA)
 				return nil, fmt.Errorf("in CoreGetAllMcis() vm loop; Cannot find " + vmKey)
 			}
-			//fmt.Println("<" + vmKeyValue.Key + "> \n" + vmKeyValue.Value)
-			//vmTmp := vmOverview{}
 			vmTmp := TbVmInfo{}
 			json.Unmarshal([]byte(vmKeyValue.Value), &vmTmp)
 			vmTmp.Id = v1
@@ -417,10 +406,8 @@ func CoreGetMcisVmInfo(nsId string, mcisId string, vmId string) (*TbVmInfo, erro
 	fmt.Println("[Get MCIS-VM info for id]" + vmId)
 
 	key := common.GenMcisKey(nsId, mcisId, "")
-	//fmt.Println(key)
 
 	vmKey := common.GenMcisKey(nsId, mcisId, vmId)
-	//fmt.Println(vmKey)
 	vmKeyValue, err := common.CBStore.Get(vmKey)
 	if err != nil {
 		common.CBLog.Error(err)
@@ -430,11 +417,8 @@ func CoreGetMcisVmInfo(nsId string, mcisId string, vmId string) (*TbVmInfo, erro
 	}
 
 	if vmKeyValue == nil {
-		//mapA := map[string]string{"message": "Cannot find " + key}
-		//return c.JSON(http.StatusOK, &mapA)
 		return nil, fmt.Errorf("Cannot find " + key)
 	}
-	//fmt.Println("<" + vmKeyValue.Key + "> \n" + vmKeyValue.Value)
 	vmTmp := TbVmInfo{}
 	json.Unmarshal([]byte(vmKeyValue.Value), &vmTmp)
 	vmTmp.Id = vmId
@@ -484,7 +468,6 @@ func GetMcisObject(nsId string, mcisId string) (TbMcisInfo, error) {
 
 // GetVmObject is func to get VM object
 func GetVmObject(nsId string, mcisId string, vmId string) (TbVmInfo, error) {
-	//fmt.Println("[GetVmObject] mcisId: " + mcisId + ", vmId: " + vmId)
 	key := common.GenMcisKey(nsId, mcisId, vmId)
 	keyValue, err := common.CBStore.Get(key)
 	if keyValue == nil || err != nil {
@@ -516,7 +499,7 @@ func GetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 	fmt.Println("[GetMcisStatus]" + mcisId)
 
 	key := common.GenMcisKey(nsId, mcisId, "")
-	//fmt.Println(key)
+
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
 		common.CBLog.Error(err)
@@ -527,8 +510,6 @@ func GetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 		common.CBLog.Error(err)
 		return &McisStatusInfo{}, err
 	}
-	//fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
-	//fmt.Println("===============================================")
 
 	mcisStatus := McisStatusInfo{}
 	json.Unmarshal([]byte(keyValue.Value), &mcisStatus)
@@ -537,7 +518,6 @@ func GetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 	json.Unmarshal([]byte(keyValue.Value), &mcisTmp)
 
 	vmList, err := ListVmId(nsId, mcisId)
-	//fmt.Println("=============================================== %#v", vmList)
 	if err != nil {
 		common.CBLog.Error(err)
 		return &McisStatusInfo{}, err
@@ -751,7 +731,6 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 	fmt.Println("[GetVmStatus]" + vmId)
 	key := common.GenMcisKey(nsId, mcisId, vmId)
 	errorInfo := TbVmStatusInfo{}
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil || keyValue == nil {
@@ -764,7 +743,7 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 	if unmarshalErr != nil {
 		fmt.Println("unmarshalErr:", unmarshalErr)
 	}
-	fmt.Println("\n[Calling SPIDER]START")
+	fmt.Println("\n[Calling SPIDER] START")
 	fmt.Println("CspVmId: " + temp.CspViewVmDetail.IId.NameId)
 
 	cspVmId := temp.CspViewVmDetail.IId.NameId
@@ -787,7 +766,6 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 		tempReq := VMStatusReqInfo{}
 		tempReq.ConnectionName = temp.ConnectionName
 		payload, _ := json.MarshalIndent(tempReq, "", "  ")
-		//fmt.Println("payload: " + string(payload)) // for debug
 
 		client := &http.Client{
 			CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -805,7 +783,6 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 		req.Header.Add("Content-Type", "application/json")
 
 		res, err := client.Do(req)
-		//fmt.Println("Called CB-Spider API.")
 
 		if err != nil {
 			fmt.Println(err)
@@ -854,9 +831,7 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 
 	}
 
-	//common.PrintJsonPretty(statusResponseTmp)
 	fmt.Println(statusResponseTmp)
-	//fmt.Println("[Calling SPIDER]END\n")
 
 	vmStatusTmp := TbVmStatusInfo{}
 	vmStatusTmp.PublicIp = statusResponseTmp.PublicIP
@@ -876,7 +851,6 @@ func GetVmIp(nsId string, mcisId string, vmId string) (string, string) {
 
 	fmt.Printf("[GetVmIp] " + vmId)
 	key := common.GenMcisKey(nsId, mcisId, vmId)
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -885,9 +859,6 @@ func GetVmIp(nsId string, mcisId string, vmId string) (string, string) {
 		common.CBLog.Error(err)
 		// return nil, err
 	}
-
-	//fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
-	//fmt.Println("===============================================")
 
 	json.Unmarshal([]byte(keyValue.Value), &content)
 
@@ -947,9 +918,8 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 	// 	}
 	// }()
 
-	//fmt.Println("[GetVmStatus]" + vmId)
 	key := common.GenMcisKey(nsId, mcisId, vmId)
-	//fmt.Println(key)
+
 	errorInfo := TbVmStatusInfo{}
 
 	keyValue, err := common.CBStore.Get(key)
@@ -958,10 +928,6 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 		fmt.Println(err)
 		return errorInfo, err
 	}
-
-	// fmt.Println(keyValue.Value)
-	// fmt.Println("<" + keyValue.Key + "> \n")
-	// fmt.Println("===============================================")
 
 	temp := TbVmInfo{}
 	unmarshalErr := json.Unmarshal([]byte(keyValue.Value), &temp)
@@ -1007,7 +973,6 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 			tempReq := VMStatusReqInfo{}
 			tempReq.ConnectionName = temp.ConnectionName
 			payload, _ := json.MarshalIndent(tempReq, "", "  ")
-			//fmt.Println("payload: " + string(payload)) // for debug
 
 			client := &http.Client{
 				CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -1140,8 +1105,6 @@ func GetVmStatus(nsId string, mcisId string, vmId string) (TbVmStatusInfo, error
 	vmStatusTmp.CreatedTime = temp.CreatedTime
 	vmStatusTmp.SystemMessage = temp.SystemMessage
 
-	// fmt.Println("[VM Native Status]" + temp.Id + ":" + nativeStatus)
-
 	//Correct undefined status using TargetAction
 	if vmStatusTmp.TargetAction == ActionCreate {
 		if statusResponseTmp.Status == StatusUndefined {
@@ -1265,7 +1228,6 @@ func CoreGetMcisVmStatus(nsId string, mcisId string, vmId string) (*TbVmStatusIn
 	fmt.Println("[status VM]")
 
 	vmKey := common.GenMcisKey(nsId, mcisId, vmId)
-	//fmt.Println(vmKey)
 	vmKeyValue, err := common.CBStore.Get(vmKey)
 	if err != nil {
 		err = fmt.Errorf("in CoreGetMcisVmStatus(); CBStore.Get() returned an error")
@@ -1274,8 +1236,6 @@ func CoreGetMcisVmStatus(nsId string, mcisId string, vmId string) (*TbVmStatusIn
 	}
 
 	if vmKeyValue == nil {
-		//mapA := map[string]string{"message": "Cannot find " + vmKey}
-		//return c.JSON(http.StatusOK, &mapA)
 		return nil, fmt.Errorf("Cannot find " + vmKey)
 	}
 
@@ -1314,10 +1274,6 @@ func UpdateMcisInfo(nsId string, mcisInfoData TbMcisInfo) {
 			common.CBLog.Error(err)
 		}
 	}
-	//fmt.Println("===========================")
-	//vmkeyValue, _ := common.CBStore.Get(key)
-	//fmt.Println("<" + vmkeyValue.Key + "> \n" + vmkeyValue.Value)
-	//fmt.Println("===========================")
 }
 
 // UpdateVmInfo is func to update VM Info
@@ -1340,11 +1296,6 @@ func UpdateVmInfo(nsId string, mcisId string, vmInfoData TbVmInfo) {
 			common.CBLog.Error(err)
 		}
 	}
-
-	//fmt.Println("===========================")
-	//vmkeyValue, _ := common.CBStore.Get(key)
-	//fmt.Println("<" + vmkeyValue.Key + "> \n" + vmkeyValue.Value)
-	//fmt.Println("===========================")
 }
 
 // [Delete MCIS and VM object]
@@ -1565,8 +1516,6 @@ func CoreDelAllMcis(nsId string, option string) (string, error) {
 	}
 
 	if len(mcisList) == 0 {
-		//mapA := map[string]string{"message": "No MCIS to delete"}
-		//return c.JSON(http.StatusOK, &mapA)
 		return "No MCIS to delete", nil
 	}
 
@@ -1574,8 +1523,6 @@ func CoreDelAllMcis(nsId string, option string) (string, error) {
 		err := DelMcis(nsId, v, option)
 		if err != nil {
 			common.CBLog.Error(err)
-			//mapA := map[string]string{"message": "Failed to delete All MCISs"}
-			//return c.JSON(http.StatusFailedDependency, &mapA)
 			return "", fmt.Errorf("Failed to delete All MCISs")
 		}
 	}
@@ -1605,7 +1552,6 @@ func GetVmTemplate(nsId string, mcisId string, algo string) (TbVmInfo, error) {
 	fmt.Println("[GetVmTemplate]" + mcisId + " by algo: " + algo)
 
 	vmList, err := ListVmId(nsId, mcisId)
-	//fmt.Println(vmList)
 	if err != nil {
 		common.CBLog.Error(err)
 		return TbVmInfo{}, err

--- a/src/core/mcis/monitoring.go
+++ b/src/core/mcis/monitoring.go
@@ -363,10 +363,8 @@ func InstallMonitorAgentToMcis(nsId string, mcisId string, mcisServiceType strin
 		resultTmp.VmIp = v.VmIp
 		resultTmp.Result = v.Result
 		content.ResultArray = append(content.ResultArray, resultTmp)
-		//fmt.Println("result from goroutin " + v)
 	}
 
-	//fmt.Printf("%+v\n", content)
 	common.PrintJsonPretty(content)
 
 	return content, nil
@@ -419,9 +417,8 @@ func GetMonitoringData(nsId string, mcisId string, metric string) (MonResultSimp
 		vmIp, _ := GetVmIp(nsId, mcisId, vmId)
 
 		// DF: Get vm on-demand monitoring metric info
-		// Path Para: /ns/:nsId/mcis/:mcisId/vm/:vmId/agent_ip/:agent_ip/metric/:metric_name/ondemand-monitoring-info
+		// Path Param: /ns/:nsId/mcis/:mcisId/vm/:vmId/agent_ip/:agent_ip/metric/:metric_name/ondemand-monitoring-info
 		cmd := "/ns/" + nsId + "/mcis/" + mcisId + "/vm/" + vmId + "/agent_ip/" + vmIp + "/metric/" + metric + "/ondemand-monitoring-info"
-		//fmt.Println("[CMD] " + cmd)
 
 		go CallGetMonitoringAsync(&wg, nsId, mcisId, vmId, vmIp, method, metric, cmd, &resultArray)
 
@@ -432,11 +429,9 @@ func GetMonitoringData(nsId string, mcisId string, metric string) (MonResultSimp
 	content.McisId = mcisId
 	for _, v := range resultArray {
 		content.McisMonitoring = append(content.McisMonitoring, v)
-		//fmt.Println("result from goroutin " + v)
 	}
 
 	fmt.Printf("%+v\n", content)
-	//common.PrintJsonPretty(content)
 
 	return content, nil
 
@@ -464,7 +459,6 @@ func CallGetMonitoringAsync(wg *sync.WaitGroup, nsID string, mcisID string, vmID
 			Timeout: time.Duration(responseLimit) * time.Minute,
 		}
 		req, err := http.NewRequest(method, url, nil)
-		// errStr := ""
 		if err != nil {
 			common.CBLog.Error(err)
 			errStr = err.Error()
@@ -512,11 +506,8 @@ func CallGetMonitoringAsync(wg *sync.WaitGroup, nsID string, mcisID string, vmID
 		if err != nil {
 			common.CBLog.Error(err)
 		}
-		fmt.Println(result) // for debug
 		response = result
 	}
-
-	//common.PrintJsonPretty(response) // for debuging
 
 	if !gjson.Valid(response) {
 		fmt.Println("!gjson.Valid(response)")

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -106,7 +106,6 @@ func OrchestrationController() {
 		return
 	}
 
-	//fmt.Println("")
 	for _, nsId := range nsList {
 
 		mcisPolicyList := ListMcisPolicyId(nsId)
@@ -118,7 +117,6 @@ func OrchestrationController() {
 		for _, v := range mcisPolicyList {
 
 			key := common.GenMcisPolicyKey(nsId, v, "")
-			//fmt.Println(key)
 			keyValue, err := common.CBStore.Get(key)
 			if err != nil {
 				common.CBLog.Error(err)
@@ -128,11 +126,8 @@ func OrchestrationController() {
 			}
 
 			if keyValue == nil {
-				//mapA := map[string]string{"message": "Cannot find " + key}
-				//return c.JSON(http.StatusOK, &mapA)
 				fmt.Println("keyValue is nil")
 			}
-			//fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
 			mcisPolicyTmp := McisPolicyInfo{}
 			json.Unmarshal([]byte(keyValue.Value), &mcisPolicyTmp)
 
@@ -180,12 +175,10 @@ func OrchestrationController() {
 							mcisPolicyTmp.Policy[policyIndex].Status = AutoStatusError
 							break
 						}
-						//common.PrintJsonPretty(content)
 
 						//Statistic
 						sumMcis := 0.0
 						for _, monData := range content.McisMonitoring {
-							//fmt.Println("[monData.Value: ] " + monData.Value)
 							monDataValue, _ := strconv.ParseFloat(monData.Value, 64)
 							sumMcis += monDataValue
 						}
@@ -411,10 +404,6 @@ func UpdateMcisPolicyInfo(nsId string, mcisPolicyInfoData McisPolicyInfo) {
 	if err != nil && !strings.Contains(err.Error(), common.CbStoreKeyNotFoundErrorString) {
 		common.CBLog.Error(err)
 	}
-	//fmt.Println("===========================")
-	//vmkeyValue, _ := common.CBStore.Get(key)
-	//fmt.Println("<" + vmkeyValue.Key + "> \n" + vmkeyValue.Value)
-	//fmt.Println("===========================")
 }
 
 // CreateMcisPolicy create McisPolicyInfo object in DB according to user's requirements.
@@ -456,8 +445,6 @@ func CreateMcisPolicy(nsId string, mcisId string, u *McisPolicyInfo) (McisPolicy
 	Key := common.GenMcisPolicyKey(nsId, content.Id, "")
 	Val, _ := json.Marshal(content)
 
-	//fmt.Println("Key: ", Key)
-	//fmt.Println("Val: ", Val)
 	err = common.CBStore.Put(Key, string(Val))
 	if err != nil {
 		common.CBLog.Error(err)
@@ -553,7 +540,7 @@ func ListMcisPolicyId(nsId string) []string {
 		common.CBLog.Error(err)
 		return nil
 	}
-	//fmt.Println("[Get MCIS Policy ID list]")
+
 	key := "/ns/" + nsId + "/policy/mcis"
 	keyValue, err := common.CBStore.GetList(key, true)
 	if err != nil {

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -265,13 +265,13 @@ type CheckVmDynamicReqInfo struct {
 //
 
 // SpiderVMReqInfoWrapper is struct from CB-Spider (VMHandler.go) for wrapping SpiderVMInfo
-type SpiderVMReqInfoWrapper struct { // Spider
+type SpiderVMReqInfoWrapper struct {
 	ConnectionName string
 	ReqInfo        SpiderVMInfo
 }
 
 // SpiderVMInfo is struct from CB-Spider for VM information
-type SpiderVMInfo struct { // Spider
+type SpiderVMInfo struct {
 	// Fields for request
 	Name               string
 	ImageName          string
@@ -511,8 +511,6 @@ func CorePostMcisVm(nsId string, mcisId string, vmInfoData *TbVmInfo) (*TbVmInfo
 
 	vmStatus, err := GetVmStatus(nsId, mcisId, vmInfoData.Id)
 	if err != nil {
-		//mapA := map[string]string{"message": "Cannot find " + common.GenMcisKey(nsId, mcisId, "")}
-		//return c.JSON(http.StatusOK, &mapA)
 		return nil, fmt.Errorf("Cannot find " + common.GenMcisKey(nsId, mcisId, vmInfoData.Id))
 	}
 
@@ -972,7 +970,6 @@ func CreateMcis(nsId string, req *TbMcisReq, option string) (*TbMcisInfo, error)
 	UpdateMcisInfo(nsId, mcisTmp)
 
 	fmt.Println("[MCIS has been created]" + mcisId)
-	//common.PrintJsonPretty(mcisTmp)
 
 	// Install CB-Dragonfly monitoring agent
 
@@ -1230,9 +1227,6 @@ func AddVmToMcis(wg *sync.WaitGroup, nsId string, mcisId string, vmInfoData *TbV
 
 	vmInfoData.Location = common.GetCloudLocation(strings.ToLower(configTmp.ProviderName), strings.ToLower(nativeRegion))
 
-	//fmt.Printf("\n[configTmp]\n %+v regionTmp %+v \n", configTmp, regionTmp)
-	//fmt.Printf("\n[vmInfoData.Location]\n %+v\n", vmInfoData.Location)
-
 	//AddVmInfoToMcis(nsId, mcisId, *vmInfoData)
 	// Make VM object
 	key = common.GenMcisKey(nsId, mcisId, vmInfoData.Id)
@@ -1244,13 +1238,11 @@ func AddVmToMcis(wg *sync.WaitGroup, nsId string, mcisId string, vmInfoData *TbV
 	}
 
 	fmt.Printf("\n[AddVmToMcis Befor request vmInfoData]\n")
-	//common.PrintJsonPretty(vmInfoData)
 
 	//instanceIds, publicIPs := CreateVm(&vmInfoData)
 	err = CreateVm(nsId, mcisId, vmInfoData, option)
 
 	fmt.Printf("\n[AddVmToMcis After request vmInfoData]\n")
-	//common.PrintJsonPretty(vmInfoData)
 
 	if err != nil {
 		vmInfoData.Status = StatusFailed
@@ -1449,7 +1441,6 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo, option string) e
 		req, err := http.NewRequest(method, url, strings.NewReader(string(payload)))
 
 		if err != nil {
-			//fmt.Println(err)
 			common.CBLog.Error(err)
 			return err
 		}
@@ -1458,7 +1449,6 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo, option string) e
 
 		res, err := client.Do(req)
 		if err != nil {
-			//common.PrintJsonPretty(err)
 			common.CBLog.Error(err)
 			return err
 		}
@@ -1467,7 +1457,6 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo, option string) e
 		body, err := ioutil.ReadAll(res.Body)
 
 		if err != nil {
-			//common.PrintJsonPretty(err)
 			common.CBLog.Error(err)
 			return err
 		}

--- a/src/core/mcis/recommendation.go
+++ b/src/core/mcis/recommendation.go
@@ -263,8 +263,6 @@ func RecommendVmLocation(nsId string, specList *[]mcir.TbSpecInfo, param *[]Para
 				fmt.Printf("\n distances : %v %v %v %v %v \n", distances, max, min, float32(distances[i].distance), (*specList)[distances[i].index].EvaluationScore09)
 			}
 
-			//fmt.Printf("\n distances : %v \n", *specList)
-
 		case "coordinateWithin":
 			//
 		case "coordinateFair":
@@ -392,7 +390,7 @@ func GetRecommendList(nsId string, cpuSize string, memSize string, diskSize stri
 		Price          string
 		ConnectionName string
 	}
-	//fmt.Println("[Get MCISs")
+
 	key := common.GenMcisKey(nsId, "", "") + "/cpuSize/" + cpuSize + "/memSize/" + memSize + "/diskSize/" + diskSize
 	fmt.Println(key)
 	keyValue, err := common.CBStore.GetList(key, true)
@@ -474,8 +472,6 @@ func CorePostMcisRecommend(nsId string, req *McisRecommendReq) ([]TbVmRecommendI
 
 		if err != nil {
 			common.CBLog.Error(err)
-			//mapA := map[string]string{"message": "Failed to recommend MCIS"}
-			//return c.JSON(http.StatusFailedDependency, &mapA)
 			return nil, fmt.Errorf("Failed to recommend MCIS")
 		}
 

--- a/src/core/mcis/remoteCommand.go
+++ b/src/core/mcis/remoteCommand.go
@@ -124,17 +124,15 @@ func RemoteCommandToMcisVm(nsId string, mcisId string, vmId string, req *McisCmd
 
 	vmIp, sshPort := GetVmIp(nsId, mcisId, vmId)
 
-	//fmt.Printf("[vmIp] " +vmIp)
-
 	//sshKey := req.SshKey
 	cmd := req.Command
 
 	// find vaild username
 	userName, sshKey, err := VerifySshUserName(nsId, mcisId, vmId, vmIp, sshPort, req.UserName)
-	// Eventhough VerifySshUserName is not complete, Try RunRemoteCommand
+	// Even though VerifySshUserName is not complete, Try RunRemoteCommand
 	// With RunRemoteCommand, error will be checked again
 	if err == nil {
-		// Just logging the error (but it is net a faultal )
+		// Just logging the error (but it is net a faultal)
 		common.CBLog.Info(err)
 	}
 
@@ -145,8 +143,6 @@ func RemoteCommandToMcisVm(nsId string, mcisId string, vmId string, req *McisCmd
 
 	result, err := RunRemoteCommand(vmIp, sshPort, userName, sshKey, cmd)
 	if err != nil {
-		//return c.JSON(http.StatusInternalServerError, err)
-		//return "", errors.New(err.Error() + *result)
 		return ("[ERROR: " + err.Error() + "]\n " + *result), nil
 	}
 	return *result, nil
@@ -435,7 +431,6 @@ func GetVmSshKey(nsId string, mcisId string, vmId string) (string, string, strin
 
 	fmt.Println("[GetVmSshKey]" + vmId)
 	key := common.GenMcisKey(nsId, mcisId, vmId)
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -444,9 +439,6 @@ func GetVmSshKey(nsId string, mcisId string, vmId string) (string, string, strin
 		common.CBLog.Error(err)
 		// return nil, err
 	}
-
-	//fmt.Println("<" + keyValue.Key + "> \n" + keyValue.Value)
-	//fmt.Println("===============================================")
 
 	json.Unmarshal([]byte(keyValue.Value), &content)
 

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -124,9 +124,7 @@ func CheckMcis(nsId string, mcisId string) (bool, error) {
 	}
 	fmt.Println("[Check mcis] " + mcisId)
 
-	//key := "/ns/" + nsId + "/mcis/" + mcisId
 	key := common.GenMcisKey(nsId, mcisId, "")
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -176,7 +174,6 @@ func CheckVm(nsId string, mcisId string, vmId string) (bool, error) {
 	fmt.Println("[Check vm] " + mcisId + ", " + vmId)
 
 	key := common.GenMcisKey(nsId, mcisId, vmId)
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {
@@ -217,9 +214,7 @@ func CheckMcisPolicy(nsId string, mcisId string) (bool, error) {
 	}
 	fmt.Println("[Check McisPolicy] " + mcisId)
 
-	//key := "/ns/" + nsId + "/mcis/" + mcisId
 	key := common.GenMcisPolicyKey(nsId, mcisId, "")
-	//fmt.Println(key)
 
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil {


### PR DESCRIPTION
@seokho-son 특히

- [Tidy comments in 'api/rest/server/mcis'](https://github.com/cloud-barista/cb-tumblebug/commit/c5f555e2bf0c3b3641d95cc97a17c586b95b1346) (c5f555e2bf0c3b3641d95cc97a17c586b95b1346)
- [Tidy comments in 'core/mcis'](https://github.com/cloud-barista/cb-tumblebug/commit/de5d54e4caca908169578e9bdd25d43645ed50ed) (de5d54e4caca908169578e9bdd25d43645ed50ed)

를 보시고
삭제하지 않는 것이 좋은 코드가 있다면
알려 주시면 감사하겠습니다. 😊

(리뷰 편의를 위해 commit을 쪼갰으며, merge 시에는 Squash and merge 가 어떨까 합니다. 😊)