### PR TITLE
[Show and discuss] Process request log in middlewares

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/mcis"
@@ -84,7 +85,7 @@ func RestGetHealth(c echo.Context) error {
 	okMessage := common.SimpleMsg{}
 	okMessage.Message = "API server of CB-Tumblebug is alive"
 
-	c.Logger().Printf("Inside of RestGetHealth() handler")
+	log.Debug().Msg("Inside of RestGetHealth() handler")
 
 	return c.JSON(http.StatusOK, &okMessage)
 }

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -84,6 +84,8 @@ func RestGetHealth(c echo.Context) error {
 	okMessage := common.SimpleMsg{}
 	okMessage.Message = "API server of CB-Tumblebug is alive"
 
+	c.Logger().Printf("Inside of RestGetHealth() handler")
+
 	return c.JSON(http.StatusOK, &okMessage)
 }
 

--- a/src/api/rest/server/mcis/remoteCommand.go
+++ b/src/api/rest/server/mcis/remoteCommand.go
@@ -39,10 +39,11 @@ import (
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/cmd/mcis/{mcisId} [post]
 func RestPostCmdMcis(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+	// reqID, idErr := common.StartRequestWithLog(c)
+	// if idErr != nil {
+	// 	return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
+	// }
+	reqID := c.Request().Header.Get(echo.HeaderXRequestID)
 
 	nsId := c.Param("nsId")
 	mcisId := c.Param("mcisId")
@@ -67,7 +68,9 @@ func RestPostCmdMcis(c echo.Context) error {
 
 	common.PrintJsonPretty(result)
 
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return c.JSON(http.StatusOK, result)
+
+	// return common.EndRequestWithLog(c, reqID, err, result)
 
 }
 

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -17,7 +17,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"mime"
 
 	// "log"
 	"os/signal"
@@ -146,16 +145,11 @@ func RunServer(port string) {
 			log.Debug().Msgf("(BodyDump middleware) Request ID: %s", reqID)
 
 			// Get the content type
-			contentTypeAndCharset := c.Response().Header().Get(echo.HeaderContentType)
-			// log.Trace().Msg(c.Response().Header().Get(echo.HeaderContentType))
-			contentType, _, err := mime.ParseMediaType(contentTypeAndCharset)
-			if err != nil {
-				log.Error().Err(err).Msgf("Error parsing content type: %s", err)
-			}
-			// log.Trace().Msg(c.Response().Header().Get(echo.HeaderContentType))
+			contentType := c.Response().Header().Get(echo.HeaderContentType)
+			log.Trace().Msgf("contentType: %s", contentType)
 
-			// Dump the response body if content type is "application/json"
-			if contentType == "application/json" {
+			// Dump the response body if content type is "application/json" or "application/json; charset=UTF-8"
+			if contentType == echo.MIMEApplicationJSONCharsetUTF8 || contentType == echo.MIMEApplicationJSON {
 				// Load or check the request by ID
 				if v, ok := common.RequestMap.Load(reqID); ok {
 					log.Trace().Msg("OK, common.RequestMap.Load(reqID)")

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -114,8 +114,11 @@ func RunServer(port string) {
 
 			log.Debug().Msgf("(Request ID middleware) Request ID: %s", reqID)
 			if _, ok := common.RequestMap.Load(reqID); ok {
-				return fmt.Errorf("the x-request-id is already in use")
+				return fmt.Errorf("the X-Request-Id is already in use")
 			}
+
+			// Set "X-Request-Id" in response header
+			c.Response().Header().Set(echo.HeaderXRequestID, reqID)
 
 			details := common.RequestDetails{
 				StartTime:   time.Now(),

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"mime"
 
 	// "log"
 	"os/signal"
@@ -98,8 +99,9 @@ func RunServer(port string) {
 	// Customized middleware for request logging
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			c.Logger().Printf("Start - RequestLog()")
-			// make X-Request-Id visible to all handlers
+			// log.Debug().Msg("Start - Request ID middleware")
+
+			// Make X-Request-Id visible to all handlers
 			c.Response().Header().Set("Access-Control-Expose-Headers", echo.HeaderXRequestID)
 
 			// Get or generate Request ID
@@ -111,7 +113,7 @@ func RunServer(port string) {
 			// Set Request on the context
 			c.Set("RequestID", reqID)
 
-			c.Logger().Printf("Request ID: %s", reqID)
+			log.Debug().Msgf("(Request ID middleware) Request ID: %s", reqID)
 			if _, ok := common.RequestMap.Load(reqID); ok {
 				return fmt.Errorf("the x-request-id is already in use")
 			}
@@ -123,7 +125,7 @@ func RunServer(port string) {
 			}
 			common.RequestMap.Store(reqID, details)
 
-			c.Logger().Printf("End - RequestLog()")
+			// log.Debug().Msg("End - Request ID middleware")
 
 			return next(c)
 		}
@@ -131,47 +133,68 @@ func RunServer(port string) {
 
 	e.Use(middleware.BodyDumpWithConfig(middleware.BodyDumpConfig{
 		Skipper: func(c echo.Context) bool {
-			if c.Path() == "/tumblebug/swagger" {
+			if c.Path() == "/tumblebug/api" {
 				return true
 			}
 			return false
 		},
 		Handler: func(c echo.Context, reqBody, resBody []byte) {
-			c.Logger().Printf("Start - BodyDump()")
+			// log.Debug().Msg("Start - BodyDump() middleware")
 
+			// Get the request ID
 			reqID := c.Get("RequestID").(string)
-			c.Logger().Printf("Request ID: %s", reqID)
-			if v, ok := common.RequestMap.Load(reqID); ok {
-				c.Logger().Printf("OK, common.RequestMap.Load(reqID)")
-				details := v.(common.RequestDetails)
-				details.EndTime = time.Now()
+			log.Debug().Msgf("(BodyDump middleware) Request ID: %s", reqID)
 
-				c.Response().Header().Set("X-Request-ID", reqID)
+			// Get the content type
+			contentTypeAndCharset := c.Response().Header().Get(echo.HeaderContentType)
+			// log.Trace().Msg(c.Response().Header().Get(echo.HeaderContentType))
+			contentType, _, err := mime.ParseMediaType(contentTypeAndCharset)
+			if err != nil {
+				log.Error().Err(err).Msgf("Error parsing content type: %s", err)
+			}
+			// log.Trace().Msg(c.Response().Header().Get(echo.HeaderContentType))
 
-				// 1XX: Information responses
-				// 2XX: Successful responses (200 OK, 201 Created, 202 Accepted, 204 No Content)
-				// 3XX: Redirection messages
-				// 4XX: Client error responses (400 Bad Request, 401 Unauthorized, 404 Not Found, 408 Request Timeout)
-				// 5XX: Server error responses (500 Internal Server Error, 501 Not Implemented, 503 Service Unavailable)
-				if c.Response().Status >= 400 && c.Response().Status <= 599 {
-					c.Logger().Printf("Error, c.Response().Status")
+			// Dump the response body if content type is "application/json"
+			if contentType == "application/json" {
+				// Load or check the request by ID
+				if v, ok := common.RequestMap.Load(reqID); ok {
+					log.Trace().Msg("OK, common.RequestMap.Load(reqID)")
+					details := v.(common.RequestDetails)
+					details.EndTime = time.Now()
+
+					// Set "X-Request-Id" in response header
+					c.Response().Header().Set(echo.HeaderXRequestID, reqID)
+
+					// Unmarshal the response body
 					var resMap map[string]interface{}
 					err := json.Unmarshal(resBody, &resMap)
 					if err != nil {
-						// handle error
-						c.Logger().Printf("Error while unmarshaling response body: %s", err)
+						log.Error().Err(err).Msgf("Error while unmarshaling response body: %s", err)
+						log.Debug().Msgf("Response body: %s", string(reqBody))
+						log.Debug().Msgf("Response body: %s", string(resBody))
 					}
 
-					details.Status = "Error"
-					details.ErrorResponse = resMap["message"].(string)
-				} else {
-					c.Logger().Printf("Not error, c.Response().Status")
-					details.Status = "Success"
-					details.ResponseData = resBody
+					// 1XX: Information responses
+					// 2XX: Successful responses (200 OK, 201 Created, 202 Accepted, 204 No Content)
+					// 3XX: Redirection messages
+					// 4XX: Client error responses (400 Bad Request, 401 Unauthorized, 404 Not Found, 408 Request Timeout)
+					// 5XX: Server error responses (500 Internal Server Error, 501 Not Implemented, 503 Service Unavailable)
+					if c.Response().Status >= 400 && c.Response().Status <= 599 {
+						log.Trace().Msg("Error, c.Response().Status")
+						details.Status = "Error"
+						details.ErrorResponse = resMap["message"].(string)
+					} else {
+						log.Trace().Msg("Not error, c.Response().Status")
+						details.Status = "Success"
+						details.ResponseData = resMap
+					}
+
+					// Store details of the request
+					common.RequestMap.Store(reqID, details)
 				}
-				common.RequestMap.Store(reqID, details)
 			}
-			c.Logger().Printf("End - BodyDump()")
+
+			// log.Debug().Msg("Start - BodyDump() middleware")
 		},
 	}))
 

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -99,15 +99,18 @@ func RunServer(port string) {
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			c.Logger().Printf("Start - RequestLog()")
-			reqID := fmt.Sprintf("%d", time.Now().UnixNano())
-			c.Set("RequestID", reqID)
 			// make X-Request-Id visible to all handlers
-			c.Response().Header().Set("Access-Control-Expose-Headers", "X-Request-Id")
+			c.Response().Header().Set("Access-Control-Expose-Headers", echo.HeaderXRequestID)
 
-			// reqID := c.Request().Header.Get("x-request-id")
-			// if reqID == "" {
-			// 	reqID = fmt.Sprintf("%d", time.Now().UnixNano())
-			// }
+			// Get or generate Request ID
+			reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+			if reqID == "" {
+				reqID = fmt.Sprintf("%d", time.Now().UnixNano())
+			}
+
+			// Set Request on the context
+			c.Set("RequestID", reqID)
+
 			c.Logger().Printf("Request ID: %s", reqID)
 			if _, ok := common.RequestMap.Load(reqID); ok {
 				return fmt.Errorf("the x-request-id is already in use")


### PR DESCRIPTION
* Update the custom request ID middleware
* Add the custom bodydump middleware

**기존 StartRequestWithLog, EndRequestWithLog를 Middleware로 처리할 수 있도록 만든 PR 입니다.**

기존에 처리되던 매커니즘과 다르거나 지장이 있을지 몰라서 논의를 위한 PR을 열었습니다. (Draft PR)

코드 변경사항과 아래 실행 로그 확인 바랍니다. 이후, 추가 수정 보완하도록 하겠습니다.

**요약 설명:**
- Line 1-3: Request ID 미들웨어 (Request ID 발급, RequestMap 중복확인 및 저장)
- Line 4: health check 핸들러
- Line 5-9: BodyDump 미들웨어 (RequestMap 로드, 핸들러 성공/실패 확인, (실패시)RequestMap에 "Error" 및 error message 저장, (성공시) RequestMap에 "Successs" 및 resBody 저장

(참고 - 실행 이력)
```bash
{"time":"2024-03-28T23:14:07.847907353+09:00","level":"-","prefix":"echo","file":"server.go","line":"94","message":"Start - RequestLog()"}
{"time":"2024-03-28T23:14:07.847937453+09:00","level":"-","prefix":"echo","file":"server.go","line":"104","message":"Request ID: 1711635247847927053"}
{"time":"2024-03-28T23:14:07.847966453+09:00","level":"-","prefix":"echo","file":"server.go","line":"116","message":"End - RequestLog()"}
{"time":"2024-03-28T23:14:07.847983453+09:00","level":"-","prefix":"echo","file":"utility.go","line":"87","message":"Inside of RestGetHealth() handler"}
{"time":"2024-03-28T23:14:07.848012953+09:00","level":"-","prefix":"echo","file":"server.go","line":"130","message":"Start - BodyDump()"}
{"time":"2024-03-28T23:14:07.848017653+09:00","level":"-","prefix":"echo","file":"server.go","line":"133","message":"Request ID: 1711635247847927053"}
{"time":"2024-03-28T23:14:07.848020553+09:00","level":"-","prefix":"echo","file":"server.go","line":"135","message":"OK, common.RequestMap.Load(reqID)"}
{"time":"2024-03-28T23:14:07.848024153+09:00","level":"-","prefix":"echo","file":"server.go","line":"158","message":"Not error, c.Response().Status"}
{"time":"2024-03-28T23:14:07.848027753+09:00","level":"-","prefix":"echo","file":"server.go","line":"164","message":"End - BodyDump()"}
{"time":"2024-03-28T23:14:07.848031353+09:00","id":"1711635247847927053","remote_ip":"::1","host":"localhost:1323","method":"GET","uri":"/tumblebug/health","user_agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36","status":200,"error":"","latency":133600,"latency_human":"133.6µs","bytes_in":0,"bytes_out":50}
```
