### PR TITLE
Use PrivateIP for remote command for no-bastion

### DIFF
--- a/src/core/mcis/benchmark.go
+++ b/src/core/mcis/benchmark.go
@@ -145,7 +145,7 @@ func CallMilkyway(wg *sync.WaitGroup, vmList []string, nsId string, mcisId strin
 		reqTmp := MultihostBenchmarkReq{}
 		for _, vm := range vmList {
 			vmIdTmp := vm
-			vmIpTmp, _ := GetVmIp(nsId, mcisId, vmIdTmp)
+			vmIpTmp, _, _ := GetVmIp(nsId, mcisId, vmIdTmp)
 			fmt.Println("[Test for vmList " + vmIdTmp + ", " + vmIpTmp + "]")
 
 			hostTmp := BenchmarkReq{}
@@ -618,7 +618,7 @@ func BenchmarkAction(nsId string, mcisId string, action string, option string) (
 		wg.Add(1)
 
 		vmId := v
-		vmIp, _ := GetVmIp(nsId, mcisId, vmId)
+		vmIp, _, _ := GetVmIp(nsId, mcisId, vmId)
 
 		go CallMilkyway(&wg, vmList, nsId, mcisId, vmId, vmIp, action, option, &results)
 	}

--- a/src/core/mcis/manageInfo.go
+++ b/src/core/mcis/manageInfo.go
@@ -1018,15 +1018,15 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 	return vmStatusTmp, nil
 }
 
-// GetVmIp is func to get VM IP
-func GetVmIp(nsId string, mcisId string, vmId string) (string, string) {
+// GetVmIp is func to get VM IP to return PublicIP, PrivateIP, SSHPort
+func GetVmIp(nsId string, mcisId string, vmId string) (string, string, string) {
 
 	var content struct {
-		PublicIP string `json:"publicIP"`
-		SSHPort  string `json:"sshPort"`
+		PublicIP  string `json:"publicIP"`
+		PrivateIP string `json:"privateIP"`
+		SSHPort   string `json:"sshPort"`
 	}
 
-	fmt.Printf("[GetVmIp] " + vmId)
 	key := common.GenMcisKey(nsId, mcisId, vmId)
 
 	keyValue, err := common.CBStore.Get(key)
@@ -1039,9 +1039,7 @@ func GetVmIp(nsId string, mcisId string, vmId string) (string, string) {
 
 	json.Unmarshal([]byte(keyValue.Value), &content)
 
-	fmt.Printf(" %+v\n", content.PublicIP)
-
-	return content.PublicIP, content.SSHPort
+	return content.PublicIP, content.PrivateIP, content.SSHPort
 }
 
 // GetVmSpecId is func to get VM SpecId

--- a/src/core/mcis/monitoring.go
+++ b/src/core/mcis/monitoring.go
@@ -159,7 +159,7 @@ func CallMonitoringAsync(wg *sync.WaitGroup, nsID string, mcisID string, mcisSer
 
 	defer wg.Done() //goroutin sync done
 
-	vmIP, sshPort := GetVmIp(nsID, mcisID, vmID)
+	vmIP, _, sshPort := GetVmIp(nsID, mcisID, vmID)
 	userName, privateKey, err := VerifySshUserName(nsID, mcisID, vmID, vmIP, sshPort, givenUserName)
 	errStr := ""
 	if err != nil {
@@ -421,7 +421,7 @@ func GetMonitoringData(nsId string, mcisId string, metric string) (MonResultSimp
 		wg.Add(1)
 
 		vmId := v
-		vmIp, _ := GetVmIp(nsId, mcisId, vmId)
+		vmIp, _, _ := GetVmIp(nsId, mcisId, vmId)
 
 		// DF: Get vm on-demand monitoring metric info
 		// Path Param: /ns/:nsId/mcis/:mcisId/vm/:vmId/agent_ip/:agent_ip/metric/:metric_name/ondemand-monitoring-info

--- a/src/core/mcis/network.go
+++ b/src/core/mcis/network.go
@@ -384,7 +384,7 @@ func getAgentInstallationCommand(etcdEndpoints, cladnetId string) (string, error
 func installCBNetworkAgentToVM(nsId, mcisId, vmId string, mcisCmdReq McisCmdReq) (SshCmdResult, error) {
 	common.CBLog.Debug("Start.........")
 
-	vmIp, sshPort := GetVmIp(nsId, mcisId, vmId)
+	vmIp, _, sshPort := GetVmIp(nsId, mcisId, vmId)
 
 	// find vaild username
 	userName, sshKey, err := VerifySshUserName(nsId, mcisId, vmId, vmIp, sshPort, mcisCmdReq.UserName)


### PR DESCRIPTION
Use PrivateIP for remote command for no-bastion

Test result
```
[Retrieve access information for MCIS:mcis01]
{
  McisId: mcis01
  McisSubGroupAccessInfo: [
    {
      SubGroupId: g1
      BastionVmId: 
      McisVmAccessInfo: [
        {
          vmId: g1-3
          publicIP: 43.201.249.206
          privateIP: 192.168.20.197
          sshPort: 22
        }
        {
          vmId: g1-1
          publicIP: 43.202.59.92
          privateIP: 192.168.20.10
          sshPort: 22
        }
        {
          vmId: g1-2
          publicIP: 13.124.189.213
          privateIP: 192.168.20.15
          sshPort: 22
        }
        {
          vmId: g1-5
          publicIP: 3.38.193.183
          privateIP: 192.168.20.101
          sshPort: 22
        }
        {
          vmId: g1-4
          publicIP: 13.125.121.38
          privateIP: 192.168.20.102
          sshPort: 22
        }
      ]
    }
  ]
}
```

MCIS Command Request

Example Value
Model
{
  "command": "client_ip=$(echo $SSH_CLIENT | awk '{print $1}'); echo SSH client IP is: $client_ip",
  "userName": "cb-user"
}

```
[Complete: remote ssh command to MCIS]
{
  resultArray: [
    {
      mcisId: mcis01
      vmId: g1-4
      vmIp: 13.125.121.38
      result: SSH client IP is: 192.168.20.10
		
    }
    {
      mcisId: mcis01
      vmId: g1-1
      vmIp: 43.202.59.92
      result: SSH client IP is: 192.168.20.10
		
    }
    {
      mcisId: mcis01
      vmId: g1-2
      vmIp: 13.124.189.213
      result: SSH client IP is: 192.168.20.10
		
    }
    {
      mcisId: mcis01
      vmId: g1-3
      vmIp: 43.201.249.206
      result: SSH client IP is: 192.168.20.10
		
    }
    {
      mcisId: mcis01
      vmId: g1-5
      vmIp: 3.38.193.183
      result: SSH client IP is: 192.168.20.10
		
    }
  ]
}
```