### PR TITLE
Enhance `ListResource()`

### DIFF
--- a/src/api/rest/server/mcir/common.go
+++ b/src/api/rest/server/mcir/common.go
@@ -136,11 +136,6 @@ func RestGetAllResources(c echo.Context) error {
 				Image []mcir.TbImageInfo `json:"image"`
 			}
 
-			if resourceList == nil {
-				return c.JSON(http.StatusOK, &content)
-			}
-
-			// When err == nil && resourceList != nil
 			content.Image = resourceList.([]mcir.TbImageInfo) // type assertion (interface{} -> array)
 			return c.JSON(http.StatusOK, &content)
 		case common.StrSecurityGroup:
@@ -148,11 +143,6 @@ func RestGetAllResources(c echo.Context) error {
 				SecurityGroup []mcir.TbSecurityGroupInfo `json:"securityGroup"`
 			}
 
-			if resourceList == nil {
-				return c.JSON(http.StatusOK, &content)
-			}
-
-			// When err == nil && resourceList != nil
 			content.SecurityGroup = resourceList.([]mcir.TbSecurityGroupInfo) // type assertion (interface{} -> array)
 			return c.JSON(http.StatusOK, &content)
 		case common.StrSpec:
@@ -160,11 +150,6 @@ func RestGetAllResources(c echo.Context) error {
 				Spec []mcir.TbSpecInfo `json:"spec"`
 			}
 
-			if resourceList == nil {
-				return c.JSON(http.StatusOK, &content)
-			}
-
-			// When err == nil && resourceList != nil
 			content.Spec = resourceList.([]mcir.TbSpecInfo) // type assertion (interface{} -> array)
 			return c.JSON(http.StatusOK, &content)
 		case common.StrSSHKey:
@@ -172,11 +157,6 @@ func RestGetAllResources(c echo.Context) error {
 				SshKey []mcir.TbSshKeyInfo `json:"sshKey"`
 			}
 
-			if resourceList == nil {
-				return c.JSON(http.StatusOK, &content)
-			}
-
-			// When err == nil && resourceList != nil
 			content.SshKey = resourceList.([]mcir.TbSshKeyInfo) // type assertion (interface{} -> array)
 			return c.JSON(http.StatusOK, &content)
 		case common.StrVNet:
@@ -184,11 +164,6 @@ func RestGetAllResources(c echo.Context) error {
 				VNet []mcir.TbVNetInfo `json:"vNet"`
 			}
 
-			if resourceList == nil {
-				return c.JSON(http.StatusOK, &content)
-			}
-
-			// When err == nil && resourceList != nil
 			content.VNet = resourceList.([]mcir.TbVNetInfo) // type assertion (interface{} -> array)
 			return c.JSON(http.StatusOK, &content)
 		default:

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -854,10 +854,28 @@ func ListResource(nsId string, resourceType string) (interface{}, error) {
 			return res, nil
 		}
 
-		//return true, nil
+	} else { //return empty object according to resourceType
+		switch resourceType {
+		case common.StrImage:
+			res := []TbImageInfo{}
+			return res, nil
+		case common.StrSecurityGroup:
+			res := []TbSecurityGroupInfo{}
+			return res, nil
+		case common.StrSpec:
+			res := []TbSpecInfo{}
+			return res, nil
+		case common.StrSSHKey:
+			res := []TbSshKeyInfo{}
+			return res, nil
+		case common.StrVNet:
+			res := []TbVNetInfo{}
+			return res, nil
+		}
 	}
 
-	return nil, nil // When err == nil && keyValue == nil
+	err = fmt.Errorf("Some exceptional case happened. Please check the references of " + common.GetFuncName())
+	return nil, err // if interface{} == nil, make err be returned. Should not come this part if there is no err.
 }
 
 // GetAssociatedObjectCount returns the number of MCIR's associated Tumblebug objects

--- a/src/core/mcir/securitygroup.go
+++ b/src/core/mcir/securitygroup.go
@@ -197,30 +197,23 @@ func CreateSecurityGroup(nsId string, u *TbSecurityGroupReq, option string) (TbS
 			return TbSecurityGroupInfo{}, err
 		}
 
-		if resourceList != nil {
-			var content struct {
-				VNet []TbVNetInfo `json:"vNet"`
-			}
-			content.VNet = resourceList.([]TbVNetInfo) // type assertion (interface{} -> array)
+		var content struct {
+			VNet []TbVNetInfo `json:"vNet"`
+		}
+		content.VNet = resourceList.([]TbVNetInfo) // type assertion (interface{} -> array)
 
-			if len(resourceList.([]TbVNetInfo)) == 0 {
-				errString := "There is no " + common.StrVNet + " resource in " + nsId
-				err := fmt.Errorf(errString)
-				common.CBLog.Error(err)
-				return TbSecurityGroupInfo{}, err
-			}
-
-			// Assign random temporal ID to u.VNetId (should be in the same Connection with SG)
-			for _, r := range content.VNet {
-				if r.ConnectionName == u.ConnectionName {
-					u.VNetId = r.Id
-				}
-			}
-		} else {
-			errString := "nil was returned for vNet list in " + nsId
+		if len(content.VNet) == 0 {
+			errString := "There is no " + common.StrVNet + " resource in " + nsId
 			err := fmt.Errorf(errString)
 			common.CBLog.Error(err)
 			return TbSecurityGroupInfo{}, err
+		}
+
+		// Assign random temporal ID to u.VNetId (should be in the same Connection with SG)
+		for _, r := range content.VNet {
+			if r.ConnectionName == u.ConnectionName {
+				u.VNetId = r.Id
+			}
 		}
 	}
 

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -390,10 +390,10 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 				err := fmt.Errorf("an error occurred while getting resource list")
 				return nullObj, err
 			}
-			if resourceListInNs == nil {
+			resourcesInNs := resourceListInNs.([]mcir.TbVNetInfo) // type assertion
+			if len(resourcesInNs) == 0 {
 				continue
 			}
-			resourcesInNs := resourceListInNs.([]mcir.TbVNetInfo) // type assertion
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
 					temp := resourceOnTumblebugInfo{}
@@ -412,10 +412,10 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 				err := fmt.Errorf("an error occurred while getting resource list")
 				return nullObj, err
 			}
-			if resourceListInNs == nil {
+			resourcesInNs := resourceListInNs.([]mcir.TbSecurityGroupInfo) // type assertion
+			if len(resourcesInNs) == 0 {
 				continue
 			}
-			resourcesInNs := resourceListInNs.([]mcir.TbSecurityGroupInfo) // type assertion
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
 					temp := resourceOnTumblebugInfo{}
@@ -434,10 +434,10 @@ func InspectResources(connConfig string, resourceType string) (InspectResource, 
 				err := fmt.Errorf("an error occurred while getting resource list")
 				return nullObj, err
 			}
-			if resourceListInNs == nil {
+			resourcesInNs := resourceListInNs.([]mcir.TbSshKeyInfo) // type assertion
+			if len(resourcesInNs) == 0 {
 				continue
 			}
-			resourcesInNs := resourceListInNs.([]mcir.TbSshKeyInfo) // type assertion
 			for _, resource := range resourcesInNs {
 				if resource.ConnectionName == connConfig { // filtering
 					temp := resourceOnTumblebugInfo{}

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -1724,8 +1724,8 @@ RegionName[$IX,$IY]=cloudit-region01
 RegionKey01[$IX,$IY]=Region
 RegionVal01[$IX,$IY]=default
 CONN_CONFIG[$IX,$IY]=cloudit-region01
-IMAGE_NAME[$IX,$IY]=CentOS-7
-IMAGE_TYPE[$IX,$IY]="CentOS-7"
+IMAGE_NAME[$IX,$IY]=ee441331-0872-49c3-886c-1873a6e32e09
+IMAGE_TYPE[$IX,$IY]="Ubuntu 18.04"
 SPEC_NAME[$IX,$IY]=small-2
 
 


### PR DESCRIPTION
Closes #1099

@seokho-son #1104 에서 제안해 주신 대로
`ListResource()` 함수를
'호출에는 문제가 없었으나 결과가 0개인 경우'
nil interface를 return하는 것이 아니라
길이 0인 `[]Tb***Info` slice를 return하는 것으로 변경하였습니다.

이에 따라, `ListResource()` 함수의 references 중에서
`resourceList == nil` 코드로 item 개수가 0인지 확인하는 부분이 있던 경우
'적절한 type으로 assertion 후 해당 slice의 len이 0인지 체크' 하도록 코드를 변경했습니다. 😊

다음 2가지 REST API (및 각각에 대응되는 core 함수) 에 대해 테스트 했습니다.
- List vNet
- Inspect resources