### PR TITLE
Fix create-ns.sh error (fix #1085)

### DIFF
--- a/scripts/initMultiCloudEnv.sh
+++ b/scripts/initMultiCloudEnv.sh
@@ -32,7 +32,7 @@ $CBTUMBLEBUG_ROOT/src/testclient/scripts/2.configureTumblebug/load-common-resour
 
 echo -e "${BOLD}"
 while true; do
-    read -p 'Create default namespace (ns01). Do you want to proceed ? (y/n) : ' CHECKPROCEED
+    read -p 'Create default namespace (ns01) for test. Do you want to proceed ? (y/n) : ' CHECKPROCEED
     echo -e "${NC}"
     case $CHECKPROCEED in
     [Yy]*)
@@ -51,4 +51,4 @@ while true; do
     esac
 done
 
-$CBTUMBLEBUG_ROOT/src/testclient/scripts/2.configureTumblebug/create-ns.sh -n tb
+$CBTUMBLEBUG_ROOT/src/testclient/scripts/2.configureTumblebug/create-ns.sh -x ns01

--- a/src/testclient/scripts/2.configureTumblebug/create-ns.sh
+++ b/src/testclient/scripts/2.configureTumblebug/create-ns.sh
@@ -4,13 +4,15 @@ echo "####################################################################"
 echo "## 2. Namespace: Create (-x option for NameSpace Name)"
 echo "####################################################################"
 
-SCRIPT_DIR=`dirname ${BASH_SOURCE[0]-$0}`
-cd $SCRIPT_DIR
-
 source ../init.sh
 
+
+if [ ! -z "$OPTION01" ]; then
+	NSID=$OPTION01
+fi
+
 if [ -z "$NSID" ]; then
-	NSID=${OPTION01:-ns01}
+	NSID="ns01"
 fi
 
 resp=$(

--- a/src/testclient/scripts/sequentialFullTest/create-mcir-ns-cloud.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcir-ns-cloud.sh
@@ -11,7 +11,7 @@ function test_sequence() {
 	local CMDPATH=$6
 
 	../1.configureSpider/register-cloud.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
-	../2.configureTumblebug/create-ns.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../2.configureTumblebug/create-ns.sh -n $POSTFIX -f $TestSetFile
 	../3.vNet/create-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
 	if [ "${CSP}" == "gcp" ]; then
@@ -48,7 +48,7 @@ function test_sequence_allcsp_mcir() {
 	local CMDPATH=$5
 
 	../1.configureSpider/register-cloud.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
-	../2.configureTumblebug/create-ns.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../2.configureTumblebug/create-ns.sh -n $POSTFIX -f $TestSetFile
 	../3.vNet/create-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
 	if [ "${CSP}" == "gcp" ]; then

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-for-df.sh
@@ -10,7 +10,7 @@ function test_sequence()
 	local CMDPATH=$5
 
 	../1.configureSpider/register-cloud.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
-	../2.configureTumblebug/create-ns.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../2.configureTumblebug/create-ns.sh -n $POSTFIX -f $TestSetFile
 	../3.vNet/create-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
 	if [ "${CSP}" == "gcp" ]; then

--- a/src/testclient/scripts/sequentialFullTest/create-mcis-for-ws.sh
+++ b/src/testclient/scripts/sequentialFullTest/create-mcis-for-ws.sh
@@ -9,7 +9,7 @@ function test_sequence() {
 	local CMDPATH=$5
 
 	../1.configureSpider/register-cloud.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
-	../2.configureTumblebug/create-ns.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
+	../2.configureTumblebug/create-ns.sh -n $POSTFIX -f $TestSetFile
 	../3.vNet/create-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile
 	dozing 10
 	if [ "${CSP}" == "gcp" ]; then


### PR DESCRIPTION
Fix #1085

Test


son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/src/testclient/scripts/2.configureTumblebug$ ./create-ns.sh -x t01-ns-with-x
```
####################################################################
## 2. Namespace: Create (-x option for NameSpace Name)
####################################################################

{
  "id": "t01-ns-with-x",
  "name": "t01-ns-with-x",
  "description": "NameSpace for General Testing"
}
``` 

son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/src/testclient/scripts/2.configureTumblebug$ ./create-ns.sh -f ../testSet.env -x t02-ns-with-f-x
```
####################################################################
## 2. Namespace: Create (-x option for NameSpace Name)
####################################################################

{
  "id": "t02-ns-with-f-x",
  "name": "t02-ns-with-f-x",
  "description": "NameSpace for General Testing"
}
``` 

son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/src/testclient/scripts/2.configureTumblebug$ ./create-ns.sh -f ../testSet.env t03-ns-without-x
```
####################################################################
## 2. Namespace: Create (-x option for NameSpace Name)
####################################################################

{
  "message": "CreateNs(); The namespace ns01 already exists."
}
``` 

son@son:~/go/src/github.com/cloud-barista/cb-tumblebug/src/testclient/scripts/2.configureTumblebug$ ./create-ns.sh t04-ns-no-param
```
####################################################################
## 2. Namespace: Create (-x option for NameSpace Name)
####################################################################

[Warrning] Invalid option [t04-ns-no-param]

[Usage] ./create-ns.sh -param value -param value
[Example] ./create-ns.sh -n myname01 -f ../testSet.env

 -n [postfix of resources to generate and retrieve] (ex: -n myname01, default: dev01)
 -f [file path to describe a cloud test set] (ex: -f ../testSet01.env, default: ../testSet.env)

 -c [specific cloud type] (ex: -c aws, optional)
 -r [index of a specific zone of the cloud type] (ex: -r 3, optional)

 -x [any value passed to a parameter of the command] (ex: -x vmid01, optional)
 -y [any value passed to a parameter of the command] (ex: -y 3, optional)
 -z [any value passed to a parameter of the command] (ex: -z file, optional)
```