### PR TITLE
Set and get barison node assigned to subnet

### DIFF
--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -135,11 +135,12 @@ func TbSubnetReqStructLevelValidation(sl validator.StructLevel) {
 
 // TbSubnetInfo is a struct that represents TB subnet object.
 type TbSubnetInfo struct { // Tumblebug
-	Id           string
-	Name         string `validate:"required"`
-	IPv4_CIDR    string `validate:"required"`
-	KeyValueList []common.KeyValue
-	Description  string
+	Id             string
+	Name           string `validate:"required"`
+	IPv4_CIDR      string `validate:"required"`
+	BastionNodeIds []string
+	KeyValueList   []common.KeyValue
+	Description    string
 }
 
 // CreateVNet accepts vNet creation request, creates and returns an TB vNet object

--- a/src/core/mcis/manageInfo.go
+++ b/src/core/mcis/manageInfo.go
@@ -673,6 +673,7 @@ func GetVmObject(nsId string, mcisId string, vmId string) (TbVmInfo, error) {
 	key := common.GenMcisKey(nsId, mcisId, vmId)
 	keyValue, err := common.CBStore.Get(key)
 	if keyValue == nil || err != nil {
+		err = fmt.Errorf("failed to get GetVmObject (ID: %s)", key)
 		common.CBLog.Error(err)
 		return TbVmInfo{}, err
 	}


### PR DESCRIPTION
New feature for
- Set (assign) barison node to subnet for private VMs
- Get barison node list assigned to subnet

<html>
<body>
<!--StartFragment--><div class="opblock-summary opblock-summary-put" style="box-sizing: border-box; align-items: center; cursor: pointer; display: flex; padding: 5px; border-bottom: 1px solid rgb(252, 161, 48); border-top-color: rgb(252, 161, 48); border-right-color: rgb(252, 161, 48); border-left-color: rgb(252, 161, 48); color: rgb(59, 65, 81); font-family: sans-serif; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button aria-label="put ​/ns​/{nsId}​/mcis​/{mcisId}​/vm​/{targetVmId}​/bastion​/{bastionVmId}" aria-expanded="true" class="opblock-summary-control" style="color: inherit; font: inherit; font-palette: inherit; font-synthesis: inherit; forced-color-adjust: inherit; text-orientation: inherit; text-rendering: inherit; -webkit-font-smoothing: inherit; -webkit-locale: inherit; -webkit-text-orientation: inherit; -webkit-writing-mode: inherit; writing-mode: inherit; zoom: inherit; accent-color: inherit; place-content: inherit; place-items: inherit; place-self: inherit; alignment-baseline: inherit; animation-composition: inherit; animation: inherit; app-region: inherit; appearance: inherit; aspect-ratio: inherit; backdrop-filter: inherit; backface-visibility: inherit; background: inherit; background-blend-mode: inherit; baseline-shift: inherit; baseline-source: inherit; block-size: inherit; border-block: inherit; border-bottom: 0px; border-radius: inherit; border-collapse: inherit; border-end-end-radius: inherit; border-end-start-radius: inherit; border-image: inherit; border-inline: inherit; border-left: inherit; border-right: inherit; border-start-end-radius: inherit; border-start-start-radius: inherit; border-top: inherit; inset: inherit; box-shadow: inherit; box-sizing: inherit; break-after: inherit; break-before: inherit; break-inside: inherit; buffered-rendering: inherit; caption-side: inherit; caret-color: inherit; clear: inherit; clip: inherit; clip-path: inherit; clip-rule: inherit; color-interpolation: inherit; color-interpolation-filters: inherit; color-rendering: inherit; color-scheme: inherit; columns: inherit; column-fill: inherit; gap: inherit; column-rule: inherit; column-span: inherit; contain: inherit; contain-intrinsic-block-size: inherit; contain-intrinsic-size: inherit; contain-intrinsic-inline-size: inherit; container: inherit; content: inherit; content-visibility: inherit; counter-increment: inherit; counter-reset: inherit; counter-set: inherit; cursor: inherit; cx: inherit; cy: inherit; d: inherit; display: inherit; dominant-baseline: inherit; empty-cells: inherit; fill: inherit; fill-opacity: inherit; fill-rule: inherit; filter: inherit; flex: 1 1 0%; flex-flow: inherit; float: inherit; flood-color: inherit; flood-opacity: inherit; grid: inherit; grid-area: inherit; height: inherit; hyphenate-character: inherit; hyphenate-limit-chars: inherit; hyphens: inherit; image-orientation: inherit; image-rendering: inherit; initial-letter: inherit; inline-size: inherit; inset-block: inherit; inset-inline: inherit; isolation: inherit; letter-spacing: inherit; lighting-color: inherit; line-break: inherit; list-style: inherit; margin-block: inherit; margin: inherit; margin-inline: inherit; marker: inherit; mask: inherit; mask-type: inherit; math-depth: inherit; math-shift: inherit; math-style: inherit; max-block-size: inherit; max-height: inherit; max-inline-size: inherit; max-width: inherit; min-block-size: inherit; min-height: inherit; min-inline-size: inherit; min-width: inherit; mix-blend-mode: inherit; object-fit: inherit; object-position: inherit; object-view-box: inherit; offset: inherit; opacity: inherit; order: inherit; orphans: inherit; outline: inherit; outline-offset: inherit; overflow-anchor: inherit; overflow-clip-margin: inherit; overflow-wrap: inherit; overflow: inherit; overscroll-behavior-block: inherit; overscroll-behavior-inline: inherit; overscroll-behavior: inherit; padding-block: inherit; padding: 0px; padding-inline: inherit; page: inherit; page-orientation: inherit; paint-order: inherit; perspective: inherit; perspective-origin: inherit; pointer-events: inherit; position: inherit; quotes: inherit; r: inherit; resize: inherit; rotate: inherit; ruby-position: inherit; rx: inherit; ry: inherit; scale: inherit; scroll-behavior: inherit; scroll-margin-block: inherit; scroll-margin: inherit; scroll-margin-inline: inherit; scroll-padding-block: inherit; scroll-padding: inherit; scroll-padding-inline: inherit; scroll-snap-align: inherit; scroll-snap-stop: inherit; scroll-snap-type: inherit; scroll-timeline: inherit; scrollbar-gutter: inherit; shape-image-threshold: inherit; shape-margin: inherit; shape-outside: inherit; shape-rendering: inherit; size: inherit; speak: inherit; stop-color: inherit; stop-opacity: inherit; stroke: inherit; stroke-dasharray: inherit; stroke-dashoffset: inherit; stroke-linecap: inherit; stroke-linejoin: inherit; stroke-miterlimit: inherit; stroke-opacity: inherit; stroke-width: inherit; tab-size: inherit; table-layout: inherit; text-align: inherit; text-align-last: inherit; text-anchor: inherit; text-combine-upright: inherit; text-decoration: inherit; text-decoration-skip-ink: inherit; text-emphasis: inherit; text-emphasis-position: inherit; text-indent: inherit; text-overflow: inherit; text-shadow: inherit; text-size-adjust: inherit; text-transform: inherit; text-underline-offset: inherit; text-underline-position: inherit; white-space: inherit; timeline-scope: inherit; touch-action: inherit; transform: inherit; transform-box: inherit; transform-origin: inherit; transform-style: inherit; transition: inherit; translate: inherit; user-select: inherit; vector-effect: inherit; vertical-align: inherit; view-timeline: inherit; view-timeline-inset: inherit; view-transition-name: inherit; visibility: inherit; border-spacing: inherit; -webkit-box-align: inherit; -webkit-box-decoration-break: inherit; -webkit-box-direction: inherit; -webkit-box-flex: inherit; -webkit-box-ordinal-group: inherit; -webkit-box-orient: inherit; -webkit-box-pack: inherit; -webkit-box-reflect: inherit; -webkit-highlight: inherit; -webkit-line-break: inherit; -webkit-line-clamp: inherit; -webkit-mask-box-image: inherit; -webkit-mask: inherit; -webkit-mask-composite: inherit; -webkit-print-color-adjust: inherit; -webkit-rtl-ordering: inherit; -webkit-ruby-position: inherit; -webkit-tap-highlight-color: inherit; -webkit-text-combine: inherit; -webkit-text-decorations-in-effect: inherit; -webkit-text-fill-color: inherit; -webkit-text-security: inherit; -webkit-text-stroke: inherit; -webkit-user-drag: inherit; -webkit-user-modify: inherit; widows: inherit; width: inherit; will-change: inherit; word-break: inherit; word-spacing: inherit; x: inherit; y: inherit; z-index: inherit;"><span class="opblock-summary-method" style="box-sizing: inherit; background: rgb(252, 161, 48); border-radius: 3px; color: rgb(255, 255, 255); font-family: sans-serif; font-size: 14px; font-weight: 700; min-width: 80px; padding: 6px 0px; text-align: center; text-shadow: rgba(0, 0, 0, 0.1) 0px 1px 0px;">PUT</span><span class="opblock-summary-path" data-path="/ns/{nsId}/mcis/{mcisId}/vm/{targetVmId}/bastion/{bastionVmId}" style="box-sizing: inherit; align-items: center; color: rgb(59, 65, 81); display: flex; font-family: monospace; font-size: 16px; font-weight: 600; padding: 0px 10px; word-break: break-word; flex-shrink: 0; max-width: calc((100% - 110px) - 15rem);"><a class="nostyle" href="http://localhost:1323/tumblebug/swagger/index.html#/[Infra%20service]%20MCIS%20Remote%20command/put_ns__nsId__mcis__mcisId__vm__targetVmId__bastion__bastionVmId_" style="box-sizing: border-box; background-color: transparent; display: inline; color: inherit; cursor: pointer; text-decoration: inherit;"><span style="box-sizing: inherit;">/ns<wbr style="box-sizing: inherit;">/{nsId}<wbr style="box-sizing: inherit;">/mcis<wbr style="box-sizing: inherit;">/{mcisId}<wbr style="box-sizing: inherit;">/vm<wbr style="box-sizing: inherit;">/{targetVmId}<wbr style="box-sizing: inherit;">/bastion<wbr style="box-sizing: inherit;">/{bastionVmId}</span></a></span><div class="opblock-summary-description" style="box-sizing: border-box; color: rgb(59, 65, 81); flex: 1 1 auto; font-family: sans-serif; font-size: 13px; word-break: break-word;">Set bastion nodes for a VM</div><svg class="arrow" width="20" height="20" aria-hidden="true" focusable="false"><use href="#large-arrow-up" xlink:href="#large-arrow-up"></use></svg></button><div class="view-line-link copy-to-clipboard" title="Copy to clipboard" style="box-sizing: border-box; cursor: pointer; margin: 0px; position: unset; top: 2px; transition: all 0.5s ease 0s; width: 0px; align-items: center; background: rgb(125, 130, 147); border: none; border-radius: 4px; bottom: 10px; display: flex; height: 26px; justify-content: center; right: 100px;"><svg width="15" height="16"><use href="#copy" xlink:href="#copy"></use></svg></div></div><div class="no-margin" style="box-sizing: border-box; border: none; height: auto; margin: 0px; padding: 0px; color: rgb(59, 65, 81); font-family: sans-serif; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="opblock-body" style="box-sizing: border-box;"><div class="opblock-description-wrapper" style="box-sizing: border-box; color: rgb(59, 65, 81); font-family: sans-serif; font-size: 12px; margin: 0px 0px 5px; padding: 15px 20px;"><div class="opblock-description" style="box-sizing: border-box;"><div class="markdown" style="box-sizing: border-box;"><p style="box-sizing: border-box; color: rgb(59, 65, 81); font-family: sans-serif; font-size: 14px; margin: 1em auto; word-break: break-word;">Set bastion nodes for a VM</p></div></div></div><div class="opblock-section" style="box-sizing: border-box;"><div class="opblock-section-header" style="box-sizing: border-box; align-items: center; background: rgba(255, 255, 255, 0.8); box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px; display: flex; min-height: 50px; padding: 8px 20px;"><div class="tab-header" style="box-sizing: border-box; display: flex; flex: 1 1 0%;"><h4 class="opblock-title" style="box-sizing: border-box; color: rgb(59, 65, 81); flex: 1 1 0%; font-family: sans-serif; font-size: 14px; margin: 0px;">Parameters</h4></div><div class="try-out" style="box-sizing: border-box;"><button class="btn try-out__btn cancel" style="box-sizing: inherit; font-family: sans-serif; font-size: 14px; line-height: 1.15; margin: 0px 0px 0px 1.25rem; overflow: visible; text-transform: none; appearance: button; cursor: pointer; background: transparent; border: 2px solid rgb(255, 96, 96); border-radius: 4px; box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px; color: rgb(255, 96, 96); font-weight: 700; padding: 5px 23px; transition: all 0.3s ease 0s;">Cancel</button></div></div><div class="parameters-container" style="box-sizing: border-box;"><div class="table-container" style="box-sizing: border-box; padding: 20px;">

Name | Description
-- | --
nsId *string(path) | Namespace ID
mcisId *string(path) | MCIS ID
targetVmId *string(path) | Target VM ID
bastionVmId *string(path) | Bastion VM ID

</div></div></div></div></div><!--EndFragment-->
</body>
</html>PUT
[/ns/{nsId}/mcis/{mcisId}/vm/{targetVmId}/bastion/{bastionVmId}](http://localhost:1323/tumblebug/swagger/index.html#/[Infra%20service]%20MCIS%20Remote%20command/put_ns__nsId__mcis__mcisId__vm__targetVmId__bastion__bastionVmId_)
Set bastion nodes for a VM


Parameters
Cancel
Name	Description
nsId *
string
(path)
Namespace ID

ns01
mcisId *
string
(path)
MCIS ID

mcis01
targetVmId *
string
(path)
Target VM ID

vm01
bastionVmId *
string
(path)
Bastion VM ID

bastion01


<html>
<body>
<!--StartFragment--><div class="opblock-summary opblock-summary-get" style="box-sizing: border-box; align-items: center; cursor: pointer; display: flex; padding: 5px; border-bottom: 1px solid rgb(97, 175, 254); border-top-color: rgb(97, 175, 254); border-right-color: rgb(97, 175, 254); border-left-color: rgb(97, 175, 254); color: rgb(59, 65, 81); font-family: sans-serif; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><button aria-label="get ​/ns​/{nsId}​/mcis​/{mcisId}​/vm​/{targetVmId}​/bastion" aria-expanded="true" class="opblock-summary-control" style="color: inherit; font: inherit; font-palette: inherit; font-synthesis: inherit; forced-color-adjust: inherit; text-orientation: inherit; text-rendering: inherit; -webkit-font-smoothing: inherit; -webkit-locale: inherit; -webkit-text-orientation: inherit; -webkit-writing-mode: inherit; writing-mode: inherit; zoom: inherit; accent-color: inherit; place-content: inherit; place-items: inherit; place-self: inherit; alignment-baseline: inherit; animation-composition: inherit; animation: inherit; app-region: inherit; appearance: inherit; aspect-ratio: inherit; backdrop-filter: inherit; backface-visibility: inherit; background: inherit; background-blend-mode: inherit; baseline-shift: inherit; baseline-source: inherit; block-size: inherit; border-block: inherit; border-bottom: 0px; border-radius: inherit; border-collapse: inherit; border-end-end-radius: inherit; border-end-start-radius: inherit; border-image: inherit; border-inline: inherit; border-left: inherit; border-right: inherit; border-start-end-radius: inherit; border-start-start-radius: inherit; border-top: inherit; inset: inherit; box-shadow: inherit; box-sizing: inherit; break-after: inherit; break-before: inherit; break-inside: inherit; buffered-rendering: inherit; caption-side: inherit; caret-color: inherit; clear: inherit; clip: inherit; clip-path: inherit; clip-rule: inherit; color-interpolation: inherit; color-interpolation-filters: inherit; color-rendering: inherit; color-scheme: inherit; columns: inherit; column-fill: inherit; gap: inherit; column-rule: inherit; column-span: inherit; contain: inherit; contain-intrinsic-block-size: inherit; contain-intrinsic-size: inherit; contain-intrinsic-inline-size: inherit; container: inherit; content: inherit; content-visibility: inherit; counter-increment: inherit; counter-reset: inherit; counter-set: inherit; cursor: inherit; cx: inherit; cy: inherit; d: inherit; display: inherit; dominant-baseline: inherit; empty-cells: inherit; fill: inherit; fill-opacity: inherit; fill-rule: inherit; filter: inherit; flex: 1 1 0%; flex-flow: inherit; float: inherit; flood-color: inherit; flood-opacity: inherit; grid: inherit; grid-area: inherit; height: inherit; hyphenate-character: inherit; hyphenate-limit-chars: inherit; hyphens: inherit; image-orientation: inherit; image-rendering: inherit; initial-letter: inherit; inline-size: inherit; inset-block: inherit; inset-inline: inherit; isolation: inherit; letter-spacing: inherit; lighting-color: inherit; line-break: inherit; list-style: inherit; margin-block: inherit; margin: inherit; margin-inline: inherit; marker: inherit; mask: inherit; mask-type: inherit; math-depth: inherit; math-shift: inherit; math-style: inherit; max-block-size: inherit; max-height: inherit; max-inline-size: inherit; max-width: inherit; min-block-size: inherit; min-height: inherit; min-inline-size: inherit; min-width: inherit; mix-blend-mode: inherit; object-fit: inherit; object-position: inherit; object-view-box: inherit; offset: inherit; opacity: inherit; order: inherit; orphans: inherit; outline: inherit; outline-offset: inherit; overflow-anchor: inherit; overflow-clip-margin: inherit; overflow-wrap: inherit; overflow: inherit; overscroll-behavior-block: inherit; overscroll-behavior-inline: inherit; overscroll-behavior: inherit; padding-block: inherit; padding: 0px; padding-inline: inherit; page: inherit; page-orientation: inherit; paint-order: inherit; perspective: inherit; perspective-origin: inherit; pointer-events: inherit; position: inherit; quotes: inherit; r: inherit; resize: inherit; rotate: inherit; ruby-position: inherit; rx: inherit; ry: inherit; scale: inherit; scroll-behavior: inherit; scroll-margin-block: inherit; scroll-margin: inherit; scroll-margin-inline: inherit; scroll-padding-block: inherit; scroll-padding: inherit; scroll-padding-inline: inherit; scroll-snap-align: inherit; scroll-snap-stop: inherit; scroll-snap-type: inherit; scroll-timeline: inherit; scrollbar-gutter: inherit; shape-image-threshold: inherit; shape-margin: inherit; shape-outside: inherit; shape-rendering: inherit; size: inherit; speak: inherit; stop-color: inherit; stop-opacity: inherit; stroke: inherit; stroke-dasharray: inherit; stroke-dashoffset: inherit; stroke-linecap: inherit; stroke-linejoin: inherit; stroke-miterlimit: inherit; stroke-opacity: inherit; stroke-width: inherit; tab-size: inherit; table-layout: inherit; text-align: inherit; text-align-last: inherit; text-anchor: inherit; text-combine-upright: inherit; text-decoration: inherit; text-decoration-skip-ink: inherit; text-emphasis: inherit; text-emphasis-position: inherit; text-indent: inherit; text-overflow: inherit; text-shadow: inherit; text-size-adjust: inherit; text-transform: inherit; text-underline-offset: inherit; text-underline-position: inherit; white-space: inherit; timeline-scope: inherit; touch-action: inherit; transform: inherit; transform-box: inherit; transform-origin: inherit; transform-style: inherit; transition: inherit; translate: inherit; user-select: inherit; vector-effect: inherit; vertical-align: inherit; view-timeline: inherit; view-timeline-inset: inherit; view-transition-name: inherit; visibility: inherit; border-spacing: inherit; -webkit-box-align: inherit; -webkit-box-decoration-break: inherit; -webkit-box-direction: inherit; -webkit-box-flex: inherit; -webkit-box-ordinal-group: inherit; -webkit-box-orient: inherit; -webkit-box-pack: inherit; -webkit-box-reflect: inherit; -webkit-highlight: inherit; -webkit-line-break: inherit; -webkit-line-clamp: inherit; -webkit-mask-box-image: inherit; -webkit-mask: inherit; -webkit-mask-composite: inherit; -webkit-print-color-adjust: inherit; -webkit-rtl-ordering: inherit; -webkit-ruby-position: inherit; -webkit-tap-highlight-color: inherit; -webkit-text-combine: inherit; -webkit-text-decorations-in-effect: inherit; -webkit-text-fill-color: inherit; -webkit-text-security: inherit; -webkit-text-stroke: inherit; -webkit-user-drag: inherit; -webkit-user-modify: inherit; widows: inherit; width: inherit; will-change: inherit; word-break: inherit; word-spacing: inherit; x: inherit; y: inherit; z-index: inherit;"><span class="opblock-summary-method" style="box-sizing: inherit; background: rgb(97, 175, 254); border-radius: 3px; color: rgb(255, 255, 255); font-family: sans-serif; font-size: 14px; font-weight: 700; min-width: 80px; padding: 6px 0px; text-align: center; text-shadow: rgba(0, 0, 0, 0.1) 0px 1px 0px;">GET</span><span class="opblock-summary-path" data-path="/ns/{nsId}/mcis/{mcisId}/vm/{targetVmId}/bastion" style="box-sizing: inherit; align-items: center; color: rgb(59, 65, 81); display: flex; font-family: monospace; font-size: 16px; font-weight: 600; padding: 0px 10px; word-break: break-word; flex-shrink: 0; max-width: calc((100% - 110px) - 15rem);"><a class="nostyle" href="http://localhost:1323/tumblebug/swagger/index.html#/[Infra%20service]%20MCIS%20Remote%20command/get_ns__nsId__mcis__mcisId__vm__targetVmId__bastion" style="box-sizing: border-box; background-color: transparent; display: inline; color: inherit; cursor: pointer; text-decoration: inherit;"><span style="box-sizing: inherit;">/ns<wbr style="box-sizing: inherit;">/{nsId}<wbr style="box-sizing: inherit;">/mcis<wbr style="box-sizing: inherit;">/{mcisId}<wbr style="box-sizing: inherit;">/vm<wbr style="box-sizing: inherit;">/{targetVmId}<wbr style="box-sizing: inherit;">/bastion</span></a></span><div class="opblock-summary-description" style="box-sizing: border-box; color: rgb(59, 65, 81); flex: 1 1 auto; font-family: sans-serif; font-size: 13px; word-break: break-word;">Get bastion nodes for a VM</div><svg class="arrow" width="20" height="20" aria-hidden="true" focusable="false"><use href="#large-arrow-up" xlink:href="#large-arrow-up"></use></svg></button><div class="view-line-link copy-to-clipboard" title="Copy to clipboard" style="box-sizing: border-box; cursor: pointer; margin: 0px; position: unset; top: 2px; transition: all 0.5s ease 0s; width: 0px; align-items: center; background: rgb(125, 130, 147); border: none; border-radius: 4px; bottom: 10px; display: flex; height: 26px; justify-content: center; right: 100px;"><svg width="15" height="16"><use href="#copy" xlink:href="#copy"></use></svg></div></div><div class="no-margin" style="box-sizing: border-box; border: none; height: auto; margin: 0px; padding: 0px; color: rgb(59, 65, 81); font-family: sans-serif; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="opblock-body" style="box-sizing: border-box;"><div class="opblock-description-wrapper" style="box-sizing: border-box; color: rgb(59, 65, 81); font-family: sans-serif; font-size: 12px; margin: 0px 0px 5px; padding: 15px 20px;"><div class="opblock-description" style="box-sizing: border-box;"><div class="markdown" style="box-sizing: border-box;"><p style="box-sizing: border-box; color: rgb(59, 65, 81); font-family: sans-serif; font-size: 14px; margin: 1em auto; word-break: break-word;">Get bastion nodes for a VM</p></div></div></div><div class="opblock-section" style="box-sizing: border-box;"><div class="opblock-section-header" style="box-sizing: border-box; align-items: center; background: rgba(255, 255, 255, 0.8); box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px; display: flex; min-height: 50px; padding: 8px 20px;"><div class="tab-header" style="box-sizing: border-box; display: flex; flex: 1 1 0%;"><h4 class="opblock-title" style="box-sizing: border-box; color: rgb(59, 65, 81); flex: 1 1 0%; font-family: sans-serif; font-size: 14px; margin: 0px;">Parameters</h4></div><div class="try-out" style="box-sizing: border-box;"><button class="btn try-out__btn cancel" style="box-sizing: inherit; font-family: sans-serif; font-size: 14px; line-height: 1.15; margin: 0px 0px 0px 1.25rem; overflow: visible; text-transform: none; appearance: button; cursor: pointer; background: transparent; border: 2px solid rgb(255, 96, 96); border-radius: 4px; box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px; color: rgb(255, 96, 96); font-weight: 700; padding: 5px 23px; transition: all 0.3s ease 0s;">Cancel</button></div></div><div class="parameters-container" style="box-sizing: border-box;"><div class="table-container" style="box-sizing: border-box; padding: 20px;">

Name | Description
-- | --
nsId *string(path) | Namespace ID
mcisId *string(path) | MCIS ID
targetVmId *string(path) | Target VM ID

</div></div></div></div></div><!--EndFragment-->
</body>
</html>
GET
[/ns/{nsId}/mcis/{mcisId}/vm/{targetVmId}/bastion](http://localhost:1323/tumblebug/swagger/index.html#/[Infra%20service]%20MCIS%20Remote%20command/get_ns__nsId__mcis__mcisId__vm__targetVmId__bastion)
Get bastion nodes for a VM
Get bastion nodes for a VM

Parameters
Cancel
Name	Description
nsId *
string
(path)
Namespace ID

ns01
mcisId *
string
(path)
MCIS ID

mcis01
targetVmId *
string
(path)
Target VM ID

g1-4