### PR TITLE
 Reconstuct resource IDs for a registered MCIS

### DIFF
--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -1565,7 +1565,37 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo, option string) e
 	//configTmp, _ := common.GetConnConfig(vmInfoData.ConnectionName)
 	//vmInfoData.Location = GetCloudLocation(strings.ToLower(configTmp.ProviderName), strings.ToLower(tempSpiderVMInfo.Region.Region))
 
-	if option != "register" {
+	if option == "register" {
+
+		// Reconstuct resource IDs
+		// vNet
+		resourceListInNs, err := mcir.ListResource(nsId, common.StrVNet, "cspVNetName", tempSpiderVMInfo.VpcIID.NameId)
+		if err != nil {
+			common.CBLog.Error(err)
+		} else {
+			resourcesInNs := resourceListInNs.([]mcir.TbVNetInfo) // type assertion
+			for _, resource := range resourcesInNs {
+				if resource.ConnectionName == tempReq.ConnectionName {
+					vmInfoData.VNetId = resource.Id
+					//vmInfoData.SubnetId = resource.SubnetInfoList
+				}
+			}
+		}
+
+		// access Key
+		resourceListInNs, err = mcir.ListResource(nsId, common.StrSSHKey, "cspSshKeyName", tempSpiderVMInfo.KeyPairIId.NameId)
+		if err != nil {
+			common.CBLog.Error(err)
+		} else {
+			resourcesInNs := resourceListInNs.([]mcir.TbSshKeyInfo) // type assertion
+			for _, resource := range resourcesInNs {
+				if resource.ConnectionName == tempReq.ConnectionName {
+					vmInfoData.SshKeyId = resource.Id
+				}
+			}
+		}
+
+	} else {
 		vmKey := common.GenMcisKey(nsId, mcisId, vmInfoData.Id)
 		//mcir.UpdateAssociatedObjectList(nsId, common.StrSSHKey, vmInfoData.SshKeyId, common.StrAdd, vmKey)
 		mcir.UpdateAssociatedObjectList(nsId, common.StrImage, vmInfoData.ImageId, common.StrAdd, vmKey)


### PR DESCRIPTION
https://github.com/cloud-barista/cb-tumblebug/issues/1055#issuecomment-1114214203

pfix - 자원간 연관관계 및 자원 정보 재구축 필요 (일부 가능한 항목만)

 - vNet, SSHKey 에 대해 진행


   {
      "id": "aws-ap-southeast-1-i-0ba32d5f4856e71e0",
      "name": "aws-ap-southeast-1-i-0ba32d5f4856e71e0",
      "idByCSP": "i-0ba32d5f4856e71e0",
      "vmGroupId": "",
      "location": {
        "latitude": "1.3700",
        "longitude": "103.8000",
        "briefAddr": "Singapore",
        "cloudType": "aws",
        "nativeRegion": "ap-southeast-1"
      },
      "status": "Running",
      "targetStatus": "None",
      "targetAction": "None",
      "monAgentStatus": "notInstalled",
      "networkAgentStatus": "notInstalled",
      "systemMessage": "",
      "createdTime": "2022-06-13 21:36:35",
      "label": "not defined",
      "description": "Ref name: csp01-shson. CSP managed VM (registered to CB-TB)",
      "region": {
        "Region": "ap-southeast-1",
        "Zone": "ap-southeast-1c"
      },
      "publicIP": "13.212.108.232",
      "sshPort": "22",
      "publicDNS": "ec2-13-212-108-232.ap-southeast-1.compute.amazonaws.com",
      "privateIP": "172.31.1.185",
      "privateDNS": "i-0ba32d5f4856e71e0.ap-southeast-1.compute.internal",
      "rootDiskType": "gp2",
      "rootDiskSize": "8",
      "rootDeviceName": "/dev/sda1",
      "vmBootDisk": "",
      "vmBlockDisk": "/dev/sda1",
      "connectionName": "aws-ap-southeast-1",
      "specId": "cannot retrieve",
      "imageId": "cannot retrieve",
      **"vNetId": "aws-ap-southeast-1-vpc-e4f4d483",**
      "subnetId": "cannot retrieve",
      "securityGroupIds": [
        "cannot retrieve"
      ],
      **"sshKeyId": "aws-ap-southeast-1-csp-key-shson",**


- 참고: sshKey 를 업데이트하여, VM 접속 가능 여부를 시도해보았으나, 정상 동작하지 않았음. (why? I am not sure)