### PR TITLE
Temporal removal of GCP from RegisterCspResAll and hotfix

### DIFF
--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -170,16 +170,17 @@ func CreateSecurityGroup(nsId string, u *TbSecurityGroupReq, option string) (TbS
 	// Assign random temporal ID to u.VNetId
 	if option == "register" && u.VNetId == "not defined" {
 		resourceList, err := ListResource(nsId, common.StrVNet)
-		var content struct {
-			VNet []TbVNetInfo `json:"vNet"`
-		}
-		content.VNet = resourceList.([]TbVNetInfo) // type assertion (interface{} -> array)
 
 		if err != nil {
 			common.CBLog.Error(err)
 			err := fmt.Errorf("Cannot ListResourceId securityGroup")
 			return TbSecurityGroupInfo{}, err
 		}
+
+		var content struct {
+			VNet []TbVNetInfo `json:"vNet"`
+		}
+		content.VNet = resourceList.([]TbVNetInfo) // type assertion (interface{} -> array)
 
 		if len(content.VNet) == 0 {
 			errString := "There is no " + common.StrVNet + " resource in " + nsId


### PR DESCRIPTION
모든 CSP 자원 등록시, GCP의 자원 등록(VPC)이 병행되면, 
소요시간이 지나치게 늘어나는 것을 확인하였음. (전체 1시간 이상)

제외하면 약 10분 정도로 완료 가능.

해결 방안 파악될 때까지 잠시 GCP 항목을 제외한 임시 내용임.