### PR TITLE
Add provisioning DataDisk to VM (including enhancements in Disk management)

### DIFF
--- a/scripts/runSpider.sh
+++ b/scripts/runSpider.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CONTAINER_NAME_READ="CB-Spider"
-CONTAINER_VERSION="0.8.0"
+CONTAINER_VERSION="0.8.1"
 CONTAINER_PORT="-p 1024:1024 -p 2048:2048"
 CONTAINER_DATA_PATH="/root/go/src/github.com/cloud-barista/cb-spider/meta_db"
 

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -3264,6 +3264,16 @@ const docTemplate = `{
                         "name": "option",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "description": "Force to attach/detach even if VM info is not matched",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -3281,6 +3291,68 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Provisioning (Create and attach) dataDisk",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Data Disk management"
+                ],
+                "summary": "Provisioning (Create and attach) dataDisk",
+                "parameters": [
+                    {
+                        "description": "Details for an Data Disk object",
+                        "name": "dataDiskInfo",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/mcir.TbDataDiskVmReq"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "mcis01",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "g1-1",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbVmInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/common.SimpleMsg"
                         }
@@ -8345,6 +8417,31 @@ const docTemplate = `{
                 },
                 "diskSize": {
                     "type": "string"
+                }
+            }
+        },
+        "mcir.TbDataDiskVmReq": {
+            "type": "object",
+            "required": [
+                "diskSize",
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "diskSize": {
+                    "type": "string",
+                    "default": "100",
+                    "example": "77"
+                },
+                "diskType": {
+                    "type": "string",
+                    "example": "default"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "aws-ap-southeast-1-datadisk"
                 }
             }
         },

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -3257,6 +3257,16 @@
                         "name": "option",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "true",
+                            "false"
+                        ],
+                        "type": "string",
+                        "description": "Force to attach/detach even if VM info is not matched",
+                        "name": "force",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -3274,6 +3284,68 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.SimpleMsg"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Provisioning (Create and attach) dataDisk",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra resource] MCIR Data Disk management"
+                ],
+                "summary": "Provisioning (Create and attach) dataDisk",
+                "parameters": [
+                    {
+                        "description": "Details for an Data Disk object",
+                        "name": "dataDiskInfo",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/mcir.TbDataDiskVmReq"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "default": "ns01",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "mcis01",
+                        "description": "MCIS ID",
+                        "name": "mcisId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "g1-1",
+                        "description": "VM ID",
+                        "name": "vmId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/mcis.TbVmInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/common.SimpleMsg"
                         }
@@ -8338,6 +8410,31 @@
                 },
                 "diskSize": {
                     "type": "string"
+                }
+            }
+        },
+        "mcir.TbDataDiskVmReq": {
+            "type": "object",
+            "required": [
+                "diskSize",
+                "name"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "diskSize": {
+                    "type": "string",
+                    "default": "100",
+                    "example": "77"
+                },
+                "diskType": {
+                    "type": "string",
+                    "example": "default"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "aws-ap-southeast-1-datadisk"
                 }
             }
         },

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -645,6 +645,24 @@ definitions:
     required:
     - diskSize
     type: object
+  mcir.TbDataDiskVmReq:
+    properties:
+      description:
+        type: string
+      diskSize:
+        default: "100"
+        example: "77"
+        type: string
+      diskType:
+        example: default
+        type: string
+      name:
+        example: aws-ap-southeast-1-datadisk
+        type: string
+    required:
+    - diskSize
+    - name
+    type: object
   mcir.TbFirewallRuleInfo:
     properties:
       cidr:
@@ -4672,6 +4690,49 @@ paths:
       summary: Get available dataDisks for a VM
       tags:
       - '[Infra resource] MCIR Data Disk management'
+    post:
+      consumes:
+      - application/json
+      description: Provisioning (Create and attach) dataDisk
+      parameters:
+      - description: Details for an Data Disk object
+        in: body
+        name: dataDiskInfo
+        required: true
+        schema:
+          $ref: '#/definitions/mcir.TbDataDiskVmReq'
+      - default: ns01
+        description: Namespace ID
+        in: path
+        name: nsId
+        required: true
+        type: string
+      - default: mcis01
+        description: MCIS ID
+        in: path
+        name: mcisId
+        required: true
+        type: string
+      - default: g1-1
+        description: VM ID
+        in: path
+        name: vmId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/mcis.TbVmInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.SimpleMsg'
+      summary: Provisioning (Create and attach) dataDisk
+      tags:
+      - '[Infra resource] MCIR Data Disk management'
     put:
       consumes:
       - application/json
@@ -4707,6 +4768,13 @@ paths:
         in: query
         name: option
         required: true
+        type: string
+      - description: Force to attach/detach even if VM info is not matched
+        enum:
+        - "true"
+        - "false"
+        in: query
+        name: force
         type: string
       produces:
       - application/json

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -298,6 +298,7 @@ func RunServer(port string) {
 	g.DELETE("/:nsId/resources/dataDisk/:resourceId", rest_mcir.RestDelResource)
 	g.DELETE("/:nsId/resources/dataDisk", rest_mcir.RestDelAllResources)
 	g.GET("/:nsId/mcis/:mcisId/vm/:vmId/dataDisk", rest_mcir.RestGetVmDataDisk)
+	g.POST("/:nsId/mcis/:mcisId/vm/:vmId/dataDisk", rest_mcir.RestPostVmDataDisk)
 	g.PUT("/:nsId/mcis/:mcisId/vm/:vmId/dataDisk", rest_mcir.RestPutVmDataDisk)
 
 	g.POST("/:nsId/resources/image", rest_mcir.RestPostImage)

--- a/src/core/mcir/datadisk.go
+++ b/src/core/mcir/datadisk.go
@@ -103,6 +103,14 @@ type TbDataDiskReq struct {
 	CspDataDiskId string `json:"cspDataDiskId"`
 }
 
+// TbDataDiskVmReq is a struct to handle 'Provisioning dataDisk to VM' request toward CB-Tumblebug.
+type TbDataDiskVmReq struct {
+	Name        string `json:"name" validate:"required" example:"aws-ap-southeast-1-datadisk"`
+	DiskType    string `json:"diskType" example:"default"`
+	DiskSize    string `json:"diskSize" validate:"required" example:"77" default:"100"`
+	Description string `json:"description,omitempty"`
+}
+
 // TbDataDiskReqStructLevelValidation func is for Validation
 func TbDataDiskReqStructLevelValidation(sl validator.StructLevel) {
 


### PR DESCRIPTION
---
- Add provisioning DataDisk to VM: a new function to combine create a DataDisk and attach it to specific VM.
  POST `/ns/{nsId}/mcis/{mcisId}/vm/{vmId}/dataDisk`  
  Provisioning (Create and attach) dataDisk

- Apply the common func (common.ExecuteHttpRequest) for internal call to DataDisk MGM 
- Enhance: DataDisk MGM error handling for #1422



---
- Minor: CB-Spider container version to 0.8.1 (and tested)