### PR TITLE
Enhance orchestration mechanism with various features

### DIFF
--- a/src/api/grpc/server/mcis/control.go
+++ b/src/api/grpc/server/mcis/control.go
@@ -402,7 +402,7 @@ func (s *MCISService) CmdMcis(ctx context.Context, req *pb.McisCmdCreateRequest)
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.CmdMcis()")
 	}
 
-	result, err := mcis.RemoteCommandToMcis(req.NsId, req.McisId, &mcisObj)
+	result, err := mcis.RemoteCommandToMcis(req.NsId, req.McisId, "", &mcisObj)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.CmdMcis()")
 	}

--- a/src/api/grpc/server/mcis/orchestration.go
+++ b/src/api/grpc/server/mcis/orchestration.go
@@ -23,7 +23,7 @@ func (s *MCISService) CreateMcisPolicy(ctx context.Context, req *pb.McisPolicyCr
 	logger.Debug("calling MCISService.CreateMcisPolicy()")
 
 	// GRPC 메시지에서 MCIS 객체로 복사
-	var mcisObj mcis.McisPolicyInfo
+	var mcisObj mcis.McisPolicyReq
 	err := gc.CopySrcToDest(&req.Item, &mcisObj)
 	if err != nil {
 		return nil, gc.ConvGrpcStatusErr(err, "", "MCISService.CreateMcisPolicy()")

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -1168,6 +1168,13 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/mcis.McisCmdReq"
                         }
+                    },
+                    {
+                        "type": "string",
+                        "default": "\"\"",
+                        "description": "subGroupId to apply the command only for VMs in subGroup of MCIS",
+                        "name": "subGroupId",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -3576,12 +3583,12 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "description": "Details for an MCIS automation policy request",
+                        "name": "mcisPolicyReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcis.McisPolicyInfo"
+                            "$ref": "#/definitions/mcis.McisPolicyReq"
                         }
                     }
                 ],
@@ -8257,16 +8264,23 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "actionType": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "ScaleOut",
+                        "ScaleIn"
+                    ],
+                    "example": "ScaleOut"
                 },
                 "placementAlgo": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "random"
                 },
                 "postCommand": {
+                    "description": "example:\"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh\"",
                     "$ref": "#/definitions/mcis.McisCmdReq"
                 },
-                "vm": {
-                    "$ref": "#/definitions/mcis.TbVmInfo"
+                "vmDynamicReq": {
+                    "$ref": "#/definitions/mcis.TbVmDynamicReq"
                 }
             }
         },
@@ -8275,7 +8289,8 @@ const docTemplate = `{
             "properties": {
                 "evaluationPeriod": {
                     "description": "evaluationPeriod",
-                    "type": "string"
+                    "type": "string",
+                    "example": "10"
                 },
                 "evaluationValue": {
                     "type": "array",
@@ -8284,15 +8299,24 @@ const docTemplate = `{
                     }
                 },
                 "metric": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "cpu"
                 },
                 "operand": {
                     "description": "10, 70, 80, 98, ...",
-                    "type": "string"
+                    "type": "string",
+                    "example": "80"
                 },
                 "operator": {
                     "description": "\u003c, \u003c=, \u003e, \u003e=, ...",
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "\u003c",
+                        "\u003c=",
+                        "\u003e",
+                        "\u003e="
+                    ],
+                    "example": "\u003e="
                 }
             }
         },
@@ -8557,7 +8581,23 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "description": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Description"
+                },
+                "policy": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.Policy"
+                    }
+                }
+            }
+        },
+        "mcis.McisPolicyReq": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Description"
                 },
                 "policy": {
                     "type": "array",
@@ -8807,6 +8847,8 @@ const docTemplate = `{
                     "enum": [
                         "location",
                         "cost",
+                        "random",
+                        "performance",
                         "latency"
                     ],
                     "example": "location"
@@ -9261,6 +9303,13 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "newVmList": {
+                    "description": "List of IDs for new VMs. Return IDs if the VMs are newly added. This field should be used for return body only.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "placementAlgo": {
                     "type": "string"
                 },
@@ -9274,6 +9323,11 @@ const docTemplate = `{
                     "description": "SystemLabel is for describing the mcis in a keyword (any string can be used) for special System purpose",
                     "type": "string",
                     "example": "Managed by CB-Tumblebug"
+                },
+                "systemMessage": {
+                    "description": "Latest system message such as error message",
+                    "type": "string",
+                    "example": "Failed because ..."
                 },
                 "targetAction": {
                     "type": "string"

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -8276,7 +8276,7 @@ const docTemplate = `{
                     "example": "random"
                 },
                 "postCommand": {
-                    "description": "example:\"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh\"",
+                    "description": "PostCommand is field for providing command to VMs after its creation. example:\"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh\"",
                     "$ref": "#/definitions/mcis.McisCmdReq"
                 },
                 "vmDynamicReq": {

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -8268,7 +8268,7 @@
                     "example": "random"
                 },
                 "postCommand": {
-                    "description": "example:\"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh\"",
+                    "description": "PostCommand is field for providing command to VMs after its creation. example:\"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh\"",
                     "$ref": "#/definitions/mcis.McisCmdReq"
                 },
                 "vmDynamicReq": {

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -1160,6 +1160,13 @@
                         "schema": {
                             "$ref": "#/definitions/mcis.McisCmdReq"
                         }
+                    },
+                    {
+                        "type": "string",
+                        "default": "\"\"",
+                        "description": "subGroupId to apply the command only for VMs in subGroup of MCIS",
+                        "name": "subGroupId",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -3568,12 +3575,12 @@
                         "required": true
                     },
                     {
-                        "description": "Details for an MCIS object",
-                        "name": "mcisInfo",
+                        "description": "Details for an MCIS automation policy request",
+                        "name": "mcisPolicyReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/mcis.McisPolicyInfo"
+                            "$ref": "#/definitions/mcis.McisPolicyReq"
                         }
                     }
                 ],
@@ -8249,16 +8256,23 @@
             "type": "object",
             "properties": {
                 "actionType": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "ScaleOut",
+                        "ScaleIn"
+                    ],
+                    "example": "ScaleOut"
                 },
                 "placementAlgo": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "random"
                 },
                 "postCommand": {
+                    "description": "example:\"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh\"",
                     "$ref": "#/definitions/mcis.McisCmdReq"
                 },
-                "vm": {
-                    "$ref": "#/definitions/mcis.TbVmInfo"
+                "vmDynamicReq": {
+                    "$ref": "#/definitions/mcis.TbVmDynamicReq"
                 }
             }
         },
@@ -8267,7 +8281,8 @@
             "properties": {
                 "evaluationPeriod": {
                     "description": "evaluationPeriod",
-                    "type": "string"
+                    "type": "string",
+                    "example": "10"
                 },
                 "evaluationValue": {
                     "type": "array",
@@ -8276,15 +8291,24 @@
                     }
                 },
                 "metric": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "cpu"
                 },
                 "operand": {
                     "description": "10, 70, 80, 98, ...",
-                    "type": "string"
+                    "type": "string",
+                    "example": "80"
                 },
                 "operator": {
                     "description": "\u003c, \u003c=, \u003e, \u003e=, ...",
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "\u003c",
+                        "\u003c=",
+                        "\u003e",
+                        "\u003e="
+                    ],
+                    "example": "\u003e="
                 }
             }
         },
@@ -8549,7 +8573,23 @@
                     "type": "string"
                 },
                 "description": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "Description"
+                },
+                "policy": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/mcis.Policy"
+                    }
+                }
+            }
+        },
+        "mcis.McisPolicyReq": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "example": "Description"
                 },
                 "policy": {
                     "type": "array",
@@ -8799,6 +8839,8 @@
                     "enum": [
                         "location",
                         "cost",
+                        "random",
+                        "performance",
                         "latency"
                     ],
                     "example": "location"
@@ -9253,6 +9295,13 @@
                 "name": {
                     "type": "string"
                 },
+                "newVmList": {
+                    "description": "List of IDs for new VMs. Return IDs if the VMs are newly added. This field should be used for return body only.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "placementAlgo": {
                     "type": "string"
                 },
@@ -9266,6 +9315,11 @@
                     "description": "SystemLabel is for describing the mcis in a keyword (any string can be used) for special System purpose",
                     "type": "string",
                     "example": "Managed by CB-Tumblebug"
+                },
+                "systemMessage": {
+                    "description": "Latest system message such as error message",
+                    "type": "string",
+                    "example": "Failed because ..."
                 },
                 "targetAction": {
                     "type": "string"

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1001,30 +1001,46 @@ definitions:
   mcis.AutoAction:
     properties:
       actionType:
+        enum:
+        - ScaleOut
+        - ScaleIn
+        example: ScaleOut
         type: string
       placementAlgo:
+        example: random
         type: string
       postCommand:
         $ref: '#/definitions/mcis.McisCmdReq'
-      vm:
-        $ref: '#/definitions/mcis.TbVmInfo'
+        description: example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh
+          -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
+      vmDynamicReq:
+        $ref: '#/definitions/mcis.TbVmDynamicReq'
     type: object
   mcis.AutoCondition:
     properties:
       evaluationPeriod:
         description: evaluationPeriod
+        example: "10"
         type: string
       evaluationValue:
         items:
           type: string
         type: array
       metric:
+        example: cpu
         type: string
       operand:
         description: 10, 70, 80, 98, ...
+        example: "80"
         type: string
       operator:
         description: <, <=, >, >=, ...
+        enum:
+        - <
+        - <=
+        - '>'
+        - '>='
+        example: '>='
         type: string
     type: object
   mcis.BenchmarkInfo:
@@ -1203,6 +1219,17 @@ definitions:
       actionLog:
         type: string
       description:
+        example: Description
+        type: string
+      policy:
+        items:
+          $ref: '#/definitions/mcis.Policy'
+        type: array
+    type: object
+  mcis.McisPolicyReq:
+    properties:
+      description:
+        example: Description
         type: string
       policy:
         items:
@@ -1379,6 +1406,8 @@ definitions:
         enum:
         - location
         - cost
+        - random
+        - performance
         - latency
         example: location
         type: string
@@ -1698,6 +1727,12 @@ definitions:
         type: string
       name:
         type: string
+      newVmList:
+        description: List of IDs for new VMs. Return IDs if the VMs are newly added.
+          This field should be used for return body only.
+        items:
+          type: string
+        type: array
       placementAlgo:
         type: string
       status:
@@ -1708,6 +1743,10 @@ definitions:
         description: SystemLabel is for describing the mcis in a keyword (any string
           can be used) for special System purpose
         example: Managed by CB-Tumblebug
+        type: string
+      systemMessage:
+        description: Latest system message such as error message
+        example: Failed because ...
         type: string
       targetAction:
         type: string
@@ -3122,6 +3161,11 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/mcis.McisCmdReq'
+      - default: '""'
+        description: subGroupId to apply the command only for VMs in subGroup of MCIS
+        in: query
+        name: subGroupId
+        type: string
       produces:
       - application/json
       responses:
@@ -4790,12 +4834,12 @@ paths:
         name: mcisId
         required: true
         type: string
-      - description: Details for an MCIS object
+      - description: Details for an MCIS automation policy request
         in: body
-        name: mcisInfo
+        name: mcisPolicyReq
         required: true
         schema:
-          $ref: '#/definitions/mcis.McisPolicyInfo'
+          $ref: '#/definitions/mcis.McisPolicyReq'
       produces:
       - application/json
       responses:

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1011,7 +1011,8 @@ definitions:
         type: string
       postCommand:
         $ref: '#/definitions/mcis.McisCmdReq'
-        description: example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh
+        description: PostCommand is field for providing command to VMs after its creation.
+          example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh
           -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
       vmDynamicReq:
         $ref: '#/definitions/mcis.TbVmDynamicReq'

--- a/src/api/rest/server/mcis/orchestration.go
+++ b/src/api/rest/server/mcis/orchestration.go
@@ -31,7 +31,7 @@ import (
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
-// @Param mcisInfo body mcis.McisPolicyInfo true "Details for an MCIS object"
+// @Param mcisPolicyReq body mcis.McisPolicyReq true "Details for an MCIS automation policy request"
 // @Success 200 {object} mcis.McisPolicyInfo
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -41,7 +41,7 @@ func RestPostMcisPolicy(c echo.Context) error {
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
 
-	req := &mcis.McisPolicyInfo{}
+	req := &mcis.McisPolicyReq{}
 	if err := c.Bind(req); err != nil {
 		return err
 	}

--- a/src/api/rest/server/mcis/remoteCommand.go
+++ b/src/api/rest/server/mcis/remoteCommand.go
@@ -81,6 +81,7 @@ type RestPostCmdMcisResponseWrapper struct {
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
 // @Param mcisCmdReq body mcis.McisCmdReq true "MCIS Command Request"
+// @Param subGroupId query string false "subGroupId to apply the command only for VMs in subGroup of MCIS" default("")
 // @Success 200 {object} RestPostCmdMcisResponseWrapper
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -89,13 +90,14 @@ func RestPostCmdMcis(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
+	subGroupId := c.QueryParam("subGroupId")
 
 	req := &mcis.McisCmdReq{}
 	if err := c.Bind(req); err != nil {
 		return err
 	}
 
-	resultArray, err := mcis.RemoteCommandToMcis(nsId, mcisId, req)
+	resultArray, err := mcis.RemoteCommandToMcis(nsId, mcisId, subGroupId, req)
 	if err != nil {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)

--- a/src/core/mcis/benchmark.go
+++ b/src/core/mcis/benchmark.go
@@ -100,7 +100,7 @@ func InstallBenchmarkAgentToMcis(nsId string, mcisId string, req *McisCmdReq) ([
 	// Replace given parameter with the installation cmd
 	req.Command = cmd
 
-	sshCmdResult, err := RemoteCommandToMcis(nsId, mcisId, req)
+	sshCmdResult, err := RemoteCommandToMcis(nsId, mcisId, "", req)
 
 	if err != nil {
 		temp := []SshCmdResult{}

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -62,9 +62,9 @@ const (
 // AutoCondition is struct for MCIS auto-control condition.
 type AutoCondition struct {
 	Metric           string   `json:"metric" example:"cpu"`
-	Operator         string   `json:"operator" example:">=" enums:"<,<=,>,>="` // <, <=, >, >=, ...
-	Operand          string   `json:"operand" example:"80"`                    // 10, 70, 80, 98, ...
-	EvaluationPeriod string   `json:"evaluationPeriod" example:"10"`           // evaluationPeriod
+	Operator         string   `json:"operator" example:">=" enums:"<,<=,>,>="`
+	Operand          string   `json:"operand" example:"80"`
+	EvaluationPeriod string   `json:"evaluationPeriod" example:"10"`
 	EvaluationValue  []string `json:"evaluationValue"`
 	//InitTime	   string 	  `json:"initTime"`  // to check start of duration
 	//Duration	   string 	  `json:"duration"`  // duration for checking

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -72,10 +72,12 @@ type AutoCondition struct {
 
 // AutoAction is struct for MCIS auto-control action.
 type AutoAction struct {
-	ActionType    string         `json:"actionType" example:"ScaleOut" enums:"ScaleOut,ScaleIn"`
-	VmDynamicReq  TbVmDynamicReq `json:"vmDynamicReq"`
-	PostCommand   McisCmdReq     `json:"postCommand"` //example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
-	PlacementAlgo string         `json:"placementAlgo" example:"random"`
+	ActionType   string         `json:"actionType" example:"ScaleOut" enums:"ScaleOut,ScaleIn"`
+	VmDynamicReq TbVmDynamicReq `json:"vmDynamicReq"`
+
+	// PostCommand is field for providing command to VMs after its creation. example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
+	PostCommand   McisCmdReq `json:"postCommand"`
+	PlacementAlgo string     `json:"placementAlgo" example:"random"`
 }
 
 // Policy is struct for MCIS auto-control Policy request that includes AutoCondition, AutoAction, Status.

--- a/src/core/mcis/recommendation.go
+++ b/src/core/mcis/recommendation.go
@@ -61,8 +61,8 @@ type PriorityInfo struct {
 
 // FilterCondition is struct for .
 type PriorityCondition struct {
-	Metric    string            `json:"metric" example:"location" enums:"location,cost,random,performance,latency"` // location,cost,latency
-	Weight    string            `json:"weight" example:"0.3" enums:"0.1,0.2,..."`                                   // 0.3
+	Metric    string            `json:"metric" example:"location" enums:"location,cost,random,performance,latency"`
+	Weight    string            `json:"weight" example:"0.3" enums:"0.1,0.2,..."`
 	Parameter []ParameterKeyVal `json:"parameter,omitempty"`
 }
 

--- a/src/core/mcis/remoteCommand.go
+++ b/src/core/mcis/remoteCommand.go
@@ -150,7 +150,7 @@ func RemoteCommandToMcisVm(nsId string, mcisId string, vmId string, req *McisCmd
 }
 
 // RemoteCommandToMcis is func to command to all VMs in MCIS by SSH
-func RemoteCommandToMcis(nsId string, mcisId string, req *McisCmdReq) ([]SshCmdResult, error) {
+func RemoteCommandToMcis(nsId string, mcisId string, subGroupId string, req *McisCmdReq) ([]SshCmdResult, error) {
 
 	err := common.CheckString(nsId)
 	if err != nil {
@@ -221,6 +221,18 @@ func RemoteCommandToMcis(nsId string, mcisId string, req *McisCmdReq) ([]SshCmdR
 	if err != nil {
 		common.CBLog.Error(err)
 		return nil, err
+	}
+	if subGroupId != "" {
+		vmListInGroup, err := ListMcisGroupVms(nsId, mcisId, subGroupId)
+		if err != nil {
+			common.CBLog.Error(err)
+			return nil, err
+		}
+		if vmListInGroup == nil {
+			err := fmt.Errorf("No VM in " + subGroupId)
+			return nil, err
+		}
+		vmList = vmListInGroup
 	}
 
 	//goroutine sync wg


### PR DESCRIPTION
- MCIS 자동 제어 메커니즘 개선 (MCIS에 신규 subGroup을 자동으로 추가하는 글로벌 ScaleOut)
- MCIS 추천 방식 추가 (Random)
- MCIS의 subGroup 단위의 원격 커맨드 옵션 추가
- 등

## MCIS 자동 제어 사용 방식
- CB-Dragonfly 배포 및 CB-TB에 설정 필수

- MCIS 자동 제어 정책 등록 (rest api)

POST [​/ns​/{nsId}​/policy​/mcis​/{mcisId}](http://localhost:1323/tumblebug/swagger/index.html#/[Infra%20service]%20MCIS%20Auto%20control%20policy%20management%20(WIP)/post_ns__nsId__policy_mcis__mcisId_) Create MCIS Automation policy

Request body 예시
```
{
  "description": "Description",
  "policy": [
    {
      "autoAction": {
        "actionType": "ScaleOut",
        "placementAlgo": "random",
        "postCommand": {
          "command": "wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
        },
        "vmDynamicReq": {
          "commonImage": "ubuntu18.04",
          "commonSpec": "aws-ap-northeast-2-t2-small",
          "description": "Description",
          "label": "DynamicVM",
          "name": "newgroup",
          "subGroupSize": "2"
        }
      },
      "autoCondition": {
        "evaluationPeriod": "10",
        "metric": "cpu",
        "operand": "30",
        "operator": ">="
      }
    }
  ]
}
```
// 참고: 이 예시를 활용하면 ScaleOut 시 VM이 Random하게 선정되어 MCIS에 자동 추가됨, vmDynamicReq 에 입력된 값 일부는 무시됨. (향후 매뉴얼 모드 추가 예정)


- MCIS (+모니터링 에이전트) 생성 후, 임의의 스트레스 로드 생성

sudo apt-get install -y stress; 
**stress -c 4 -t 500s**

![image](https://user-images.githubusercontent.com/5966944/199540843-b91ce7a7-987e-4068-8930-e06b75a5f9e3.png)

- MCIS 자동 확장 결과 확인 
  - 지정된 evaluationPeriod 에 따라, 이동평균으로 조건 만족 여부를 확인함
  - 조건에 일치하는 경우, ScaleOut 을 수행. (이때 선정되는 SubGroup (VMs)의 사양은 random하게 선정)
  - 설정된 경우 모니터링 에이전트 자동 설치
  - 지정된 경우 post remote command를 자동 수행
  - ScaleOut을 위한 VM이 running 상태가 되면, 중복 ScaleOut 발생을 막기 위해 Stabilizing 기간을 거침 (evaluationPeriod와 동일한 기간 동안)
  - 다시 평가 진행

![image](https://user-images.githubusercontent.com/5966944/199542152-89ed6fa2-73bb-4e0e-96d1-5ac897c2665b.png)

![image](https://user-images.githubusercontent.com/5966944/199542290-52255266-4bd6-4665-a997-779216b1095c.png)

![image](https://user-images.githubusercontent.com/5966944/199543733-4e3b232f-e9ab-435e-a775-e28b944c244b.png)

![image](https://user-images.githubusercontent.com/5966944/199543785-40392d70-e024-4181-b574-42f88a36cbc8.png)
