### PR TITLE
API response caching for get VM status

### DIFF
--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -462,12 +462,13 @@ func GetConnConfigList() (ConnConfigList, error) {
 	client := resty.New()
 	url := SpiderRestUrl + "/connectionconfig"
 	method := "GET"
+	var requestBody interface{} = nil
 	err := ExecuteHttpRequest(
 		client,
 		method,
 		url,
 		nil,
-		nil,
+		&requestBody,
 		&callResult,
 		MediumDuration,
 	)


### PR DESCRIPTION
This PR,
- Enhance API response caching mechanism
- Apply caching for get VM status
- Enable API call debug for resty (not enabled by config. will enhance next time.)


Test example. (it works nicely)
- Cached successfully!
- Cache hit! Expires:  -373.963826ms
- Cache item expired!

```
==============================================================================
Cached successfully!
2023/09/06 02:18:59.044565 DEBUG RESTY 
==============================================================================
~~~ REQUEST ~~~
GET  /spider/vmstatus/ns01-mc-8j0hg-g2-4  HTTP/1.1
HOST   : localhost:1024
HEADERS:
	Accept: application/json
	Content-Type: application/json
	User-Agent: go-resty/2.7.0 (https://github.com/go-resty/resty)
BODY   :
{
   "ConnectionName": "gcp-asia-northeast3"
}
------------------------------------------------------------------------------
~~~ RESPONSE ~~~
STATUS       : 200 OK
PROTO        : HTTP/1.1
RECEIVED AT  : 2023-09-06T02:18:59.044511396+09:00
TIME DURATION: 383.483586ms
HEADERS      :
	Content-Length: 21
	Content-Type: application/json; charset=UTF-8
	Date: Tue, 05 Sep 2023 17:18:59 GMT
	Vary: Origin
BODY         :
{
   "Status": "Running"
}

==============================================================================
Cached successfully!
{"time":"2023-09-06T02:18:59.045066948+09:00","id":"","remote_ip":"10.0.2.2","host":"localhost:1323","method":"GET","uri":"/tumblebug/ns/ns01/mcis?option=status","user_agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36","status":200,"error":"","latency":385523949,"latency_human":"385.523949ms","bytes_in":0,"bytes_out":4801}
[Handle API Request]
[Get MCIS List requested with option: status
[GetMcisStatus]mc-8j0hg
Cache hit! Expires:  -366.734662ms
Cache hit! Expires:  -86.4888ms
Cache hit! Expires:  -395.531122ms
Cache hit! Expires:  -373.963826ms
Cache hit! Expires:  -100.991381ms
Cache hit! Expires:  -4.375419943s
Cache hit! Expires:  -67.604366ms
Cache hit! Expires:  -4.383921366s
Cache hit! Expires:  -86.871012ms
Cache hit! Expires:  -67.185907ms
{"time":"2023-09-06T02:18:59.66131357+09:00","id":"","remote_ip":"10.0.2.2","host":"localhost:1323","method":"GET","uri":"/tumblebug/ns/ns01/mcis?option=status","user_agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36","status":200,"error":"","latency":1642112,"latency_human":"1.642112ms","bytes_in":0,"bytes_out":4801}
[Handle API Request]
[Get MCIS List requested with option: status
[GetMcisStatus]mc-8j0hg
Cache item expired!
Cache item expired!
Cache item expired!
Cache item expired!
Cache item expired!
Cache item expired!
Cache item expired!
Cache hit! Expires:  -3.382508014s
Cache item expired!
Cache hit! Expires:  -3.371330422s
2023/09/06 02:19:00.731926 DEBUG RESTY 
==============================================================================
~~~ REQUEST ~~~
GET  /spider/vmstatus/ns01-mc-8j0hg-g1-2  HTTP/1.1
HOST   : localhost:1024
HEADERS:
	Accept: application/json
	Content-Type: application/json
	User-Agent: go-resty/2.7.0 (https://github.com/go-resty/resty)
BODY   :
{
   "ConnectionName": "aws-ap-northeast-2"
}
------------------------------------------------------------------------------
~~~ RESPONSE ~~~
STATUS       : 200 OK
PROTO        : HTTP/1.1
RECEIVED AT  : 2023-09-06T02:19:00.731877146+09:00
TIME DURATION: 70.127565ms
HEADERS      :
	Content-Length: 21
	Content-Type: application/json; charset=UTF-8
	Date: Tue, 05 Sep 2023 17:19:00 GMT
	Vary: Origin
BODY         :
{
   "Status": "Running"
}

==============================================================================
Cached successfully!
2023/09/06 02:19:00.733085 DEBUG RESTY 
==============================================================================
```