### PR TITLE
Revert API path for Swagger UI to fix err

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
 
 - Swagger API 문서 업데이트 필요 시 `cb-tumblebug/src/` 에서 `make swag` 실행
   - API 문서 파일은 `cb-tumblebug/src/api/rest/docs/swagger.yaml` 에 생성됨
-  - 해당 API 문서는 http://localhost:1323/tumblebug/api 로컬에서 웹브라우저로 확인 가능 (CB-Tumblebug 구동 시 자동으로 제공)
+  - 해당 API 문서는 http://localhost:1323/tumblebug/swagger/ 로컬에서 웹브라우저로 확인 가능 (CB-Tumblebug 구동 시 자동으로 제공)
   - Swagger 기반 [API 문서 업데이트 방법 상세 정보](https://github.com/cloud-barista/cb-tumblebug/wiki/API-Document-Update)
 
 ### (3) CB-Tumblebug 실행
@@ -263,7 +263,7 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
 
 
    Access to API dashboard (username: default / password: default)
-   http://xxx.xxx.xxx.xxx:1323/tumblebug/api
+   http://xxx.xxx.xxx.xxx:1323/tumblebug/swagger/
 
   ⇨ http server started on [::]:1323
   ```

--- a/i18n/README-EN.md
+++ b/i18n/README-EN.md
@@ -166,7 +166,7 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
 
 - If Swagger API Document needs to be updated run `make swag` at `cb-tumblebug/src/` directory.
   - API document file is created at  `cb-tumblebug/src/api/rest/docs/swagger.yaml` directory.
-  - Following API document can be checked on http://localhost:1323/tumblebug/api through web browser. (Automatically provided when CB-Tumblebug is executed)
+  - Following API document can be checked on http://localhost:1323/tumblebug/swagger/ through web browser. (Automatically provided when CB-Tumblebug is executed)
 
 ### (3) Run CB-Tumblebug 
 - Run [CB-Spider](https://github.com/cloud-barista/cb-spider) in another tab
@@ -196,7 +196,7 @@ Check out [CONTRIBUTING](https://github.com/cloud-barista/cb-tumblebug/blob/main
 
 
    Access to API dashboard (username: default / password: default)
-   http://xxx.xxx.xxx.xxx:1323/tumblebug/api
+   http://xxx.xxx.xxx.xxx:1323/tumblebug/swagger/
 
   ⇨ http server started on [::]:1323
   ```

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -102,7 +102,7 @@ func RunServer(port string) {
 	//e.colorer.Printf(banner, e.colorer.Red("v"+Version), e.colorer.Blue(website))
 
 	// Route for system management
-	e.GET("/tumblebug/api", echoSwagger.WrapHandler)
+	e.GET("/tumblebug/swagger/*", echoSwagger.WrapHandler)
 	// e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
 	e.GET("/tumblebug/health", rest_common.RestGetHealth)
 	e.GET("/tumblebug/httpVersion", rest_common.RestCheckHTTPVersion)
@@ -415,7 +415,7 @@ func RunServer(port string) {
 	g.GET("/:nsId/testGetAssociatedObjectCount/:resourceType/:resourceId", rest_mcir.RestTestGetAssociatedObjectCount)
 
 	selfEndpoint := os.Getenv("SELF_ENDPOINT")
-	apidashboard := " http://" + selfEndpoint + "/tumblebug/api"
+	apidashboard := " http://" + selfEndpoint + "/tumblebug/swagger/"
 
 	if enableAuth {
 		fmt.Println(" Access to API dashboard" + " (username: " + apiUser + " / password: " + apiPass + ")")


### PR DESCRIPTION
Swag 업스트림에 의해서

swagger 키워드 이외에 다른 Path를 지정하지 못하는 것으로 판단.

기존 설정으로 revert.