### PR TITLE
Add more parameter index for register-cloud

### DIFF
--- a/src/testclient/scripts/1.configureSpider/register-cloud-interactive.sh
+++ b/src/testclient/scripts/1.configureSpider/register-cloud-interactive.sh
@@ -44,6 +44,18 @@ EOF
                  {
                      "Key" : "${CredentialKey05[$INDEX]:-NULL}",
                      "Value" : "${CredentialVal05[$INDEX]:-NULL}"
+                 },
+                 {
+                     "Key" : "${CredentialKey06[$INDEX]:-NULL}",
+                     "Value" : "${CredentialVal06[$INDEX]:-NULL}"
+                 },
+                 {
+                     "Key" : "${CredentialKey07[$INDEX]:-NULL}",
+                     "Value" : "${CredentialVal07[$INDEX]:-NULL}"
+                 },
+                 {
+                     "Key" : "${CredentialKey08[$INDEX]:-NULL}",
+                     "Value" : "${CredentialVal08[$INDEX]:-NULL}"
                  }
              ]
          }


### PR DESCRIPTION
- 1.configureSpider/register-cloud-interactive.sh 에 cloudit 크리델셜 등록을 위한 추가 파라미터를 누락하는 오류를 개선
- 향후 더 많은 크리덴셜 key/value pair가 추가될 경우를 대비하여, 3개의 index를 추가함.