### PR TITLE
Update OS and Go in workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,7 +11,9 @@ jobs:
     # Apply this job if it is a PR and by OWNER with '/approve' comment
     # TODO: the section contains('seokho-son jihoon-seo hermitkim1') needs to be updated or automated
     if: ${{ github.event.issue.pull_request && (contains('seokho-son jihoon-seo hermitkim1', github.event.comment.user.login) || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/approve') }}
-    runs-on: ubuntu-18.04
+    # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
     steps:
       # Check author_association is OWNER
       - name: Check author_association

--- a/.github/workflows/build-amd64-container-image.yaml
+++ b/.github/workflows/build-amd64-container-image.yaml
@@ -23,8 +23,9 @@ jobs:
     # Job name is "Building"
     name: Building
 
-    # This job runs on Ubuntu-latest
-    runs-on: ubuntu-18.04
+    # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
 
     steps:

--- a/.github/workflows/make-swagger.yaml
+++ b/.github/workflows/make-swagger.yaml
@@ -10,10 +10,12 @@ jobs:
   update-swagger-doc:
     name: Update Swagger doc
     if: github.repository == 'cloud-barista/cb-tumblebug'
-    runs-on: ubuntu-18.04
+    # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.17' ]
+        go-version: [ '1.19' ]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/.github/workflows/prow-commands.yml
+++ b/.github/workflows/prow-commands.yml
@@ -12,7 +12,9 @@ jobs:
   execute:
     # Execute when author_association of the comment is OWNER or MEMBER
     if: ${{ github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' }}
-    runs-on: ubuntu-18.04
+    # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
     # Execute action according to commands
     steps:
       # Check author_association

--- a/.github/workflows/publish-multi-arch-container-images.yaml
+++ b/.github/workflows/publish-multi-arch-container-images.yaml
@@ -33,8 +33,9 @@ jobs:
 
     if: github.repository == 'cloud-barista/cb-tumblebug'
 
-    # This job runs on Ubuntu-latest
-    runs-on: ubuntu-18.04
+    # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
+    # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
Workflows의 구동 OS 및 Go 버전을 변경하였습니다.
- `ubuntu-18.04` to `ubuntu-latest`
- `1.17` to `1.19`

CB-Tumblebug은container image build를 통해 코드 필드 성공 여부를 테스트하고 있기 때문에 큰 이슈를 없을 것으로 생각합니다. (Cloud-Barista의 개발/테스트를 위한 공식 OS(Ubuntu 22.04)와도 관련이 낮습니다.)

`make-swagger.yaml`는 환경을 탈 것 같아 로컬에서 수행해봤는데요. 이슈는 없었습니다.  적용 후 이슈가 발생하면 대응하겠습니다 ^^

(참고)
Ref: [GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)