### PR TITLE
Add a function for subnetting by requested rules

### DIFF
--- a/src/examples/netutil/netutil.go
+++ b/src/examples/netutil/netutil.go
@@ -42,21 +42,21 @@ func runExample(cmd *cobra.Command, args []string) {
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////
 	fmt.Println("\nDivide CIDR block into subnets to accommodate at least minimum number of subnets")
-	fmt.Println("Divide CIDR block by a specified number of hosts\n")
+	fmt.Printf("Divide CIDR block by a specified number of hosts\n")
 
 	fmt.Println("[Usecase] Get superneted VPCs and its subnets inside")
 	fmt.Printf("- Base network: %v\n", cidrBlock)
 	fmt.Printf("- Minimum number of VPCs (subnets of the base network): %d\n", minSubnets)
 	fmt.Printf("- Subnets in a VPC base on the number of hosts per subnet: %d\n", hostsPerSubnet)
 
-	subnets, err := netutil.SubnettingByMininumSubnetCount(cidrBlock, minSubnets)
+	subnets, err := netutil.SubnettingByMinimumSubnetCount(cidrBlock, minSubnets)
 	if err != nil {
 		fmt.Println(err)
 	}
 
 	for i, vpc := range subnets {
 		fmt.Printf("\nVPC[%03d]:\t%v\nSubnets:\t", i+1, vpc)
-		vpcsubnets, err := netutil.SubnettingByHosts(vpc, hostsPerSubnet)
+		vpcsubnets, err := netutil.SubnettingByMinimumHosts(vpc, hostsPerSubnet)
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -73,7 +73,7 @@ func runExample(cmd *cobra.Command, args []string) {
 	// fmt.Println("\nDivide CIDR block by a specified number of hosts")
 	// fmt.Printf("Number of hosts per subnet: %d\n", hostsPerSubnet)
 
-	// subnets, err = netutil.SubnettingByHosts(cidrBlock, hostsPerSubnet)
+	// subnets, err = netutil.SubnettingByMinimumHosts(cidrBlock, hostsPerSubnet)
 	// if err != nil {
 	// 	fmt.Println(err)
 	// }
@@ -193,5 +193,28 @@ func runExample(cmd *cobra.Command, args []string) {
 	} else {
 		fmt.Println("Network configuration is invalid.")
 	}
+
+	///////////////////////////////////////////////////////////////////////////////////////////////////
+	fmt.Println("\nSubnetting a CIDR block by requests")
+	request := netutil.SubnettingRequest{
+		CIDRBlock: cidrBlock,
+		SubnettingRules: []netutil.SubnettingRule{
+			{Type: "minSubnets", Value: minSubnets},
+			{Type: "minHosts", Value: hostsPerSubnet},
+		},
+	}
+
+	// Subnetting by requests
+	networkConfig, err := netutil.SubnettingBy(request)
+	if err != nil {
+		fmt.Println("Error subnetting network:", err)
+		return
+	}
+
+	pretty, err = json.MarshalIndent(networkConfig, "", "   ")
+	if err != nil {
+		fmt.Printf("marshaling error: %s\n", err)
+	}
+	fmt.Printf("[Subnetting result]\n%s\n", string(pretty))
 
 }


### PR DESCRIPTION
* Add models for subnetting request including CIDR block and rules
* Add SubnettingBy() and related functions
* Add GetName() which is missing member method
* (Minor) Relocate or rename some existing functions

Related to #1412 

**This PR will add a user-friendly function for subnetting a CIDR block by request rules.**
I think it's helpful to make a draft of a global muti-cloud network configuration, like the "global base network - VPCs - subnets" style. 
Note - By adding a rule, more than 3 depths are possible.

**Command**
```bash
./netutil -c "10.0.0.0/16" -s 16 -n 500
```

**Example (line 198-218)**

In this example, a CIDR Block is divided into multiple subnets by a rule `{Type: "minSubnets", Value: 16}`.
Each subnet is divided again into multiple subnets by a rule `{Type: "minHosts", Value: 500}`.

```go
	fmt.Println("\nSubnetting a CIDR block by requests")
	request := netutil.SubnettingRequest{
		CIDRBlock: cidrBlock,
		SubnettingRules: []netutil.SubnettingRule{
			{Type: "minSubnets", Value: minSubnets},
			{Type: "minHosts", Value: hostsPerSubnet},
		},
	}

	// Subnetting by requests
	networkConfig, err := netutil.SubnettingBy(request)
	if err != nil {
		fmt.Println("Error subnetting network:", err)
		return
	}

	pretty, err = json.MarshalIndent(networkConfig, "", "   ")
	if err != nil {
		fmt.Printf("marshaling error: %s\n", err)
	}
	fmt.Printf("[Subnetting result]\n%s\n", string(pretty))
```

**[Subnetting result]**
```json
{
   "cidrBlock": "10.0.0.0/16",
   "subnets": [
      {
         "cidrBlock": "10.0.0.0/20",
         "subnets": [
            {
               "cidrBlock": "10.0.0.0/23"
            },
            {
               "cidrBlock": "10.0.2.0/23"
            },
            {
               "cidrBlock": "10.0.4.0/23"
            },
            {
               "cidrBlock": "10.0.6.0/23"
            },
            {
               "cidrBlock": "10.0.8.0/23"
            },
            {
               "cidrBlock": "10.0.10.0/23"
            },
            {
               "cidrBlock": "10.0.12.0/23"
            },
            {
               "cidrBlock": "10.0.14.0/23"
            }
         ]
      },
      {
         "cidrBlock": "10.0.16.0/20",
         "subnets": [
            {
               "cidrBlock": "10.0.16.0/23"
            },
            {
               "cidrBlock": "10.0.18.0/23"
            },
            {
               "cidrBlock": "10.0.20.0/23"
            },
            {
               "cidrBlock": "10.0.22.0/23"
            },
            {
               "cidrBlock": "10.0.24.0/23"
            },
            {
               "cidrBlock": "10.0.26.0/23"
            },
            {
               "cidrBlock": "10.0.28.0/23"
            },
            {
               "cidrBlock": "10.0.30.0/23"
            }
         ]
      },
      ...
   ]
}
```

This is the same result as #1417 (except `name` field).
