### PR TITLE
Assign StatusBadRequest code for http bind error

### DIFF
--- a/src/core/common/client.go
+++ b/src/core/common/client.go
@@ -232,7 +232,11 @@ func EndRequestWithLog(c echo.Context, reqID string, err error, responseData int
 			details.Status = "Error"
 			details.ErrorResponse = err.Error()
 			RequestMap.Store(reqID, details)
-			return c.JSON(http.StatusInternalServerError, map[string]string{"message": err.Error()})
+			if responseData == nil {
+				return c.JSON(http.StatusBadRequest, map[string]string{"message": err.Error()})
+			} else {
+				return c.JSON(http.StatusInternalServerError, map[string]string{"message": err.Error()})
+			}
 		}
 
 		details.Status = "Success"


### PR DESCRIPTION
fix #1447

최소한의 수정으로 #1447 의 문제를 교정함.

- Bind 오류의 경우에 http.StatusBadRequest 를 리턴하며, 
- 나머지 경우 기존대로 http.StatusInternalServerError 리턴.