### PR TITLE
Refine supernetting and network provisioning rules to support k8s provisioning

### DIFF
--- a/src/core/common/client.go
+++ b/src/core/common/client.go
@@ -138,7 +138,7 @@ func ExecuteHttpRequest[B any, T any](
 	}
 
 	if resp.IsError() {
-		return fmt.Errorf("[Error from: %s] Status code: %s", url, resp.Status())
+		return fmt.Errorf("[Error from: %s] Status code: %s, Message: %s", url, resp.Status(), resp.Body())
 	}
 
 	// Update the cache for GET method only

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -1687,8 +1687,8 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 				reqTmp.Name = resourceName
 				reqTmp.Description = description
 
-				// set isolated private address space for each cloud region (192.168.xxx.0/24)
-				reqTmp.CidrBlock = "192.168." + strconv.Itoa(i+1) + ".0/24"
+				// set isolated private address space for each cloud region (10.i.0.0/16)
+				reqTmp.CidrBlock = "10." + strconv.Itoa(i) + ".0.0/16"
 				if strings.EqualFold(provider, "cloudit") {
 					// CLOUDIT: the list of subnets that can be created is
 					// 10.0.4.0/22,10.0.8.0/22,10.0.12.0/22,10.0.28.0/22,10.0.32.0/22,
@@ -1708,8 +1708,16 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 					reqTmp.CidrBlock = "10.0.40.0/22"
 				}
 
-				// subnet := SpiderSubnetReqInfo{Name: reqTmp.Name, IPv4_CIDR: reqTmp.CidrBlock}
-				subnet := TbSubnetReq{Name: reqTmp.Name, IPv4_CIDR: reqTmp.CidrBlock}
+				// Consist 2 subnets (10.i.0.0/18, 10.i.64.0/18)
+				// Reserve spaces for tentative 2 subnets (10.i.128.0/18, 10.i.192.0/18)
+				subnetName := reqTmp.Name
+				subnetCidr := "10." + strconv.Itoa(i) + ".0.0/18"
+				subnet := TbSubnetReq{Name: subnetName, IPv4_CIDR: subnetCidr}
+				reqTmp.SubnetInfoList = append(reqTmp.SubnetInfoList, subnet)
+
+				subnetName = reqTmp.Name + "-01"
+				subnetCidr = "10." + strconv.Itoa(i) + ".64.0/18"
+				subnet = TbSubnetReq{Name: subnetName, IPv4_CIDR: subnetCidr}
 				reqTmp.SubnetInfoList = append(reqTmp.SubnetInfoList, subnet)
 
 				common.PrintJsonPretty(reqTmp)

--- a/src/testclient/scripts/3.vNet/add-subnet.sh
+++ b/src/testclient/scripts/3.vNet/add-subnet.sh
@@ -11,10 +11,9 @@ function CallTB() {
     resp=$(
         curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}/subnet -H 'Content-Type: application/json' -d @- <<EOF
         {
-			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-${CIDRDiff}",
+			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-02",
 			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
-			"IPv4_CIDR": "192.168.${CIDRDiff}.64/28"
-			
+			"IPv4_CIDR": "10.${CIDRDiff}.128.0/18"			
 		}
 EOF
     ); echo ${resp} | jq ''
@@ -24,7 +23,7 @@ EOF
 #function create_subnet() {
 
 	echo "####################################################################"
-	echo "## 3. subnet: Create"
+	echo "## 3. subnet: Create and add to vNet"
 	echo "####################################################################"
 
 	source ../init.sh

--- a/src/testclient/scripts/3.vNet/create-vNet.sh
+++ b/src/testclient/scripts/3.vNet/create-vNet.sh
@@ -12,10 +12,13 @@ function CallTB() {
         {
 			"name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
 			"connectionName": "${CONN_CONFIG[$INDEX,$REGION]}",
-			"cidrBlock": "192.168.${CIDRDiff}.0/24",
+			"cidrBlock": "10.${CIDRDiff}.0.0/16",
 			"subnetInfoList": [ {
 				"Name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
-				"IPv4_CIDR": "192.168.${CIDRDiff}.128/28"
+				"IPv4_CIDR": "10.${CIDRDiff}.0.0/18"
+			}, {
+				"Name": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}-01",
+				"IPv4_CIDR": "10.${CIDRDiff}.64.0/18"
 			} ]
 		}
 EOF


### PR DESCRIPTION
fix #1409

Refine supernetting vNet rules to support K8s cluster provisioning.

## TestScripts

[create-vNet.sh]
- CSP[i]-VPC: 10.i.0.0/16
  - CSP[i]-Subnet[0]: 10.i.0.0/18
  - CSP[i]-Subnet[1]: 10.i.64.0/18

[add-subnet.sh]
  - CSP[i]-Subnet[2]: 10.i.128.0/18

## DefaultVNet (MCIS Dynamic)

- CSP[i]-VPC: 10.i.0.0/16
  - CSP[i]-Subnet[0]: 10.i.0.0/18
  - CSP[i]-Subnet[1]: 10.i.64.0/18
  // Reserve spaces for tentative 2 subnets (10.i.128.0/18, 10.i.192.0/18)