### PR TITLE
Update Cloud Adaptive Network API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace (
 require (
 	github.com/bramvdbogaerde/go-scp v1.0.0
 	github.com/cloud-barista/cb-dragonfly v0.5.1
-	github.com/cloud-barista/cb-larva v0.0.14
+	github.com/cloud-barista/cb-larva v0.0.15
 	github.com/cloud-barista/cb-log v0.5.0
 	github.com/cloud-barista/cb-spider v0.5.3
 	github.com/cloud-barista/cb-store v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,8 @@ github.com/cloud-barista/cb-dragonfly v0.5.1 h1:WVBvFwwnyTblFpactJI05qYyF5Gx6NjX
 github.com/cloud-barista/cb-dragonfly v0.5.1/go.mod h1:UllpEB0fBoEl5kUi7U/e5viwOFVxVA3pKhskds+vvVM=
 github.com/cloud-barista/cb-larva v0.0.14 h1:F6uyBrZH98pPMUGx7dwiCsbAVIwnnnEdc1rXrw3u99w=
 github.com/cloud-barista/cb-larva v0.0.14/go.mod h1:5vFk/GaTodU5rLsN92syam+YXT5IBdowgvG3UjsyFAQ=
+github.com/cloud-barista/cb-larva v0.0.15 h1:SLbaEwdp7b5Ugj+Mda4hnt57IVPMt/rCdAUKLNx5eHI=
+github.com/cloud-barista/cb-larva v0.0.15/go.mod h1:5vFk/GaTodU5rLsN92syam+YXT5IBdowgvG3UjsyFAQ=
 github.com/cloud-barista/cb-log v0.3.1/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJaZWV/6MOwc20c=
 github.com/cloud-barista/cb-log v0.4.0/go.mod h1:C0KNV97sw8IoLSlNuSiCGDQIuS/wXJaZWV/6MOwc20c=
 github.com/cloud-barista/cb-log v0.5.0 h1:WoUnXtNNNTA7wRgQa6sFNs57O3mLAOrh4aDHC4cU0CI=

--- a/src/core/mcis/network.go
+++ b/src/core/mcis/network.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	model "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/cb-network/model"
 	nethelper "github.com/cloud-barista/cb-larva/poc-cb-net/pkg/network-helper"
@@ -164,6 +165,9 @@ func ConfigureCloudAdaptiveNetwork(nsId string, mcisId string, netReq *NetworkRe
 			}
 
 		}(nsId, mcisId, vmId, mcisCmdReq, chanResults)
+
+		// Temporarily sleep 3 sec, to assign IPs consecutively to VMs in a VMgroup for a Cloud Adaptive Network
+		time.Sleep(3 * time.Second)
 	}
 
 	go func() {
@@ -367,7 +371,8 @@ func getAgentInstallationCommand(etcdEndpoints, cladnetId string) (string, error
 	}
 
 	// SSH command to install cb-network agents
-	placeHolderCommand := `wget https://raw.githubusercontent.com/cloud-barista/cb-larva/main/poc-cb-net/scripts/deploy-the-released-cb-network-agent.sh -O ~/deploy-the-released-cb-network-agent.sh; chmod +x ~/deploy-the-released-cb-network-agent.sh; source ~/deploy-the-released-cb-network-agent.sh '%s' %s`
+	placeHolderCommand := `wget https://raw.githubusercontent.com/cloud-barista/cb-larva/v0.0.15/poc-cb-net/scripts/deploy-the-released-cb-network-agent.sh -O ~/deploy-the-released-cb-network-agent.sh; chmod +x ~/deploy-the-released-cb-network-agent.sh; source ~/deploy-the-released-cb-network-agent.sh '%s' %s`
+	// placeHolderCommand := `wget https://raw.githubusercontent.com/cloud-barista/cb-larva/main/poc-cb-net/scripts/1.deploy-cb-network-agent.sh -O ~/1.deploy-cb-network-agent.sh -O ~/1.deploy-cb-network-agent.sh; chmod +x ~/1.deploy-cb-network-agent.sh; source ~/1.deploy-cb-network-agent.sh '%s' %s`
 
 	// additionalEncodedString := strings.Replace(etcdEndpoints, "\"", "\\\"", -1)
 	command := fmt.Sprintf(placeHolderCommand, etcdEndpoints, cladnetId)


### PR DESCRIPTION
It's a minor update to Cloud Adaptive Network API.
- Temporarily add sleep, to assign IPs consecutively to VMs in a VMgroup
- Specify the version (v0.0.15) to deploy cb-network agents (may keep this version until the next release)

I think that this PR could be reflected in the CB-Tumblebug v0.6.0 release without the v0.5.x Pre-release 😃 