### PR TITLE
Add yaml config feature to handle different available values for each cloud

### DIFF
--- a/conf/cloud_conf.yaml
+++ b/conf/cloud_conf.yaml
@@ -1,0 +1,66 @@
+cloud:
+  common:
+    enable: "y"
+    nlb:
+      enable: "y"
+      interval: "10"
+      timeout: "9"
+      threshold: "3"
+  aws:
+    enable: "y"
+    nlb:
+      enable: "y"
+      interval: "10"
+      timeout: "-1"
+      threshold: "3"
+  azure:
+    enable: "y"
+    nlb:
+      enable: "y"
+      interval: "10"
+      timeout: "9"
+      threshold: "3"
+  gcp:
+    enable: "y"
+    nlb:
+      enable: "y"
+      interval: "10"
+      timeout: "9"
+      threshold: "3"
+  alibaba:
+    enable: "y"
+    nlb:
+      enable: "y"
+      interval: "10"
+      timeout: "9"
+      threshold: "3"
+  tencent:
+    enable: "y"
+    nlb:
+      enable: "y"
+      interval: "10"
+      timeout: "9"
+      threshold: "3"
+  ibm:
+    enable: "y"
+    nlb:
+      enable: "y"
+      interval: "10"
+      timeout: "9"
+      threshold: "3"
+  openstack:
+    enable: "y"
+    nlb:
+      enable: "n"
+      interval: "10"
+      timeout: "9"
+      threshold: "3"
+  cloudit	:
+    enable: "y"
+    nlb:
+      enable: "n"
+      interval: "10"
+      timeout: "9"
+      threshold: "3"
+global:
+  port: 8080

--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -23,6 +23,40 @@ import (
 	cbstore_utils "github.com/cloud-barista/cb-store/utils"
 )
 
+// RuntimeConf is global variable for cloud config
+var RuntimeConf = RuntimeConfig{}
+
+// RuntimeConfig is structure for global variable for cloud config
+type RuntimeConfig struct {
+	Cloud Cloud `yaml:"cloud"`
+}
+
+// Cloud is structure for cloud settings per CSP
+type Cloud struct {
+	Common    CloudSetting `yaml:"common"`
+	Aws       CloudSetting `yaml:"aws"`
+	Azure     CloudSetting `yaml:"azure"`
+	Gcp       CloudSetting `yaml:"gcp"`
+	Alibaba   CloudSetting `yaml:"alibaba"`
+	Tencent   CloudSetting `yaml:"tencent"`
+	Ibm       CloudSetting `yaml:"ibm"`
+	Openstack CloudSetting `yaml:"openstack"`
+}
+
+// CloudSetting is structure for cloud settings per CSP in details
+type CloudSetting struct {
+	Enable string     `yaml:"enable"`
+	Nlb    NlbSetting `yaml:"nlb"`
+}
+
+// NlbSetting is structure for NLB setting
+type NlbSetting struct {
+	Enable    string `yaml:"enable"`
+	Interval  string `yaml:"interval"`
+	Timeout   string `yaml:"timeout"`
+	Threshold string `yaml:"threshold"`
+}
+
 // swagger:request ConfigReq
 type ConfigReq struct {
 	Name  string `json:"name" example:"SPIDER_REST_URL"`

--- a/src/core/mcis/nlb.go
+++ b/src/core/mcis/nlb.go
@@ -140,7 +140,7 @@ type TBNLBTargetGroup struct {
 	Protocol string `json:"protocol" example:"TCP"` // TCP|HTTP|HTTPS
 	Port     string `json:"port" example:"22"`      // Listener Port or 1-65535
 
-	VmGroupId string  `json:"vmGroupId" example:"group"`
+	VmGroupId string   `json:"vmGroupId" example:"group"`
 	VMs       []string `json:"vms"`
 
 	CspID        string // Optional, May be Used by Driver.
@@ -296,6 +296,23 @@ func CreateNLB(nsId string, mcisId string, u *TbNLBReq, option string) (TbNLBInf
 
 	tempReq.ReqInfo.VMGroup.Port = u.TargetGroup.Port
 	tempReq.ReqInfo.VMGroup.Protocol = u.TargetGroup.Protocol
+
+	// // TODO: update this part to assign availble values for each CSP (current code does not work)
+	fmt.Println("NLB available values (AWS): ", common.RuntimeConf.Cloud.Aws)
+	fmt.Println("NLB available values (Azure): ", common.RuntimeConf.Cloud.Azure)
+	// if cloud-type == aws {
+	// 	tempReq.ReqInfo.HealthChecker.Interval = common.RuntimeConf.Cloud.Aws.Nlb.Interval
+	// 	tempReq.ReqInfo.HealthChecker.Timeout = common.RuntimeConf.Cloud.Aws.Nlb.Timeout
+	// 	tempReq.ReqInfo.HealthChecker.Threshold = common.RuntimeConf.Cloud.Aws.Nlb.Threshold
+	// } else if cloud-type == azure {
+	// 	tempReq.ReqInfo.HealthChecker.Interval = common.RuntimeConf.Cloud.Azure.Nlb.Interval
+	// 	tempReq.ReqInfo.HealthChecker.Timeout = common.RuntimeConf.Cloud.Azure.Nlb.Timeout
+	// 	tempReq.ReqInfo.HealthChecker.Threshold = common.RuntimeConf.Cloud.Azure.Nlb.Threshold
+	// } else {
+	// 	tempReq.ReqInfo.HealthChecker.Interval = common.RuntimeConf.Cloud.Common.Nlb.Interval
+	// 	tempReq.ReqInfo.HealthChecker.Timeout = common.RuntimeConf.Cloud.Common.Nlb.Timeout
+	// 	tempReq.ReqInfo.HealthChecker.Threshold = common.RuntimeConf.Cloud.Common.Nlb.Threshold
+	// }
 
 	vmIDs, err := ListMcisGroupVms(nsId, mcisId, u.TargetGroup.VmGroupId)
 	if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -24,6 +24,7 @@ import (
 
 	//_ "github.com/go-sql-driver/mysql"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/spf13/viper"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/mcir"
@@ -35,6 +36,29 @@ import (
 	"xorm.io/xorm"
 	"xorm.io/xorm/names"
 )
+
+// init for main
+func init() {
+	profile := "cloud_conf"
+	setConfig(profile)
+}
+
+// setConfig get cloud settings from a config file
+func setConfig(profile string) {
+	viper.AddConfigPath(".")
+	viper.AddConfigPath("./conf/")
+	viper.AddConfigPath("../conf/")
+	viper.SetConfigName(profile)
+	viper.SetConfigType("yaml")
+	err := viper.ReadInConfig()
+	if err != nil { // Handle errors reading the config file
+		panic(fmt.Errorf("fatal error config file: %w", err))
+	}
+	err = viper.Unmarshal(&common.RuntimeConf)
+	if err != nil {
+		panic(err)
+	}
+}
 
 // Main Body
 
@@ -175,6 +199,8 @@ func main() {
 		//fmt.Println("gRPC server started on " + grpcserver.Port)
 		wg.Done()
 	}()
+
+	fmt.Println("RuntimeConf: ", common.RuntimeConf.Cloud)
 
 	wg.Wait()
 }


### PR DESCRIPTION
- 개발 과정 중에 CSP에 따라서 다른 값을 지정해야 하는 경우가 발생하고 있음. (예를 들어, NLB를 생성하기 위해서는 CSP별로 특정 다른 값을 입력해야 하는 상태). 이는 다양한 CSP에 대한 디버깅 및 개발에 어려움을 줌.
- CSP 별로 별도의 값을 미리 정의하여, 자동으로 지정할 수 있도록 conf 파일로 설정하고자 함.
- 이를 통해, CSP 구분하지 않고 테스트 코드나 값의 수정없이, 테스트가 진행될 수 있도록 처리 필요.

yaml config 파일의 로드 및 갱신은
https://github.com/spf13/viper (MIT 라이선스) 를 활용하였으며, 이는 cobra 등에서 많이 활용되는 오픈소스이므로, 신뢰할 수 있음.

main에서 로드된 yaml 파일의 정보는
cb-tumblebug/src/core/common pkg에서 전역 변수에 바인딩하여, 전역에서 사용할 수 있도록 되어 있음.

NLB 코드에 적용 필요.
