### PR TITLE
Update the URL to access Swagger UI

### DIFF
--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -108,7 +108,14 @@ func RunServer(port string) {
 	//e.colorer.Printf(banner, e.colorer.Red("v"+Version), e.colorer.Blue(website))
 
 	// Route for system management
-	e.GET("/tumblebug/swagger/*", echoSwagger.WrapHandler)
+	swaggerRedirect := func(c echo.Context) error {
+		return c.Redirect(http.StatusMovedPermanently, "/tumblebug/api/index.html")
+	}
+	e.GET("/tumblebug/api", swaggerRedirect)
+	e.GET("/tumblebug/api/", swaggerRedirect)
+	e.GET("/tumblebug/api/*", echoSwagger.WrapHandler)
+
+	// e.GET("/tumblebug/swagger/*", echoSwagger.WrapHandler)
 	// e.GET("/tumblebug/swaggerActive", rest_common.RestGetSwagger)
 	e.GET("/tumblebug/health", rest_common.RestGetHealth)
 	e.GET("/tumblebug/httpVersion", rest_common.RestCheckHTTPVersion)
@@ -421,7 +428,7 @@ func RunServer(port string) {
 	g.GET("/:nsId/testGetAssociatedObjectCount/:resourceType/:resourceId", rest_mcir.RestTestGetAssociatedObjectCount)
 
 	selfEndpoint := os.Getenv("SELF_ENDPOINT")
-	apidashboard := " http://" + selfEndpoint + "/tumblebug/swagger/"
+	apidashboard := " http://" + selfEndpoint + "/tumblebug/api/index.html"
 
 	if enableAuth {
 		fmt.Println(" Access to API dashboard" + " (username: " + apiUser + " / password: " + apiPass + ")")

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -428,7 +428,7 @@ func RunServer(port string) {
 	g.GET("/:nsId/testGetAssociatedObjectCount/:resourceType/:resourceId", rest_mcir.RestTestGetAssociatedObjectCount)
 
 	selfEndpoint := os.Getenv("SELF_ENDPOINT")
-	apidashboard := " http://" + selfEndpoint + "/tumblebug/api/index.html"
+	apidashboard := " http://" + selfEndpoint + "/tumblebug/api"
 
 	if enableAuth {
 		fmt.Println(" Access to API dashboard" + " (username: " + apiUser + " / password: " + apiPass + ")")


### PR DESCRIPTION
This PR will update the URL to access Swagger UI.

### Background

- Double slash issue:
`http://localhost:1323/tumblebug/swagger//index.html` appeared when I accessed the URL `http://localhost:1323/tumblebug/swagger/` on a browser. (It seems to be a bug of `swaggo/echo-swagger`.)

- Needs: 
Also, we may be needed `http://localhost:1323/tumblebug/api/index.html` as tumblebug API URL (related to https://github.com/cloud-barista/cb-tumblebug/pull/1470).