### PR TITLE
Add Makefile in the project root directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+default:
+	cd src/ && $(MAKE)
+
+cc:
+	cd src/ && $(MAKE) cc
+
+run:
+	cd src/ && $(MAKE) run
+
+runwithport:
+	cd src/ && $(MAKE) runwithport $(PORT)
+
+prod:
+	cd src/ && $(MAKE) prod
+
+clean:
+	cd src/ && $(MAKE) clean
+
+swag swagger:
+	cd src/ && $(MAKE) swag

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,26 @@
 default:
 	go build -o cb-tumblebug
+
 cc:
 	GOOS=linux GOARCH=arm go build -o cb-tumblebug-arm
-swag swagger:
-	~/go/bin/swag i -o ./api/rest/docs
+
 run:
 	./cb-tumblebug
+
 runwithport:
+	@echo "Running on port $(PORT) (Usage: make runwithport PORT=8080)"
 	./cb-tumblebug --port=$(PORT)
+
+prod:
+	@echo "Build for production"
+# Note - Using cgo write normal Go code that imports a pseudo-package "C". I may not need on cross-compiling.
+# Note - You can find possible platforms by 'go tool dist list' for GOOS and GOARCH
+# Note - Using the -ldflags parameter can help set variable values at compile time.
+# Note - Using the -s and -w linker flags can strip the debugging information.
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-s -w' -o cb-tumblebug
+
 clean:
 	rm -v cb-tumblebug cb-tumblebug-arm
+
+swag swagger:
+	~/go/bin/swag i -o ./api/rest/docs


### PR DESCRIPTION
This PR will add Makefile in the project root directory and update the existing Makefile in `/src`.

This is simply a change for development convenience. It will likely reduce the act of going in and out of directories during development.