### PR TITLE
Add StrictHostKeyChecking=no for mcis file copy

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/copy-file-to-mcis.sh
+++ b/src/testclient/scripts/sequentialFullTest/copy-file-to-mcis.sh
@@ -32,7 +32,7 @@ for rowi in $(echo "${VMARRAY}" | jq -r '.[] | @base64'); do
 		KEYFILENAME="${VMKEYID}"
 
 
-		VAR1=$(scp -i ./sshkey-tmp/$KEYFILENAME.pem ${SOURCEPATH} $USERNAME@$publicIP:${DESTPATH})
+		VAR1=$(scp -o StrictHostKeyChecking=no -i ./sshkey-tmp/$KEYFILENAME.pem ${SOURCEPATH} $USERNAME@$publicIP:${DESTPATH})
 		echo "${VAR1}" 
 
 	} &


### PR DESCRIPTION
Add StrictHostKeyChecking=no for mcis file copy

원격 파일 카피시, 인터렉티브 메시지 창을 없애기 위한 옵션