### PR TITLE
Add script for test-mcis-dynamic-all

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/test-mcis-dynamic-all.sh
+++ b/src/testclient/scripts/sequentialFullTest/test-mcis-dynamic-all.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+echo "####################################################################"
+echo "## test-mcis-dynamic-all.sh (parameters: -x (create or delete) -y numVM)"
+echo "####################################################################"
+
+
+
+source ../init.sh
+
+# create or delete
+option=${OPTION01}
+vmGroupSizeInput=${OPTION02:-1}
+
+
+PRINT="index,mcisName,connectionName,specId,image,vmGroupSize,startTime,endTime,elapsedTime,option"
+echo "${PRINT}" >./mcisTest-$option.csv
+
+
+description="Made in CB-TB"
+installMonAgent="no"
+label="DynamicVM"
+
+echo 
+
+specList=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/system-purpose-common-ns/resources/spec)
+specArray=$(jq -r '.spec' <<<"$specList")
+
+i=0
+for row in $(echo "${specArray}" | jq -r '.[] | @base64'); do
+        {
+            _jq() {
+                echo ${row} | base64 --decode | jq -r ${1}
+            }
+            connectionName=$(_jq '.connectionName')
+            specId=$(_jq '.id')
+            rootDiskType=$(_jq '.rootDiskType')
+            rootDiskSize=$(_jq '.rootDiskSize')
+            image="ubuntu18.04"
+            vmGroupSize=$vmGroupSizeInput
+            mcisName=$specId
+
+            if [ "${option}" == "create" ]; then
+                echo "[$i] connection: $connectionName / specId: $specId / image: $image / replica: $vmGroupSize "
+            elif [ "${option}" == "delete" ]; then
+                echo "[$i] mcisName: $mcisName / replica: $vmGroupSize "
+            fi
+            ((i++))
+        }
+done
+
+echo
+echo "[Test] will $option MCISs using all common Specs sequentially"
+echo "[options] Operation: $option , mcisSize: $vmGroupSizeInput , fileName: mcisTest-$option.csv"
+echo
+
+while true; do
+    read -p 'Confirm the above configuration. Do you want to proceed ? (y/n) : ' CHECKPROCEED
+    echo -e "${NC}"
+    case $CHECKPROCEED in
+        [Yy]* ) 
+            break
+            ;;
+        [Nn]* ) 
+            echo
+            echo "Cancel [$0 $@]"
+            echo "See you soon. :)"
+            echo
+            exit 1
+            ;;
+        * ) 
+            echo "Please answer yes or no.";;
+    esac
+done
+
+SECONDS=0
+
+specList=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/system-purpose-common-ns/resources/spec)
+specArray=$(jq -r '.spec' <<<"$specList")
+
+i=0
+for row in $(echo "${specArray}" | jq -r '.[] | @base64'); do
+    {
+
+        _jq() {
+            echo ${row} | base64 --decode | jq -r ${1}
+        }
+
+        connectionName=$(_jq '.connectionName')
+
+        specId=$(_jq '.id')
+        rootDiskType=$(_jq '.rootDiskType')
+        rootDiskSize=$(_jq '.rootDiskSize')
+        image="ubuntu18.04"
+        vmGroupSize=$vmGroupSizeInput
+        mcisName=$specId
+
+        echo
+        echo "mcisName: $mcisName   specId: $specId   image: $image   connectionName: $connectionName   rootDiskType: $rootDiskType   rootDiskSize: $rootDiskSize  vmGroupSize: $vmGroupSize "
+        sleepDuration=$((1 + RANDOM % 600))
+        echo "sleepDuration: $sleepDuration"
+        sleep $sleepDuration
+
+        startTime=$SECONDS
+        if [ "${option}" == "delete" ]; then
+            echo "Terminate and Delete [$mcisName]"
+            curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${mcisName}?option=terminate | jq ''
+
+
+        elif [ "${option}" == "create" ]; then
+            echo "Creat MCIS dynamic [$mcisName]"
+            VAR1=$(curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/mcisDynamic -H 'Content-Type: application/json' -d @- <<EOF
+            {
+                    "name": "${mcisName}",
+                    "description": "${description}",
+                    "installMonAgent": "${installMonAgent}",
+                    "label": "${label}",
+                    "systemLabel": "Managed-by-Tumblebug",
+                    "vm": [ {
+                            "commonImage": "${image}",
+                            "commonSpec": "${specId}",
+                            "rootDiskType": "${rootDiskType}",
+                            "rootDiskSize": "${rootDiskSize}",
+                            "vmGroupSize": "${vmGroupSize}"
+                        }
+                    ]
+            }
+EOF
+            )
+
+            echo "${VAR1}" | jq ''
+
+        fi
+        endTime=$SECONDS
+        elapsedTime=$(($endTime-$startTime))
+
+        PRINT="${i},${mcisName},${connectionName},${specId},${image},${vmGroupSize},${startTime},${endTime},${elapsedTime},${option}"
+        echo "$PRINT"
+        echo "$PRINT" >>./mcisTest-$option.csv
+
+        echo "[$i] Elapsed time: $elapsedTime s"
+        ((i++))
+
+    } &
+
+done
+wait
+
+
+
+echo "Done!"
+duration=$SECONDS
+printElapsed $@
+echo ""
+


### PR DESCRIPTION

공통 Spec으로 등록되어 있는 모든 Spec을 대상으로

MCIS를 자동 모드로 생성해주는 시험 스크립트. (대규모 MCIS 테스트)

### 사용 방법

 - ./test-mcis-dynamic-all.sh -f ../testSet.env -x create
   - y 옵션으로 vm 레플리카 수를 지정할 수 있음
 - ./test-mcis-dynamic-all.sh -f ../testSet.env -x delete
   - delete 는 terminate & delete 임

![image](https://user-images.githubusercontent.com/5966944/174502187-1fd2019b-55d4-4a36-9a59-6d5197eeddf2.png)
