### PR TITLE
Remove associated NLBs with MCIS del

### DIFF
--- a/src/api/grpc/server/mcis/control.go
+++ b/src/api/grpc/server/mcis/control.go
@@ -199,7 +199,7 @@ func (s *MCISService) DeleteMcis(ctx context.Context, req *pb.TbMcisQryRequest) 
 
 	logger.Debug("calling MCISService.DeleteMcis()")
 
-	err := mcis.DelMcis(req.NsId, req.McisId, req.Option)
+	_, err := mcis.DelMcis(req.NsId, req.McisId, req.Option)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.DeleteMcis()")
 	}

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -1880,7 +1880,7 @@ var doc = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
+                            "$ref": "#/definitions/common.IdList"
                         }
                     },
                     "404": {

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -1865,7 +1865,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
+                            "$ref": "#/definitions/common.IdList"
                         }
                     },
                     "404": {

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -3472,7 +3472,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/common.SimpleMsg'
+            $ref: '#/definitions/common.IdList'
         "404":
           description: Not Found
           schema:

--- a/src/api/rest/server/mcis/manageInfo.go
+++ b/src/api/rest/server/mcis/manageInfo.go
@@ -194,7 +194,7 @@ func RestPutMcis(c echo.Context) error {
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
 // @Param option query string false "Option for delete MCIS (support force delete)" Enums(terminate,force)
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis/{mcisId} [delete]
 func RestDelMcis(c echo.Context) error {
@@ -203,15 +203,14 @@ func RestDelMcis(c echo.Context) error {
 	mcisId := c.Param("mcisId")
 	option := c.QueryParam("option")
 
-	err := mcis.DelMcis(nsId, mcisId, option)
+	output, err := mcis.DelMcis(nsId, mcisId, option)
 	if err != nil {
 		common.CBLog.Error(err)
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
 
-	mapA := map[string]string{"message": "Deleted the MCIS " + mcisId}
-	return c.JSON(http.StatusOK, &mapA)
+	return c.JSON(http.StatusOK, output)
 }
 
 // RestDelAllMcis godoc


### PR DESCRIPTION

- MCIS 삭제 시, 내부에 연관된 NLB도 모두 삭제하도록 자원 정리 자동화.
- MCIS 삭제 결과에 대한 세부 정보 제공.


Request URL
```
http://localhost:1323/tumblebug/ns/ns01/mcis/mcis01
```

Response body
```
{
  "output": [
    "VM: group-0-1 [Done]",
    "VM: group-0-2 [Done]",
    "VM: group-0-3 [Done]",
    "vmGroup: group-0 [Done]",
    "NLB: group-0 [Done]",
    "MCIS: mcis01 [Done]"
  ]
}
```