### PR TITLE
Stop and rollback for MCIS dynamic with no init

### DIFF
--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -40,6 +40,8 @@ import (
 	"reflect"
 
 	validator "github.com/go-playground/validator/v10"
+
+	"github.com/rs/zerolog/log"
 )
 
 // CB-Store
@@ -1718,10 +1720,8 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 
 				resultInfo, err := CreateVNet(nsId, &reqTmp, "")
 				if err != nil {
-					common.CBLog.Error(err)
-					// If already exist, error will occur
-					// Even if error, do not return here to update information
-					// return err
+					log.Error().Err(err).Msg("Failed to create vNet")
+					return err
 				}
 				fmt.Printf("[%d] Registered Default vNet\n", i)
 				common.PrintJsonPretty(resultInfo)
@@ -1755,10 +1755,8 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 
 				resultInfo, err := CreateSecurityGroup(nsId, &reqTmp, "")
 				if err != nil {
-					common.CBLog.Error(err)
-					// If already exist, error will occur
-					// Even if error, do not return here to update information
-					// return err
+					log.Error().Err(err).Msg("Failed to create SecurityGroup")
+					return err
 				}
 				fmt.Printf("[%d] Registered Default SecurityGroup\n", i)
 				common.PrintJsonPretty(resultInfo)
@@ -1776,10 +1774,8 @@ func LoadDefaultResource(nsId string, resType string, connectionName string) err
 
 				resultInfo, err := CreateSshKey(nsId, &reqTmp, "")
 				if err != nil {
-					common.CBLog.Error(err)
-					// If already exist, error will occur
-					// Even if error, do not return here to update information
-					// return err
+					log.Error().Err(err).Msg("Failed to create SshKey")
+					return err
 				}
 				fmt.Printf("[%d] Registered Default SSHKey\n", i)
 				common.PrintJsonPretty(resultInfo)


### PR DESCRIPTION

MCIS Dynamic 으로 프로비저닝 진행시, 
- 기존: 동적 리소스의 일부가 생성되지 않아도, MCIS및 VM 생성 시도
- 변경: 동적 리소스가 하나라도 준비되지 않은 경우, MCIS및 VM 생성을 시도하지 않고 오류 리턴.
  - 기본 자원 전체 삭제 시도를 통해서 기본적인 rollback을 진행 