### PR TITLE
Add 'GetAvailableDataDisks' feature

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -2501,7 +2501,8 @@ const docTemplate = `{
                         "enum": [
                             "default",
                             "status",
-                            "idsInDetail"
+                            "idsInDetail",
+                            "availableDataDisk"
                         ],
                         "type": "string",
                         "description": "Option for MCIS",
@@ -2520,6 +2521,9 @@ const docTemplate = `{
                                 {
                                     "type": "object",
                                     "properties": {
+                                        "[AVAILABLEDATADISK]": {
+                                            "$ref": "#/definitions/mcis.RestGetAvailableDataDisksResponse"
+                                        },
                                         "[DEFAULT]": {
                                             "$ref": "#/definitions/mcis.TbVmInfo"
                                         },
@@ -2532,6 +2536,75 @@ const docTemplate = `{
                                     }
                                 }
                             ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update MCIS VM",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra service] MCIS Provisioning management"
+                ],
+                "summary": "Update MCIS VM",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "mcis01",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "vm01",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "attachDataDisk",
+                            "detachDataDisk"
+                        ],
+                        "type": "string",
+                        "description": "Option for MCIS",
+                        "name": "option",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbVmInfo"
                         }
                     },
                     "404": {
@@ -2612,85 +2685,6 @@ const docTemplate = `{
             }
         },
         "/ns/{nsId}/mcis/{mcisId}/vm/{vmId}/{command}": {
-            "put": {
-                "description": "Attach/Detach data disk to/from VM",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Infra resource] MCIR Data Disk management"
-                ],
-                "summary": "Attach/Detach data disk to/from VM",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "ns01",
-                        "description": "Namespace ID",
-                        "name": "nsId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "mcis01",
-                        "description": "MCIS ID",
-                        "name": "mcisId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "vm01",
-                        "description": "VM ID",
-                        "name": "vmId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "enum": [
-                            "attachDataDisk",
-                            "detachDataDisk"
-                        ],
-                        "type": "string",
-                        "description": "Command to perform",
-                        "name": "command",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Data disk ID to attach/detach",
-                        "name": "dataDisk",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/mcir.TbAttachDetachDataDiskReq"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/mcis.TbVmInfo"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    }
-                }
-            },
             "post": {
                 "description": "Create VM snapshot",
                 "consumes": [
@@ -7081,17 +7075,6 @@ const docTemplate = `{
                 }
             }
         },
-        "mcir.TbAttachDetachDataDiskReq": {
-            "type": "object",
-            "required": [
-                "dataDiskId"
-            ],
-            "properties": {
-                "dataDiskId": {
-                    "type": "string"
-                }
-            }
-        },
         "mcir.TbCustomImageInfo": {
             "type": "object",
             "properties": {
@@ -8618,6 +8601,17 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcis.TbNLBInfo"
+                    }
+                }
+            }
+        },
+        "mcis.RestGetAvailableDataDisksResponse": {
+            "type": "object",
+            "properties": {
+                "dataDisk": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -2493,7 +2493,8 @@
                         "enum": [
                             "default",
                             "status",
-                            "idsInDetail"
+                            "idsInDetail",
+                            "availableDataDisk"
                         ],
                         "type": "string",
                         "description": "Option for MCIS",
@@ -2512,6 +2513,9 @@
                                 {
                                     "type": "object",
                                     "properties": {
+                                        "[AVAILABLEDATADISK]": {
+                                            "$ref": "#/definitions/mcis.RestGetAvailableDataDisksResponse"
+                                        },
                                         "[DEFAULT]": {
                                             "$ref": "#/definitions/mcis.TbVmInfo"
                                         },
@@ -2524,6 +2528,75 @@
                                     }
                                 }
                             ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "Update MCIS VM",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra service] MCIS Provisioning management"
+                ],
+                "summary": "Update MCIS VM",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "mcis01",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "vm01",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "attachDataDisk",
+                            "detachDataDisk"
+                        ],
+                        "type": "string",
+                        "description": "Option for MCIS",
+                        "name": "option",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbVmInfo"
                         }
                     },
                     "404": {
@@ -2604,85 +2677,6 @@
             }
         },
         "/ns/{nsId}/mcis/{mcisId}/vm/{vmId}/{command}": {
-            "put": {
-                "description": "Attach/Detach data disk to/from VM",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Infra resource] MCIR Data Disk management"
-                ],
-                "summary": "Attach/Detach data disk to/from VM",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "ns01",
-                        "description": "Namespace ID",
-                        "name": "nsId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "mcis01",
-                        "description": "MCIS ID",
-                        "name": "mcisId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "vm01",
-                        "description": "VM ID",
-                        "name": "vmId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "enum": [
-                            "attachDataDisk",
-                            "detachDataDisk"
-                        ],
-                        "type": "string",
-                        "description": "Command to perform",
-                        "name": "command",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Data disk ID to attach/detach",
-                        "name": "dataDisk",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/mcir.TbAttachDetachDataDiskReq"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/mcis.TbVmInfo"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    }
-                }
-            },
             "post": {
                 "description": "Create VM snapshot",
                 "consumes": [
@@ -7073,17 +7067,6 @@
                 }
             }
         },
-        "mcir.TbAttachDetachDataDiskReq": {
-            "type": "object",
-            "required": [
-                "dataDiskId"
-            ],
-            "properties": {
-                "dataDiskId": {
-                    "type": "string"
-                }
-            }
-        },
         "mcir.TbCustomImageInfo": {
             "type": "object",
             "properties": {
@@ -8610,6 +8593,17 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcis.TbNLBInfo"
+                    }
+                }
+            }
+        },
+        "mcis.RestGetAvailableDataDisksResponse": {
+            "type": "object",
+            "properties": {
+                "dataDisk": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -404,13 +404,6 @@ definitions:
       count:
         type: string
     type: object
-  mcir.TbAttachDetachDataDiskReq:
-    properties:
-      dataDiskId:
-        type: string
-    required:
-    - dataDiskId
-    type: object
   mcir.TbCustomImageInfo:
     properties:
       associatedObjectList:
@@ -1470,6 +1463,13 @@ definitions:
       nlb:
         items:
           $ref: '#/definitions/mcis.TbNLBInfo'
+        type: array
+    type: object
+  mcis.RestGetAvailableDataDisksResponse:
+    properties:
+      dataDisk:
+        items:
+          type: string
         type: array
     type: object
   mcis.RestGetBenchmarkRequest:
@@ -3996,6 +3996,7 @@ paths:
         - default
         - status
         - idsInDetail
+        - availableDataDisk
         in: query
         name: option
         type: string
@@ -4008,6 +4009,8 @@ paths:
             allOf:
             - $ref: '#/definitions/mcis.JSONResult'
             - properties:
+                '[AVAILABLEDATADISK]':
+                  $ref: '#/definitions/mcis.RestGetAvailableDataDisksResponse'
                 '[DEFAULT]':
                   $ref: '#/definitions/mcis.TbVmInfo'
                 '[IDNAME]':
@@ -4024,6 +4027,54 @@ paths:
           schema:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get VM in specified MCIS
+      tags:
+      - '[Infra service] MCIS Provisioning management'
+    put:
+      consumes:
+      - application/json
+      description: Update MCIS VM
+      parameters:
+      - default: ns01
+        description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - default: mcis01
+        description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - default: vm01
+        description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
+      - description: Option for MCIS
+        enum:
+        - attachDataDisk
+        - detachDataDisk
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.TbVmInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Update MCIS VM
       tags:
       - '[Infra service] MCIS Provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vm/{vmId}/{command}:
@@ -4075,61 +4126,6 @@ paths:
       summary: Create VM snapshot
       tags:
       - '[Infra resource] VM snapshot management'
-    put:
-      consumes:
-      - application/json
-      description: Attach/Detach data disk to/from VM
-      parameters:
-      - default: ns01
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mcis01
-        description: MCIS ID
-        in: path
-        name: mcisId
-        required: true
-        type: string
-      - default: vm01
-        description: VM ID
-        in: path
-        name: vmId
-        required: true
-        type: string
-      - description: Command to perform
-        enum:
-        - attachDataDisk
-        - detachDataDisk
-        in: path
-        name: command
-        required: true
-        type: string
-      - description: Data disk ID to attach/detach
-        in: body
-        name: dataDisk
-        required: true
-        schema:
-          $ref: '#/definitions/mcir.TbAttachDetachDataDiskReq'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/mcis.TbVmInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/common.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/common.SimpleMsg'
-      summary: Attach/Detach data disk to/from VM
-      tags:
-      - '[Infra resource] MCIR Data Disk management'
   /ns/{nsId}/mcis/{mcisId}/vmgroup:
     get:
       consumes:

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/cloud-barista/cb-tumblebug/src/core/mcir"
 	"github.com/cloud-barista/cb-tumblebug/src/core/mcis"
 	"github.com/labstack/echo/v4"
 )
@@ -104,6 +103,7 @@ func RestGetControlMcisVm(c echo.Context) error {
 	}
 }
 
+/* Moved to RestPutMcisVm()
 // RestPutMcisVmWithCmd godoc
 // @Summary Attach/Detach data disk to/from VM
 // @Description Attach/Detach data disk to/from VM
@@ -124,8 +124,9 @@ func RestPutMcisVmWithCmd(c echo.Context) error {
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
 	vmId := c.Param("vmId")
+	command := c.Param("command")
 
-	command := strings.Split(c.Path(), "/")[8]
+	// command := strings.Split(c.Path(), "/")[8]
 	// c.Path(): /tumblebug/ns/:nsId/mcis/{mcisId}/vm/{vmId}/attachDataDisk
 
 	u := &mcir.TbAttachDetachDataDiskReq{}
@@ -152,6 +153,58 @@ func RestPutMcisVmWithCmd(c echo.Context) error {
 	}
 	return nil
 }
+*/
+
+/* Integrated into RestGetMcisVm()
+// RestGetMcisVmWithCmd godoc
+// @Summary Get available data disks attachable to VM
+// @Description Get available data disks attachable to VM
+// @Tags [Infra resource] MCIR Data Disk management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Param mcisId path string true "MCIS ID" default(mcis01)
+// @Param vmId path string true "VM ID" default(vm01)
+// @Param command path string true "Command to perform" Enums(availableDataDisk)
+// @Success 200 {object} RestGetMcisVmWithCmdResponse
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /ns/{nsId}/mcis/{mcisId}/vm/{vmId}/{command} [get]
+func RestGetMcisVmWithCmd(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+	mcisId := c.Param("mcisId")
+	vmId := c.Param("vmId")
+	command := c.Param("command")
+
+	// command := strings.Split(c.Path(), "/")[8]
+	// c.Path(): /tumblebug/ns/:nsId/mcis/{mcisId}/vm/{vmId}/attachDataDisk
+
+	switch command {
+	case "availableDataDisk":
+		dataDiskIDs, err := mcis.GetAvailableDataDiskIDs(nsId, mcisId, vmId)
+		if err != nil {
+			mapA := map[string]string{"message": err.Error()}
+			return c.JSON(http.StatusNotFound, &mapA)
+		}
+
+		// common.PrintJsonPretty(result)
+		// var content struct {
+		// 	DataDisk []string `json:"dataDisk"`
+		// }
+		content := RestGetMcisVmWithCmdResponse{
+			DataDisk: dataDiskIDs,
+		}
+
+		return c.JSON(http.StatusOK, &content)
+
+	default:
+		mapA := map[string]string{"message": "Supported commands: availableDataDisk"}
+		return c.JSON(http.StatusNotFound, &mapA)
+	}
+	return nil
+}
+*/
 
 // RestPostMcisVmWithCmd godoc
 // @Summary Create VM snapshot

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -194,9 +194,11 @@ func RunServer(port string) {
 	g.GET("/:nsId/mcis/:mcisId/vmgroup/:vmgroupId", rest_mcis.RestGetMcisGroupVms)
 
 	//g.GET("/:nsId/mcis/:mcisId/vm", rest_mcis.RestGetAllMcisVm)
-	//g.PUT("/:nsId/mcis/:mcisId/vm/:vmId", rest_mcis.RestPutMcisVm)
-	g.PUT("/:nsId/mcis/:mcisId/vm/:vmId/attachDataDisk", rest_mcis.RestPutMcisVmWithCmd)
-	g.PUT("/:nsId/mcis/:mcisId/vm/:vmId/detachDataDisk", rest_mcis.RestPutMcisVmWithCmd)
+	g.PUT("/:nsId/mcis/:mcisId/vm/:vmId", rest_mcis.RestPutMcisVm)
+	// g.PUT("/:nsId/mcis/:mcisId/vm/:vmId/attachDataDisk", rest_mcis.RestPutMcisVmWithCmd)
+	// g.PUT("/:nsId/mcis/:mcisId/vm/:vmId/detachDataDisk", rest_mcis.RestPutMcisVmWithCmd)
+	// g.PUT("/:nsId/mcis/:mcisId/vm/:vmId/:command", rest_mcis.RestPutMcisVmWithCmd)
+	// g.GET("/:nsId/mcis/:mcisId/vm/:vmId/:command", rest_mcis.RestGetMcisVmWithCmd)
 	g.DELETE("/:nsId/mcis/:mcisId/vm/:vmId", rest_mcis.RestDelMcisVm)
 	//g.DELETE("/:nsId/mcis/:mcisId/vm", rest_mcis.RestDelAllMcisVm)
 

--- a/src/testclient/scripts/11.dataDisk/attach-dataDisk.sh
+++ b/src/testclient/scripts/11.dataDisk/attach-dataDisk.sh
@@ -6,7 +6,7 @@ echo "####################################################################"
 
 source ../init.sh
 
-curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}-1/attachDataDisk -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}-1?option=attachDataDisk -H 'Content-Type: application/json' -d \
 		'{
 			"dataDiskId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
 		}' | jq ''

--- a/src/testclient/scripts/11.dataDisk/available-dataDisk.sh
+++ b/src/testclient/scripts/11.dataDisk/available-dataDisk.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "####################################################################"
+echo "## 11. dataDisk: Get available dataDisks"
+echo "####################################################################"
+
+source ../init.sh
+
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}-1?option=availableDataDisk | jq ''

--- a/src/testclient/scripts/11.dataDisk/detach-dataDisk.sh
+++ b/src/testclient/scripts/11.dataDisk/detach-dataDisk.sh
@@ -6,7 +6,7 @@ echo "####################################################################"
 
 source ../init.sh
 
-curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}-1/detachDataDisk -H 'Content-Type: application/json' -d \
+curl -H "${AUTH}" -sX PUT http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}-1?option=detachDataDisk -H 'Content-Type: application/json' -d \
 		'{
 			"dataDiskId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
 		}' | jq ''


### PR DESCRIPTION
특정 VM에 대해
'GetAvailableDataDisks' REST API를 실행하면
해당 VM의 connectionName을 읽고
TB dataDisk object들 중에서

1. connectionName 이 매치되는 것
2. 상태가 `Available` 인 것

들을 filter하여 그 ID 목록을 반환합니다.

[Request]
`./available-dataDisk.sh -n jhseo -c aws -r 1`
GET `http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${VMID}?option=availableDataDisk`

[Response]
```json
{
  "dataDisk": [
    "aws-ap-southeast-1-jhseo"
  ]
}
```