### PR TITLE
Provide comprehensive usecase output for netutil ex

### DIFF
--- a/src/examples/netutil/netutil.go
+++ b/src/examples/netutil/netutil.go
@@ -42,33 +42,48 @@ func runExample(cmd *cobra.Command, args []string) {
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////
 	fmt.Println("\nDivide CIDR block into subnets to accommodate at least minimum number of subnets")
+	fmt.Println("Divide CIDR block by a specified number of hosts\n")
 
-	fmt.Printf("Minimum number of subnets: %d\n", minSubnets)
+	fmt.Println("[Usecase] Get superneted VPCs and its subnets inside")
+	fmt.Printf("- Base network: %v\n", cidrBlock)
+	fmt.Printf("- Minimum number of VPCs (subnets of the base network): %d\n", minSubnets)
+	fmt.Printf("- Subnets in a VPC base on the number of hosts per subnet: %d\n", hostsPerSubnet)
 
 	subnets, err := netutil.SubnettingByMininumSubnetCount(cidrBlock, minSubnets)
 	if err != nil {
 		fmt.Println(err)
 	}
 
-	for _, subnet := range subnets {
-		fmt.Println(subnet)
+	for i, vpc := range subnets {
+		fmt.Printf("\nVPC[%03d]:\t%v\nSubnets:\t", i+1, vpc)
+		vpcsubnets, err := netutil.SubnettingByHosts(vpc, hostsPerSubnet)
+		if err != nil {
+			fmt.Println(err)
+		}
+		for j, subnet := range vpcsubnets {
+			fmt.Printf("%v", subnet)
+			if j < len(vpcsubnets)-1 {
+				fmt.Print(", ")
+			}
+		}
+		fmt.Println("")
 	}
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////
-	fmt.Println("\nDivide CIDR block by a specified number of hosts")
-	fmt.Printf("Number of hosts per subnet: %d\n", hostsPerSubnet)
+	// fmt.Println("\nDivide CIDR block by a specified number of hosts")
+	// fmt.Printf("Number of hosts per subnet: %d\n", hostsPerSubnet)
 
-	subnets, err = netutil.SubnettingByHosts(cidrBlock, hostsPerSubnet)
-	if err != nil {
-		fmt.Println(err)
-	}
+	// subnets, err = netutil.SubnettingByHosts(cidrBlock, hostsPerSubnet)
+	// if err != nil {
+	// 	fmt.Println(err)
+	// }
 
-	for _, subnet := range subnets {
-		fmt.Println(subnet)
-	}
+	// for _, subnet := range subnets {
+	// 	fmt.Printf("%v, ", subnet)
+	// }
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////
-	fmt.Println("\nGet Network Address")
+	fmt.Println("\n\nGet Network Address")
 	networkAddress, err := netutil.GetNetworkAddr(cidrBlock)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
I understand the current example is focused on checking each functionality. 
But, for a better understanding, how about providing a comprehensive output for netutil example? based on a relative usecase for cb-tumblebug?
(Global base network - VPCs - subnets)

This PR suggests modified output style.

./netutil -c "10.0.0.0/16" -s 16 -n 500
```
Starting netuil example

Divide CIDR block into subnets to accommodate at least minimum number of subnets
Divide CIDR block by a specified number of hosts

[Usecase] Get superneted VPCs and its subnets inside
- Base network: 10.0.0.0/16
- Minimum number of VPCs (subnets of the base network): 16
- Subnets in a VPC base on the number of hosts per subnet: 500

VPC[001]:       10.0.0.0/20
Subnets:        10.0.0.0/23, 10.0.2.0/23, 10.0.4.0/23, 10.0.6.0/23, 10.0.8.0/23, 10.0.10.0/23, 10.0.12.0/23, 10.0.14.0/23

VPC[002]:       10.0.16.0/20
Subnets:        10.0.16.0/23, 10.0.18.0/23, 10.0.20.0/23, 10.0.22.0/23, 10.0.24.0/23, 10.0.26.0/23, 10.0.28.0/23, 10.0.30.0/23

VPC[003]:       10.0.32.0/20
Subnets:        10.0.32.0/23, 10.0.34.0/23, 10.0.36.0/23, 10.0.38.0/23, 10.0.40.0/23, 10.0.42.0/23, 10.0.44.0/23, 10.0.46.0/23

VPC[004]:       10.0.48.0/20
Subnets:        10.0.48.0/23, 10.0.50.0/23, 10.0.52.0/23, 10.0.54.0/23, 10.0.56.0/23, 10.0.58.0/23, 10.0.60.0/23, 10.0.62.0/23

VPC[005]:       10.0.64.0/20
Subnets:        10.0.64.0/23, 10.0.66.0/23, 10.0.68.0/23, 10.0.70.0/23, 10.0.72.0/23, 10.0.74.0/23, 10.0.76.0/23, 10.0.78.0/23

VPC[006]:       10.0.80.0/20
Subnets:        10.0.80.0/23, 10.0.82.0/23, 10.0.84.0/23, 10.0.86.0/23, 10.0.88.0/23, 10.0.90.0/23, 10.0.92.0/23, 10.0.94.0/23

VPC[007]:       10.0.96.0/20
Subnets:        10.0.96.0/23, 10.0.98.0/23, 10.0.100.0/23, 10.0.102.0/23, 10.0.104.0/23, 10.0.106.0/23, 10.0.108.0/23, 10.0.110.0/23

VPC[008]:       10.0.112.0/20
Subnets:        10.0.112.0/23, 10.0.114.0/23, 10.0.116.0/23, 10.0.118.0/23, 10.0.120.0/23, 10.0.122.0/23, 10.0.124.0/23, 10.0.126.0/23

VPC[009]:       10.0.128.0/20
Subnets:        10.0.128.0/23, 10.0.130.0/23, 10.0.132.0/23, 10.0.134.0/23, 10.0.136.0/23, 10.0.138.0/23, 10.0.140.0/23, 10.0.142.0/23

VPC[010]:       10.0.144.0/20
Subnets:        10.0.144.0/23, 10.0.146.0/23, 10.0.148.0/23, 10.0.150.0/23, 10.0.152.0/23, 10.0.154.0/23, 10.0.156.0/23, 10.0.158.0/23

VPC[011]:       10.0.160.0/20
Subnets:        10.0.160.0/23, 10.0.162.0/23, 10.0.164.0/23, 10.0.166.0/23, 10.0.168.0/23, 10.0.170.0/23, 10.0.172.0/23, 10.0.174.0/23

VPC[012]:       10.0.176.0/20
Subnets:        10.0.176.0/23, 10.0.178.0/23, 10.0.180.0/23, 10.0.182.0/23, 10.0.184.0/23, 10.0.186.0/23, 10.0.188.0/23, 10.0.190.0/23

VPC[013]:       10.0.192.0/20
Subnets:        10.0.192.0/23, 10.0.194.0/23, 10.0.196.0/23, 10.0.198.0/23, 10.0.200.0/23, 10.0.202.0/23, 10.0.204.0/23, 10.0.206.0/23

VPC[014]:       10.0.208.0/20
Subnets:        10.0.208.0/23, 10.0.210.0/23, 10.0.212.0/23, 10.0.214.0/23, 10.0.216.0/23, 10.0.218.0/23, 10.0.220.0/23, 10.0.222.0/23

VPC[015]:       10.0.224.0/20
Subnets:        10.0.224.0/23, 10.0.226.0/23, 10.0.228.0/23, 10.0.230.0/23, 10.0.232.0/23, 10.0.234.0/23, 10.0.236.0/23, 10.0.238.0/23

VPC[016]:       10.0.240.0/20
Subnets:        10.0.240.0/23, 10.0.242.0/23, 10.0.244.0/23, 10.0.246.0/23, 10.0.248.0/23, 10.0.250.0/23, 10.0.252.0/23, 10.0.254.0/23
```