### PR TITLE
Feat: StartVmWithSnapshot + RegisterConsequentVolumes

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -8690,6 +8690,9 @@ const docTemplate = `{
                 "imageName": {
                     "type": "string"
                 },
+                "imageType": {
+                    "type": "string"
+                },
                 "keyPairIId": {
                     "$ref": "#/definitions/common.IID"
                 },
@@ -9393,6 +9396,7 @@ const docTemplate = `{
                     "example": "i-014fa6ede6ada0b2c"
                 },
                 "imageId": {
+                    "description": "ImageType        string   ` + "`" + `json:\"imageType\"` + "`" + `",
                     "type": "string"
                 },
                 "label": {

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -8682,6 +8682,9 @@
                 "imageName": {
                     "type": "string"
                 },
+                "imageType": {
+                    "type": "string"
+                },
                 "keyPairIId": {
                     "$ref": "#/definitions/common.IID"
                 },
@@ -9385,6 +9388,7 @@
                     "example": "i-014fa6ede6ada0b2c"
                 },
                 "imageId": {
+                    "description": "ImageType        string   `json:\"imageType\"`",
                     "type": "string"
                 },
                 "label": {

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1515,6 +1515,8 @@ definitions:
         $ref: '#/definitions/common.IID'
       imageName:
         type: string
+      imageType:
+        type: string
       keyPairIId:
         $ref: '#/definitions/common.IID'
       keyPairName:
@@ -2029,6 +2031,7 @@ definitions:
         example: i-014fa6ede6ada0b2c
         type: string
       imageId:
+        description: ImageType        string   `json:"imageType"`
         type: string
       label:
         type: string

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -134,9 +134,9 @@ func RestPutMcisVmWithCmd(c echo.Context) error {
 	}
 
 	switch command {
-	case "attachDataDisk":
+	case mcis.AttachDataDisk:
 		fallthrough
-	case "detachDataDisk":
+	case mcis.DetachDataDisk:
 		result, err := mcis.AttachDetachDataDisk(nsId, mcisId, vmId, command, u.DataDiskId)
 		if err != nil {
 			mapA := map[string]string{"message": err.Error()}

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -242,7 +242,7 @@ func GetCspResourceId(nsId string, resourceType string, resourceId string) (stri
 	case StrCustomImage:
 		content := mcirIds{}
 		json.Unmarshal([]byte(keyValue.Value), &content)
-		return content.CspCustomImageId, nil
+		return content.CspCustomImageName, nil
 	case StrSSHKey:
 		content := mcirIds{}
 		json.Unmarshal([]byte(keyValue.Value), &content)
@@ -933,4 +933,30 @@ func CheckElement(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+const (
+	// Random string generation
+	letterBytes   = "abcdefghijklmnopqrstuvwxyz1234567890"
+	letterIdxBits = 6
+	letterIdxMask = 1<<letterIdxBits - 1
+	letterIdxMax  = 63 / letterIdxBits
+)
+
+/* generate a random string (from CB-MCKS source code) */
+func GenerateNewRandomString(n int) string {
+	randSrc := rand.NewSource(time.Now().UnixNano()) //Random source by nano time
+	b := make([]byte, n)
+	for i, cache, remain := n-1, randSrc.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = randSrc.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+	return string(b)
 }

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -155,6 +155,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	// In CheckResource() above, calling 'CBStore.Get()' and checking err parts exist.
 	// So, in here, we don't need to check whether keyValue == nil or err != nil.
 
+	/* Disabled the deletion protection feature
 	associatedList, _ := GetAssociatedObjectList(nsId, resourceType, resourceId)
 	if len(associatedList) == 0 {
 		// continue
@@ -164,6 +165,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 		common.CBLog.Error(err)
 		return err
 	}
+	*/
 
 	//cspType := common.GetResourcesCspType(nsId, resourceType, resourceId)
 

--- a/src/core/mcis/control.go
+++ b/src/core/mcis/control.go
@@ -577,7 +577,11 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mcisId string, vmId string,
 				//When VM is restared, temporal PublicIP will be chanaged. Need update.
 				UpdateVmPublicIp(nsId, mcisId, temp)
 			} else { // if action == ActionTerminate
-				mcir.UpdateAssociatedObjectList(nsId, common.StrImage, temp.ImageId, common.StrDelete, key)
+				_, err = mcir.UpdateAssociatedObjectList(nsId, common.StrImage, temp.ImageId, common.StrDelete, key)
+				if err != nil {
+					mcir.UpdateAssociatedObjectList(nsId, common.StrCustomImage, temp.ImageId, common.StrDelete, key)
+				}
+
 				mcir.UpdateAssociatedObjectList(nsId, common.StrSpec, temp.SpecId, common.StrDelete, key)
 				mcir.UpdateAssociatedObjectList(nsId, common.StrSSHKey, temp.SshKeyId, common.StrDelete, key)
 				mcir.UpdateAssociatedObjectList(nsId, common.StrVNet, temp.VNetId, common.StrDelete, key)

--- a/src/core/mcis/snapshot.go
+++ b/src/core/mcis/snapshot.go
@@ -17,8 +17,6 @@ package mcis
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
-	"time"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/mcir"
@@ -45,7 +43,7 @@ func CreateVmSnapshot(nsId string, mcisId string, vmId string, snapshotName stri
 	json.Unmarshal([]byte(keyValue.Value), &vm)
 
 	if snapshotName == "" {
-		snapshotName = fmt.Sprintf("%s-%s", vm.Name, GenerateNewRandomString(5))
+		snapshotName = fmt.Sprintf("%s-%s", vm.Name, common.GenerateNewRandomString(5))
 	}
 
 	tempReq := mcir.SpiderMyImageReq{
@@ -134,7 +132,7 @@ func CreateVmSnapshot(nsId string, mcisId string, vmId string, snapshotName stri
 	// // create 'n' dataDisks
 	// for _, v := range difference_dataDisks {
 	// 	tempTbDataDiskReq := mcir.TbDataDiskReq{
-	// 		Name:           fmt.Sprintf("%s-%s", vm.Name, GenerateNewRandomString(5)),
+	// 		Name:           fmt.Sprintf("%s-%s", vm.Name, common.GenerateNewRandomString(5)),
 	// 		ConnectionName: vm.ConnectionName,
 	// 		CspDataDiskId:  v.IdByCsp,
 	// 	}
@@ -162,30 +160,4 @@ func Difference_dataDisks(a, b []resourceOnTumblebugInfo) []resourceOnTumblebugI
 		}
 	}
 	return diff
-}
-
-const (
-	// Random string generation
-	letterBytes   = "abcdefghijklmnopqrstuvwxyz1234567890"
-	letterIdxBits = 6
-	letterIdxMask = 1<<letterIdxBits - 1
-	letterIdxMax  = 63 / letterIdxBits
-)
-
-/* generate a random string (from CB-MCKS source code) */
-func GenerateNewRandomString(n int) string {
-	randSrc := rand.NewSource(time.Now().UnixNano()) //Random source by nano time
-	b := make([]byte, n)
-	for i, cache, remain := n-1, randSrc.Int63(), letterIdxMax; i >= 0; {
-		if remain == 0 {
-			cache, remain = randSrc.Int63(), letterIdxMax
-		}
-		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
-			b[i] = letterBytes[idx]
-			i--
-		}
-		cache >>= letterIdxBits
-		remain--
-	}
-	return string(b)
 }

--- a/src/testclient/scripts/8.mcis/add-vm-to-mcis.sh
+++ b/src/testclient/scripts/8.mcis/add-vm-to-mcis.sh
@@ -1,32 +1,26 @@
 #!/bin/bash
 
-#function add-vm-to-mcis() {
+echo "####################################################################"
+echo "## 8. vm: Add VM to MCIS"
+echo "####################################################################"
 
+source ../init.sh
 
-	TestSetFile=${5:-../testSet.env}
-    
-    if [ ! -f "$TestSetFile" ]; then
-        echo "$TestSetFile does not exist."
-        exit
-    fi
-	source $TestSetFile
-    source ../conf.env
-	
-	echo "####################################################################"
-	echo "## 8. vm: Create MCIS"
-	echo "####################################################################"
+# NUMVM=${OPTION01:-1}
 
-	CSP=${1}
-	REGION=${2:-1}
-	POSTFIX=${3:-developer}
-	MCISPREFIX=${4:-avengers}
-	MCISID=${POSTFIX}
+if [[ -z "${DISK_TYPE[$INDEX,$REGION]}" ]]; then
+	RootDiskType="default"
+else
+	RootDiskType="${DISK_TYPE[$INDEX,$REGION]}"
+fi
 
-	source ../common-functions.sh
-	getCloudIndex $CSP
+if [[ -z "${DISK_SIZE[$INDEX,$REGION]}" ]]; then
+	RootDiskSize="default"
+else
+	RootDiskSize="${DISK_SIZE[$INDEX,$REGION]}"
+fi
 
-	
-	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/mcis/$MCISID/vm -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/mcis/$MCISID/vm -H 'Content-Type: application/json' -d \
 		'{
 			"name": "'${CONN_CONFIG[$INDEX,$REGION]}'",
 			"imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
@@ -41,7 +35,4 @@
 			"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
 			"description": "description",
 			"vmUserPassword": ""
-		}' | jq '' 
-#}
-
-#add-vm-to-mcis
+		}' | jq ''


### PR DESCRIPTION
## [주의]
- 기존에는 각 MCIR object의 `AssociatedObjectList`에 하나 이상의 VM이 기재되어 있으면 해당 MCIR 삭제를 차단했지만
  이 PR에서는 모든 MCIR에 대해 해당 제한을 해제했습니다.
- `AssociatedObjectList`에 하나 이상의 VM이 기재되어 있는 MCIR을 삭제 시도 하면
  삭제할 수 없는 자원의 경우 CB-Spider 또는 CSP 수준에서 에러를 반환할 것입니다.
- CB-Spider에는 `VMReq`, `VMInfo` struct에 `ImageType` 필드가 추가되었고, 여기에 `MyImage` 라고 명시하는 방식인데
  이 PR에서는 CB-Tumblebug의 `VMReq`, `VMInfo` struct에 `ImageType` 필드를 추가하지 않았습니다.
  추후에 이 필드가 있는 것이 더 좋겠다고 결정되면, 추가할 수도 있겠습니다.

## [StartVmWithSnapshot]
- VM 생성 시, `imageId` 필드에
  미리 생성해 둔 TB `customImage` 객체의 ID를 입력
- TB 내부적으로, 다음 순서로 시도
  - 해당 NS의 TB customImage 조회 (← 이 PR에서 추가됨)
  - 해당 NS의 TB image 조회
  - SystemCommonNs 의 TB image 조회
- `CreateVm` 함수의 마지막 부분에서 'RegisterConsequentVolumes' 동작 수행

## [RegisterConsequentVolumes]
- VM snapshot으로 VM을 실행했을 때, 이로 인해 생성된 CSP 볼륨 자원을 TB dataDisk object로 등록

---

# [AWS 테스트 기록]

## [MCIS에 VM 추가]
(`imageId` 필드에: 미리 생성해 둔 TB `customImage` 객체의 ID를 입력)

[Request]
`cb-tumblebug/src/testclient/scripts/8.mcis/add-vm-to-mcis.sh -n jhseo -c aws -r 1`
POST `http://$TumblebugServer/tumblebug/ns/$NSID/mcis/$MCISID/vm`
```json
{
  "name": "'${CONN_CONFIG[$INDEX,$REGION]}'",
  "imageId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
  "vmUserAccount": "cb-user",
  "connectionName": "'${CONN_CONFIG[$INDEX,$REGION]}'",
  "sshKeyId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
  "specId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
  "securityGroupIds": [
    "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
  ],
  "vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
  "subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
  "description": "description",
  "vmUserPassword": ""
}
```

[Response (VM info)]
```json
{
...
  "dataDiskIds": [
    "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-0",
    "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1"
  ]
...
}
```

## [TB dataDisk object 생성 확인]
`cb-tumblebug/src/testclient/scripts/11.dataDisk/id-list-dataDisk.sh`
GET `http://$TumblebugServer/tumblebug/ns/$NSID/resources/dataDisk?option=id`

```json
{
  "output": [
    "aws-ap-southeast-1-jhseo",
    "jhseo-datadisk",
    "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-0",
    "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1"
  ]
}
```

`cb-tumblebug/src/testclient/scripts/11.dataDisk/list-dataDisk.sh`
GET `http://$TumblebugServer/tumblebug/ns/$NSID/resources/dataDisk`

```json
[
  {
    "id": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-0",
    "name": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-0",
    "connectionName": "aws-ap-southeast-1",
    "diskType": "gp2",
    "diskSize": "77",
    "cspDataDiskId": "vol-0f48b09bfb318ce34",
    "cspDataDiskName": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-0",
    "status": "Attached",
    "associatedObjectList": [
      "/ns/ns01/mcis/jhseo/vm/aws-ap-southeast-1"
    ],
    "createdTime": "2022-10-07T08:23:53.275Z",
    "keyValueList": [
      {
        "Key": "Encrypted",
        "Value": "false"
      },
      {
        "Key": "Iops",
        "Value": "231"
      },
      {
        "Key": "MultiAttachEnabled",
        "Value": "false"
      }
    ],
    "systemLabel": "Registered from CB-Spider resource"
  },
  {
    "id": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
    "name": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
    "connectionName": "aws-ap-southeast-1",
    "diskType": "gp2",
    "diskSize": "100",
    "cspDataDiskId": "vol-0ecc7f32364c6b4f0",
    "cspDataDiskName": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
    "status": "Attached",
    "associatedObjectList": [
      "/ns/ns01/mcis/jhseo/vm/aws-ap-southeast-1"
    ],
    "createdTime": "2022-10-07T08:23:53.362Z",
    "keyValueList": [
      {
        "Key": "Encrypted",
        "Value": "false"
      },
      {
        "Key": "Iops",
        "Value": "300"
      },
      {
        "Key": "MultiAttachEnabled",
        "Value": "false"
      }
    ],
    "systemLabel": "Registered from CB-Spider resource"
  }
]
```

## [해당 dataDisk detach]
`cb-tumblebug/src/testclient/scripts/11.dataDisk/detach-dataDisk.sh -n jhseo -c aws -r 1`
PUT `http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}/detachDataDisk`
```json
{
...
  "dataDiskId": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1"
...
}
```

`cb-tumblebug/src/testclient/scripts/8.mcis/list-mcis.sh | less`
GET `http://$TumblebugServer/tumblebug/ns/$NSID/mcis`
```json
{
  "dataDiskIds": [
    "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-0"
  ]
}
```

`cb-tumblebug/src/testclient/scripts/11.dataDisk/list-dataDisk.sh`
```json
{
  "id": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
  "name": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
  "connectionName": "aws-ap-southeast-1",
  "diskType": "gp2",
  "diskSize": "100",
  "cspDataDiskId": "vol-0ecc7f32364c6b4f0",
  "cspDataDiskName": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
  "status": "Available",
  "associatedObjectList": [],
  "createdTime": "2022-10-07T08:23:53.362Z",
  "keyValueList": [
    {
      "Key": "Encrypted",
      "Value": "false"
    },
    {
      "Key": "Iops",
      "Value": "300"
    },
    {
      "Key": "MultiAttachEnabled",
      "Value": "false"
    }
  ],
  "systemLabel": "Registered from CB-Spider resource"
}
```
(`associatedObjectList` 필드가 깨끗해졌음)

## [해당 dataDisk 다시 attach]
`cb-tumblebug/src/testclient/scripts/11.dataDisk/attach-dataDisk.sh -n jhseo -c aws -r 1`
PUT `http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}/attachDataDisk`
```json
{
  "dataDiskId": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1"
}
```

`cb-tumblebug/src/testclient/scripts/8.mcis/list-mcis.sh | less`
```json
{
  "dataDiskIds": [
    "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-0",
    "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1"
  ]
}
```

`cb-tumblebug/src/testclient/scripts/11.dataDisk/list-dataDisk.sh`

```json
{
  "id": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
  "name": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
  "connectionName": "aws-ap-southeast-1",
  "diskType": "gp2",
  "diskSize": "100",
  "cspDataDiskId": "vol-0ecc7f32364c6b4f0",
  "cspDataDiskName": "ns01-jhseo-aws-ap-southeast-1-ccvu45t6qs8ajcsubh5g-disk-1",
  "status": "Attached",
  "associatedObjectList": [
    "/ns/ns01/mcis/jhseo/vm/aws-ap-southeast-1"
  ],
  "createdTime": "2022-10-07T08:23:53.362Z",
  "keyValueList": [
    {
      "Key": "Encrypted",
      "Value": "false"
    },
    {
      "Key": "Iops",
      "Value": "300"
    },
    {
      "Key": "MultiAttachEnabled",
      "Value": "false"
    }
  ],
  "systemLabel": "Registered from CB-Spider resource"
}
```
(`associatedObjectList` 에 VM key가 다시 기재됨)

## [dataDisk가 attach 되어 있는 VM을 terminate]
(성공)

## [남겨진 dataDisk들을 TB REST API 이용하여 삭제]
(성공)