### PR TITLE
Replace deprecated io/ioutil from golang

### DIFF
--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -17,7 +17,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -515,7 +515,7 @@ func RestForwardAnyReqToAny(c echo.Context) error {
 	method := "GET"
 	var requestBody interface{}
 	if c.Request().Body != nil {
-		bodyBytes, err := ioutil.ReadAll(c.Request().Body)
+		bodyBytes, err := io.ReadAll(c.Request().Body)
 		if err != nil {
 			return common.EndRequestWithLog(c, reqID, fmt.Errorf("Failed to read request body: %v", err), nil)
 		}

--- a/src/core/common/client.go
+++ b/src/core/common/client.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -250,13 +250,13 @@ func ExtractRequestInfo(r *http.Request) RequestInfo {
 	//var bodyString string
 	var bodyObject interface{}
 	if r.Body != nil { // Check if the body is not nil
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err == nil {
 			//bodyString = string(bodyBytes)
 			json.Unmarshal(bodyBytes, &bodyObject) // Try to unmarshal to a JSON object
 
 			// Important: Write the body back for further processing
-			r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+			r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		}
 	}
 

--- a/src/core/mcis/benchmark.go
+++ b/src/core/mcis/benchmark.go
@@ -17,7 +17,7 @@ package mcis
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	//"log"
 	"strconv"
@@ -174,7 +174,7 @@ func CallMilkyway(wg *sync.WaitGroup, vmList []string, nsId string, mcisId strin
 		log.Error().Err(err).Msg("")
 		errStr = err.Error()
 	} else {
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			errStr = err.Error()

--- a/src/core/mcis/monitoring.go
+++ b/src/core/mcis/monitoring.go
@@ -16,24 +16,17 @@ package mcis
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	validator "github.com/go-playground/validator/v10"
 	"github.com/rs/zerolog/log"
 	"github.com/tidwall/gjson"
-
-	"fmt"
-	"io/ioutil"
-
-	//"log"
-
-	"strconv"
-	"strings"
-
-	// REST API (echo)
-	"net/http"
-
-	"sync"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 )
@@ -130,7 +123,7 @@ func CheckDragonflyEndpoint() error {
 		return err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Err(err).Msg("")
 		return err
@@ -236,7 +229,7 @@ func CallMonitoringAsync(wg *sync.WaitGroup, nsID string, mcisID string, mcisSer
 		errStr += "/ " + err.Error()
 	} else {
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			errStr += "/ " + err.Error()
@@ -496,7 +489,7 @@ func CallGetMonitoringAsync(wg *sync.WaitGroup, nsID string, mcisID string, vmID
 			errStr = err1.Error()
 		}
 
-		body, err2 := ioutil.ReadAll(res.Body)
+		body, err2 := io.ReadAll(res.Body)
 		if err2 != nil {
 			log.Error().Err(err2).Msg("")
 			errStr = err2.Error()


### PR DESCRIPTION
Replace deprecated functions. (Deprecation of io/ioutil as of Go 1.16)

https://go.dev/doc/go1.16#ioutil

```
Deprecation of io/ioutil
The [io/ioutil](https://go.dev/pkg/io/ioutil/) package has turned out to be a poorly defined and hard to understand collection of things. All functionality provided by the package has been moved to other packages. The io/ioutil package remains and will continue to work as before, but we encourage new code to use the new definitions in the [io](https://go.dev/pkg/io/) and [os](https://go.dev/pkg/os/) packages. Here is a list of the new locations of the names exported by io/ioutil:

[Discard](https://go.dev/pkg/io/ioutil/#Discard) => [io.Discard](https://go.dev/pkg/io/#Discard)
[NopCloser](https://go.dev/pkg/io/ioutil/#NopCloser) => [io.NopCloser](https://go.dev/pkg/io/#NopCloser)
[ReadAll](https://go.dev/pkg/io/ioutil/#ReadAll) => [io.ReadAll](https://go.dev/pkg/io/#ReadAll)
[ReadDir](https://go.dev/pkg/io/ioutil/#ReadDir) => [os.ReadDir](https://go.dev/pkg/os/#ReadDir) (note: returns a slice of [os.DirEntry](https://go.dev/pkg/os/#DirEntry) rather than a slice of [fs.FileInfo](https://go.dev/pkg/io/fs/#FileInfo))
[ReadFile](https://go.dev/pkg/io/ioutil/#ReadFile) => [os.ReadFile](https://go.dev/pkg/os/#ReadFile)
[TempDir](https://go.dev/pkg/io/ioutil/#TempDir) => [os.MkdirTemp](https://go.dev/pkg/os/#MkdirTemp)
[TempFile](https://go.dev/pkg/io/ioutil/#TempFile) => [os.CreateTemp](https://go.dev/pkg/os/#CreateTemp)
[WriteFile](https://go.dev/pkg/io/ioutil/#WriteFile) => [os.WriteFile](https://go.dev/pkg/os/#WriteFile)
```