### PR TITLE
Skip BasicAuth in some cases and add disable option to env config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,8 @@ ENV DB_PASSWORD cb_tumblebug
 # API Setting
 # ALLOW_ORIGINS (ex: https://cloud-barista.org,xxx.xxx.xxx.xxx or * for all)
 ENV ALLOW_ORIGINS *
+## Set SKIP_BASIC_AUTH=true to skip basic auth for all routes (i.e., url or path)
+ENV SKIP_BASIC_AUTH false
 ENV API_USERNAME default
 ENV API_PASSWORD default
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ ENV DB_PASSWORD cb_tumblebug
 # API Setting
 # ALLOW_ORIGINS (ex: https://cloud-barista.org,xxx.xxx.xxx.xxx or * for all)
 ENV ALLOW_ORIGINS *
-## Set SKIP_BASIC_AUTH=true to skip basic auth for all routes (i.e., url or path)
-ENV SKIP_BASIC_AUTH false
+## Set ENABLE_AUTH=true currently for basic auth for all routes (i.e., url or path)
+ENV ENABLE_AUTH true
 ENV API_USERNAME default
 ENV API_PASSWORD default
 

--- a/conf/setup.env
+++ b/conf/setup.env
@@ -9,6 +9,8 @@ export API_USERNAME=default
 export API_PASSWORD=default
 ## ALLOW_ORIGINS (ex: https://cloud-barista.org,http://localhost:8080 or * for all)
 export ALLOW_ORIGINS=*
+## Set SKIP_BASIC_AUTH=true to skip basic auth for all routes (i.e., url or path)
+export SKIP_BASIC_AUTH=false
 ## Set SELF_ENDPOINT, to access Swagger API dashboard outside (Ex: export SELF_ENDPOINT=x.x.x.x:1323)
 export SELF_ENDPOINT=localhost:1323
 

--- a/conf/setup.env
+++ b/conf/setup.env
@@ -9,8 +9,8 @@ export API_USERNAME=default
 export API_PASSWORD=default
 ## ALLOW_ORIGINS (ex: https://cloud-barista.org,http://localhost:8080 or * for all)
 export ALLOW_ORIGINS=*
-## Set SKIP_BASIC_AUTH=true to skip basic auth for all routes (i.e., url or path)
-export SKIP_BASIC_AUTH=false
+## Set ENABLE_AUTH=true currently for basic auth for all routes (i.e., url or path)
+export ENABLE_AUTH=true
 ## Set SELF_ENDPOINT, to access Swagger API dashboard outside (Ex: export SELF_ENDPOINT=x.x.x.x:1323)
 export SELF_ENDPOINT=localhost:1323
 

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -107,30 +107,30 @@ func RunServer(port string) {
 	}))
 
 	// Conditions to prevent abnormal operation due to typos (e.g., ture, falss, etc.)
-	skipBasicAuthOption := os.Getenv("SKIP_BASIC_AUTH") == "true"
+	enableAuth := os.Getenv("ENABLE_AUTH") == "true"
 
 	apiUser := os.Getenv("API_USERNAME")
 	apiPass := os.Getenv("API_PASSWORD")
 
-	e.Use(middleware.BasicAuthWithConfig(middleware.BasicAuthConfig{
-		Skipper: func(c echo.Context) bool {
-			if skipBasicAuthOption ||
-				c.Path() == "/tumblebug/health" ||
-				c.Path() == "/tumblebug/httpVersion" {
-				// c.Path() == "/tumblebug/swagger/*" {
-				return true
-			}
-			return false
-		},
-		Validator: func(username, password string, c echo.Context) (bool, error) {
-			// Be careful to use constant time comparison to prevent timing attacks
-			if subtle.ConstantTimeCompare([]byte(username), []byte(apiUser)) == 1 &&
-				subtle.ConstantTimeCompare([]byte(password), []byte(apiPass)) == 1 {
-				return true, nil
-			}
-			return false, nil
-		},
-	}))
+	if enableAuth {
+		e.Use(middleware.BasicAuthWithConfig(middleware.BasicAuthConfig{
+			Skipper: func(c echo.Context) bool {
+				if c.Path() == "/tumblebug/health" ||
+					c.Path() == "/tumblebug/httpVersion" {
+					return true
+				}
+				return false
+			},
+			Validator: func(username, password string, c echo.Context) (bool, error) {
+				// Be careful to use constant time comparison to prevent timing attacks
+				if subtle.ConstantTimeCompare([]byte(username), []byte(apiUser)) == 1 &&
+					subtle.ConstantTimeCompare([]byte(password), []byte(apiPass)) == 1 {
+					return true, nil
+				}
+				return false, nil
+			},
+		}))
+	}
 
 	fmt.Println("\n \n ")
 	fmt.Printf(banner)
@@ -379,7 +379,9 @@ func RunServer(port string) {
 	selfEndpoint := os.Getenv("SELF_ENDPOINT")
 	apidashboard := " http://" + selfEndpoint + "/tumblebug/swagger/index.html"
 
-	fmt.Println(" Access to API dashboard" + " (username: " + apiUser + " / password: " + apiPass + ")")
+	if enableAuth {
+		fmt.Println(" Access to API dashboard" + " (username: " + apiUser + " / password: " + apiPass + ")")
+	}
 	fmt.Printf(noticeColor, apidashboard)
 	fmt.Println("\n ")
 

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"log"
 	"os/signal"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -107,12 +106,15 @@ func RunServer(port string) {
 		AllowMethods: []string{http.MethodGet, http.MethodPut, http.MethodPost, http.MethodDelete},
 	}))
 
+	// Conditions to prevent abnormal operation due to typos (e.g., ture, falss, etc.)
+	skipBasicAuthOption := os.Getenv("SKIP_BASIC_AUTH") == "true"
+
 	apiUser := os.Getenv("API_USERNAME")
 	apiPass := os.Getenv("API_PASSWORD")
 
 	e.Use(middleware.BasicAuthWithConfig(middleware.BasicAuthConfig{
 		Skipper: func(c echo.Context) bool {
-			if strings.HasPrefix(c.Request().Host, "localhost") ||
+			if skipBasicAuthOption ||
 				c.Path() == "/tumblebug/health" ||
 				c.Path() == "/tumblebug/httpVersion" {
 				// c.Path() == "/tumblebug/swagger/*" {


### PR DESCRIPTION
This PR will skip BasicAuth in the following cases:
- Host is "localhost",
- checking CB-Tumblebug health by /tumblebug/health, and
- checking HTTP version by /tumblebug/httpVersion.

I think it will make it a bit more convenient during development.

Please let me know if you have any issues.