### PR TITLE
Enhance output for mcis status

### DIFF
--- a/src/core/mcis/manageInfo.go
+++ b/src/core/mcis/manageInfo.go
@@ -587,10 +587,11 @@ func GetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 	}
 
 	numVm := len(mcisStatus.Vm)
-	numUnNormalStatus := statusFlag[0] + statusFlag[9]
-	numNormalStatus := numVm - numUnNormalStatus
+	//numUnNormalStatus := statusFlag[0] + statusFlag[9]
+	//numNormalStatus := numVm - numUnNormalStatus
+	runningStatus := statusFlag[2]
 
-	proportionStr := "-" + strconv.Itoa(tmpMax) + "(" + strconv.Itoa(numNormalStatus) + "/" + strconv.Itoa(numVm) + ")"
+	proportionStr := ":" + strconv.Itoa(tmpMax) + " (R:" + strconv.Itoa(runningStatus) + "/" + strconv.Itoa(numVm) + ")"
 	if tmpMax == numVm {
 		mcisStatus.Status = statusFlagStr[tmpMaxIndex] + proportionStr
 	} else if tmpMax < numVm {
@@ -600,7 +601,7 @@ func GetMcisStatus(nsId string, mcisId string) (*McisStatusInfo, error) {
 	}
 	// for representing Failed status in front.
 
-	proportionStr = "-" + strconv.Itoa(statusFlag[0]) + "(" + strconv.Itoa(numNormalStatus) + "/" + strconv.Itoa(numVm) + ")"
+	proportionStr = ":" + strconv.Itoa(statusFlag[0]) + " (R:" + strconv.Itoa(runningStatus) + "/" + strconv.Itoa(numVm) + ")"
 	if statusFlag[0] > 0 {
 		mcisStatus.Status = "Partial-" + statusFlagStr[0] + proportionStr
 		if statusFlag[0] == numVm {


### PR DESCRIPTION
mcis 전체 상태를 표시 방식을 아래와 같이 변경하여 가독성 향상.

`현재 MCIS 대표 상태`:`관련된 VM수` (R:`러닝 상태 VM수`/`전체 VM수`)