### PR TITLE
Update Repository Ownership (jihoon-seo and yunkon-kim)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,8 +9,8 @@ jobs:
   # Check auto merge contiditons of PR and proceed merging
   automerge:
     # Apply this job if it is a PR and by OWNER with '/approve' comment
-    # TODO: the section contains('seokho-son jihoon-seo yunkon-kim') needs to be updated or automated
-    if: ${{ github.event.issue.pull_request && (contains('seokho-son jihoon-seo yunkon-kim', github.event.comment.user.login) || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/approve') }}
+    # TODO: the section contains('seokho-son yunkon-kim') needs to be updated or automated
+    if: ${{ github.event.issue.pull_request && (contains('seokho-son yunkon-kim', github.event.comment.user.login) || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/approve') }}
     # This job runs on Ubuntu-latest (Ubuntu 20.04 LTS checked on 2022-09-06)
     # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
     runs-on: ubuntu-latest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,10 @@
 # Code owners of CB-Tumblebug
 
-# These owners will be the default owners for everything in this repo. 
+# These owners will be the default owners for everything in this repo.
+# @jihoon-seo is the emeritus maintainer, and we are deeply grateful for his invaluable contributions over the years
 # They will be requested for review when someone opens a pull request.
-*       @seokho-son @jihoon-seo
+*       @seokho-son @yunkon-kim
 
 # These subderectory owners own any files in the .github/
 # directory which includes github workflows.
-/.github/workflows/**  @jihoon-seo @yunkon-kim @seokho-son
+/.github/workflows/**  @yunkon-kim @seokho-son

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
 reviewers:
 - seokho-son
-- jihoon-seo
 - yunkon-kim
 
 approvers:
 - seokho-son
-- jihoon-seo
 - yunkon-kim


### PR DESCRIPTION
This PR aims to update the ownership roles within this repository as follows:
- @jihoon-seo: transitioning from Maintainer to Emeritus.
- @yunkon-kim: transitioning from Workflow Approver to Maintainer.

Additionally, an important note has been appended to the CODEOWNERS file to acknowledge @jihoon-seo's invaluable contributions over the years as an Emeritus Maintainer:

```plaintext
# @jihoon-seo is now an Emeritus Maintainer, and we are profoundly grateful for his invaluable contributions over the years.
