### PR TITLE
Remove historic add VM way

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -2452,66 +2452,6 @@ const docTemplate = `{
                         }
                     }
                 }
-            },
-            "post": {
-                "description": "Create multiple VMs by subGroup in specified MCIS",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Infra service] MCIS Provisioning management"
-                ],
-                "summary": "Create multiple VMs by subGroup in specified MCIS",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "ns01",
-                        "description": "Namespace ID",
-                        "name": "nsId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "mcis01",
-                        "description": "MCIS ID",
-                        "name": "mcisId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Details for subGroup",
-                        "name": "vmReq",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/mcis.TbVmReq"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/mcis.TbMcisInfo"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    }
-                }
             }
         },
         "/ns/{nsId}/mcis/{mcisId}/subgroup/{subgroupId}": {
@@ -2546,7 +2486,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "group-0",
+                        "default": "g1",
                         "description": "subGroup ID",
                         "name": "subgroupId",
                         "in": "path",
@@ -2614,7 +2554,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "group-0",
+                        "default": "g1",
                         "description": "subGroup ID",
                         "name": "subgroupId",
                         "in": "path",
@@ -2654,7 +2594,7 @@ const docTemplate = `{
         },
         "/ns/{nsId}/mcis/{mcisId}/vm": {
             "post": {
-                "description": "Create VM in specified MCIS",
+                "description": "Create and add homogeneous VMs(subGroup) to a specified MCIS (Set subGroupSize for multiple VMs)",
                 "consumes": [
                     "application/json"
                 ],
@@ -2664,7 +2604,7 @@ const docTemplate = `{
                 "tags": [
                     "[Infra service] MCIS Provisioning management"
                 ],
-                "summary": "Create VM in specified MCIS",
+                "summary": "Create and add homogeneous VMs(subGroup) to a specified MCIS (Set subGroupSize for multiple VMs)",
                 "parameters": [
                     {
                         "type": "string",
@@ -2683,7 +2623,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Details for an VM object",
+                        "description": "Details for VMs(subGroup)",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
@@ -2696,7 +2636,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcis.TbVmInfo"
+                            "$ref": "#/definitions/mcis.TbMcisInfo"
                         }
                     },
                     "404": {
@@ -9181,7 +9121,7 @@ const docTemplate = `{
                 },
                 "subGroupId": {
                     "type": "string",
-                    "example": "group-0"
+                    "example": "g1"
                 },
                 "vms": {
                     "type": "array",
@@ -9206,7 +9146,7 @@ const docTemplate = `{
                 },
                 "subGroupId": {
                     "type": "string",
-                    "example": "group-0"
+                    "example": "g1"
                 }
             }
         },

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -2444,66 +2444,6 @@
                         }
                     }
                 }
-            },
-            "post": {
-                "description": "Create multiple VMs by subGroup in specified MCIS",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[Infra service] MCIS Provisioning management"
-                ],
-                "summary": "Create multiple VMs by subGroup in specified MCIS",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "default": "ns01",
-                        "description": "Namespace ID",
-                        "name": "nsId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "mcis01",
-                        "description": "MCIS ID",
-                        "name": "mcisId",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Details for subGroup",
-                        "name": "vmReq",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/mcis.TbVmReq"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/mcis.TbMcisInfo"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
-                        }
-                    }
-                }
             }
         },
         "/ns/{nsId}/mcis/{mcisId}/subgroup/{subgroupId}": {
@@ -2538,7 +2478,7 @@
                     },
                     {
                         "type": "string",
-                        "default": "group-0",
+                        "default": "g1",
                         "description": "subGroup ID",
                         "name": "subgroupId",
                         "in": "path",
@@ -2606,7 +2546,7 @@
                     },
                     {
                         "type": "string",
-                        "default": "group-0",
+                        "default": "g1",
                         "description": "subGroup ID",
                         "name": "subgroupId",
                         "in": "path",
@@ -2646,7 +2586,7 @@
         },
         "/ns/{nsId}/mcis/{mcisId}/vm": {
             "post": {
-                "description": "Create VM in specified MCIS",
+                "description": "Create and add homogeneous VMs(subGroup) to a specified MCIS (Set subGroupSize for multiple VMs)",
                 "consumes": [
                     "application/json"
                 ],
@@ -2656,7 +2596,7 @@
                 "tags": [
                     "[Infra service] MCIS Provisioning management"
                 ],
-                "summary": "Create VM in specified MCIS",
+                "summary": "Create and add homogeneous VMs(subGroup) to a specified MCIS (Set subGroupSize for multiple VMs)",
                 "parameters": [
                     {
                         "type": "string",
@@ -2675,7 +2615,7 @@
                         "required": true
                     },
                     {
-                        "description": "Details for an VM object",
+                        "description": "Details for VMs(subGroup)",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
@@ -2688,7 +2628,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/mcis.TbVmInfo"
+                            "$ref": "#/definitions/mcis.TbMcisInfo"
                         }
                     },
                     "404": {
@@ -9173,7 +9113,7 @@
                 },
                 "subGroupId": {
                     "type": "string",
-                    "example": "group-0"
+                    "example": "g1"
                 },
                 "vms": {
                     "type": "array",
@@ -9198,7 +9138,7 @@
                 },
                 "subGroupId": {
                     "type": "string",
-                    "example": "group-0"
+                    "example": "g1"
                 }
             }
         },

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1881,7 +1881,7 @@ definitions:
         example: TCP
         type: string
       subGroupId:
-        example: group-0
+        example: g1
         type: string
       vms:
         items:
@@ -1899,7 +1899,7 @@ definitions:
         example: TCP
         type: string
       subGroupId:
-        example: group-0
+        example: g1
         type: string
     type: object
   mcis.TbScaleOutSubGroupReq:
@@ -3952,47 +3952,6 @@ paths:
       summary: List SubGroup IDs in a specified MCIS
       tags:
       - '[Infra service] MCIS Provisioning management'
-    post:
-      consumes:
-      - application/json
-      description: Create multiple VMs by subGroup in specified MCIS
-      parameters:
-      - default: ns01
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mcis01
-        description: MCIS ID
-        in: path
-        name: mcisId
-        required: true
-        type: string
-      - description: Details for subGroup
-        in: body
-        name: vmReq
-        required: true
-        schema:
-          $ref: '#/definitions/mcis.TbVmReq'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/mcis.TbMcisInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/common.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/common.SimpleMsg'
-      summary: Create multiple VMs by subGroup in specified MCIS
-      tags:
-      - '[Infra service] MCIS Provisioning management'
   /ns/{nsId}/mcis/{mcisId}/subgroup/{subgroupId}:
     get:
       consumes:
@@ -4011,7 +3970,7 @@ paths:
         name: mcisId
         required: true
         type: string
-      - default: group-0
+      - default: g1
         description: subGroup ID
         in: path
         name: subgroupId
@@ -4058,7 +4017,7 @@ paths:
         name: mcisId
         required: true
         type: string
-      - default: group-0
+      - default: g1
         description: subGroup ID
         in: path
         name: subgroupId
@@ -4092,7 +4051,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create VM in specified MCIS
+      description: Create and add homogeneous VMs(subGroup) to a specified MCIS (Set
+        subGroupSize for multiple VMs)
       parameters:
       - default: ns01
         description: Namespace ID
@@ -4106,7 +4066,7 @@ paths:
         name: mcisId
         required: true
         type: string
-      - description: Details for an VM object
+      - description: Details for VMs(subGroup)
         in: body
         name: vmReq
         required: true
@@ -4118,7 +4078,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/mcis.TbVmInfo'
+            $ref: '#/definitions/mcis.TbMcisInfo'
         "404":
           description: Not Found
           schema:
@@ -4127,7 +4087,8 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/common.SimpleMsg'
-      summary: Create VM in specified MCIS
+      summary: Create and add homogeneous VMs(subGroup) to a specified MCIS (Set subGroupSize
+        for multiple VMs)
       tags:
       - '[Infra service] MCIS Provisioning management'
   /ns/{nsId}/mcis/{mcisId}/vm/{vmId}:

--- a/src/api/rest/server/mcis/manageInfo.go
+++ b/src/api/rest/server/mcis/manageInfo.go
@@ -358,7 +358,7 @@ func RestDelMcisVm(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
-// @Param subgroupId path string true "subGroup ID" default(group-0)
+// @Param subgroupId path string true "subGroup ID" default(g1)
 // @Param option query string false "Option" Enums(id)
 // @Success 200 {object} common.IdList
 // @Failure 404 {object} common.SimpleMsg

--- a/src/api/rest/server/mcis/provisioning.go
+++ b/src/api/rest/server/mcis/provisioning.go
@@ -150,53 +150,19 @@ func RestPostMcisDynamicCheckRequest(c echo.Context) error {
 }
 
 // RestPostMcisVm godoc
-// @Summary Create VM in specified MCIS
-// @Description Create VM in specified MCIS
+// @Summary Create and add homogeneous VMs(subGroup) to a specified MCIS (Set subGroupSize for multiple VMs)
+// @Description Create and add homogeneous VMs(subGroup) to a specified MCIS (Set subGroupSize for multiple VMs)
 // @Tags [Infra service] MCIS Provisioning management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
-// @Param vmReq body mcis.TbVmReq true "Details for an VM object"
-// @Success 200 {object} mcis.TbVmInfo
+// @Param vmReq body mcis.TbVmReq true "Details for VMs(subGroup)"
+// @Success 200 {object} mcis.TbMcisInfo
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/mcis/{mcisId}/vm [post]
 func RestPostMcisVm(c echo.Context) error {
-
-	nsId := c.Param("nsId")
-	mcisId := c.Param("mcisId")
-
-	vmInfoData := &mcis.TbVmInfo{}
-	if err := c.Bind(vmInfoData); err != nil {
-		return err
-	}
-	common.PrintJsonPretty(*vmInfoData)
-
-	result, err := mcis.CorePostMcisVm(nsId, mcisId, vmInfoData)
-	if err != nil {
-		mapA := map[string]string{"message": err.Error()}
-		return c.JSON(http.StatusInternalServerError, &mapA)
-	}
-	common.PrintJsonPretty(*result)
-
-	return c.JSON(http.StatusCreated, result)
-}
-
-// RestPostMcisSubGroup godoc
-// @Summary Create multiple VMs by subGroup in specified MCIS
-// @Description Create multiple VMs by subGroup in specified MCIS
-// @Tags [Infra service] MCIS Provisioning management
-// @Accept  json
-// @Produce  json
-// @Param nsId path string true "Namespace ID" default(ns01)
-// @Param mcisId path string true "MCIS ID" default(mcis01)
-// @Param vmReq body mcis.TbVmReq true "Details for subGroup"
-// @Success 200 {object} mcis.TbMcisInfo
-// @Failure 404 {object} common.SimpleMsg
-// @Failure 500 {object} common.SimpleMsg
-// @Router /ns/{nsId}/mcis/{mcisId}/subgroup [post]
-func RestPostMcisSubGroup(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
@@ -225,7 +191,7 @@ func RestPostMcisSubGroup(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
-// @Param subgroupId path string true "subGroup ID" default(group-0)
+// @Param subgroupId path string true "subGroup ID" default(g1)
 // @Param vmReq body mcis.TbScaleOutSubGroupReq true "subGroup scaleOut request"
 // @Success 200 {object} mcis.TbMcisInfo
 // @Failure 404 {object} common.SimpleMsg

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -187,11 +187,10 @@ func RunServer(port string) {
 	g.DELETE("/:nsId/mcis", rest_mcis.RestDelAllMcis)
 
 	g.POST("/:nsId/mcis/:mcisId/vm", rest_mcis.RestPostMcisVm)
-	g.POST("/:nsId/mcis/:mcisId/subgroup", rest_mcis.RestPostMcisSubGroup)
-	g.POST("/:nsId/mcis/:mcisId/subgroup/:subgroupId", rest_mcis.RestPostMcisSubGroupScaleOut)
 	g.GET("/:nsId/mcis/:mcisId/vm/:vmId", rest_mcis.RestGetMcisVm)
 	g.GET("/:nsId/mcis/:mcisId/subgroup", rest_mcis.RestGetMcisGroupIds)
 	g.GET("/:nsId/mcis/:mcisId/subgroup/:subgroupId", rest_mcis.RestGetMcisGroupVms)
+	g.POST("/:nsId/mcis/:mcisId/subgroup/:subgroupId", rest_mcis.RestPostMcisSubGroupScaleOut)
 
 	//g.GET("/:nsId/mcis/:mcisId/vm", rest_mcis.RestGetAllMcisVm)
 	// g.PUT("/:nsId/mcis/:mcisId/vm/:vmId", rest_mcis.RestPutMcisVm)

--- a/src/core/mcis/nlb.go
+++ b/src/core/mcis/nlb.go
@@ -176,14 +176,14 @@ type SpiderNLBHealthInfo struct {
 type TbNLBTargetGroupReq struct {
 	Protocol   string `json:"protocol" example:"TCP"` // TCP|HTTP|HTTPS
 	Port       string `json:"port" example:"80"`      // Listener Port or 1-65535
-	SubGroupId string `json:"subGroupId" example:"group-0"`
+	SubGroupId string `json:"subGroupId" example:"g1"`
 }
 
 type TbNLBTargetGroupInfo struct {
 	Protocol string `json:"protocol" example:"TCP"` // TCP|HTTP|HTTPS
 	Port     string `json:"port" example:"80"`      // Listener Port or 1-65535
 
-	SubGroupId string   `json:"subGroupId" example:"group-0"`
+	SubGroupId string   `json:"subGroupId" example:"g1"`
 	VMs        []string `json:"vms"`
 
 	KeyValueList []common.KeyValue

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -678,8 +678,13 @@ func CreateMcisGroupVm(nsId string, mcisId string, vmRequest *TbVmReq, newSubGro
 	var wg sync.WaitGroup
 
 	// subGroup handling
-	subGroupSize, _ := strconv.Atoi(vmRequest.SubGroupSize)
+	subGroupSize, err := strconv.Atoi(vmRequest.SubGroupSize)
 	fmt.Printf("subGroupSize: %v\n", subGroupSize)
+
+	// make subGroup default (any VM going to be in a subGroup)
+	if subGroupSize < 1 || err != nil {
+		subGroupSize = 1
+	}
 
 	vmStartIndex := 1
 


### PR DESCRIPTION
- 기존의 MCIS에 단일 VM을 추가하던 방식을 삭제
- VM을 1개라도 생성하면, 해당 VM은 1개의 subGroup에 기본으로 소속됨
- MCIS에 VM을 추가하는 API는 1개로 단일화함  
  - POST /ns/{nsId}/mcis/{mcisId}/vm
  - subGroupSize에 따라서 동종의 VM이 생성
  - 만약 해당 필드를 사용하지 않거나, 값이 0 이하인 경우에도, 이 값은 1로 자체 보정하여, VM이 subGroup에 속하도록 함.

### "subGroupSize": "3" 를 지정한 경우 예시
```
{
  "connectionName": "aws-ap-northeast-2",
  "description": "Description",
  "imageId": "aws-ap-northeast-2-ubuntu18-04",
  "label": "no",
  "name": "g2",
  "rootDiskSize": "default",
  "rootDiskType": "default",
  "securityGroupIds": [
      "ns01-systemdefault-aws-ap-northeast-2"
  ],
  "specId": "aws-ap-northeast-2-t3a-nano",
  "sshKeyId": "ns01-systemdefault-aws-ap-northeast-2",
  "subGroupSize": "3",
  "subnetId": "ns01-systemdefault-aws-ap-northeast-2",
  "vNetId": "ns01-systemdefault-aws-ap-northeast-2"
}
```
VM 6개에서 9개로 추가
![image](https://user-images.githubusercontent.com/5966944/196541048-65441d3d-071c-425e-b145-0b874be7b022.png)


### "subGroupSize": "" 필드를 제시하지 않은 경우 예시
```
{
  "connectionName": "aws-ap-northeast-2",
  "description": "Description",
  "imageId": "aws-ap-northeast-2-ubuntu18-04",
  "label": "no",
  "name": "g2",
  "rootDiskSize": "default",
  "rootDiskType": "default",
  "securityGroupIds": [
      "ns01-systemdefault-aws-ap-northeast-2"
  ],
  "specId": "aws-ap-northeast-2-t3a-nano",
  "sshKeyId": "ns01-systemdefault-aws-ap-northeast-2",
  "subnetId": "ns01-systemdefault-aws-ap-northeast-2",
  "vNetId": "ns01-systemdefault-aws-ap-northeast-2"
}
```

기존과 동일하게 VM이 1개만 추가됨.
![image](https://user-images.githubusercontent.com/5966944/196541349-f73f748b-c769-40a2-a0c5-4b97dd29dd20.png)
