### PR TITLE
Add vm (id) list filtering feature

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -1788,6 +1788,20 @@ const docTemplate = `{
                         "description": "Option",
                         "name": "option",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "connectionName",
+                        "description": "(for option==id) Field key for filtering (ex: connectionName)",
+                        "name": "filterKey",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "aws-ap-northeast-2",
+                        "description": "(for option==id) Field value for filtering (ex: aws-ap-northeast-2)",
+                        "name": "filterVal",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -1780,6 +1780,20 @@
                         "description": "Option",
                         "name": "option",
                         "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "connectionName",
+                        "description": "(for option==id) Field key for filtering (ex: connectionName)",
+                        "name": "filterKey",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "aws-ap-northeast-2",
+                        "description": "(for option==id) Field value for filtering (ex: aws-ap-northeast-2)",
+                        "name": "filterVal",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -3551,6 +3551,16 @@ paths:
         in: query
         name: option
         type: string
+      - default: connectionName
+        description: '(for option==id) Field key for filtering (ex: connectionName)'
+        in: query
+        name: filterKey
+        type: string
+      - default: aws-ap-northeast-2
+        description: '(for option==id) Field value for filtering (ex: aws-ap-northeast-2)'
+        in: query
+        name: filterVal
+        type: string
       produces:
       - application/json
       responses:

--- a/src/api/rest/server/mcis/manageInfo.go
+++ b/src/api/rest/server/mcis/manageInfo.go
@@ -42,6 +42,8 @@ type JSONResult struct {
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
 // @Param option query string false "Option" Enums(default, id, status)
+// @Param filterKey query string false "(for option==id) Field key for filtering (ex: connectionName)" default(connectionName)
+// @Param filterVal query string false "(for option==id) Field value for filtering (ex: aws-ap-northeast-2)" default(aws-ap-northeast-2)
 // @success 200 {object} JSONResult{[DEFAULT]=mcis.TbMcisInfo,[ID]=common.IdList,[STATUS]=mcis.McisStatusInfo} "Different return structures by the given action param"
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -52,11 +54,13 @@ func RestGetMcis(c echo.Context) error {
 	mcisId := c.Param("mcisId")
 
 	option := c.QueryParam("option")
+	filterKey := c.QueryParam("filterKey")
+	filterVal := c.QueryParam("filterVal")
 
 	if option == "id" {
 		content := common.IdList{}
 		var err error
-		content.IdList, err = mcis.ListVmId(nsId, mcisId)
+		content.IdList, err = mcis.ListVmByFilter(nsId, mcisId, filterKey, filterVal)
 		if err != nil {
 			mapA := map[string]string{"message": err.Error()}
 			return c.JSON(http.StatusInternalServerError, &mapA)


### PR DESCRIPTION
Based on user request : 
https://cloud-barista.slack.com/archives/CJQ7575PU/p1666154205390509

입력 예시
```
curl -X 'GET' \
  'http://localhost:1323/tumblebug/ns/ns01/mcis/mcis01?option=id&filterKey=connectionName&filterVal=aws-ap-northeast-2' \
  -H 'accept: application/json'
```

<html>
<body>
<!--StartFragment-->

Code | Details
-- | --
200 | Response body {   "output": [     "g1-1",     "g1-2"   ] }

<!--EndFragment-->
</body>
</html>

```
curl -X 'GET' \
  'http://localhost:1323/tumblebug/ns/ns01/mcis/mcis01?option=id&filterKey=connectionName&filterVal=gcp-asia-northeast3' \
  -H 'accept: application/json'
```

<html>
<body>
<!--StartFragment-->

200 | Response body{   "output": [     "g2-1",     "g2-2",     "g2-3"   ] }
-- | --


<!--EndFragment-->
</body>
</html>

참고: option을 id로 한 경우에만 필터링이 적용됩니다.

![image](https://user-images.githubusercontent.com/5966944/196719296-6520b83c-6667-4bed-be20-7781b58dd8d9.png)
