### PR TITLE
Fix pattern unmatched issue in api log skipper

### DIFF
--- a/src/api/rest/server/middlewares/custom-middleware.go
+++ b/src/api/rest/server/middlewares/custom-middleware.go
@@ -18,14 +18,14 @@ func Zerologger(skipPatterns [][]string) echo.MiddlewareFunc {
 			path := c.Request().URL.Path
 			query := c.Request().URL.RawQuery
 			for _, patterns := range skipPatterns {
-				match := true
+				isAllMatched := true
 				for _, pattern := range patterns {
 					if !strings.Contains(path+query, pattern) {
-						match = false
+						isAllMatched = false
 						break
 					}
 				}
-				if match {
+				if isAllMatched {
 					return true
 				}
 			}

--- a/src/api/rest/server/middlewares/custom-middleware.go
+++ b/src/api/rest/server/middlewares/custom-middleware.go
@@ -12,11 +12,20 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func Zerologger(skipPatterns []string) echo.MiddlewareFunc {
+func Zerologger(skipPatterns [][]string) echo.MiddlewareFunc {
 	return middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		Skipper: func(c echo.Context) bool {
-			for _, pattern := range skipPatterns {
-				if strings.Contains(c.Request().URL.Path, pattern) {
+			path := c.Request().URL.Path
+			query := c.Request().URL.RawQuery
+			for _, patterns := range skipPatterns {
+				match := true
+				for _, pattern := range patterns {
+					if !strings.Contains(path+query, pattern) {
+						match = false
+						break
+					}
+				}
+				if match {
 					return true
 				}
 			}

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -89,9 +89,9 @@ func RunServer(port string) {
 
 	// Middleware
 	// e.Use(middleware.Logger())
-	APILogSkipPatterns := []string{
-		"/tumblebug/api",
-		"/mcis?option=status",
+	APILogSkipPatterns := [][]string{
+		{"/tumblebug/api"},
+		{"/mcis", "option=status"},
 	}
 	e.Use(middlewares.Zerologger(APILogSkipPatterns))
 


### PR DESCRIPTION
 - 기존 코드에는 URL.Path 로 패턴 매칭하여, 쿼리 파라미터 처리가 되지 않는 문제가 있었음.
 - 이를 개선하며, 다중 스트링 중복 매칭을 지원할 수 있게 수정.