### PR TITLE
Modify 'serviceType' value in InstallMonAgentReq

### DIFF
--- a/src/api/grpc/server/mcis/monitor.go
+++ b/src/api/grpc/server/mcis/monitor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/api/grpc/logger"
 	pb "github.com/cloud-barista/cb-tumblebug/src/api/grpc/protobuf/cbtumblebug"
 
+	common "github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/mcis"
 )
 
@@ -29,8 +30,8 @@ func (s *MCISService) InstallMonitorAgentToMcis(ctx context.Context, req *pb.Mci
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.InstallMonitorAgentToMcis()")
 	}
 
-	mcisTmpSystemLabel := mcis.DefaultSystemLabel
-	content, err := mcis.InstallMonitorAgentToMcis(req.NsId, req.McisId, mcisTmpSystemLabel, &mcisObj)
+	// mcisTmpSystemLabel := mcis.DefaultSystemLabel
+	content, err := mcis.InstallMonitorAgentToMcis(req.NsId, req.McisId, common.StrVM, &mcisObj)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.InstallMonitorAgentToMcis()")
 	}

--- a/src/api/rest/server/mcis/monitoring.go
+++ b/src/api/rest/server/mcis/monitoring.go
@@ -45,8 +45,8 @@ func RestPostInstallMonitorAgentToMcis(c echo.Context) error {
 		return err
 	}
 
-	mcisTmpSystemLabel := mcis.DefaultSystemLabel
-	content, err := mcis.InstallMonitorAgentToMcis(nsId, mcisId, mcisTmpSystemLabel, req)
+	// mcisTmpSystemLabel := mcis.DefaultSystemLabel
+	content, err := mcis.InstallMonitorAgentToMcis(nsId, mcisId, common.StrVM, req)
 	if err != nil {
 		common.CBLog.Error(err)
 		return err

--- a/src/core/mcis/monitoring.go
+++ b/src/core/mcis/monitoring.go
@@ -192,7 +192,7 @@ func CallMonitoringAsync(wg *sync.WaitGroup, nsID string, mcisID string, mcisSer
 	UpdateVmInfo(nsID, mcisID, vmInfoTmp)
 
 	if mcisServiceType == "" {
-		mcisServiceType = "default"
+		mcisServiceType = common.StrVM
 	}
 
 	url := common.DragonflyRestUrl + cmd

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -589,7 +589,7 @@ func CorePostMcisVm(nsId string, mcisId string, vmInfoData *TbVmInfo) (*TbVmInfo
 			reqToMon.UserName = "cb-user" // this MCIS user name is temporal code. Need to improve.
 
 			fmt.Printf("\n[InstallMonitorAgentToMcis]\n\n")
-			content, err := InstallMonitorAgentToMcis(nsId, mcisId, mcisTmp.SystemLabel, reqToMon)
+			content, err := InstallMonitorAgentToMcis(nsId, mcisId, common.StrVM, reqToMon)
 			if err != nil {
 				common.CBLog.Error(err)
 				//mcisTmp.InstallMonAgent = "no"
@@ -854,7 +854,7 @@ func CreateMcisGroupVm(nsId string, mcisId string, vmRequest *TbVmReq, newSubGro
 			reqToMon.UserName = "cb-user" // this MCIS user name is temporal code. Need to improve.
 
 			fmt.Printf("\n[InstallMonitorAgentToMcis]\n\n")
-			content, err := InstallMonitorAgentToMcis(nsId, mcisId, mcisTmp.SystemLabel, reqToMon)
+			content, err := InstallMonitorAgentToMcis(nsId, mcisId, common.StrVM, reqToMon)
 			if err != nil {
 				common.CBLog.Error(err)
 				//mcisTmp.InstallMonAgent = "no"
@@ -1112,7 +1112,7 @@ func CreateMcis(nsId string, req *TbMcisReq, option string) (*TbMcisInfo, error)
 			time.Sleep(60 * time.Second)
 
 			fmt.Printf("\n[InstallMonitorAgentToMcis]\n\n")
-			content, err := InstallMonitorAgentToMcis(nsId, mcisId, mcisTmp.SystemLabel, reqToMon)
+			content, err := InstallMonitorAgentToMcis(nsId, mcisId, common.StrVM, reqToMon)
 			if err != nil {
 				common.CBLog.Error(err)
 				//mcisTmp.InstallMonAgent = "no"


### PR DESCRIPTION
[현황 - CB-TB 측면]
- CB-Dragonfly에 POST http://localhost:9090/dragonfly/agent 요청을 날릴 때,
  `service_type` 필드의 값을 `const DefaultSystemLabel string` = "Managed by CB-Tumblebug" 으로 채워서 보냈습니다.
- 사용자 → TB → DF 순서로 call 하도록 하면 사용자는 다음의 TB 에러 메시지를 보게 되는데, 디테일이 표시되지 않습니다.
```
[Calling DRAGONFLY] START
cb-tumblebug                 | VM:ns01/jhseo/aws-us-east-2, URL:http://cb-dragonfly:9090/dragonfly/agent, userName:cb-user, cspType:aws, service_type:Managed by CB-Tumblebug
cb-tumblebug                 | Called CB-DRAGONFLY API
cb-tumblebug                 | HTTP Status code: 400
cb-tumblebug                 | [CLOUD-BARISTA].[ERROR]: 2022-10-24 06:48:35 monitoring.go:255, github.com/cloud-barista/cb-tumblebug/src/core/mcis.CallMonitoringAsync() - HTTP Status: not in 200-399 
cb-tumblebug                 | [CLOUD-BARISTA].[ERROR]: 2022-10-24 06:48:35 monitoring.go:280, github.com/cloud-barista/cb-tumblebug/src/core/mcis.CallMonitoringAsync() - [Monitoring Agent deployment errors] / HTTP Status: not in 200-399 
```

[현황 - CB-DF 측면]
- CB-Dragonfly 코드를 보면, 이 필드는 모니터링 대상이 1) MCKS 인지 2) MCIS 인지를 판별하기 위한 것이며,
  - [이 필드의 값이 "mck8s", "kubernetes", "k8s" 중 하나이면 MCKS로 판별하고](https://github.com/cloud-barista/cb-dragonfly/blob/e2b66d74b6b67039672c77ca46904f961a5c155a/pkg/util/utility.go#L266-L267)
  - [이 필드의 값이 "mcis", "vm" 중 하나이면 MCIS로 판별합니다.](https://github.com/cloud-barista/cb-dragonfly/blob/e2b66d74b6b67039672c77ca46904f961a5c155a/pkg/util/utility.go#L270-L271)
- 위의 TB 요청과 같이 이 필드의 값을 "Managed by CB-Tumblebug"로 채워서 보내면
    CB-Dragonfly는 에러를 반환합니다.
  - [관련 CB-DF 코드](https://github.com/cloud-barista/cb-dragonfly/blob/e2b66d74b6b67039672c77ca46904f961a5c155a/pkg/api/rest/agent/agent.go#L40-L62)

[Req to DF]
```json
{
  "userName": "cb-user",
  "cspType": "aws",
  "service_type": "Managed by CB-Tumblebug"
}
```

[Resp from DF]
```json
{
  "message": "unsupported agentType: Managed by CB-Tumblebug"
}
```

---

[개선]
이 PR은, TB → DF 로 보내는 install agent req 의 `service_type` 필드에
`common.StrVM` = "vm" 을 채워서 보내도록 변경합니다.