### PR TITLE
Enhance RegisterCspNativeResourcesAll usability

### DIFF
--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -63,6 +63,14 @@ func RandomSleep(from int, to int) {
 	time.Sleep(time.Duration(n) * time.Millisecond)
 }
 
+// GetFuncName is func to get the name of the running function
+func GetFuncName() string {
+	pc := make([]uintptr, 1)
+	runtime.Callers(2, pc)
+	f := runtime.FuncForPC(pc[0])
+	return f.Name()
+}
+
 // CheckString is func to check string by the given rule `[a-z]([-a-z0-9]*[a-z0-9])?`
 func CheckString(name string) error {
 
@@ -88,6 +96,17 @@ func ToLower(name string) string {
 	out = strings.ReplaceAll(out, " ", "-")
 	out = strings.ToLower(out)
 	return out
+}
+
+// ChangeIdString is func to change strings in id or name (special chars to -, to lower string )
+func ChangeIdString(name string) string {
+	// Regex for letters and numbers
+	reg, _ := regexp.Compile("[^a-zA-Z0-9]+")
+	changedString := strings.ToLower(reg.ReplaceAllString(name, "-"))
+	if changedString[len(changedString)-1:] == "-" {
+		changedString += "r"
+	}
+	return changedString
 }
 
 // GenMcisKey is func to generate a key used in keyValue store
@@ -369,9 +388,9 @@ func GetConnConfig(ConnConfigName string) (ConnConfig, error) {
 			return content, err
 		}
 
-		fmt.Println("HTTP Status code: " + strconv.Itoa(resp.StatusCode()))
 		switch {
 		case resp.StatusCode() >= 400 || resp.StatusCode() < 200:
+			fmt.Println(" - HTTP Status: " + strconv.Itoa(resp.StatusCode()) + " in " + GetFuncName())
 			err := fmt.Errorf(string(resp.Body()))
 			CBLog.Error(err)
 			content := ConnConfig{}
@@ -451,9 +470,9 @@ func GetConnConfigList() (ConnConfigList, error) {
 			return content, err
 		}
 
-		fmt.Println("HTTP Status code: " + strconv.Itoa(resp.StatusCode()))
 		switch {
 		case resp.StatusCode() >= 400 || resp.StatusCode() < 200:
+			fmt.Println(" - HTTP Status: " + strconv.Itoa(resp.StatusCode()) + " in " + GetFuncName())
 			err := fmt.Errorf(string(resp.Body()))
 			CBLog.Error(err)
 			content := ConnConfigList{}
@@ -538,9 +557,9 @@ func GetRegion(RegionName string) (Region, error) {
 			return content, err
 		}
 
-		fmt.Println("HTTP Status code: " + strconv.Itoa(resp.StatusCode()))
 		switch {
 		case resp.StatusCode() >= 400 || resp.StatusCode() < 200:
+			fmt.Println(" - HTTP Status: " + strconv.Itoa(resp.StatusCode()) + " in " + GetFuncName())
 			err := fmt.Errorf(string(resp.Body()))
 			CBLog.Error(err)
 			content := Region{}
@@ -652,9 +671,9 @@ func GetRegionList() (RegionList, error) {
 			return content, err
 		}
 
-		fmt.Println("HTTP Status code: " + strconv.Itoa(resp.StatusCode()))
 		switch {
 		case resp.StatusCode() >= 400 || resp.StatusCode() < 200:
+			fmt.Println(" - HTTP Status: " + strconv.Itoa(resp.StatusCode()) + " in " + GetFuncName())
 			err := fmt.Errorf(string(resp.Body()))
 			CBLog.Error(err)
 			content := RegionList{}


### PR DESCRIPTION

다음과 같이, registerationOverview 제공
```
{
  "elapsedTime": 286,
  "registeredConnection": 152,
  "availableConnection": 132,
  "registerationOverview": {
    "vNet": 1,
    "securityGroup": 0,
    "sshKey": 0,
    "vm": 0,
    "failed": 28
  },
  "registerationResult": [
    {
      "connectionName": "alibaba-ap-northeast-1",
      "systemMessage": "",
      "elapsedTime": 104,
      "registerationOverview": {
        "vNet": 0,

```

참고: 발견된 문제
```
    {
      "connectionName": "aws-ap-northeast-2",
      "systemMessage": "",
      "elapsedTime": 34,
      "registerationOverview": {
        "vNet": 0,
        "securityGroup": 0,
        "sshKey": 0,
        "vm": 0,
        "failed": 2
      },
      "registerationOutputs": {
        "output": [
          "sshKey: aws-ap-northeast-2-eksctl-my-cluster-nodegroup-ng-82857a41-c2-bb-8e-22-cb-89-d7-6b-04-c2-80-c4-82-e2-35-a3  [Failed] The sshKey aws-ap-northeast-2-eksctl-my-cluster-nodegroup-ng-82857a41-c2-bb-8e-22-cb-89-d7-6b-04-c2-80-c4-82-e2-35-a3 already exists.",
          "sshKey: aws-ap-northeast-2-eksctl-nextcloud-nodegroup-ng-9eae9c88-c2-bb-8e-22-cb-89-d7-6b-04-c2-80-c4-82-e2-35-a3  [Failed] The sshKey aws-ap-northeast-2-eksctl-nextcloud-nodegroup-ng-9eae9c88-c2-bb-8e-22-cb-89-d7-6b-04-c2-80-c4-82-e2-35-a3 already exists."
        ]
      }
    },
```

aws-ap-northeast-2-eksctl-nextcloud-nodegroup-ng-9eae9c88-c2-bb-8e-22-cb-89-d7-6b-04-c2-80-c4-82-e2-35-a3 
가 이미 등록되어 있으나,

Inspect 목록에서 계속 나옴. (Spider 동작 확인 필요)

```
1	ns01-aws-ap-northeast-2-eksctl-my-cluster-nodegroup-ng-82857a41-c2-bb-8e-22-cb-89-d7-6b-04-c2-80-c4-82-e2-35-a3	( bb )	
2	ns01-aws-ap-northeast-2-eksctl-nextcloud-nodegroup-ng-9eae9c88-c2-bb-8e-22-cb-89-d7-6b-04-c2-80-c4-82-e2-35-a3	( bb )	

1	( eksctl-my-cluster-nodegroup-ng-82857a41-c2:bb:8e:22:cb:89:d7:6b:04:c2:80:c4:82:e2:35:a3 )	eksctl-my-cluster-nodegroup-ng-82857a41-c2:bb:8e:22:cb:89:d7:6b:04:c2:80:c4:82:e2:35:a3	
2	( eksctl-nextcloud-nodegroup-ng-9eae9c88-c2:bb:8e:22:cb:89:d7:6b:04:c2:80:c4:82:e2:35:a3 )	eksctl-nextcloud-nodegroup-ng-9eae9c88-c2:bb:8e:22:cb:89:d7:6b:04:c2:80:c4:82:e2:35:a3
```