### PR TITLE
Set CORS ALLOW_ORIGINS as ENV

### DIFF
--- a/conf/setup.env
+++ b/conf/setup.env
@@ -13,12 +13,16 @@ export DB_DATABASE=cb_tumblebug
 export DB_USER=cb_tumblebug
 export DB_PASSWORD=cb_tumblebug
 
+# API Setting
+# ALLOW_ORIGINS (ex: https://cloud-barista.org,xxx.xxx.xxx.xxx,*)
+export ALLOW_ORIGINS=*
 export API_USERNAME=default
 export API_PASSWORD=default
 
 export CB_NETWORK_SERVICE_ENDPOINT=localhost:8053
 # comma separated such as "aaa.aaa.aaa.aaa:2379,bbb.bbb.bbb.bbb:2379,..."
 export CB_NETWORK_ETCD_ENDPOINTS="localhost:2379"
+
 
 # Set period for auto control goroutine invocation
 export AUTOCONTROL_DURATION_MS=10000

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"log"
 	"os/signal"
 	"sync"
 	"syscall"
@@ -93,8 +94,14 @@ func RunServer(port string) {
 	// e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
 	e.GET("/tumblebug/health", rest_common.RestGetHealth)
 
+	allowedOrigins := os.Getenv("ALLOW_ORIGINS")
+	if allowedOrigins == "" {
+		log.Fatal("ALLOW_ORIGINS env variable for CORS is " + allowedOrigins +
+			". Please provide a proper value and source setup.env again. EXITING...")
+		// allowedOrigins = "*"
+	}
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins: []string{"*"},
+		AllowOrigins: []string{allowedOrigins},
 		AllowMethods: []string{http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete},
 	}))
 
@@ -353,7 +360,7 @@ func RunServer(port string) {
 	fmt.Printf(noticeColor, apidashboard)
 	fmt.Println("\n ")
 
-	// A context for graceful shutdown (It is based on the signal package)
+	// A context for graceful shutdown (It is based on the signal package)selfEndpoint := os.Getenv("SELF_ENDPOINT")
 	// NOTE -
 	// Use os.Interrupt Ctrl+C or Ctrl+Break on Windows
 	// Use syscall.KILL for Kill(can't be caught or ignored) (POSIX)


### PR DESCRIPTION
Set CORS ALLOW_ORIGINS as ENV

```
>  # API Setting
>  # ALLOW_ORIGINS (ex: https://cloud-barista.org,xxx.xxx.xxx.xxx,*)
```

```
allowedOrigins := os.Getenv("ALLOW_ORIGINS")
	if allowedOrigins == "" {
		log.Fatal("ALLOW_ORIGINS env variable for CORS is " + allowedOrigins +
			". Please provide a proper value and source setup.env again. EXITING...")
		// allowedOrigins = "*"
	}
	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
		AllowOrigins: []string{allowedOrigins},
		AllowMethods: []string{http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete},
	}))
```