### PR TITLE
Extend API rate limit from 1 to 2 in a sec

### DIFF
--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -177,10 +177,10 @@ func RunServer(port string) {
 	// path specific timeout and ratelimit
 	g.GET("/:nsId/mcis/:mcisId", rest_mcis.RestGetMcis, middleware.TimeoutWithConfig(
 		middleware.TimeoutConfig{Timeout: 60 * time.Second}),
-		middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(1)))
+		middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(2)))
 	g.GET("/:nsId/mcis", rest_mcis.RestGetAllMcis, middleware.TimeoutWithConfig(
 		middleware.TimeoutConfig{Timeout: 60 * time.Second}),
-		middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(1)))
+		middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(2)))
 
 	g.PUT("/:nsId/mcis/:mcisId", rest_mcis.RestPutMcis)
 	g.DELETE("/:nsId/mcis/:mcisId", rest_mcis.RestDelMcis)


### PR DESCRIPTION
Extend API rate limit from 1 to 2 in a sec

클라이언트 중에, API 테스트를 위한 preflight 처리를 하는 경우가 있어서

rate limit 완화.