### PR TITLE
Add forward any (GET) request to any (CB-Spider) internal system 

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -294,6 +294,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/forward/{path}": {
+            "post": {
+                "description": "Forward any (GET) request to CB-Spider",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Admin] System utility"
+                ],
+                "summary": "Forward any (GET) request to CB-Spider",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "vmspec",
+                        "description": "Internal call path to CB-Spider (path without /spider/ prefix) - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc] for more details",
+                        "name": "path",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body (various formats) - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc] for more details",
+                        "name": "Request",
+                        "in": "body",
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "Check Tumblebug is alive",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -287,6 +287,48 @@
                 }
             }
         },
+        "/forward/{path}": {
+            "post": {
+                "description": "Forward any (GET) request to CB-Spider",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Admin] System utility"
+                ],
+                "summary": "Forward any (GET) request to CB-Spider",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "vmspec",
+                        "description": "Internal call path to CB-Spider (path without /spider/ prefix) - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc] for more details",
+                        "name": "path",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Request body (various formats) - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc] for more details",
+                        "name": "Request",
+                        "in": "body",
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "Check Tumblebug is alive",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -2715,6 +2715,37 @@ paths:
       summary: Get registered ConnConfig info
       tags:
       - '[Admin] Multi-Cloud environment configuration'
+  /forward/{path}:
+    post:
+      consumes:
+      - application/json
+      description: Forward any (GET) request to CB-Spider
+      parameters:
+      - default: vmspec
+        description: Internal call path to CB-Spider (path without /spider/ prefix)
+          - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc]
+          for more details
+        in: path
+        name: path
+        required: true
+        type: string
+      - description: Request body (various formats) - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc]
+          for more details
+        in: body
+        name: Request
+        schema:
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Forward any (GET) request to CB-Spider
+      tags:
+      - '[Admin] System utility'
   /health:
     get:
       consumes:

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
@@ -458,6 +459,10 @@ func RestRegisterCspNativeResourcesAll(c echo.Context) error {
 func RestForwardAnyReqToAny(c echo.Context) error {
 	reqID := common.StartRequestWithLog(c)
 	reqPath := c.Param("*")
+	reqPath, err := url.PathUnescape(reqPath)
+	if err != nil {
+		return common.EndRequestWithLog(c, reqID, err, nil)
+	}
 
 	fmt.Printf("reqPath: %s\n", reqPath)
 

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -190,6 +190,8 @@ func RunServer(port string) {
 	e.GET("/tumblebug/ns/:nsId/loadDefaultResource", rest_mcir.RestLoadDefaultResource)
 	e.DELETE("/tumblebug/ns/:nsId/defaultResources", rest_mcir.RestDelAllDefaultResources)
 
+	e.POST("/tumblebug/forward/*", rest_common.RestForwardAnyReqToAny)
+
 	// Route for NameSpace subgroup
 	g := e.Group("/tumblebug/ns", common.NsValidation())
 


### PR DESCRIPTION
## With this PR, you can call CB-Spider request indirectly by CB-Tumblebug.

### Ex: Call CB-Spider API within CB-Tumblebug API
![image](https://github.com/cloud-barista/cb-tumblebug/assets/5966944/dfa68994-c6b2-4f00-a8e2-fce6ccdf93fb)

### Ex: CB-Spider API
![image](https://github.com/cloud-barista/cb-tumblebug/assets/5966944/36f7ba92-46ea-4b4e-8e88-ac17f4890aa3)

- Note: the reason why we need to use POST method for a CB-Spider GET request is that Swagger UI does not accept GET with request body.