### PR TITLE
Add and update cb-network APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace (
 require (
 	github.com/bramvdbogaerde/go-scp v1.0.0
 	github.com/cloud-barista/cb-dragonfly v0.4.4
-	github.com/cloud-barista/cb-larva v0.0.13
+	github.com/cloud-barista/cb-larva v0.0.14
 	github.com/cloud-barista/cb-log v0.5.0
 	github.com/cloud-barista/cb-spider v0.4.19
 	github.com/cloud-barista/cb-store v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/cloud-barista/cb-larva v0.0.10 h1:twi6txmAhXpsji4bCrzVKgGi1x0gwr1q8wj
 github.com/cloud-barista/cb-larva v0.0.10/go.mod h1:Awo2l9VpeTfzjx6GhnAthtEMBEmhFZYvmN/GXpEuMK0=
 github.com/cloud-barista/cb-larva v0.0.13 h1:AObvwtK+IY6U2mhZrDs6zhYP9c2I6ciTIqMXhQPmJt4=
 github.com/cloud-barista/cb-larva v0.0.13/go.mod h1:5vFk/GaTodU5rLsN92syam+YXT5IBdowgvG3UjsyFAQ=
+github.com/cloud-barista/cb-larva v0.0.14 h1:F6uyBrZH98pPMUGx7dwiCsbAVIwnnnEdc1rXrw3u99w=
+github.com/cloud-barista/cb-larva v0.0.14/go.mod h1:5vFk/GaTodU5rLsN92syam+YXT5IBdowgvG3UjsyFAQ=
 github.com/cloud-barista/cb-log v0.3.1/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJaZWV/6MOwc20c=
 github.com/cloud-barista/cb-log v0.4.0/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJaZWV/6MOwc20c=
 github.com/cloud-barista/cb-log v0.5.0 h1:WoUnXtNNNTA7wRgQa6sFNs57O3mLAOrh4aDHC4cU0CI=

--- a/src/api/rest/server/mcis/network.go
+++ b/src/api/rest/server/mcis/network.go
@@ -53,47 +53,39 @@ func RestPostConfigureCloudAdaptiveNetworkToMcis(c echo.Context) error {
 
 	}
 
-	// mcisTmpSystemLabel := mcis.DefaultSystemLabel
-	// content, err := mcis.InstallMonitorAgentToMcis(nsId, mcisId, mcisTmpSystemLabel, req)
-	// if err != nil {
-	// 	common.CBLog.Error(err)
-	// 	return err
-	// }
-
 	return c.JSON(http.StatusOK, contents)
 }
 
-/*
-// RestGetMonitorData godoc
-// @Summary Get monitoring data of specified MCIS for specified monitoring metric (cpu, memory, disk, network)
-// @Description Get monitoring data of specified MCIS for specified monitoring metric (cpu, memory, disk, network)
-// @Tags [Infra service] MCIS Resource monitor (for developer)
+// RestPostInjectCloudInformationForCloudAdaptiveNetwork godoc
+// @Summary Inject Cloud Information For Cloud Adaptive Network
+// @Description Inject Cloud Information For Cloud Adaptive Network
+// @Tags [Infra service] MCIS Cloud Adaptive Network (for developer)
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
-// @Param metric path string true "Metric type: cpu, memory, disk, network"
-// @Success 200 {object} mcis.MonResultSimpleResponse
+// @Param networkReq body mcis.NetworkReq true "Details for the network request body"
+// @Success 200 {object} mcis.AgentInstallContentWrapper
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
-// @Router /ns/{nsId}/monitoring/mcis/{mcisId}/metric/{metric} [get]
-func RestGetMonitorData(c echo.Context) error {
+// @Router /ns/{nsId}/network/mcis/{mcisId} [put]
+func RestPutInjectCloudInformationForCloudAdaptiveNetwork(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
-	metric := c.Param("metric")
 
-	req := &mcis.McisCmdReq{}
-	if err := c.Bind(req); err != nil {
+	netReq := &mcis.NetworkReq{}
+	if err := c.Bind(netReq); err != nil {
 		return err
 	}
 
-	content, err := mcis.GetMonitoringData(nsId, mcisId, metric)
+	contents, err := mcis.InjectCloudInformationForCloudAdaptiveNetwork(nsId, mcisId, netReq)
+
 	if err != nil {
 		common.CBLog.Error(err)
 		return err
+
 	}
 
-	return c.JSON(http.StatusOK, content)
+	return c.JSON(http.StatusOK, contents)
 }
-*/

--- a/src/api/rest/server/mcis/network.go
+++ b/src/api/rest/server/mcis/network.go
@@ -56,7 +56,7 @@ func RestPostConfigureCloudAdaptiveNetworkToMcis(c echo.Context) error {
 	return c.JSON(http.StatusOK, contents)
 }
 
-// RestPostInjectCloudInformationForCloudAdaptiveNetwork godoc
+// RestPutInjectCloudInformationForCloudAdaptiveNetwork godoc
 // @Summary Inject Cloud Information For Cloud Adaptive Network
 // @Description Inject Cloud Information For Cloud Adaptive Network
 // @Tags [Infra service] MCIS Cloud Adaptive Network (for developer)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -207,6 +207,7 @@ func RunServer(port string) {
 
 	// MCIS Cloud Adaptive Network (for developer)
 	g.POST("/:nsId/network/mcis/:mcisId", rest_mcis.RestPostConfigureCloudAdaptiveNetworkToMcis)
+	g.PUT("/:nsId/network/mcis/:mcisId", rest_mcis.RestPutInjectCloudInformationForCloudAdaptiveNetwork)
 
 	//MCIR Management
 	g.POST("/:nsId/resources/image", rest_mcir.RestPostImage)

--- a/src/core/mcis/network.go
+++ b/src/core/mcis/network.go
@@ -115,7 +115,7 @@ func ConfigureCloudAdaptiveNetwork(nsId string, mcisId string, netReq *NetworkRe
 
 	// Prepare the installation command
 	etcdEndpointsJSON, _ := json.Marshal(etcdEndpoints)
-	command, err := makeInstallationCommand(string(etcdEndpointsJSON), cladnetSpec.CladnetID)
+	command, err := getAgentInstallationCommand(string(etcdEndpointsJSON), cladnetSpec.CladnetID)
 	if err != nil {
 		common.CBLog.Error(err)
 		return AgentInstallContentWrapper{}, err
@@ -359,7 +359,7 @@ func createProperCloudAdaptiveNetwork(networkServiceEndpoint string, ipCIDRs []s
 	return tempSpec, nil
 }
 
-func makeInstallationCommand(etcdEndpoints, cladnetId string) (string, error) {
+func getAgentInstallationCommand(etcdEndpoints, cladnetId string) (string, error) {
 
 	if etcdEndpoints == "" || cladnetId == "" {
 		err := fmt.Sprintf("no enough parameters etcdEndpoints(%+v), cladnetId(%+v)", etcdEndpoints, cladnetId)
@@ -536,11 +536,16 @@ func InjectCloudInformationForCloudAdaptiveNetwork(nsId string, mcisId string, n
 				// Update the peer
 				updatedPeer, err := updateDetailsOfPeer(serviceEndpoint, cladnetSpec.CladnetID, peer.HostID, tempCloudInfo)
 				if err != nil {
-					return AgentInstallContentWrapper{}, err
+					common.CBLog.Error(err)
 				}
 				common.CBLog.Printf("The updated peer: %#v\n", updatedPeer)
 
-				updatedPeerBytes, _ := json.Marshal(updatedPeer)
+				updatedPeerBytes, err := json.Marshal(updatedPeer)
+				if err != nil {
+					common.CBLog.Error(err)
+					tempPeer := model.Peer{}
+					updatedPeerBytes, _ = json.Marshal(tempPeer)
+				}
 				updatedPeerString := string(updatedPeerBytes)
 
 				tempContent := AgentInstallContent{}

--- a/src/core/mcis/network.go
+++ b/src/core/mcis/network.go
@@ -25,6 +25,7 @@ import (
 
 	model "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/cb-network/model"
 	nethelper "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/network-helper"
+	ruletype "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/rule-type"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/mcir"
 	"github.com/go-resty/resty/v2"
@@ -93,7 +94,7 @@ func ConfigureCloudAdaptiveNetwork(nsId string, mcisId string, netReq *NetworkRe
 	}
 
 	// if not exist
-	if cladnetSpec.ID == "" {
+	if cladnetSpec.CladnetID == "" {
 
 		// Get subnet list
 		ipNetworksInMCIS, err := getSubnetsInMCIS(nsId, mcisId, vmIdList)
@@ -110,11 +111,16 @@ func ConfigureCloudAdaptiveNetwork(nsId string, mcisId string, netReq *NetworkRe
 		}
 	}
 
-	common.CBLog.Printf("Struct: %#v\n", cladnetSpec)
+	common.CBLog.Printf("CLADNet spec: %#v\n", cladnetSpec)
 
 	// Prepare the installation command
 	etcdEndpointsJSON, _ := json.Marshal(etcdEndpoints)
-	command := makeInstallationCommand(string(etcdEndpointsJSON), cladnetSpec.ID)
+	command, err := makeInstallationCommand(string(etcdEndpointsJSON), cladnetSpec.CladnetID)
+	if err != nil {
+		common.CBLog.Error(err)
+		return AgentInstallContentWrapper{}, err
+	}
+
 	common.CBLog.Printf("Command: %#v\n", command)
 
 	// Replace given parameter with the installation cmd
@@ -214,9 +220,9 @@ func getCloudAdaptiveNetwork(networkServiceEndpoint string, cladnetId string) (m
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
 		SetPathParams(map[string]string{
-			"cladnet-id": cladnetId,
+			"cladnetId": cladnetId,
 		}).
-		Get(fmt.Sprintf("http://%s/v1/cladnet/{cladnet-id}", networkServiceEndpoint))
+		Get(fmt.Sprintf("http://%s/v1/cladnet/{cladnetId}", networkServiceEndpoint))
 	// Output print
 	log.Printf("\nError: %v\n", err)
 	common.CBLog.Printf("Time: %v\n", resp.Time())
@@ -226,6 +232,10 @@ func getCloudAdaptiveNetwork(networkServiceEndpoint string, cladnetId string) (m
 		common.CBLog.Error(err)
 		return model.CLADNetSpecification{}, err
 	}
+
+	json.Unmarshal(resp.Body(), &cladnetSpec)
+	common.CBLog.Printf("%+v\n", cladnetSpec)
+	common.CBLog.Printf("The specification of a Cloud Adaptive Network: %+v", cladnetSpec)
 
 	common.CBLog.Debug("End.........")
 	return cladnetSpec, nil
@@ -274,15 +284,13 @@ func getSubnetsInMCIS(nsId string, mcisId string, vmList []string) ([]string, er
 }
 
 // createProperCloudAdaptiveNetwork requests available IPv4 private address spaces and uses the recommended address space.
-func createProperCloudAdaptiveNetwork(networkServiceEndpoint string, ipNetworks []string, cladnetName string, cladnetDescription string) (model.CLADNetSpecification, error) {
+func createProperCloudAdaptiveNetwork(networkServiceEndpoint string, ipCIDRs []string, cladnetName string, cladnetDescription string) (model.CLADNetSpecification, error) {
 	common.CBLog.Debug("Start.........")
 
-	var spec model.CLADNetSpecification
-
-	ipNetworksHolder := `{"ipNetworks": %s}`
-	tempJSON, _ := json.Marshal(ipNetworks)
-	ipNetworksString := fmt.Sprintf(ipNetworksHolder, string(tempJSON))
-	fmt.Println(ipNetworksString)
+	ipv4CidrsHolder := `{"ipv4Cidrs": %s}`
+	tempJSON, _ := json.Marshal(ipCIDRs)
+	ipv4CidrsString := fmt.Sprintf(ipv4CidrsHolder, string(tempJSON))
+	fmt.Println(ipv4CidrsString)
 
 	client := resty.New()
 
@@ -290,8 +298,8 @@ func createProperCloudAdaptiveNetwork(networkServiceEndpoint string, ipNetworks 
 	resp, err := client.R().
 		SetHeader("Content-Type", "application/json").
 		SetHeader("Accept", "application/json").
-		SetBody(ipNetworksString).
-		Post(fmt.Sprintf("http://%s/v1/cladnet/available-ipv4-address-spaces", networkServiceEndpoint))
+		SetBody(ipv4CidrsString).
+		Post(fmt.Sprintf("http://%s/v1/cladnet/availableIPv4AddressSpaces", networkServiceEndpoint))
 	// Output print
 	common.CBLog.Printf("\nError: %v\n", err)
 	common.CBLog.Printf("Time: %v\n", resp.Time())
@@ -308,9 +316,21 @@ func createProperCloudAdaptiveNetwork(networkServiceEndpoint string, ipNetworks 
 	common.CBLog.Printf("%+v\n", availableIPv4PrivateAddressSpaces)
 	common.CBLog.Printf("RecommendedIpv4PrivateAddressSpace: %#v", availableIPv4PrivateAddressSpaces.RecommendedIPv4PrivateAddressSpace)
 
-	cladnetSpecHolder := `{"id": "", "name": "%s", "ipv4AddressSpace": "%s", "description": "%s"}`
-	cladnetSpecString := fmt.Sprintf(cladnetSpecHolder,
-		cladnetName, availableIPv4PrivateAddressSpaces.RecommendedIPv4PrivateAddressSpace, cladnetDescription)
+	// if the cladnetName is unique, it can be used CladnetID.
+	reqSpec := &model.CLADNetSpecification{
+		CladnetID:        cladnetName,
+		Name:             cladnetName,
+		Ipv4AddressSpace: availableIPv4PrivateAddressSpaces.RecommendedIPv4PrivateAddressSpace,
+		Description:      cladnetDescription,
+	}
+	// cladnetSpecHolder := `{"cladnetID": "", "name": "%s", "ipv4AddressSpace": "%s", "description": "%s", ruleType": ""}`
+	// cladnetSpecString := fmt.Sprintf(cladnetSpecHolder,
+	// 	cladnetName, availableIPv4PrivateAddressSpaces.RecommendedIPv4PrivateAddressSpace, cladnetDescription)
+	cladnetSpecByte, errMarshal := json.Marshal(reqSpec)
+	cladnetSpecString := string(cladnetSpecByte)
+	if errMarshal != nil {
+		return model.CLADNetSpecification{}, err
+	}
 	common.CBLog.Printf("%#v\n", cladnetSpecString)
 
 	// Request to create a Cloud Adaptive Network
@@ -329,21 +349,30 @@ func createProperCloudAdaptiveNetwork(networkServiceEndpoint string, ipNetworks 
 		return model.CLADNetSpecification{}, err
 	}
 
-	json.Unmarshal(resp.Body(), &spec)
-	common.CBLog.Printf("%#v\n", spec)
+	var tempSpec model.CLADNetSpecification
+	err = json.Unmarshal(resp.Body(), &tempSpec)
+	if err != nil {
+		return model.CLADNetSpecification{}, err
+	}
 
 	common.CBLog.Debug("End.........")
-	return spec, nil
+	return tempSpec, nil
 }
 
-func makeInstallationCommand(etcdEndpoints, cladnetId string) string {
+func makeInstallationCommand(etcdEndpoints, cladnetId string) (string, error) {
+
+	if etcdEndpoints == "" || cladnetId == "" {
+		err := fmt.Sprintf("no enough parameters etcdEndpoints(%+v), cladnetId(%+v)", etcdEndpoints, cladnetId)
+		return "", errors.New(err)
+	}
+
 	// SSH command to install cb-network agents
-	placeHolderCommand := `wget https://raw.githubusercontent.com/cloud-barista/cb-larva/develop/poc-cb-net/scripts/1.deploy-cb-network-agent.sh -O ~/1.deploy-cb-network-agent.sh; chmod +x ~/1.deploy-cb-network-agent.sh; source ~/1.deploy-cb-network-agent.sh '%s' %s`
+	placeHolderCommand := `wget https://raw.githubusercontent.com/cloud-barista/cb-larva/main/poc-cb-net/scripts/deploy-the-released-cb-network-agent.sh -O ~/deploy-the-released-cb-network-agent.sh; chmod +x ~/deploy-the-released-cb-network-agent.sh; source ~/deploy-the-released-cb-network-agent.sh '%s' %s`
 
 	// additionalEncodedString := strings.Replace(etcdEndpoints, "\"", "\\\"", -1)
 	command := fmt.Sprintf(placeHolderCommand, etcdEndpoints, cladnetId)
 
-	return command
+	return command, nil
 }
 
 // installCBNetworkAgentToMcis installs cb-network agent to VMs in an MCIS by the remote command
@@ -403,3 +432,264 @@ func installCBNetworkAgentToVM(nsId, mcisId, vmId string, mcisCmdReq McisCmdReq)
 // 	common.CBLog.Debug("End.........")
 // 	return sshCmdResult, nil
 // }
+
+// InjectCloudInformationForCloudAdaptiveNetwork injects cloud information for a cloud adaptive network
+func InjectCloudInformationForCloudAdaptiveNetwork(nsId string, mcisId string, netReq *NetworkReq) (AgentInstallContentWrapper, error) {
+	common.CBLog.Debug("Start.........")
+
+	if err := common.CheckString(nsId); err != nil {
+		common.CBLog.Error(err)
+		return AgentInstallContentWrapper{}, err
+	}
+
+	if err := common.CheckString(mcisId); err != nil {
+		common.CBLog.Error(err)
+		return AgentInstallContentWrapper{}, err
+	}
+
+	if _, err := CheckMcis(nsId, mcisId); err != nil {
+		return AgentInstallContentWrapper{}, err
+	}
+
+	serviceEndpoint := netReq.ServiceEndpoint
+	// if the parameter is not passed, try to read from the environment variable
+	if serviceEndpoint == "" {
+		common.CBLog.Printf("read env for CB_NETWORK_SERVICE_ENDPOINT")
+		// Get an endpoint of cb-network service
+		serviceEndpoint = os.Getenv("CB_NETWORK_SERVICE_ENDPOINT")
+		if serviceEndpoint == "" {
+			return AgentInstallContentWrapper{}, errors.New("there is no CB_NETWORK_SERVICE_ENDPOINT")
+		}
+	}
+	common.CBLog.Printf("Network service endpoint: %+v", serviceEndpoint)
+
+	// etcdEndpoints := netReq.EtcdEndpoints
+	// // if the parameter is not passed, try to read from the environment variable
+	// if len(etcdEndpoints) == 0 {
+	// 	common.CBLog.Printf("read env for CB_NETWORK_ETCD_ENDPOINTS")
+	// 	// Get endpoints of cb-network etcd which should be accessible from the remote
+	// 	etcdEndpoints = strings.Split(os.Getenv("CB_NETWORK_ETCD_ENDPOINTS"), ",")
+	// 	if len(etcdEndpoints) == 0 {
+	// 		return AgentInstallContentWrapper{}, errors.New("there is no CB_NETWORK_ETCD_ENDPOINTS")
+	// 	}
+	// }
+	// common.CBLog.Printf("etcd endpoints: %+v", etcdEndpoints)
+
+	// Get Cloud Adaptive Network
+	cladnetSpec, err := getCloudAdaptiveNetwork(serviceEndpoint, mcisId)
+	if err != nil {
+		common.CBLog.Error(err)
+		return AgentInstallContentWrapper{}, err
+	}
+	common.CBLog.Printf("CLADNet spec: %#v\n", cladnetSpec)
+
+	// Get Peers in Cloud Adaptive Network (NOTE - mcisId is equal to cladnetID)
+	peers, err := getPeersInCloudAdaptiveNetwork(serviceEndpoint, cladnetSpec.CladnetID)
+	if err != nil {
+		common.CBLog.Error(err)
+		return AgentInstallContentWrapper{}, err
+	}
+	common.CBLog.Printf("Peers: %#v\n", peers)
+
+	// Get a list of VM ID
+	vmIdList, err := ListVmId(nsId, mcisId)
+	if err != nil {
+		common.CBLog.Error(err)
+		return AgentInstallContentWrapper{}, err
+	}
+	common.CBLog.Printf("VM list: %v\n", vmIdList)
+
+	// Change the rule type of cloud adaptive network
+	cladnetSpec.RuleType = ruletype.CostPrioritized
+	cladnetSpec, err = updateCloudAdaptiveNetwork(serviceEndpoint, cladnetSpec)
+	if err != nil {
+		common.CBLog.Error(err)
+		return AgentInstallContentWrapper{}, err
+	}
+	common.CBLog.Printf("CLADNet spec: %#v\n", cladnetSpec)
+
+	//// Inject cloud information to each peer in the Cloud Adaptive network
+	contents := AgentInstallContentWrapper{}
+
+	for _, vmId := range vmIdList {
+		vmObject, _ := GetVmObject(nsId, mcisId, vmId)
+		// jsonBytes, _ := json.Marshal(vmObject)
+		// doc := string(jsonBytes)
+		// common.CBLog.Printf("## vmObject ==> %+v\n", doc)
+
+		for _, peer := range peers.Peers {
+
+			// Public IP seem to be unique currently (or when installing agent, vmId shoud be passed.)
+			if peer.HostPublicIP == vmObject.PublicIP {
+
+				// Set cloud information
+				tempCloudInfo := model.CloudInformation{
+					ProviderName:       vmObject.Location.CloudType,
+					RegionID:           vmObject.CspViewVmDetail.Region.Region,
+					AvailabilityZoneID: vmObject.CspViewVmDetail.Region.Zone,
+					VirtualNetworkID:   vmObject.CspViewVmDetail.VpcIID.SystemId,
+					SubnetID:           vmObject.CspViewVmDetail.SubnetIID.SystemId,
+				}
+				common.CBLog.Printf("## vmId: %+v\n", vmId)
+				common.CBLog.Printf("## %#v\n", tempCloudInfo)
+
+				// Update the peer
+				updatedPeer, err := updateDetailsOfPeer(serviceEndpoint, cladnetSpec.CladnetID, peer.HostID, tempCloudInfo)
+				if err != nil {
+					return AgentInstallContentWrapper{}, err
+				}
+				common.CBLog.Printf("The updated peer: %#v\n", updatedPeer)
+
+				updatedPeerBytes, _ := json.Marshal(updatedPeer)
+				updatedPeerString := string(updatedPeerBytes)
+
+				tempContent := AgentInstallContent{}
+				tempContent.McisId = mcisId
+				tempContent.VmId = vmId
+				tempContent.VmIp = vmObject.PublicIP
+				tempContent.Result = updatedPeerString
+
+				contents.ResultArray = append(contents.ResultArray, tempContent)
+			}
+		}
+	}
+
+	common.CBLog.Debug("End.........")
+	return contents, nil
+}
+
+// getPeersInCloudAdaptiveNetwork retrieves peers in a Cloud Adaptive Network
+func getPeersInCloudAdaptiveNetwork(networkServiceEndpoint string, cladnetId string) (model.Peers, error) {
+	common.CBLog.Debug("Start.........")
+
+	client := resty.New()
+
+	// Request a recommendation of available IPv4 private address spaces.
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetPathParams(map[string]string{
+			"cladnetId": cladnetId,
+		}).
+		Get(fmt.Sprintf("http://%s/v1/cladnet/{cladnetId}/peer", networkServiceEndpoint))
+	// Output print
+	log.Printf("\nError: %v\n", err)
+	common.CBLog.Printf("Time: %v\n", resp.Time())
+	common.CBLog.Printf("Body: %v\n", resp)
+
+	if err != nil {
+		common.CBLog.Error(err)
+		return model.Peers{}, err
+	}
+
+	var peers model.Peers
+
+	err = json.Unmarshal(resp.Body(), &peers)
+	if err != nil {
+		common.CBLog.Error(err)
+		return model.Peers{}, err
+	}
+	common.CBLog.Printf("%+v\n", peers)
+	common.CBLog.Printf("Peers in a Cloud Adaptive Network: %+v", peers)
+
+	if len(peers.Peers) == 0 {
+		return model.Peers{}, errors.New("could not find any Peers")
+	}
+
+	common.CBLog.Debug("End.........")
+	return peers, nil
+}
+
+// updateCloudAdaptiveNetwork updates the specification of a Cloud Adaptive Network.
+func updateCloudAdaptiveNetwork(networkServiceEndpoint string, cladnetSpec model.CLADNetSpecification) (model.CLADNetSpecification, error) {
+	common.CBLog.Debug("Start.........")
+
+	jsonBytes, errMarshal := json.Marshal(cladnetSpec)
+	if errMarshal != nil {
+		return model.CLADNetSpecification{}, errMarshal
+	}
+	doc := string(jsonBytes)
+	common.CBLog.Printf("CLADNetSpecification (JSON string): %v\n", doc)
+
+	client := resty.New()
+	// Request a recommendation of available IPv4 private address spaces.
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetPathParams(map[string]string{
+			"cladnetId": cladnetSpec.CladnetID,
+		}).
+		SetBody(doc).
+		Put(fmt.Sprintf("http://%s/v1/cladnet/{cladnetId}", networkServiceEndpoint))
+	// Output print
+	log.Printf("\nError: %v\n", err)
+	common.CBLog.Printf("Time: %v\n", resp.Time())
+	common.CBLog.Printf("Body: %v\n", resp)
+
+	if err != nil {
+		common.CBLog.Error(err)
+		return model.CLADNetSpecification{}, err
+	}
+
+	var spec model.CLADNetSpecification
+
+	err = json.Unmarshal(resp.Body(), &spec)
+	if err != nil {
+		common.CBLog.Error(err)
+		return model.CLADNetSpecification{}, err
+	}
+	common.CBLog.Printf("%+v\n", spec)
+	common.CBLog.Printf("The updated CLADNetSpecification: %+v", spec)
+
+	common.CBLog.Debug("End.........")
+	return spec, nil
+
+}
+
+// updateDetailsOfPeer updates the peers with cloud information (i.e., details).
+func updateDetailsOfPeer(networkServiceEndpoint string, cladnetId string, hostId string, details model.CloudInformation) (model.Peer, error) {
+	common.CBLog.Debug("Start.........")
+
+	cloudInformationHolder := `{"cloudInformation": %s}`
+	jsonBytes, errMarshal := json.Marshal(details)
+	if errMarshal != nil {
+		return model.Peer{}, errMarshal
+	}
+	doc := fmt.Sprintf(cloudInformationHolder, string(jsonBytes))
+
+	common.CBLog.Printf("CloudInforamtion (JSON string): %v\n", doc)
+
+	client := resty.New()
+	// Request a recommendation of available IPv4 private address spaces.
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetHeader("Accept", "application/json").
+		SetPathParams(map[string]string{
+			"cladnetId": cladnetId,
+			"hostId":    hostId,
+		}).
+		SetBody(doc).
+		Put(fmt.Sprintf("http://%s/v1/cladnet/{cladnetId}/peer/{hostId}/details", networkServiceEndpoint))
+	// Output print
+	log.Printf("\nError: %v\n", err)
+	common.CBLog.Printf("Time: %v\n", resp.Time())
+	common.CBLog.Printf("Body: %v\n", resp)
+
+	if err != nil {
+		common.CBLog.Error(err)
+		return model.Peer{}, err
+	}
+
+	var peer model.Peer
+
+	err = json.Unmarshal(resp.Body(), &peer)
+	if err != nil {
+		common.CBLog.Error(err)
+		return model.Peer{}, err
+	}
+	common.CBLog.Printf("%+v\n", peer)
+	common.CBLog.Printf("The updated peer: %+v", peer)
+
+	common.CBLog.Debug("End.........")
+	return peer, nil
+}


### PR DESCRIPTION
cb-network APIs 변경사항을 반영하고, CB-Tumblebug에 신규 API를 추가하는 PR 입니다.

신규 API는 Cloud Adaptive Network에 클라우드 정보를 주입하기 위한 API 입니다.
Note - 클라우드 정보는 CB-Tumblebug TbVmInfo 객체의 CloudType, Region, Zone, VpcIID.SystemId, SubnetIID.SystemId를 활용 합니다.

변경사항 요약은 아래와 같습니다 ^^

### 변경사항 요약
- Upgrade the cb-network packages to v0.0.14
- Add a new API to inject cloud information for Cloud Adaptive Network
- Add handler functions for the new API
- Update to align with the cb-network v0.0.14 APIs