### PR TITLE
Add mcisFlag for register existing VMs

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -407,6 +407,7 @@ type RestRegisterCspNativeResourcesRequest struct {
 // @Produce  json
 // @Param Request body RestRegisterCspNativeResourcesRequest true "Specify connectionName, NS Id, and MCIS Name""
 // @Param option query string false "Option to specify resourceType" Enums(onlyVm, exceptVm)
+// @Param mcisFlag query string false "Flag to show VMs in a collective MCIS form (y,n)" Enums(y, n) default(y)
 // @Success 200 {object} mcis.RegisterResourceResult
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -418,8 +419,9 @@ func RestRegisterCspNativeResources(c echo.Context) error {
 		return err
 	}
 	option := c.QueryParam("option")
+	mcisFlag := c.QueryParam("mcisFlag")
 
-	content, err := mcis.RegisterCspNativeResources(u.NsId, u.ConnectionName, u.McisName, option)
+	content, err := mcis.RegisterCspNativeResources(u.NsId, u.ConnectionName, u.McisName, option, mcisFlag)
 
 	if err != nil {
 		common.CBLog.Error(err)
@@ -445,6 +447,7 @@ type RestRegisterCspNativeResourcesRequestAll struct {
 // @Produce  json
 // @Param Request body RestRegisterCspNativeResourcesRequestAll true "Specify NS Id and MCIS Name"
 // @Param option query string false "Option to specify resourceType" Enums(onlyVm, exceptVm)
+// @Param mcisFlag query string false "Flag to show VMs in a collective MCIS form (y,n)" Enums(y, n) default(y)
 // @Success 200 {object} mcis.RegisterResourceAllResult
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -456,8 +459,9 @@ func RestRegisterCspNativeResourcesAll(c echo.Context) error {
 		return err
 	}
 	option := c.QueryParam("option")
+	mcisFlag := c.QueryParam("mcisFlag")
 
-	content, err := mcis.RegisterCspNativeResourcesAll(u.NsId, u.McisName, option)
+	content, err := mcis.RegisterCspNativeResourcesAll(u.NsId, u.McisName, option, mcisFlag)
 
 	if err != nil {
 		common.CBLog.Error(err)

--- a/src/core/mcis/utility.go
+++ b/src/core/mcis/utility.go
@@ -878,7 +878,7 @@ type registerationOverview struct {
 }
 
 // RegisterCspNativeResourcesAll func registers all CSP-native resources into CB-TB
-func RegisterCspNativeResourcesAll(nsId string, mcisId string, option string) (RegisterResourceAllResult, error) {
+func RegisterCspNativeResourcesAll(nsId string, mcisId string, option string, mcisFlag string) (RegisterResourceAllResult, error) {
 	startTime := time.Now()
 
 	connectionConfigList, err := common.GetConnConfigList()
@@ -913,7 +913,7 @@ func RegisterCspNativeResourcesAll(nsId string, mcisId string, option string) (R
 
 			common.RandomSleep(0, 50)
 
-			registerResult, err := RegisterCspNativeResources(nsId, k.ConfigName, mcisNameForRegister, option)
+			registerResult, err := RegisterCspNativeResources(nsId, k.ConfigName, mcisNameForRegister, option, mcisFlag)
 			if err != nil {
 				common.CBLog.Error(err)
 			}
@@ -952,7 +952,7 @@ func RegisterCspNativeResourcesAll(nsId string, mcisId string, option string) (R
 }
 
 // RegisterCspNativeResources func registers all CSP-native resources into CB-TB
-func RegisterCspNativeResources(nsId string, connConfig string, mcisId string, option string) (RegisterResourceResult, error) {
+func RegisterCspNativeResources(nsId string, connConfig string, mcisId string, option string, mcisFlag string) (RegisterResourceResult, error) {
 	startTime := time.Now()
 
 	optionFlag := "register"
@@ -1142,8 +1142,12 @@ func RegisterCspNativeResources(nsId string, connConfig string, mcisId string, o
 			vm.ConnectionName = connConfig
 			vm.IdByCSP = r.IdByCsp
 			vm.Description = "Ref name: " + r.RefNameOrId + ". CSP managed VM (registered to CB-TB)"
-			vm.Name = vm.ConnectionName + "-" + vm.IdByCSP
+			vm.Name = vm.ConnectionName + "-" + r.RefNameOrId + "-" + vm.IdByCSP
 			vm.Name = common.ChangeIdString(vm.Name)
+			if mcisFlag == "n" {
+				// (if mcisFlag == "n") create a mcis for each vm
+				req.Name = vm.Name
+			}
 			vm.Label = "not defined"
 
 			vm.ImageId = "cannot retrieve"


### PR DESCRIPTION
기존 자원 등록 관련 개선

- 기존 방식: 리전 단위로 모든 VM을 1개의 MCIS에 의무적으로 포함
- 개선 방식: mcisFlag 옵션("n" 지정)을 제공하여, 개별 VM을 포함하는 MCIS들로 생성

