### PR TITLE
Make X-Request-Id visible to all handlers

### DIFF
--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -91,6 +91,8 @@ func RunServer(port string) {
 		return func(c echo.Context) error {
 			reqID := fmt.Sprintf("%d", time.Now().UnixNano())
 			c.Set("RequestID", reqID)
+			// make X-Request-Id visible to all handlers
+			c.Response().Header().Set("Access-Control-Expose-Headers", "X-Request-Id")
 			return next(c)
 		}
 	})


### PR DESCRIPTION
 - 보통 API의 response header는 따로 허용하지 않는 경우, 브라우저에서 조회가 되지 않는다고 함. (개발자 도구로 확인은 가능)
 - 이를 명시적으로 허용하도록 코드 개선. 

PR 적용되면, MapUI 대시보드에서 활용 가능.

![image](https://github.com/cloud-barista/cb-tumblebug/assets/5966944/f0cbf921-15a5-436e-844b-faa6c7d426cc)
