### PR TITLE
Add runTF.sh to run poc-mc-net-tf container

### DIFF
--- a/scripts/exportCredentials.sh
+++ b/scripts/exportCredentials.sh
@@ -86,8 +86,8 @@ done < "$credentialFile"
 
 {
     echo "[default]"
-    echo "aws_access_key_id=$aws_access_key_id"
-    echo "aws_secret_access_key=$aws_secret_access_key"
+    echo "AWS_ACCESS_KEY_ID=$aws_access_key_id"
+    echo "AWS_SECRET_ACCESS_KEY=$aws_secret_access_key"
 } > "$saveTo/aws_credential"
 
 cat > "$saveTo/gcp_credential.json" << EOF
@@ -107,10 +107,10 @@ cat > "$saveTo/gcp_credential.json" << EOF
 EOF
 
 {
-    echo "client_id=$azure_client_id"
-    echo "client_secret=$azure_client_secret"
-    echo "tenant_id=$azure_tenant_id"
-    echo "subscription_id=$azure_subscription_id"
+    echo "ARM_CLIENT_ID=$azure_client_id"
+    echo "ARM_CLIENT_SECRET=$azure_client_secret"
+    echo "ARM_TENANT_ID=$azure_tenant_id"
+    echo "ARM_SUBSCRIPTION_ID=$azure_subscription_id"
 } > "$saveTo/azure_credential"
 
 

--- a/scripts/runTF.sh
+++ b/scripts/runTF.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+CONTAINER_NAME_READ="poc-mc-net-tf"
+CONTAINER_VERSION="0.0.3"
+CONTAINER_PORT="-p 8888:8888"
+CONTAINER_DATA_PATH="/app/.tofu"
+
+if [ -z "$CBTUMBLEBUG_ROOT" ]; then
+    SCRIPT_DIR=`dirname ${BASH_SOURCE[0]-$0}`
+    export CBTUMBLEBUG_ROOT=`cd $SCRIPT_DIR && cd .. && pwd`
+fi
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$parent_path"
+
+# The credential directory and file path
+credential_dir="$CBTUMBLEBUG_ROOT/conf/.credtmp"
+aws_credential="$credential_dir/credentials"
+azure_credential="$credential_dir/credential-azure.env"
+gcp_credential="$credential_dir/credential-gcp.json"
+
+# The exported credentials from the credential.conf file
+exported_aws_credential="$credential_dir/aws_credential"
+exported_azure_credential="$credential_dir/azure_credential"
+exported_gcp_credential="$credential_dir/gcp_credential.json"
+
+# Check if credential files exist
+if [ ! -f "$aws_credential" ] || [ ! -f "$gcp_credential" ] || [ ! -f "$azure_credential" ]; then
+
+    # Check if the exported credentials exist
+    if [ ! -f "$exported_aws_credential" ] || [ ! -f "$exported_gcp_credential" ] || [ ! -f "$exported_azure_credential" ]; then
+        ./exportCredentials.sh
+    fi    
+    # Move the exported credentials to the credential directory
+    mv $exported_aws_credential $aws_credential
+    mv $exported_gcp_credential $gcp_credential
+    mv $exported_azure_credential $azure_credential    
+fi
+
+CONTAINER_ENV="--env-file $credential_dir/credentials \
+--env-file $credential_dir/credential-azure.env \
+--mount type=bind,source=$credential_dir/,target=/app/secrets/"
+
+./runContainer.sh "$CONTAINER_NAME_READ" "$CONTAINER_VERSION" "$CONTAINER_PORT" "$CONTAINER_DATA_PATH" "$CONTAINER_ENV"


### PR DESCRIPTION
* Align the exported AWS and Azure credentials with Tofu requirements
* Export and rename AWS, Azure, and GCP credentials
* Inject the credentials when the poc-mc-net-tf container runs

Related to #1439 