### PR TITLE
Add check http version

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -85,6 +85,27 @@ func RestGetHealth(c echo.Context) error {
 	return c.JSON(http.StatusOK, &okMessage)
 }
 
+// RestCheckHTTPVersion godoc
+// @Summary Check HTTP version of incoming request
+// @Description Checks and logs the HTTP version of the incoming request to the server console.
+// @Tags [Admin] System management
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} common.SimpleMsg
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /httpVersion [get]
+func RestCheckHTTPVersion(c echo.Context) error {
+	// Access the *http.Request object from the echo.Context
+	req := c.Request()
+
+	// Determine the HTTP protocol version of the request
+	okMessage := common.SimpleMsg{}
+	okMessage.Message = req.Proto
+
+	return c.JSON(http.StatusOK, &okMessage)
+}
+
 /*
 // RestGetSwagger func is to get API document web.
 // RestGetSwagger godoc

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -93,6 +93,7 @@ func RunServer(port string) {
 	e.GET("/tumblebug/swagger/*", echoSwagger.WrapHandler)
 	// e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
 	e.GET("/tumblebug/health", rest_common.RestGetHealth)
+	e.GET("/tumblebug/httpVersion", rest_common.RestCheckHTTPVersion)
 
 	allowedOrigins := os.Getenv("ALLOW_ORIGINS")
 	if allowedOrigins == "" {


### PR DESCRIPTION
To retrieve, CB-TB API HTTP version.

<html>
<body>
<!--StartFragment-->

Code | Details
-- | --
200 | Response bodyDownload{   "message": "HTTP/1.1" }

Response headers content-length: 23  content-type: application/json; charset=UTF-8  date: Mon,18 Sep 2023 06:31:45 GMT  vary: Origin

<!--EndFragment-->
</body>
</html>