### PR TITLE
Add support for NCP-VPC

### DIFF
--- a/assets/cloudconnection.csv
+++ b/assets/cloudconnection.csv
@@ -117,6 +117,8 @@ NCP,ncp-us-western,ncp-us-western,USWN,US West,ncp-driver-v1.0.so,ncp-driver01
 NCP,ncp-germany,ncp-germany,DEN,Germany,ncp-driver-v1.0.so,ncp-driver01
 NCP,ncp-singapore,ncp-singapore,SGN,Singapore,ncp-driver-v1.0.so,ncp-driver01
 NCP,ncp-japan,ncp-japan,JPN,Japan,ncp-driver-v1.0.so,ncp-driver01
+NCPVPC,ncpvpc-kr1,ncpvpc-kr1,KR,Korea 1,ncpvpc-driver-v1.0.so,ncpvpc-driver01
+NCPVPC,ncpvpc-singapore,ncpvpc-singapore,SGN,Singapore 4,ncpvpc-driver-v1.0.so,ncpvpc-driver01
 CLOUDIT,cloudit-region01,cloudit-region01,default,Korea Seoul (Internal),cloudit-driver-v1.0.so,cloudit-driver01
 TENCENT,tencent-ap-singapore,tencent-ap-singapore,ap-singapore,Singapore,tencent-driver-v1.0.so,tencent-driver01
 TENCENT,tencent-ap-jakarta,tencent-ap-jakarta,ap-jakarta,Jakarta,tencent-driver-v1.0.so,tencent-driver01

--- a/assets/cloudimage.csv
+++ b/assets/cloudimage.csv
@@ -1,4 +1,7 @@
 ProviderName,connectionName,cspImageId,OsType
+MOCK,testcloud01-seoul,mock-vmimage-01,Ubuntu 18.04
+MOCK,testcloud02-canada,mock-vmimage-01,Ubuntu 18.04
+MOCK,testcloud03-frankfurt,mock-vmimage-01,Ubuntu 18.04
 AWS,aws-ap-southeast-1,ami-061eb2b23f9f8839c,Ubuntu 18.04
 AWS,aws-ca-central-1,ami-0d0eaed20348a3389,Ubuntu 18.04
 AWS,aws-us-west-1,ami-0dd655843c87b6930,Ubuntu 18.04
@@ -108,7 +111,15 @@ ALIBABA,alibaba-cn-heyuan,ubuntu_18_04_x64_20G_alibase_20220322.vhd,Ubuntu 18.04
 ALIBABA,alibaba-cn-chengdu,ubuntu_18_04_x64_20G_alibase_20220428.vhd,Ubuntu 18.04
 ALIBABA,alibaba-cn-wulanchabu,ubuntu_18_04_x64_20G_alibase_20220428.vhd,Ubuntu 18.04
 ALIBABA,alibaba-cn-guangzhou,ubuntu_18_04_x64_20G_alibase_20220322.vhd,Ubuntu 18.04
-CLOUDIT,cloudit-region01,ee441331-0872-49c3-886c-1873a6e32e09,CentOS-7
+OPENSTACK,openstack-region01,ubuntu-18.04,Ubuntu 18.04
+NCP,ncp-korea1,SPSW0LINUX000130,Ubuntu 18.04
+NCP,ncp-us-western,SPSW0LINUX000130,Ubuntu 18.04
+NCP,ncp-germany,SPSW0LINUX000130,Ubuntu 18.04
+NCP,ncp-singapore,SPSW0LINUX000130,Ubuntu 18.04
+NCP,ncp-japan,SPSW0LINUX000130,Ubuntu 18.04
+NCPVPC,ncpvpc-kr1,SW.VSVR.OS.LNX64.UBNTU.SVR1804.B050,Ubuntu 18.04
+NCPVPC,ncpvpc-singapore,SW.VSVR.OS.LNX64.UBNTU.SVR1804.B050,Ubuntu 18.04
+CLOUDIT,cloudit-region01,ee441331-0872-49c3-886c-1873a6e32e09,Ubuntu 18.04
 TENCENT,tencent-ap-singapore,img-pi0ii46r,Ubuntu 18.04
 TENCENT,tencent-ap-jakarta,img-pi0ii46r,Ubuntu 18.04
 TENCENT,tencent-ap-seoul,img-pi0ii46r,Ubuntu 18.04
@@ -127,14 +138,23 @@ TENCENT,tencent-ap-beijing,img-pi0ii46r,Ubuntu 18.04
 TENCENT,tencent-ap-chengdu,img-pi0ii46r,Ubuntu 18.04
 TENCENT,tencent-ap-chongqing,img-pi0ii46r,Ubuntu 18.04
 TENCENT,tencent-ap-hongkong,img-pi0ii46r,Ubuntu 18.04
+KTCLOUD,kt-kr-central-a,45e20478-6c24-4c32-a5e5-2ba2d464a8d1,Ubuntu 18.04
+KTCLOUD,kt-kr-central-b,45e20478-6c24-4c32-a5e5-2ba2d464a8d1,Ubuntu 18.04
+KTCLOUD,kt-kr-seoul-m,45e20478-6c24-4c32-a5e5-2ba2d464a8d1,Ubuntu 18.04
+KTCLOUD,kt-kr-seoul-m2,63de6d04-7f1b-4924-8e95-1acd6581ca0c,Ubuntu 18.04
+KTCLOUD,kt-us-west,45e20478-6c24-4c32-a5e5-2ba2d464a8d1,Ubuntu 18.04
+KTCLOUD,kt-kr-kimhae,45e20478-6c24-4c32-a5e5-2ba2d464a8d1,Ubuntu 18.04
+IBM,ibm-us-south,r006-9de77234-3189-42f8-982d-f2266477cfe0,Ubuntu 18.04
+IBM,ibm-br-sao,r042-92d1cd12-f014-4b9a-abf8-c5ca6494a9e5,Ubuntu 18.04
+IBM,ibm-ca-tor,r038-e92647cf-8be9-438a-b94c-251cc86bc99a,Ubuntu 18.04
+IBM,ibm-us-east,r014-dc446598-a1b5-41c3-a1d6-add3afaf264e,Ubuntu 18.04
+IBM,ibm-eu-de,r010-1f68eb2d-f35c-4959-8f4b-2b2f9cf78102,Ubuntu 18.04
+IBM,ibm-eu-gb,r018-1d7417c6-893e-49d4-b14d-9643d6b29812,Ubuntu 18.04
+IBM,ibm-jp-osa,r034-522c639c-52e1-4cab-8dfb-bc0fb9f6f577,Ubuntu 18.04
+IBM,ibm-au-syd,r026-a8c25ce6-0ca1-43e9-9b41-411c6217b8b8,Ubuntu 18.04
+IBM,ibm-jp-tok,r022-61fdadec-6b03-4bd2-bfca-62cd16f5673f,Ubuntu 18.04
+NHNCLOUD,nhncloud-kr-pangyo,5396655e-166a-4875-80d2-ed8613aa054f,Ubuntu 18.04
+NHNCLOUD,nhncloud-kr-pyeongchon,71893505-923c-4982-b0eb-844eb520661c,Ubuntu 18.04
+NHNCLOUD,nhncloud-jp-tokyo,ca69fad9-92f3-4c9b-a6e4-7e8b0e4d3a58,Ubuntu 18.04
 CLOUDTWIN,cloudtwin-region01,ubuntu18.04-sshd-systemd,Ubuntu 18.04
-NCP,ncp-korea1,SPSW0LINUX000130,Ubuntu 18.04
-NCP,ncp-us-western,SPSW0LINUX000130,Ubuntu 18.04
-NCP,ncp-germany,SPSW0LINUX000130,Ubuntu 18.04
-NCP,ncp-singapore,SPSW0LINUX000130,Ubuntu 18.04
-NCP,ncp-japan,SPSW0LINUX000130,Ubuntu 18.04
 MOCK,mock-seoul,mock-vmimage-01,Ubuntu 18.04
-OPENSTACK,openstack-region01,ubuntu-18.04,Ubuntu 18.04
-MOCK,testcloud01-seoul,mock-vmimage-01,Ubuntu 18.04
-MOCK,testcloud02-canada,mock-vmimage-01,Ubuntu 18.04
-MOCK,testcloud03-frankfurt,mock-vmimage-01,Ubuntu 18.04

--- a/assets/cloudlocation.csv
+++ b/assets/cloudlocation.csv
@@ -120,6 +120,10 @@ ncp,sgn-1,Singapore,1.3400,103.7041
 ncp,jpn-1,Japan,35.6895,139.6917
 ncp,uswn-1,US Western,37.3500,-121.9600
 ncp,den-1,Germany,50.1109,8.6821
+ncpvpc,kr-1,South Korea (Seoul),37.4767,126.8841
+ncpvpc,kr-2,South Korea (Seoul),37.3881,126.9705
+ncpvpc,sgn-4,Singapore,1.3400,103.7041
+ncpvpc,sgn-5,Singapore,1.3400,103.7041
 openstack,regionone,South Korea (Daejeon),36.3804,127.3650
 tencent,ap-singapore,Southeast Asia (Singapore),1.352083,103.819839
 tencent,ap-jakarta,Southeast Asia (Jakarta),-6.175110,106.865036

--- a/conf/template.credentials.conf
+++ b/conf/template.credentials.conf
@@ -100,6 +100,18 @@ CredentialKey02[$IndexNCP]=ClientSecret
 CredentialVal02[$IndexNCP]=       #{{YOURS}}
 
 
+## NCP VPC
+CredentialName[$IndexNCPVPC]=ncpvpc-credential01
+
+CredentialKey01[$IndexNCPVPC]=ClientId
+#Fill in {{YOUR-NCPVPC-Credentidal-ID}} Ex:SFLEKJEFLJIEIVJOLJSEOIV
+CredentialVal01[$IndexNCPVPC]=       #{{YOURS}}
+
+CredentialKey02[$IndexNCPVPC]=ClientSecret
+#Fill in {{YOUR-NCPVPC-Credentidal-Secret}} Ex:fsfdlkfjselSDfjlejklsj/LFJSDLKfjleJKLDJ0
+CredentialVal02[$IndexNCPVPC]=       #{{YOURS}}
+
+
 ## Cloud-Twin
 CredentialName[$IndexCloudTwin]=cloudtwin-credential01
 

--- a/src/testclient/scripts/conf.env
+++ b/src/testclient/scripts/conf.env
@@ -1708,6 +1708,82 @@ SPEC_NAME[$IX,$IY]=${CommonSpecSmall[$IX]}
 
 
 
+
+
+
+
+
+###########################################
+## NCP VPC (4 Regions)
+IX=$IndexNCPVPC
+ProviderName[$IX]=NCPVPC
+DriverLibFileName[$IX]=ncpvpc-driver-v1.0.so
+DriverName[$IX]=ncpvpc-driver01
+CommonImageUbuntu1804[$IX]=SW.VSVR.OS.LNX64.UBNTU.SVR1804.B050
+CommonSpecSmall[$IX]=SVR.VSVR.HICPU.C002.M004.NET.SSD.B050.G002
+CommonSpecMedium[$IX]=SVR.VSVR.HICPU.C004.M008.NET.SSD.B050.G002
+CommonImageType[$IX]="Ubuntu 18.04"
+
+# Region01
+IY=$NcpVpcKorea1
+# Location: NCPVPC Korea 1
+RegionLocation[$IX,$IY]="Korea 1"
+RegionName[$IX,$IY]=ncpvpc-kr1
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=KR
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=KR-1
+CONN_CONFIG[$IX,$IY]=ncpvpc-kr1
+IMAGE_NAME[$IX,$IY]=${CommonImageUbuntu1804[$IX]}
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpecSmall[$IX]}
+
+# # Region02
+# IY=$NcpVpcKorea2
+# # Location: NCPVPC Korea 2
+# RegionLocation[$IX,$IY]="Korea 2"
+# RegionName[$IX,$IY]=ncpvpc-kr2
+# RegionKey01[$IX,$IY]=Region
+# RegionVal01[$IX,$IY]=KR
+# RegionKey02[$IX,$IY]=Zone
+# RegionVal02[$IX,$IY]=KR-2
+# CONN_CONFIG[$IX,$IY]=ncpvpc-kr2
+# IMAGE_NAME[$IX,$IY]=${CommonImageUbuntu1804[$IX]}
+# IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+# SPEC_NAME[$IX,$IY]=${CommonSpecSmall[$IX]}
+
+# Region03
+IY=$NcpVpcSingapore4
+# Location: NCPVPC Singapore 4
+RegionLocation[$IX,$IY]="Singapore 4"
+RegionName[$IX,$IY]=ncpvpc-singapore
+RegionKey01[$IX,$IY]=Region
+RegionVal01[$IX,$IY]=SGN
+RegionKey02[$IX,$IY]=Zone
+RegionVal02[$IX,$IY]=SGN-4
+CONN_CONFIG[$IX,$IY]=ncpvpc-singapore
+IMAGE_NAME[$IX,$IY]=${CommonImageUbuntu1804[$IX]}
+IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+SPEC_NAME[$IX,$IY]=${CommonSpecSmall[$IX]}
+
+# # Region04
+# IY=$NcpVpcSingapore5
+# # Location: NCPVPC Singapore 5
+# RegionLocation[$IX,$IY]="Singapore 5"
+# RegionName[$IX,$IY]=ncpvpc-singapore
+# RegionKey01[$IX,$IY]=Region
+# RegionVal01[$IX,$IY]=SGN
+# RegionKey02[$IX,$IY]=Zone
+# RegionVal02[$IX,$IY]=SGN-5
+# CONN_CONFIG[$IX,$IY]=ncpvpc-singapore
+# IMAGE_NAME[$IX,$IY]=${CommonImageUbuntu1804[$IX]}
+# IMAGE_TYPE[$IX,$IY]=${CommonImageType[$IX]}
+# SPEC_NAME[$IX,$IY]=${CommonSpecSmall[$IX]}
+
+
+
+
+
 ###########################################
 ## Cloudit (1 Regions)
 IX=$IndexCloudit
@@ -2495,6 +2571,9 @@ function getCloudIndex()
 	elif [ "${CSP}" == "ncp" ]; then
 		# echo "[NCP driver]"
 		CSPIndex=$IndexNCP
+	elif [ "${CSP}" == "ncpvpc" ]; then
+		# echo "[NCPVPC driver]"
+		CSPIndex=$IndexNCPVPC
 	elif [ "${CSP}" == "cloudtwin" ]; then
 		# echo "[Cloud-Twin driver]"
 		CSPIndex=$IndexCloudTwin
@@ -2560,24 +2639,27 @@ function getCloudIndexGeneral()
 	elif [ "${CSP}" == "ncp" ]; then
 		# echo "[NCP driver]"
 		CSPIndex=k
+	elif [ "${CSP}" == "ncpvpc" ]; then
+		# echo "[NCPVPC driver]"
+		CSPIndex=l
 	elif [ "${CSP}" == "cloudtwin" ]; then
 		# echo "[Cloud-Twin driver]"
-		CSPIndex=l
+		CSPIndex=m
 	elif [ "${CSP}" == "cloudit" ]; then
 		# echo "[Cloudit driver]"
-		CSPIndex=m
+		CSPIndex=n
 	elif [ "${CSP}" == "tencent" ]; then
 		# echo "[Tencent driver]"
-		CSPIndex=n
+		CSPIndex=o
 	elif [ "${CSP}" == "ktcloud" ]; then
 		# echo "[KTcloud driver]"
-		CSPIndex=o
+		CSPIndex=p
 	elif [ "${CSP}" == "ibm" ]; then
 		# echo "[IBM-VPC driver]"
-		CSPIndex=p
+		CSPIndex=q
 	elif [ "${CSP}" == "nhncloud" ]; then
 		# echo "[NHN Cloud driver]"
-		CSPIndex=q
+		CSPIndex=r
 	else
 		echo "[No acceptable argument was provided (all, aws, azure, gcp, alibaba, mock, openstack, ...).]"
 		exit

--- a/src/testclient/scripts/testSet.env
+++ b/src/testclient/scripts/testSet.env
@@ -9,7 +9,7 @@ AgentInstallOn=no
 ## Number of CSP types and corresponding regions
 NumCSP=3
 
-TotalNumCSP=16
+TotalNumCSP=17
 
 ## Define sequential test order for cloud types 
 # Note: you can change order by replacing lines (automatically assign continuous numbers starting from 1)
@@ -24,6 +24,7 @@ IndexGCP=$((++IX))
 IndexAlibaba=$((++IX))
 IndexOpenstack=$((++IX))
 IndexNCP=$((++IX))
+IndexNCPVPC=$((++IX))
 IndexCloudit=$((++IX))
 IndexTencent=$((++IX))
 IndexKTcloud=$((++IX))
@@ -43,6 +44,7 @@ CSPType[$IndexAzure]=azure
 CSPType[$IndexMock]=mock
 CSPType[$IndexOpenstack]=openstack
 CSPType[$IndexNCP]=ncp
+CSPType[$IndexNCPVPC]=ncpvpc
 CSPType[$IndexCloudTwin]=cloudtwin
 CSPType[$IndexCloudit]=cloudit
 CSPType[$IndexTencent]=tencent
@@ -223,6 +225,22 @@ NcpUsWestern=$((++IY))				# Location: NCP US West
 NcpGermany=$((++IY))				# Location: NCP Germany
 NcpSingapore=$((++IY))				# Location: NCP Singapore
 NcpJapan=$((++IY))					# Location: NCP Japan
+
+
+
+
+
+# NCP VPC (Total: 4 Regions / Recommend: ? Regions / Not tested yet)
+NumRegion[$IndexNCPVPC]=1
+
+TotalNumRegion[$IndexNCPVPC]=2
+
+IY=0
+NcpVpcKorea1=$((++IY))					# Location: NCP VPC Korea 1
+# NcpVpcKorea2=$((++IY))				    # Location: NCP VPC Korea 2
+NcpVpcSingapore4=$((++IY))				# Location: NCP VPC Singapore 4
+# NcpVpcSingapore5=$((++IY))				# Location: NCP VPC Singapore 5
+
 
 
 


### PR DESCRIPTION
- `create-all.sh` 및 `clean-all.sh` 테스트 스크립트로 각종 자원 + VM 생성/삭제 되는 것을 확인했습니다. 😊
- 현재 NCP-VPC 는 한국, 싱가폴 리전에서만 사용 가능한 것으로 보입니다.
  https://console.ncloud.com/vpc-compute/server
  ![image](https://user-images.githubusercontent.com/46767780/168244107-d88e616f-22aa-408d-91e9-1b52b90d03ba.png)

---

[Memo]
https://github.com/cloud-barista/cb-tumblebug/pull/1111#discussion_r871959331

> assets/cloudconnection.csv 정보의 소스는 src/testclient/scripts/conf.env 이며,
> 
> src/testclient/scripts/misc/gen-csv-conn-config.sh 를 실행하면,
> src/testclient/scripts/conf.env 의 내용을 assets/cloudconnection.csv CSV 형태로 변환하여 파일을 생성해줍니다.