### PR TITLE
Add get VM ID Name info in detail

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -2500,7 +2500,8 @@ const docTemplate = `{
                     {
                         "enum": [
                             "default",
-                            "status"
+                            "status",
+                            "idsInDetail"
                         ],
                         "type": "string",
                         "description": "Option for MCIS",
@@ -2521,6 +2522,9 @@ const docTemplate = `{
                                     "properties": {
                                         "[DEFAULT]": {
                                             "$ref": "#/definitions/mcis.TbVmInfo"
+                                        },
+                                        "[IDNAME]": {
+                                            "$ref": "#/definitions/mcis.TbIdNameInDetailInfo"
                                         },
                                         "[STATUS]": {
                                             "$ref": "#/definitions/mcis.TbVmStatusInfo"
@@ -8645,6 +8649,23 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "mcis.TbIdNameInDetailInfo": {
+            "type": "object",
+            "properties": {
+                "idInCsp": {
+                    "type": "string"
+                },
+                "idInSp": {
+                    "type": "string"
+                },
+                "idInTb": {
+                    "type": "string"
+                },
+                "nameInCsp": {
+                    "type": "string"
                 }
             }
         },

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -2492,7 +2492,8 @@
                     {
                         "enum": [
                             "default",
-                            "status"
+                            "status",
+                            "idsInDetail"
                         ],
                         "type": "string",
                         "description": "Option for MCIS",
@@ -2513,6 +2514,9 @@
                                     "properties": {
                                         "[DEFAULT]": {
                                             "$ref": "#/definitions/mcis.TbVmInfo"
+                                        },
+                                        "[IDNAME]": {
+                                            "$ref": "#/definitions/mcis.TbIdNameInDetailInfo"
                                         },
                                         "[STATUS]": {
                                             "$ref": "#/definitions/mcis.TbVmStatusInfo"
@@ -8637,6 +8641,23 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "mcis.TbIdNameInDetailInfo": {
+            "type": "object",
+            "properties": {
+                "idInCsp": {
+                    "type": "string"
+                },
+                "idInSp": {
+                    "type": "string"
+                },
+                "idInTb": {
+                    "type": "string"
+                },
+                "nameInCsp": {
+                    "type": "string"
                 }
             }
         },

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1584,6 +1584,17 @@ definitions:
           type: string
         type: array
     type: object
+  mcis.TbIdNameInDetailInfo:
+    properties:
+      idInCsp:
+        type: string
+      idInSp:
+        type: string
+      idInTb:
+        type: string
+      nameInCsp:
+        type: string
+    type: object
   mcis.TbMcisDynamicReq:
     properties:
       description:
@@ -3910,6 +3921,7 @@ paths:
         enum:
         - default
         - status
+        - idsInDetail
         in: query
         name: option
         type: string
@@ -3924,6 +3936,8 @@ paths:
             - properties:
                 '[DEFAULT]':
                   $ref: '#/definitions/mcis.TbVmInfo'
+                '[IDNAME]':
+                  $ref: '#/definitions/mcis.TbIdNameInDetailInfo'
                 '[STATUS]':
                   $ref: '#/definitions/mcis.TbVmStatusInfo'
               type: object

--- a/src/api/rest/server/mcis/manageInfo.go
+++ b/src/api/rest/server/mcis/manageInfo.go
@@ -253,8 +253,8 @@ func RestDelAllMcis(c echo.Context) error {
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
 // @Param vmId path string true "VM ID" default(vm01)
-// @Param option query string false "Option for MCIS" Enums(default, status)
-// @success 200 {object} JSONResult{[DEFAULT]=mcis.TbVmInfo,[STATUS]=mcis.TbVmStatusInfo} "Different return structures by the given option param"
+// @Param option query string false "Option for MCIS" Enums(default, status, idsInDetail)
+// @success 200 {object} JSONResult{[DEFAULT]=mcis.TbVmInfo,[STATUS]=mcis.TbVmStatusInfo,[IDNAME]=mcis.TbIdNameInDetailInfo} "Different return structures by the given option param"
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis/{mcisId}/vm/{vmId} [get]
@@ -276,6 +276,17 @@ func RestGetMcisVm(c echo.Context) error {
 		}
 
 		common.PrintJsonPretty(*result)
+
+		return c.JSON(http.StatusOK, result)
+
+	} else if option == "idsInDetail" {
+
+		result, err := mcis.GetVmIdNameInDetail(nsId, mcisId, vmId)
+		if err != nil {
+			common.CBLog.Error(err)
+			mapA := map[string]string{"message": err.Error()}
+			return c.JSON(http.StatusInternalServerError, &mapA)
+		}
 
 		return c.JSON(http.StatusOK, result)
 

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -394,6 +394,14 @@ type TbVmInfo struct {
 	CspViewVmDetail SpiderVMInfo `json:"cspViewVmDetail,omitempty"`
 }
 
+// TbVmIdNameInDetailInfo is struct for details related with ID and Name
+type TbIdNameInDetailInfo struct {
+	IdInTb    string `json:"idInTb"`
+	IdInSp    string `json:"idInSp"`
+	IdInCsp   string `json:"idInCsp"`
+	NameInCsp string `json:"nameInCsp"`
+}
+
 // StatusCountInfo is struct to count the number of VMs in each status. ex: Running=4, Suspended=8.
 type StatusCountInfo struct {
 


### PR DESCRIPTION
CSP가 관리하는 VM의 오브젝트 ID 및 Name 을 리턴하는 옵션 추가

사용방법

curl -X 'GET' \
  'http://localhost:1323/tumblebug/ns/ns01/mcis/mcis01/vm/group-0-1?option=idsInDetail' \
  -H 'accept: application/json'
Request URL
http://localhost:1323/tumblebug/ns/ns01/mcis/mcis01/vm/group-0-1?option=idsInDetail


<!--StartFragment--><h4 style="box-sizing: border-box; color: rgb(59, 65, 81); font-family: sans-serif; font-size: 12px; margin: 10px 0px 5px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgba(97, 175, 254, 0.1); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Server response</h4>


Response body
{   
"idInTb": "group-0-1",   
"idInSp": "ns01-mcis01-group-0-1",   
"idInCsp": "i-08ff24c283049194e",  
"nameInCsp": "ns01-mcis01-group-0-1-ccrd5ge7p30g08fo2j10" 
}


