### PR TITLE
Update `availableDataDisk` REST API

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -2869,9 +2869,24 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Different return structures by the given option param",
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestGetAvailableDataDisksResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/mcir.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "[DEFAULT]": {
+                                            "$ref": "#/definitions/mcir.RestGetAllDataDiskResponse"
+                                        },
+                                        "[ID]": {
+                                            "$ref": "#/definitions/common.IdList"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "404": {
@@ -7255,17 +7270,6 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcir.TbVNetInfo"
-                    }
-                }
-            }
-        },
-        "mcir.RestGetAvailableDataDisksResponse": {
-            "type": "object",
-            "properties": {
-                "dataDisk": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
                     }
                 }
             }

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -2861,9 +2861,24 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Different return structures by the given option param",
                         "schema": {
-                            "$ref": "#/definitions/mcir.RestGetAvailableDataDisksResponse"
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/mcir.JSONResult"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "[DEFAULT]": {
+                                            "$ref": "#/definitions/mcir.RestGetAllDataDiskResponse"
+                                        },
+                                        "[ID]": {
+                                            "$ref": "#/definitions/common.IdList"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     },
                     "404": {
@@ -7247,17 +7262,6 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/mcir.TbVNetInfo"
-                    }
-                }
-            }
-        },
-        "mcir.RestGetAvailableDataDisksResponse": {
-            "type": "object",
-            "properties": {
-                "dataDisk": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
                     }
                 }
             }

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -319,13 +319,6 @@ definitions:
           $ref: '#/definitions/mcir.TbVNetInfo'
         type: array
     type: object
-  mcir.RestGetAvailableDataDisksResponse:
-    properties:
-      dataDisk:
-        items:
-          type: string
-        type: array
-    type: object
   mcir.RestLookupImageRequest:
     properties:
       connectionName:
@@ -4289,9 +4282,16 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Different return structures by the given option param
           schema:
-            $ref: '#/definitions/mcir.RestGetAvailableDataDisksResponse'
+            allOf:
+            - $ref: '#/definitions/mcir.JSONResult'
+            - properties:
+                '[DEFAULT]':
+                  $ref: '#/definitions/mcir.RestGetAllDataDiskResponse'
+                '[ID]':
+                  $ref: '#/definitions/common.IdList'
+              type: object
         "404":
           description: Not Found
           schema:

--- a/src/core/mcis/manageInfo.go
+++ b/src/core/mcis/manageInfo.go
@@ -1727,7 +1727,7 @@ func AttachDetachDataDisk(nsId string, mcisId string, vmId string, command strin
 	return vm, nil
 }
 
-func GetAvailableDataDiskIDs(nsId string, mcisId string, vmId string) ([]string, error) {
+func GetAvailableDataDisks(nsId string, mcisId string, vmId string, option string) (interface{}, error) {
 	vmKey := common.GenMcisKey(nsId, mcisId, vmId)
 
 	// Check existence of the key. If no key, no update.
@@ -1758,23 +1758,27 @@ func GetAvailableDataDiskIDs(nsId string, mcisId string, vmId string) ([]string,
 	tbDataDisks := []mcir.TbDataDiskInfo{}
 	json.Unmarshal(jsonString, &tbDataDisks)
 
-	idList := []string{}
+	if option != "id" {
+		return tbDataDisks, nil
+	} else { // option == "id"
+		idList := []string{}
 
-	for _, v := range tbDataDisks {
-		// Update Tb dataDisk object's status
-		newObj, err := mcir.GetResource(nsId, common.StrDataDisk, v.Id)
-		if err != nil {
-			common.CBLog.Error(err)
-			return nil, err
-		}
-		tempObj := newObj.(mcir.TbDataDiskInfo)
+		for _, v := range tbDataDisks {
+			// Update Tb dataDisk object's status
+			newObj, err := mcir.GetResource(nsId, common.StrDataDisk, v.Id)
+			if err != nil {
+				common.CBLog.Error(err)
+				return nil, err
+			}
+			tempObj := newObj.(mcir.TbDataDiskInfo)
 
-		if v.ConnectionName == vm.ConnectionName && tempObj.Status == "Available" {
-			idList = append(idList, v.Id)
+			if v.ConnectionName == vm.ConnectionName && tempObj.Status == "Available" {
+				idList = append(idList, v.Id)
+			}
 		}
+
+		return idList, nil
 	}
-
-	return idList, nil
 }
 
 // [Delete MCIS and VM object]

--- a/src/testclient/scripts/11.dataDisk/available-dataDisk-id.sh
+++ b/src/testclient/scripts/11.dataDisk/available-dataDisk-id.sh
@@ -6,4 +6,4 @@ echo "####################################################################"
 
 source ../init.sh
 
-curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}-1/dataDisk | jq ''
+curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/mcis/${MCISID}/vm/${CONN_CONFIG[$INDEX,$REGION]}-1/dataDisk?option=id | jq ''


### PR DESCRIPTION
- GET `/ns/{nsId}/mcis/{mcisId}/vm/{vmId}/dataDisk` : available한 dataDisk들의 객체들을 반환
- GET `/ns/{nsId}/mcis/{mcisId}/vm/{vmId}/dataDisk?option=id` : available한 dataDisk들의 ID들을 반환

---

`❯ ./available-dataDisk.sh -n jhseo -c aws -r 1`
GET `/ns/{nsId}/mcis/{mcisId}/vm/{vmId}/dataDisk`
```json
{
  "dataDisk": [
    {
      "id": "aws-ap-southeast-1-jhseo",
      "name": "aws-ap-southeast-1-jhseo",
      "connectionName": "aws-ap-southeast-1",
      "diskType": "standard",
      "diskSize": "77",
      "cspDataDiskId": "vol-07e0329d4f1021203",
      "cspDataDiskName": "ns01-aws-ap-southeast-1-jhseo",
      "status": "Available",
      "associatedObjectList": [],
      "createdTime": "2022-10-31T05:48:00.016Z",
      "keyValueList": [
        {
          "Key": "Encrypted",
          "Value": "false"
        },
        {
          "Key": "MultiAttachEnabled",
          "Value": "false"
        }
      ]
    }
  ]
}
```

---

`❯ ./available-dataDisk-id.sh -n jhseo -c aws -r 1`
GET `/ns/{nsId}/mcis/{mcisId}/vm/{vmId}/dataDisk?option=id`
```json
{
  "output": [
    "aws-ap-southeast-1-jhseo"
  ]
}
```
(available dataDisk ID를 담고 있던 필드 이름이
기존에는 `dataDisk` 였는데, 이것이 `output` 으로 바뀌었음에 유의)