### PR TITLE
Add CreateSystemMcisDynamic for network probe

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -6809,6 +6809,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/systemMcis": {
+            "post": {
+                "description": "Create System MCIS Dynamically for Special Purpose",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra service] MCIS Provisioning management"
+                ],
+                "summary": "Create System MCIS Dynamically for Special Purpose in NS:system-purpose-common-ns",
+                "parameters": [
+                    {
+                        "enum": [
+                            "probe"
+                        ],
+                        "type": "string",
+                        "description": "Option for the purpose of system MCIS",
+                        "name": "option",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbMcisInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/{nsId}/checkResource/{resourceType}/{resourceId}": {
             "get": {
                 "description": "Check resources' existence",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -6801,6 +6801,52 @@
                 }
             }
         },
+        "/systemMcis": {
+            "post": {
+                "description": "Create System MCIS Dynamically for Special Purpose",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra service] MCIS Provisioning management"
+                ],
+                "summary": "Create System MCIS Dynamically for Special Purpose in NS:system-purpose-common-ns",
+                "parameters": [
+                    {
+                        "enum": [
+                            "probe"
+                        ],
+                        "type": "string",
+                        "description": "Option for the purpose of system MCIS",
+                        "name": "option",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbMcisInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/{nsId}/checkResource/{resourceType}/{resourceId}": {
             "get": {
                 "description": "Check resources' existence",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -6956,6 +6956,36 @@ paths:
         all Clouds to CB-Tumblebug
       tags:
       - '[Admin] System management'
+  /systemMcis:
+    post:
+      consumes:
+      - application/json
+      description: Create System MCIS Dynamically for Special Purpose
+      parameters:
+      - description: Option for the purpose of system MCIS
+        enum:
+        - probe
+        in: query
+        name: option
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.TbMcisInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Create System MCIS Dynamically for Special Purpose in NS:system-purpose-common-ns
+      tags:
+      - '[Infra service] MCIS Provisioning management'
 securityDefinitions:
   BasicAuth:
     type: basic

--- a/src/api/rest/server/mcis/provisioning.go
+++ b/src/api/rest/server/mcis/provisioning.go
@@ -88,6 +88,37 @@ func RestPostRegisterCSPNativeVM(c echo.Context) error {
 	return c.JSON(http.StatusCreated, result)
 }
 
+// RestPostSystemMcis godoc
+// @Summary Create System MCIS Dynamically for Special Purpose in NS:system-purpose-common-ns
+// @Description Create System MCIS Dynamically for Special Purpose
+// @Tags [Infra service] MCIS Provisioning management
+// @Accept  json
+// @Produce  json
+// @Param option query string false "Option for the purpose of system MCIS" Enums(probe)
+// @Success 200 {object} TbMcisInfo
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /systemMcis [post]
+func RestPostSystemMcis(c echo.Context) error {
+
+	option := c.QueryParam("option")
+
+	req := &mcis.TbMcisDynamicReq{}
+	if err := c.Bind(req); err != nil {
+		return err
+	}
+
+	result, err := mcis.CreateSystemMcisDynamic(option)
+	if err != nil {
+		mapA := map[string]string{"message": err.Error()}
+		return c.JSON(http.StatusInternalServerError, &mapA)
+	}
+
+	common.PrintJsonPretty(*result)
+
+	return c.JSON(http.StatusCreated, result)
+}
+
 // RestPostMcisDynamic godoc
 // @Summary Create MCIS Dynamically
 // @Description Create MCIS Dynamically from common spec and image

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -169,6 +169,7 @@ func RunServer(port string) {
 
 	e.POST("/tumblebug/mcisRecommendVm", rest_mcis.RestRecommendVm)
 	e.POST("/tumblebug/mcisDynamicCheckRequest", rest_mcis.RestPostMcisDynamicCheckRequest)
+	e.POST("/tumblebug/systemMcis", rest_mcis.RestPostSystemMcis)
 
 	g.POST("/:nsId/mcisDynamic", rest_mcis.RestPostMcisDynamic)
 	g.POST("/:nsId/mcis/:mcisId/vmDynamic", rest_mcis.RestPostMcisVmDynamic)


### PR DESCRIPTION
### Add CreateSystemMcisDynamic for network probe

- 전 지역에 1개의 network probe를 생성하는 시스템용 MCIS 생성 기능.
- 각 CSP의 지역별 네트워크 응답 속도 (latency) 측정 용도 (admin 입장에서만 사용)

### Add recommend option for csp and region

- provider (ex: "operand": "gcp"), 
- region (ex: "operand": "eu-central"), 
- specname (ex: "operand": "large") 

등 문자열 일치 조건으로 추천

참고: https://github.com/cloud-barista/cb-tumblebug/discussions/1234