### PR TITLE
Use universal func for remote command

### DIFF
--- a/src/api/rest/server/mcis/remoteCommand.go
+++ b/src/api/rest/server/mcis/remoteCommand.go
@@ -26,41 +26,6 @@ type RestPostCmdMcisVmResponse struct {
 	Result string `json:"result"`
 }
 
-// RestPostCmdMcisVm godoc
-// @Summary Send a command to specified VM
-// @Description Send a command to specified VM
-// @Tags [Infra service] MCIS Remote command
-// @Accept  json
-// @Produce  json
-// @Param nsId path string true "Namespace ID" default(ns01)
-// @Param mcisId path string true "MCIS ID" default(mcis01)
-// @Param vmId path string true "VM ID" default(g1-1)
-// @Param mcisCmdReq body mcis.McisCmdReq true "MCIS Command Request"
-// @Success 200 {object} RestPostCmdMcisVmResponse
-// @Failure 404 {object} common.SimpleMsg
-// @Failure 500 {object} common.SimpleMsg
-// @Router /ns/{nsId}/cmd/mcis/{mcisId}/vm/{vmId} [post]
-func RestPostCmdMcisVm(c echo.Context) error {
-
-	nsId := c.Param("nsId")
-	mcisId := c.Param("mcisId")
-	vmId := c.Param("vmId")
-
-	req := &mcis.McisCmdReq{}
-	if err := c.Bind(req); err != nil {
-		return err
-	}
-
-	result, err := mcis.RemoteCommandToMcisVm(nsId, mcisId, vmId, req)
-	if err != nil {
-		mapA := map[string]string{"message": err.Error()}
-		return c.JSON(http.StatusInternalServerError, &mapA)
-	}
-
-	response := RestPostCmdMcisVmResponse{Result: result}
-	return c.JSON(http.StatusOK, response)
-}
-
 type RestPostCmdMcisResponse struct {
 	McisId string `json:"mcisId"`
 	VmId   string `json:"vmId"`
@@ -81,7 +46,8 @@ type RestPostCmdMcisResponseWrapper struct {
 // @Param nsId path string true "Namespace ID" default(ns01)
 // @Param mcisId path string true "MCIS ID" default(mcis01)
 // @Param mcisCmdReq body mcis.McisCmdReq true "MCIS Command Request"
-// @Param subGroupId query string false "subGroupId to apply the command only for VMs in subGroup of MCIS" default("")
+// @Param subGroupId query string false "subGroupId to apply the command only for VMs in subGroup of MCIS" default()
+// @Param vmId query string false "vmId to apply the command only for a VM in MCIS" default()
 // @Success 200 {object} RestPostCmdMcisResponseWrapper
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
@@ -91,13 +57,14 @@ func RestPostCmdMcis(c echo.Context) error {
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
 	subGroupId := c.QueryParam("subGroupId")
+	vmId := c.QueryParam("vmId")
 
 	req := &mcis.McisCmdReq{}
 	if err := c.Bind(req); err != nil {
 		return err
 	}
 
-	resultArray, err := mcis.RemoteCommandToMcis(nsId, mcisId, subGroupId, req)
+	resultArray, err := mcis.RemoteCommandToMcis(nsId, mcisId, subGroupId, vmId, req)
 	if err != nil {
 		mapA := map[string]string{"message": err.Error()}
 		return c.JSON(http.StatusInternalServerError, &mapA)

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -218,7 +218,6 @@ func RunServer(port string) {
 	g.GET("/:nsId/control/mcis/:mcisId/vm/:vmId", rest_mcis.RestGetControlMcisVm)
 
 	g.POST("/:nsId/cmd/mcis/:mcisId", rest_mcis.RestPostCmdMcis)
-	g.POST("/:nsId/cmd/mcis/:mcisId/vm/:vmId", rest_mcis.RestPostCmdMcisVm)
 	g.POST("/:nsId/installBenchmarkAgent/mcis/:mcisId", rest_mcis.RestPostInstallBenchmarkAgentToMcis)
 	g.POST("/:nsId/benchmark/mcis/:mcisId", rest_mcis.RestGetBenchmark)
 	g.POST("/:nsId/benchmarkAll/mcis/:mcisId", rest_mcis.RestGetAllBenchmark)

--- a/src/core/mcis/benchmark.go
+++ b/src/core/mcis/benchmark.go
@@ -108,7 +108,7 @@ func InstallBenchmarkAgentToMcis(nsId string, mcisId string, req *McisCmdReq, op
 	// Replace given parameter with the installation cmd
 	req.Command = cmd
 
-	sshCmdResult, err := RemoteCommandToMcis(nsId, mcisId, "", req)
+	sshCmdResult, err := RemoteCommandToMcis(nsId, mcisId, "", "", req)
 
 	if err != nil {
 		temp := []SshCmdResult{}

--- a/src/core/mcis/nlb.go
+++ b/src/core/mcis/nlb.go
@@ -343,13 +343,13 @@ func CreateMcSwNlb(nsId string, mcisId string, req *TbNLBReq, option string) (Tb
 
 	// Deploy SW NLB
 	cmd := common.RuntimeConf.Nlbsw.CommandNlbPrepare
-	_, err = RemoteCommandToMcis(nsId, nlbMcisId, "", &McisCmdReq{Command: cmd})
+	_, err = RemoteCommandToMcis(nsId, nlbMcisId, "", "", &McisCmdReq{Command: cmd})
 	if err != nil {
 		common.CBLog.Error(err)
 		return emptyObj, err
 	}
 	cmd = common.RuntimeConf.Nlbsw.CommandNlbDeploy + " " + mcisId + " " + common.ToLower(req.Listener.Protocol) + " " + req.Listener.Port
-	_, err = RemoteCommandToMcis(nsId, nlbMcisId, "", &McisCmdReq{Command: cmd})
+	_, err = RemoteCommandToMcis(nsId, nlbMcisId, "", "", &McisCmdReq{Command: cmd})
 	if err != nil {
 		common.CBLog.Error(err)
 		return emptyObj, err
@@ -367,7 +367,7 @@ func CreateMcSwNlb(nsId string, mcisId string, req *TbNLBReq, option string) (Tb
 		for _, k := range v.McisVmAccessInfo {
 
 			cmd = common.RuntimeConf.Nlbsw.CommandNlbAddTargetNode + " " + k.VmId + " " + k.PublicIP + " " + req.TargetGroup.Port
-			_, err = RemoteCommandToMcis(nsId, nlbMcisId, "", &McisCmdReq{Command: cmd})
+			_, err = RemoteCommandToMcis(nsId, nlbMcisId, "", "", &McisCmdReq{Command: cmd})
 			if err != nil {
 				common.CBLog.Error(err)
 				return emptyObj, err
@@ -377,7 +377,7 @@ func CreateMcSwNlb(nsId string, mcisId string, req *TbNLBReq, option string) (Tb
 	}
 
 	cmd = common.RuntimeConf.Nlbsw.CommandNlbApplyConfig
-	_, err = RemoteCommandToMcis(nsId, nlbMcisId, "", &McisCmdReq{Command: cmd})
+	_, err = RemoteCommandToMcis(nsId, nlbMcisId, "", "", &McisCmdReq{Command: cmd})
 	if err != nil {
 		common.CBLog.Error(err)
 		return emptyObj, err

--- a/src/core/mcis/orchestration.go
+++ b/src/core/mcis/orchestration.go
@@ -351,7 +351,7 @@ func OrchestrationController() {
 						nullMcisCmdReq := McisCmdReq{}
 						if autoAction.PostCommand != nullMcisCmdReq {
 							fmt.Println("[Post Command to VM] " + autoAction.PostCommand.Command)
-							_, cmdErr := RemoteCommandToMcis(nsId, mcisPolicyTmp.Id, common.ToLower(autoAction.VmDynamicReq.Name), &autoAction.PostCommand)
+							_, cmdErr := RemoteCommandToMcis(nsId, mcisPolicyTmp.Id, common.ToLower(autoAction.VmDynamicReq.Name), "", &autoAction.PostCommand)
 							if cmdErr != nil {
 								mcisPolicyTmp.Policy[policyIndex].Status = AutoStatusError
 								UpdateMcisPolicyInfo(nsId, mcisPolicyTmp)


### PR DESCRIPTION
Use universal func for remote command

- remove /ns/{nsId}/cmd/mcis/{mcisId}/vm/{vmId}
- use /ns/{nsId}/cmd/mcis/{mcisId} with Param vmId query