### PR TITLE
Self host LLM use case (initial code)

### DIFF
--- a/scripts/usecases/llm/README.md
+++ b/scripts/usecases/llm/README.md
@@ -1,0 +1,76 @@
+
+# LLM Service Management Scripts
+
+This document describes a set of scripts designed to manage an LLM (Large Language Model) service. These scripts facilitate starting the service (`startServer.sh`), checking its status (`statusServer.sh`), and stopping the service (`stopServer.sh`).
+
+## Prerequisites
+
+- A Linux-based system
+- Python 3 installed
+- pip (Python package manager)
+- sudo privileges or root access
+
+## Installation & Setup
+
+### 1. Start Server
+
+Starts the LLM service by installing necessary Python packages and running a FastAPI-based service in the background.
+
+```bash
+sudo ./startServer.sh
+```
+
+To download and prepare `startServer.sh` script for execution:
+
+```bash
+wget https://example.com/path/to/startServer.sh
+chmod +x startServer.sh
+```
+
+### 2. Check Server Status
+
+Checks the status of the currently running LLM service. If the service is running, it outputs the contents of recent logs.
+
+```bash
+./statusServer.sh
+```
+
+To download and prepare `statusServer.sh` script for execution:
+
+```bash
+wget https://example.com/path/to/statusServer.sh
+chmod +x statusServer.sh
+```
+
+### 3. Stop Server
+
+Stops the running LLM service by safely terminating all related processes.
+
+```bash
+./stopServer.sh
+```
+
+To download and prepare `stopServer.sh` script for execution:
+
+```bash
+wget https://example.com/path/to/stopServer.sh
+chmod +x stopServer.sh
+```
+
+## Testing the Server
+
+Once the server is running, you can test the LLM service with the following `curl` command. This command sends a text generation request to the service, testing its operational status.
+
+```bash
+curl -X POST http://{PUBLICIP}:5001/v1/generateText \
+     -H "Content-Type: application/json" \
+     -d '{"prompt": "Who is president of US?"}'
+```
+
+Replace `{PUBLICIP}` with the public IP address of the server where the LLM service is running.
+
+## Notes
+
+- These scripts operate a Python-based LLM service using FastAPI and Uvicorn.
+- Service logs are saved to `~/llm_nohup.out` by default.
+- Server testing utilizes the service's public IP address and port number `5001`.

--- a/scripts/usecases/llm/README.md
+++ b/scripts/usecases/llm/README.md
@@ -1,20 +1,25 @@
+## Introduction
 
-# LLM Service Management Scripts
+- LLM Deployment on Cloud VM
 
-This document describes a set of scripts designed to manage an LLM (Large Language Model) service. These scripts facilitate starting the service (`startServer.sh`), checking its status (`statusServer.sh`), and stopping the service (`stopServer.sh`).
+This document describes a set of scripts designed to deploy an 
+LLM (Large Language Model) service. These scripts facilitate starting 
+the service (`startServer.sh`), checking its status (`statusServer.sh`), 
+and stopping the service (`stopServer.sh`).
 
-## Prerequisites
+## Installation & Setup
+
+### Prerequisites
 
 - A Linux-based system
 - Python 3 installed
 - pip (Python package manager)
 - sudo privileges or root access
 
-## Installation & Setup
-
 ### 1. Start Server
 
-Starts the LLM service by installing necessary Python packages and running a FastAPI-based service in the background.
+Starts the LLM service by installing necessary Python packages 
+and running a FastAPI-based service in the background.
 
 ```bash
 sudo ./startServer.sh
@@ -29,7 +34,8 @@ chmod +x startServer.sh
 
 ### 2. Check Server Status
 
-Checks the status of the currently running LLM service. If the service is running, it outputs the contents of recent logs.
+Checks the status of the currently running LLM service. If the 
+service is running, it outputs the contents of recent logs.
 
 ```bash
 ./statusServer.sh
@@ -59,7 +65,9 @@ chmod +x stopServer.sh
 
 ## Testing the Server
 
-Once the server is running, you can test the LLM service with the following `curl` command. This command sends a text generation request to the service, testing its operational status.
+Once the server is running, you can test the LLM service with 
+the following `curl` command. This command sends a text generation 
+request to the service, testing its operational status.
 
 ```bash
 curl -X POST http://{PUBLICIP}:5001/v1/generateText \
@@ -67,7 +75,8 @@ curl -X POST http://{PUBLICIP}:5001/v1/generateText \
      -d '{"prompt": "Who is president of US?"}'
 ```
 
-Replace `{PUBLICIP}` with the public IP address of the server where the LLM service is running.
+Replace `{PUBLICIP}` with the public IP address of the server 
+where the LLM service is running.
 
 ## Notes
 

--- a/scripts/usecases/llm/startServer.sh
+++ b/scripts/usecases/llm/startServer.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Define script variables
+SCRIPT_NAME=$(basename "$0")
+LLM_PYTHON_FILE=~/runCloudLLM.py
+LOG_FILE=~/llm_nohup.out
+
+# Step 1: Check for root/sudo
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run as root or with sudo" 
+   exit 1
+fi
+
+# Step 2: Update system and install Python3-pip
+echo "[$SCRIPT_NAME] Updating system and installing Python3-pip..."
+apt-get update
+apt-get install -y python3-pip
+
+# Step 3: Install required Python packages
+echo "[$SCRIPT_NAME] Installing required Python packages..."
+pip3 install openai==0.28.1 langchain -U langchain-community gptcache
+
+# Check if the pip install was successful
+if [ $? -ne 0 ]; then
+    echo "[$SCRIPT_NAME] Failed to install Python packages. Exiting."
+    exit 1
+fi
+
+# Step 4: Create the Python script for LLM
+echo "[$SCRIPT_NAME] Creating the Python script for LLM..."
+cat <<EOF > $LLM_PYTHON_FILE
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+import langchain
+from langchain_community.llms import VLLM
+import uvicorn
+
+app = FastAPI()
+
+llm = VLLM(model="tiiuae/falcon-7b-instruct",
+           trust_remote_code=True,
+           max_new_tokens=50,
+           temperature=0.6)
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+@app.post("/v1/generateText")
+async def generateText(request: Request) -> JSONResponse:
+    request_dict = await request.json()
+    prompt = request_dict.get("prompt", "")
+    output = llm(prompt)
+    return JSONResponse(content={"text": output})
+
+EOF
+
+# Step 5: Run the Python script in the background
+echo "[$SCRIPT_NAME] Starting LLM service in the background..."
+nohup python3 $LLM_PYTHON_FILE > $LOG_FILE 2>&1 &
+
+echo "[$SCRIPT_NAME] LLM service started. Logs are available at $LOG_FILE"

--- a/scripts/usecases/llm/statusServer.sh
+++ b/scripts/usecases/llm/statusServer.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Define script variables
+SCRIPT_NAME=$(basename "$0")
+SERVICE_NAME="runCloudLLM.py"
+LOG_FILE=~/llm_nohup.out
+
+echo "[$SCRIPT_NAME] Checking status of the LLM service..."
+
+# Check if the LLM service is running
+PID=$(ps aux | grep "$SERVICE_NAME" | grep -v grep | awk '{print $2}')
+
+if [ -z "$PID" ]; then
+    echo "[$SCRIPT_NAME] LLM service is not running."
+else
+    echo "[$SCRIPT_NAME] LLM service is running. PID: $PID"
+    echo "[$SCRIPT_NAME] Showing the last 20 lines of the log file ($LOG_FILE):"
+    tail -n 20 "$LOG_FILE"
+fi

--- a/scripts/usecases/llm/stopServer.sh
+++ b/scripts/usecases/llm/stopServer.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Define script variables
+SCRIPT_NAME=$(basename "$0")
+SERVICE_NAME="runCloudLLM.py"
+
+echo "[$SCRIPT_NAME] Attempting to stop the LLM service..."
+
+# Find the PID of the LLM service
+PIDS=$(ps aux | grep "$SERVICE_NAME" | grep -v grep | awk '{print $2}')
+
+if [ -z "$PIDS" ]; then
+    echo "[$SCRIPT_NAME] No LLM service is currently running."
+else
+    # Kill the LLM service processes
+    for PID in $PIDS; do
+        kill $PID
+        if [ $? -eq 0 ]; then
+            echo "[$SCRIPT_NAME] Successfully stopped the LLM service (PID: $PID)."
+        else
+            echo "[$SCRIPT_NAME] Failed to stop the LLM service (PID: $PID)."
+        fi
+    done
+fi


### PR DESCRIPTION
- LLM을 쉽게 배포해볼 수 있는 유스케이스 추가.
- 하기 spec, image set에서 실행 가능
  - AWS,aws-us-east-2, `ami-0c616d2c080a12072`, `Ubuntu 20.04`
  - AWS,aws-us-east-2, `g5.2xlarge`

# LLM Service Scripts

This document describes a set of scripts designed to manage an LLM (Large Language Model) service. These scripts facilitate starting the service (`startServer.sh`), checking its status (`statusServer.sh`), and stopping the service (`stopServer.sh`).

## Prerequisites

- A Linux-based system
- Python 3 installed
- pip (Python package manager)
- sudo privileges or root access

## Installation & Setup

### 1. Start Server

Starts the LLM service by installing necessary Python packages and running a FastAPI-based service in the background.

```bash
sudo ./startServer.sh
```

To download and prepare `startServer.sh` script for execution:

```bash
wget https://example.com/path/to/startServer.sh
chmod +x startServer.sh
```

### 2. Check Server Status

Checks the status of the currently running LLM service. If the service is running, it outputs the contents of recent logs.

```bash
./statusServer.sh
```

To download and prepare `statusServer.sh` script for execution:

```bash
wget https://example.com/path/to/statusServer.sh
chmod +x statusServer.sh
```

### 3. Stop Server

Stops the running LLM service by safely terminating all related processes.

```bash
./stopServer.sh
```

To download and prepare `stopServer.sh` script for execution:

```bash
wget https://example.com/path/to/stopServer.sh
chmod +x stopServer.sh
```

## Testing the Server

Once the server is running, you can test the LLM service with the following `curl` command. This command sends a text generation request to the service, testing its operational status.

```bash
curl -X POST http://{PUBLICIP}:5001/v1/generateText \
     -H "Content-Type: application/json" \
     -d '{"prompt": "Who is president of US?"}'
```

Replace `{PUBLICIP}` with the public IP address of the server where the LLM service is running.

## Notes

- These scripts operate a Python-based LLM service using FastAPI and Uvicorn.
- Service logs are saved to `~/llm_nohup.out` by default.
- Server testing utilizes the service's public IP address and port number `5001`.

# ACK
Thanks for useful guide to deploy self-hosted LLM.
- https://medium.com/@chinmayd49/self-host-llm-with-ec2-vllm-langchain-fastapi-llm-cache-and-huggingface-model-7a2efa2dcdab