### PR TITLE
Add scaleOut feature for VMGroup in a MCIS

### DIFF
--- a/src/api/grpc/server/mcis/control.go
+++ b/src/api/grpc/server/mcis/control.go
@@ -265,7 +265,7 @@ func (s *MCISService) CreateMcisVMGroup(ctx context.Context, req *pb.TbVmGroupCr
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.CreateMcisVMGroup()")
 	}
 
-	result, err := mcis.CreateMcisGroupVm(req.NsId, req.McisId, &mcisObj)
+	result, err := mcis.CreateMcisGroupVm(req.NsId, req.McisId, &mcisObj, true)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.CreateMcisVMGroup()")
 	}

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -2788,6 +2788,74 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "post": {
+                "description": "ScaleOut VM group in specified MCIS",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra service] MCIS Provisioning management"
+                ],
+                "summary": "ScaleOut VM group in specified MCIS",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "mcis01",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "group-0",
+                        "description": "VM Group ID",
+                        "name": "vmgroupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "VM Group scaleOut request",
+                        "name": "vmReq",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbScaleOutVmGroupReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbMcisInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
             }
         },
         "/ns/{nsId}/mcisDynamic": {
@@ -8317,6 +8385,19 @@ const docTemplate = `{
                 "vNetId": {
                     "type": "string",
                     "example": "ns01-systemdefault-aws-ap-northeast-2"
+                }
+            }
+        },
+        "mcis.TbScaleOutVmGroupReq": {
+            "type": "object",
+            "required": [
+                "vmGroupSize"
+            ],
+            "properties": {
+                "vmGroupSize": {
+                    "description": "Define addtional VMs to scaleOut",
+                    "type": "string",
+                    "example": "2"
                 }
             }
         },

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -2780,6 +2780,74 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "description": "ScaleOut VM group in specified MCIS",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra service] MCIS Provisioning management"
+                ],
+                "summary": "ScaleOut VM group in specified MCIS",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "mcis01",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "group-0",
+                        "description": "VM Group ID",
+                        "name": "vmgroupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "VM Group scaleOut request",
+                        "name": "vmReq",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbScaleOutVmGroupReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbMcisInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
             }
         },
         "/ns/{nsId}/mcisDynamic": {
@@ -8309,6 +8377,19 @@
                 "vNetId": {
                     "type": "string",
                     "example": "ns01-systemdefault-aws-ap-northeast-2"
+                }
+            }
+        },
+        "mcis.TbScaleOutVmGroupReq": {
+            "type": "object",
+            "required": [
+                "vmGroupSize"
+            ],
+            "properties": {
+                "vmGroupSize": {
+                    "description": "Define addtional VMs to scaleOut",
+                    "type": "string",
+                    "example": "2"
                 }
             }
         },

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1716,6 +1716,15 @@ definitions:
     - type
     - vNetId
     type: object
+  mcis.TbScaleOutVmGroupReq:
+    properties:
+      vmGroupSize:
+        description: Define addtional VMs to scaleOut
+        example: "2"
+        type: string
+    required:
+    - vmGroupSize
+    type: object
   mcis.TbVmDynamicReq:
     properties:
       commonImage:
@@ -3959,6 +3968,53 @@ paths:
           schema:
             $ref: '#/definitions/common.SimpleMsg'
       summary: List VMs with a VMGroup label in a specified MCIS
+      tags:
+      - '[Infra service] MCIS Provisioning management'
+    post:
+      consumes:
+      - application/json
+      description: ScaleOut VM group in specified MCIS
+      parameters:
+      - default: ns01
+        description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - default: mcis01
+        description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - default: group-0
+        description: VM Group ID
+        in: path
+        name: vmgroupId
+        required: true
+        type: string
+      - description: VM Group scaleOut request
+        in: body
+        name: vmReq
+        required: true
+        schema:
+          $ref: '#/definitions/mcis.TbScaleOutVmGroupReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.TbMcisInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: ScaleOut VM group in specified MCIS
       tags:
       - '[Infra service] MCIS Provisioning management'
   /ns/{nsId}/mcisDynamic:

--- a/src/api/rest/server/mcis/provisioning.go
+++ b/src/api/rest/server/mcis/provisioning.go
@@ -207,7 +207,42 @@ func RestPostMcisVmGroup(c echo.Context) error {
 	}
 	common.PrintJsonPretty(*vmInfoData)
 
-	result, err := mcis.CreateMcisGroupVm(nsId, mcisId, vmInfoData)
+	result, err := mcis.CreateMcisGroupVm(nsId, mcisId, vmInfoData, true)
+	if err != nil {
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(http.StatusInternalServerError, &mapA)
+	}
+	common.PrintJsonPretty(*result)
+
+	return c.JSON(http.StatusCreated, result)
+}
+
+// RestPostMcisVmGroupScaleOut godoc
+// @Summary ScaleOut VM group in specified MCIS
+// @Description ScaleOut VM group in specified MCIS
+// @Tags [Infra service] MCIS Provisioning management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Param mcisId path string true "MCIS ID" default(mcis01)
+// @Param vmgroupId path string true "VM Group ID" default(group-0)
+// @Param vmReq body mcis.TbScaleOutVmGroupReq true "VM Group scaleOut request"
+// @Success 200 {object} mcis.TbMcisInfo
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /ns/{nsId}/mcis/{mcisId}/vmgroup/{vmgroupId} [post]
+func RestPostMcisVmGroupScaleOut(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+	mcisId := c.Param("mcisId")
+	vmgroupId := c.Param("vmgroupId")
+
+	scaleOutReq := &mcis.TbScaleOutVmGroupReq{}
+	if err := c.Bind(scaleOutReq); err != nil {
+		return err
+	}
+
+	result, err := mcis.ScaleOutMcisVmGroup(nsId, mcisId, vmgroupId, scaleOutReq.VmGroupSize)
 	if err != nil {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)

--- a/src/api/rest/server/mcis/provisioning.go
+++ b/src/api/rest/server/mcis/provisioning.go
@@ -242,7 +242,7 @@ func RestPostMcisVmGroupScaleOut(c echo.Context) error {
 		return err
 	}
 
-	result, err := mcis.ScaleOutMcisVmGroup(nsId, mcisId, vmgroupId, scaleOutReq.VmGroupSize)
+	result, err := mcis.ScaleOutMcisVmGroup(nsId, mcisId, vmgroupId, scaleOutReq.NumVMsToAdd)
 	if err != nil {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -188,6 +188,7 @@ func RunServer(port string) {
 
 	g.POST("/:nsId/mcis/:mcisId/vm", rest_mcis.RestPostMcisVm)
 	g.POST("/:nsId/mcis/:mcisId/vmgroup", rest_mcis.RestPostMcisVmGroup)
+	g.POST("/:nsId/mcis/:mcisId/vmgroup/:vmgroupId", rest_mcis.RestPostMcisVmGroupScaleOut)
 	g.GET("/:nsId/mcis/:mcisId/vm/:vmId", rest_mcis.RestGetMcisVm)
 	g.GET("/:nsId/mcis/:mcisId/vmgroup", rest_mcis.RestGetMcisGroupIds)
 	g.GET("/:nsId/mcis/:mcisId/vmgroup/:vmgroupId", rest_mcis.RestGetMcisGroupVms)

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -212,7 +212,7 @@ type TbVmReq struct {
 // TbVmReq is struct to get requirements to create a new server instance
 type TbScaleOutVmGroupReq struct {
 	// Define addtional VMs to scaleOut
-	VmGroupSize string `json:"vmGroupSize" validate:"required" example:"2"`
+	NumVMsToAdd string `json:"numVMsToAdd" validate:"required" example:"2"`
 
 	//tobe added accoring to new future capability
 }
@@ -561,7 +561,7 @@ func CorePostMcisVm(nsId string, mcisId string, vmInfoData *TbVmInfo) (*TbVmInfo
 }
 
 // ScaleOutMcisVmGroup is func to create MCIS groupVM
-func ScaleOutMcisVmGroup(nsId string, mcisId string, vmGroupId string, numAddition string) (*TbMcisInfo, error) {
+func ScaleOutMcisVmGroup(nsId string, mcisId string, vmGroupId string, numVMsToAdd string) (*TbMcisInfo, error) {
 	vmIdList, err := ListMcisGroupVms(nsId, mcisId, vmGroupId)
 	if err != nil {
 		temp := &TbMcisInfo{}
@@ -586,7 +586,7 @@ func ScaleOutMcisVmGroup(nsId string, mcisId string, vmGroupId string, numAdditi
 	vmTemplate.RootDiskSize = vmObj.RootDiskSize
 	vmTemplate.Description = vmObj.Description
 
-	vmTemplate.VmGroupSize = numAddition
+	vmTemplate.VmGroupSize = numVMsToAdd
 
 	result, err := CreateMcisGroupVm(nsId, mcisId, vmTemplate, true)
 	if err != nil {
@@ -690,7 +690,7 @@ func CreateMcisGroupVm(nsId string, mcisId string, vmRequest *TbVmReq, newVmGrou
 				}
 				// add the number of existing VMs in the VMGroup with requested number for additions
 				vmGroupInfoData.VmGroupSize = strconv.Itoa(existingVmSize + vmGroupSize)
-				vmStartIndex = vmStartIndex + existingVmSize + 1
+				vmStartIndex = existingVmSize + 1
 			} else {
 				err = fmt.Errorf("Duplicated VMGroup ID")
 				common.CBLog.Error(err)

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -209,6 +209,14 @@ type TbVmReq struct {
 	RootDiskSize     string   `json:"rootDiskSize,omitempty" example:"default, 30, 42, ..."` // "default", Integer (GB): ["50", ..., "1000"]
 }
 
+// TbVmReq is struct to get requirements to create a new server instance
+type TbScaleOutVmGroupReq struct {
+	// Define addtional VMs to scaleOut
+	VmGroupSize string `json:"vmGroupSize" validate:"required" example:"2"`
+
+	//tobe added accoring to new future capability
+}
+
 // TbVmDynamicReq is struct to get requirements to create a new server instance dynamically (with default resource option)
 type TbVmDynamicReq struct {
 	// VM name or VM group name if is (not empty) && (> 0). If it is a group, actual VM name will be generated with -N postfix.
@@ -552,8 +560,45 @@ func CorePostMcisVm(nsId string, mcisId string, vmInfoData *TbVmInfo) (*TbVmInfo
 	return vmInfoData, nil
 }
 
+// ScaleOutMcisVmGroup is func to create MCIS groupVM
+func ScaleOutMcisVmGroup(nsId string, mcisId string, vmGroupId string, numAddition string) (*TbMcisInfo, error) {
+	vmIdList, err := ListMcisGroupVms(nsId, mcisId, vmGroupId)
+	if err != nil {
+		temp := &TbMcisInfo{}
+		return temp, err
+	}
+	vmObj, err := GetVmObject(nsId, mcisId, vmIdList[0])
+
+	vmTemplate := &TbVmReq{}
+
+	// only take template required to create VM
+	vmTemplate.Name = vmObj.VmGroupId
+	vmTemplate.ConnectionName = vmObj.ConnectionName
+	vmTemplate.ImageId = vmObj.ImageId
+	vmTemplate.SpecId = vmObj.SpecId
+	vmTemplate.VNetId = vmObj.VNetId
+	vmTemplate.SubnetId = vmObj.SubnetId
+	vmTemplate.SecurityGroupIds = vmObj.SecurityGroupIds
+	vmTemplate.SshKeyId = vmObj.SshKeyId
+	vmTemplate.VmUserAccount = vmObj.VmUserAccount
+	vmTemplate.VmUserPassword = vmObj.VmUserPassword
+	vmTemplate.RootDiskType = vmObj.RootDiskType
+	vmTemplate.RootDiskSize = vmObj.RootDiskSize
+	vmTemplate.Description = vmObj.Description
+
+	vmTemplate.VmGroupSize = numAddition
+
+	result, err := CreateMcisGroupVm(nsId, mcisId, vmTemplate, true)
+	if err != nil {
+		temp := &TbMcisInfo{}
+		return temp, err
+	}
+	return result, nil
+
+}
+
 // CreateMcisGroupVm is func to create MCIS groupVM
-func CreateMcisGroupVm(nsId string, mcisId string, vmRequest *TbVmReq) (*TbMcisInfo, error) {
+func CreateMcisGroupVm(nsId string, mcisId string, vmRequest *TbVmReq, newVmGroup bool) (*TbMcisInfo, error) {
 
 	err := common.CheckString(nsId)
 	if err != nil {
@@ -618,30 +663,54 @@ func CreateMcisGroupVm(nsId string, mcisId string, vmRequest *TbVmReq) (*TbMcisI
 	vmGroupSize, _ := strconv.Atoi(vmRequest.VmGroupSize)
 	fmt.Printf("vmGroupSize: %v\n", vmGroupSize)
 
+	vmStartIndex := 1
+
 	if vmGroupSize > 0 {
 
 		fmt.Println("=========================== Create MCIS VM Group object")
-		key := common.GenMcisVmGroupKey(nsId, mcisId, vmRequest.Name)
 
-		// TODO: Enhancement Required. Need to check existing VM Group. Need to update it if exist.
 		vmGroupInfoData := TbVmGroupInfo{}
 		vmGroupInfoData.Id = vmRequest.Name
 		vmGroupInfoData.Name = vmRequest.Name
 		vmGroupInfoData.VmGroupSize = vmRequest.VmGroupSize
 
-		for i := 0; i < vmGroupSize; i++ {
+		key := common.GenMcisVmGroupKey(nsId, mcisId, vmRequest.Name)
+		keyValue, err := common.CBStore.Get(key)
+		if err != nil {
+			err = fmt.Errorf("In CreateMcisGroupVm(); CBStore.Get(): " + err.Error())
+			common.CBLog.Error(err)
+		}
+		if keyValue != nil {
+			if newVmGroup {
+				json.Unmarshal([]byte(keyValue.Value), &vmGroupInfoData)
+				existingVmSize, err := strconv.Atoi(vmGroupInfoData.VmGroupSize)
+				if err != nil {
+					err = fmt.Errorf("In CreateMcisGroupVm(); CBStore.Get(): " + err.Error())
+					common.CBLog.Error(err)
+				}
+				// add the number of existing VMs in the VMGroup with requested number for additions
+				vmGroupInfoData.VmGroupSize = strconv.Itoa(existingVmSize + vmGroupSize)
+				vmStartIndex = vmStartIndex + existingVmSize + 1
+			} else {
+				err = fmt.Errorf("Duplicated VMGroup ID")
+				common.CBLog.Error(err)
+				return nil, err
+			}
+		}
+
+		for i := vmStartIndex; i < vmGroupSize+vmStartIndex; i++ {
 			vmGroupInfoData.VmId = append(vmGroupInfoData.VmId, vmGroupInfoData.Id+"-"+strconv.Itoa(i))
 		}
 
 		val, _ := json.Marshal(vmGroupInfoData)
-		err := common.CBStore.Put(key, string(val))
+		err = common.CBStore.Put(key, string(val))
 		if err != nil {
 			common.CBLog.Error(err)
 		}
-		keyValue, err := common.CBStore.Get(key)
+		// check stored vmGroup object
+		keyValue, err = common.CBStore.Get(key)
 		if err != nil {
-			common.CBLog.Error(err)
-			err = fmt.Errorf("In CreateMcisGroupVm(); CBStore.Get() returned an error.")
+			err = fmt.Errorf("In CreateMcisGroupVm(); CBStore.Get(): " + err.Error())
 			common.CBLog.Error(err)
 			// return nil, err
 		}
@@ -651,14 +720,14 @@ func CreateMcisGroupVm(nsId string, mcisId string, vmRequest *TbVmReq) (*TbMcisI
 
 	}
 
-	for i := 0; i <= vmGroupSize; i++ {
+	for i := vmStartIndex; i <= vmGroupSize+vmStartIndex; i++ {
 		vmInfoData := TbVmInfo{}
 
 		if vmGroupSize == 0 { // for VM (not in a group)
 			vmInfoData.Name = vmRequest.Name
 		} else { // for VM (in a group)
-			if i == vmGroupSize {
-				break // if vmGroupSize != 0 && vmGroupSize == i, skip the final loop
+			if i == vmGroupSize+vmStartIndex {
+				break
 			}
 			vmInfoData.VmGroupId = vmRequest.Name
 			// TODO: Enhancement Required. Need to check existing VM Group. Need to update it if exist.
@@ -666,7 +735,6 @@ func CreateMcisGroupVm(nsId string, mcisId string, vmRequest *TbVmReq) (*TbMcisI
 			fmt.Println("===========================")
 			fmt.Println("vmInfoData.Name: " + vmInfoData.Name)
 			fmt.Println("===========================")
-
 		}
 		vmInfoData.Id = vmInfoData.Name
 
@@ -859,6 +927,8 @@ func CreateMcis(nsId string, req *TbMcisReq, option string) (*TbMcisInfo, error)
 	//goroutin
 	var wg sync.WaitGroup
 
+	vmStartIndex := 1
+
 	for _, k := range vmRequest {
 
 		// VM Group handling
@@ -875,7 +945,7 @@ func CreateMcis(nsId string, req *TbMcisReq, option string) (*TbMcisInfo, error)
 			vmGroupInfoData.Name = common.ToLower(k.Name)
 			vmGroupInfoData.VmGroupSize = k.VmGroupSize
 
-			for i := 0; i < vmGroupSize; i++ {
+			for i := vmStartIndex; i < vmGroupSize+vmStartIndex; i++ {
 				vmGroupInfoData.VmId = append(vmGroupInfoData.VmId, vmGroupInfoData.Id+"-"+strconv.Itoa(i))
 			}
 
@@ -897,14 +967,14 @@ func CreateMcis(nsId string, req *TbMcisReq, option string) (*TbMcisInfo, error)
 
 		}
 
-		for i := 0; i <= vmGroupSize; i++ {
+		for i := vmStartIndex; i <= vmGroupSize+vmStartIndex; i++ {
 			vmInfoData := TbVmInfo{}
 
 			if vmGroupSize == 0 { // for VM (not in a group)
 				vmInfoData.Name = common.ToLower(k.Name)
 			} else { // for VM (in a group)
-				if i == vmGroupSize {
-					break // if vmGroupSize != 0 && vmGroupSize == i, skip the final loop
+				if i == vmGroupSize+vmStartIndex {
+					break
 				}
 				vmInfoData.VmGroupId = common.ToLower(k.Name)
 				vmInfoData.Name = common.ToLower(k.Name) + "-" + strconv.Itoa(i)


### PR DESCRIPTION

MCIS에 포함되어 있는 VMGroup을 기준으로, 
MCIS를 확장(Group에 포함된 VM 추가)하는 기능 제공
 - 추가되는 VM은 지정된 Group에 포함되며, 병렬로 생성 및 추가.
 - VM의 ID는 기존에 있는 VM들과 유사하게 포스트픽스 숫자 증가하는 형태로 구성됨(ID 중복 방지). (ex: group0-1, group0-2, ...)

### 사용법

curl -X 'POST' \
  'http://localhost:1323/tumblebug/ns/ns01/mcis/mc-6oghb/vmgroup/group-0' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "vmGroupSize": "3"
}'

### Before
![image](https://user-images.githubusercontent.com/5966944/192271636-cd0d7d39-11d8-45ce-942f-049b9a085641.png)


### After
![image](https://user-images.githubusercontent.com/5966944/192272271-6f9e17b4-8105-416e-9ce5-48e5707f2446.png)
