### PR TITLE
Auto-assign bastion node

### DIFF
--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -1835,5 +1835,12 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo, option string) e
 
 	UpdateVmInfo(nsId, mcisId, *vmInfoData)
 
+	// Assign a Bastion if none (randomly)
+	_, err = SetBastionNodes(nsId, mcisId, vmInfoData.Id, "")
+	if err != nil {
+		// just log error and continue
+		common.CBLog.Error(err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
- 기능 추가: MCIS 생성 또는 Scaling 할 때, 기 지정된 Bastion node가 신규 생성되는 VM들의 subnet에 지정되어 있지 않은 경우, 자동으로 가장 앞선/PublicIP를 가지고 있는 VM을 자동으로 Bastion node로 지정