### PR TITLE
Add Swagger godoc for CustomImage REST APIs

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -3550,6 +3550,85 @@ const docTemplate = `{
             }
         },
         "/ns/{nsId}/resources/customImage": {
+            "get": {
+                "description": "List all customImages or customImages' ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Custom Image management"
+                ],
+                "summary": "List all customImages or customImages' ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "id"
+                        ],
+                        "type": "string",
+                        "description": "Option",
+                        "name": "option",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field key for filtering (ex:guestOS)",
+                        "name": "filterKey",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field value for filtering (ex: Ubuntu18.04)",
+                        "name": "filterVal",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Different return structures by the given option param",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/mcir.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "[DEFAULT]": {
+                                            "$ref": "#/definitions/mcir.RestGetAllCustomImageResponse"
+                                        },
+                                        "[ID]": {
+                                            "$ref": "#/definitions/common.IdList"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Create Custom Image",
                 "consumes": [
@@ -3578,7 +3657,8 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Option: ",
                         "name": "option",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     },
                     {
                         "description": "Details for an Custom Image object",
@@ -3605,6 +3685,146 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete all customImages",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Custom Image management"
+                ],
+                "summary": "Delete all customImages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "",
+                        "description": "Delete resources containing matched ID-substring only",
+                        "name": "match",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.IdList"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/ns/{nsId}/resources/customImage/{customImageId}": {
+            "get": {
+                "description": "Get customImage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Custom Image management"
+                ],
+                "summary": "Get customImage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "customImage ID",
+                        "name": "customImageId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcir.TbCustomImageInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete customImage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Custom Image management"
+                ],
+                "summary": "Delete customImage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "customImage ID",
+                        "name": "customImageId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/common.SimpleMsg"
                         }
@@ -6816,6 +7036,17 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcir.TbSpecInfo"
+                    }
+                }
+            }
+        },
+        "mcir.RestGetAllCustomImageResponse": {
+            "type": "object",
+            "properties": {
+                "customImage": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcir.TbCustomImageInfo"
                     }
                 }
             }

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -3542,6 +3542,85 @@
             }
         },
         "/ns/{nsId}/resources/customImage": {
+            "get": {
+                "description": "List all customImages or customImages' ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Custom Image management"
+                ],
+                "summary": "List all customImages or customImages' ID",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "enum": [
+                            "id"
+                        ],
+                        "type": "string",
+                        "description": "Option",
+                        "name": "option",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field key for filtering (ex:guestOS)",
+                        "name": "filterKey",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field value for filtering (ex: Ubuntu18.04)",
+                        "name": "filterVal",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Different return structures by the given option param",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/mcir.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "[DEFAULT]": {
+                                            "$ref": "#/definitions/mcir.RestGetAllCustomImageResponse"
+                                        },
+                                        "[ID]": {
+                                            "$ref": "#/definitions/common.IdList"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Create Custom Image",
                 "consumes": [
@@ -3570,7 +3649,8 @@
                         "type": "string",
                         "description": "Option: ",
                         "name": "option",
-                        "in": "query"
+                        "in": "query",
+                        "required": true
                     },
                     {
                         "description": "Details for an Custom Image object",
@@ -3597,6 +3677,146 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete all customImages",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Custom Image management"
+                ],
+                "summary": "Delete all customImages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "",
+                        "description": "Delete resources containing matched ID-substring only",
+                        "name": "match",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.IdList"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
+        "/ns/{nsId}/resources/customImage/{customImageId}": {
+            "get": {
+                "description": "Get customImage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Custom Image management"
+                ],
+                "summary": "Get customImage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "customImage ID",
+                        "name": "customImageId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcir.TbCustomImageInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete customImage",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Custom Image management"
+                ],
+                "summary": "Delete customImage",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "customImage ID",
+                        "name": "customImageId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/common.SimpleMsg"
                         }
@@ -6808,6 +7028,17 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcir.TbSpecInfo"
+                    }
+                }
+            }
+        },
+        "mcir.RestGetAllCustomImageResponse": {
+            "type": "object",
+            "properties": {
+                "customImage": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcir.TbCustomImageInfo"
                     }
                 }
             }

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -270,6 +270,13 @@ definitions:
           $ref: '#/definitions/mcir.TbSpecInfo'
         type: array
     type: object
+  mcir.RestGetAllCustomImageResponse:
+    properties:
+      customImage:
+        items:
+          $ref: '#/definitions/mcir.TbCustomImageInfo'
+        type: array
+    type: object
   mcir.RestGetAllDataDiskResponse:
     properties:
       dataDisk:
@@ -4701,6 +4708,86 @@ paths:
       tags:
       - '[Infra service] MCIS Provisioning management'
   /ns/{nsId}/resources/customImage:
+    delete:
+      consumes:
+      - application/json
+      description: Delete all customImages
+      parameters:
+      - default: ns01
+        description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - default: ""
+        description: Delete resources containing matched ID-substring only
+        in: query
+        name: match
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.IdList'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete all customImages
+      tags:
+      - '[Infra resource] MCIR Custom Image management'
+    get:
+      consumes:
+      - application/json
+      description: List all customImages or customImages' ID
+      parameters:
+      - default: ns01
+        description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: Option
+        enum:
+        - id
+        in: query
+        name: option
+        type: string
+      - description: Field key for filtering (ex:guestOS)
+        in: query
+        name: filterKey
+        type: string
+      - description: 'Field value for filtering (ex: Ubuntu18.04)'
+        in: query
+        name: filterVal
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Different return structures by the given option param
+          schema:
+            allOf:
+            - $ref: '#/definitions/mcir.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcir.RestGetAllCustomImageResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+              type: object
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: List all customImages or customImages' ID
+      tags:
+      - '[Infra resource] MCIR Custom Image management'
     post:
       consumes:
       - application/json
@@ -4717,6 +4804,7 @@ paths:
         - register
         in: query
         name: option
+        required: true
         type: string
       - description: Details for an Custom Image object
         in: body
@@ -4740,6 +4828,71 @@ paths:
           schema:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Create Custom Image
+      tags:
+      - '[Infra resource] MCIR Custom Image management'
+  /ns/{nsId}/resources/customImage/{customImageId}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete customImage
+      parameters:
+      - default: ns01
+        description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: customImage ID
+        in: path
+        name: customImageId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Delete customImage
+      tags:
+      - '[Infra resource] MCIR Custom Image management'
+    get:
+      consumes:
+      - application/json
+      description: Get customImage
+      parameters:
+      - default: ns01
+        description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - description: customImage ID
+        in: path
+        name: customImageId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcir.TbCustomImageInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Get customImage
       tags:
       - '[Infra resource] MCIR Custom Image management'
   /ns/{nsId}/resources/dataDisk:

--- a/src/api/rest/server/mcir/customimage.go
+++ b/src/api/rest/server/mcir/customimage.go
@@ -30,7 +30,7 @@ import (
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
-// @Param option query string false "Option: " Enums(register)
+// @Param option query string true "Option: " Enums(register)
 // @Param customImageInfo body mcir.TbCustomImageReq true "Details for an Custom Image object"
 // @Success 200 {object} mcir.TbCustomImageInfo
 // @Failure 404 {object} common.SimpleMsg
@@ -60,4 +60,77 @@ func RestPostCustomImage(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, &mapA)
 	}
 	return c.JSON(http.StatusCreated, content)
+}
+
+// RestGetCustomImage godoc
+// @Summary Get customImage
+// @Description Get customImage
+// @Tags [Infra resource] MCIR Custom Image management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Param customImageId path string true "customImage ID"
+// @Success 200 {object} mcir.TbCustomImageInfo
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /ns/{nsId}/resources/customImage/{customImageId} [get]
+func RestGetCustomImage(c echo.Context) error {
+	// This is a dummy function for Swagger.
+	return nil
+}
+
+// Response structure for RestGetAllCustomImage
+type RestGetAllCustomImageResponse struct {
+	CustomImage []mcir.TbCustomImageInfo `json:"customImage"`
+}
+
+// RestGetAllCustomImage godoc
+// @Summary List all customImages or customImages' ID
+// @Description List all customImages or customImages' ID
+// @Tags [Infra resource] MCIR Custom Image management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Param option query string false "Option" Enums(id)
+// @Param filterKey query string false "Field key for filtering (ex:guestOS)"
+// @Param filterVal query string false "Field value for filtering (ex: Ubuntu18.04)"
+// @Success 200 {object} JSONResult{[DEFAULT]=RestGetAllCustomImageResponse,[ID]=common.IdList} "Different return structures by the given option param"
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /ns/{nsId}/resources/customImage [get]
+func RestGetAllCustomImage(c echo.Context) error {
+	// This is a dummy function for Swagger.
+	return nil
+}
+
+// RestDelCustomImage godoc
+// @Summary Delete customImage
+// @Description Delete customImage
+// @Tags [Infra resource] MCIR Custom Image management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Param customImageId path string true "customImage ID"
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Router /ns/{nsId}/resources/customImage/{customImageId} [delete]
+func RestDelCustomImage(c echo.Context) error {
+	// This is a dummy function for Swagger.
+	return nil
+}
+
+// RestDelAllCustomImage godoc
+// @Summary Delete all customImages
+// @Description Delete all customImages
+// @Tags [Infra resource] MCIR Custom Image management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(ns01)
+// @Param match query string false "Delete resources containing matched ID-substring only" default()
+// @Success 200 {object} common.IdList
+// @Failure 404 {object} common.SimpleMsg
+// @Router /ns/{nsId}/resources/customImage [delete]
+func RestDelAllCustomcustomImage(c echo.Context) error {
+	// This is a dummy function for Swagger.
+	return nil
 }


### PR DESCRIPTION
아래 REST API 에 대한 dummy 함수 + Swagger godoc 을 추가하여, Swagger 페이지에 표시되도록 변경
- GET `/ns/{nsId}/resources/customImage/{customImageId}`
- GET `/ns/{nsId}/resources/customImage`
- DELETE `/ns/{nsId}/resources/customImage/{customImageId}`
- DELETE `/ns/{nsId}/resources/customImage`
- (참고: POST `/ns/{nsId}/resources/customImage` REST API는 `?option=register` 로만 호출 가능)