### PR TITLE
Fix missing CredentialName on `conf/template.credentials.conf`

### DIFF
--- a/conf/template.credentials.conf
+++ b/conf/template.credentials.conf
@@ -1,6 +1,8 @@
 ### Cloud API Credentials
 
 ## AWS
+CredentialName[$IndexAWS]=aws-credential01
+
 # ClientId(aws_access_key_id)
 # ex: AKIASSSSSSSSSSS56DJH
 CredentialKey01[$IndexAWS]=ClientId


### PR DESCRIPTION
This PR will recover CredentialName for AWS on `conf/template.credentials.conf` and resolve the issue below.
- Issue: Registration of all AWS-related items failed when running `initMultiCloudEnv.sh`.