### PR TITLE
Enhance latency map creation

### DIFF
--- a/scripts/cleanDB.sh
+++ b/scripts/cleanDB.sh
@@ -17,7 +17,7 @@ echo
 echo ==========================================================
 echo "[Info]"
 echo ==========================================================
-echo "This script will ${LGREEN}remove all MetaDate in Local DataBases.${NC}"
+echo -e "This script will ${LGREEN}remove all MetaDate in Local DataBases.${NC}"
 echo "(MetaData from both CB-Tumblebug and CB-Spider container)"
 echo
 echo -e "Will remove following directories and files"

--- a/scripts/runSpider.sh
+++ b/scripts/runSpider.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CONTAINER_NAME_READ="CB-Spider"
-CONTAINER_VERSION="0.6.13"
+CONTAINER_VERSION="0.6.14"
 CONTAINER_PORT="-p 1024:1024 -p 2048:2048"
 CONTAINER_DATA_PATH="/root/go/src/github.com/cloud-barista/cb-spider/meta_db"
 

--- a/src/core/mcis/benchmark.go
+++ b/src/core/mcis/benchmark.go
@@ -231,7 +231,7 @@ func RunAllBenchmarks(nsId string, mcisId string, host string) (*BenchmarkInfoAr
 
 	content := BenchmarkInfoArray{}
 
-	allBenchCmd := []string{"cpus", "cpum", "memR", "memW", "fioR", "fioW", "dbR", "dbW", "rtt"}
+	allBenchCmd := []string{"cpus", "cpum", "memR", "memW", "fioR", "fioW", "dbR", "dbW"}
 
 	resultMap := make(map[string]SpecBenchmarkInfo)
 
@@ -297,13 +297,15 @@ func RunAllBenchmarks(nsId string, mcisId string, host string) (*BenchmarkInfoAr
 		csvWriter.Flush()
 	}
 
+	const empty = ""
+
 	const mrttArrayXMax = 300
 	const mrttArrayYMax = 300
 	mrttArray := make([][]string, mrttArrayXMax)
 	for i := 0; i < mrttArrayXMax; i++ {
 		mrttArray[i] = make([]string, mrttArrayYMax)
 		for j := 0; j < mrttArrayYMax; j++ {
-			mrttArray[i][j] = ""
+			mrttArray[i][j] = empty
 		}
 	}
 
@@ -347,7 +349,7 @@ func RunAllBenchmarks(nsId string, mcisId string, host string) (*BenchmarkInfoAr
 		if refIndex == 0 {
 			continue
 		}
-		if refVal == "" {
+		if refVal == empty {
 			break
 		}
 		orgIndex := rttIndexMapX[refVal]
@@ -366,7 +368,7 @@ func RunAllBenchmarks(nsId string, mcisId string, host string) (*BenchmarkInfoAr
 	// change index name from specId to regionName
 	for i := 1; i < len(mrttArray[0]); i++ {
 		targetSpecId := mrttArray[0][i]
-		if targetSpecId == "" {
+		if targetSpecId == empty {
 			break
 		}
 		tempInterface, err := mcir.GetResource(common.SystemCommonNs, common.StrSpec, targetSpecId)
@@ -375,6 +377,16 @@ func RunAllBenchmarks(nsId string, mcisId string, host string) (*BenchmarkInfoAr
 			err = common.CopySrcToDest(&tempInterface, &specInfo)
 			mrttArray[0][i] = specInfo.RegionName
 			mrttArray[i][0] = specInfo.RegionName
+		}
+	}
+
+	// Fill empty with transpose matix
+	for i := 1; i < len(mrttArray[0]); i++ {
+		firstValue := mrttArray[i][1]
+		if firstValue == empty {
+			for j := 1; j < len(mrttArray[0]); j++ {
+				mrttArray[i][j] = mrttArray[j][i]
+			}
 		}
 	}
 

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -1263,6 +1263,9 @@ func CreateSystemMcisDynamic(option string) (*TbMcisInfo, error) {
 
 				vmReq.Label = vmReq.CommonSpec
 				vmReq.Name = vmReq.CommonSpec
+
+				vmReq.RootDiskType = specList[0].RootDiskType
+				vmReq.RootDiskSize = specList[0].RootDiskSize
 				req.Vm = append(req.Vm, *vmReq)
 			}
 		}


### PR DESCRIPTION

 - latency map 생성시, 일부 정상 동작하지 않아서 빈 라인으로 남아 있는 항목을, 행렬을 전치하여 채워 넣도록 처리
 - Spider 0.6.14 버전 확인 및 스크립트 업데이트