### PR TITLE
Enable coordinateFair option for recommend by location

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -672,7 +672,7 @@ const docTemplate = `{
         },
         "/mcisRecommendVm": {
             "post": {
-                "description": "Recommend MCIS plan (filter and priority)",
+                "description": "Recommend MCIS plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234",
                 "consumes": [
                     "application/json"
                 ],

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -664,7 +664,7 @@
         },
         "/mcisRecommendVm": {
             "post": {
-                "description": "Recommend MCIS plan (filter and priority)",
+                "description": "Recommend MCIS plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234",
                 "consumes": [
                     "application/json"
                 ],

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -2799,7 +2799,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Recommend MCIS plan (filter and priority)
+      description: Recommend MCIS plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
       parameters:
       - description: Recommend MCIS plan (filter and priority)
         in: body

--- a/src/api/rest/server/mcis/recommendation.go
+++ b/src/api/rest/server/mcis/recommendation.go
@@ -24,7 +24,7 @@ import (
 
 // RestRecommendVm godoc
 // @Summary Recommend MCIS plan (filter and priority)
-// @Description Recommend MCIS plan (filter and priority)
+// @Description Recommend MCIS plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
 // @Tags [Infra service] MCIS Provisioning management
 // @Accept  json
 // @Produce  json


### PR DESCRIPTION
Enable coordinateFair option for recommend by location

예시
```
{
  "filter": {
    "policy": [
      {
        "condition": [
          {
            "operand": "4",
            "operator": "<="
          }
        ],
        "metric": "cpu"
      }
    ]
  },
  "limit": "5",
  "priority": {
    "policy": [
      {
        "metric": "location",
        "parameter": [
          {
            "key": "coordinateFair",
            "val": [
              "39.1848/128.2488", "34.0599/131.5093", "36.1672/139.7769"
            ]
          }
        ],
        "weight": "0.3"
      }
    ]
  }
}
```

39.1848 : 128.2488
34.0599 : 131.5093
36.1672 : 139.7769 
를 지정하면, 중심 포인트를 찾은 후, 해당 중심 포인트에서 가장 가까운 리전들을 제공