### PR TITLE
Safely waiting for CB-Spider for CB-TB ready

### DIFF
--- a/scripts/runSpider.sh
+++ b/scripts/runSpider.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CONTAINER_NAME_READ="CB-Spider"
-CONTAINER_VERSION="0.8.12"
+CONTAINER_VERSION="0.8.13"
 CONTAINER_PORT="-p 1024:1024 -p 2048:2048"
 CONTAINER_DATA_PATH="/root/go/src/github.com/cloud-barista/cb-spider/meta_db"
 

--- a/src/core/common/client.go
+++ b/src/core/common/client.go
@@ -191,10 +191,12 @@ func ExecuteHttpRequest[B any, T any](
 	}
 
 	if err != nil {
+		requestDone(requestKey)
 		return fmt.Errorf("[Error from: %s] Message: %s", url, err.Error())
 	}
 
 	if resp.IsError() {
+		requestDone(requestKey)
 		return fmt.Errorf("[Error from: %s] Status code: %s, Message: %s", url, resp.Status(), resp.Body())
 	}
 

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -417,6 +417,34 @@ func CheckConnConfigAvailable(connConfigName string) (bool, error) {
 	return true, nil
 }
 
+// CheckSpiderStatus is func to check if CB-Spider is ready
+func CheckSpiderReady() error {
+
+	var callResult interface{}
+	client := resty.New()
+	url := SpiderRestUrl + "/readyz"
+	method := "GET"
+	requestBody := NoBody
+
+	err := ExecuteHttpRequest(
+		client,
+		method,
+		url,
+		nil,
+		SetUseBody(requestBody),
+		&requestBody,
+		&callResult,
+		ShortDuration,
+	)
+
+	if err != nil {
+		//log.Err(err).Msg("")
+		return err
+	}
+
+	return nil
+}
+
 // GetConnConfigList is func to list filtered connection configs
 func GetConnConfigList(filterCredentialHolder string, filterVerified bool, filterRegionRepresentative bool) (ConnConfigList, error) {
 	var filteredConnections ConnConfigList
@@ -647,7 +675,7 @@ func RegisterCredential(req CredentialReq) (CredentialInfo, error) {
 	var callResult CredentialInfo
 	requestBody := reqToSpider
 
-	PrintJsonPretty(requestBody)
+	//PrintJsonPretty(requestBody)
 
 	err := ExecuteHttpRequest(
 		client,
@@ -664,7 +692,7 @@ func RegisterCredential(req CredentialReq) (CredentialInfo, error) {
 		log.Error().Err(err).Msg("")
 		return CredentialInfo{}, err
 	}
-	PrintJsonPretty(callResult)
+	//PrintJsonPretty(callResult)
 
 	callResult.CredentialHolder = req.CredentialHolder
 	callResult.ProviderName = strings.ToLower(callResult.ProviderName)

--- a/src/main.go
+++ b/src/main.go
@@ -175,6 +175,24 @@ func setConfig() {
 	// fmt.Printf("%+v\n", common.RuntimeCloudInfo)
 	common.PrintCloudInfoTable(common.RuntimeCloudInfo)
 
+	// Wait until CB-Spider is ready
+	maxAttempts := 60 // (3 mins)
+	attempt := 0
+
+	for attempt < maxAttempts {
+		if common.CheckSpiderReady() == nil {
+			log.Info().Msg("CB-Spider is now ready.")
+			break
+		}
+		log.Info().Msgf("CB-Spider at %s is not ready. Attempt %d/%d", common.SpiderRestUrl, attempt+1, maxAttempts)
+		time.Sleep(3 * time.Second)
+		attempt++
+	}
+
+	if attempt == maxAttempts {
+		panic("Failed to confirm CB-Spider readiness within the allowed time. \nCheck the connection to CB-Spider.")
+	}
+
 	err = common.RegisterAllCloudInfo()
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to register cloud info")


### PR DESCRIPTION
CB-TB 서버 안정성 향상 개선.

- CB-TB 시작시, 3초 단위로 CB-Spider의 서버 준비 상태를 확인하고
- 60번 초과시 CB-TB를 종료함. (이후 사용자가 CB-SP 서버 검토 후, 재실행 필요)

```
3:17AM INF main.go:187 > CB-Spider at http://localhost:1024/spider is not ready. Attempt 1/60
3:17AM INF main.go:187 > CB-Spider at http://localhost:1024/spider is not ready. Attempt 2/60
3:17AM INF main.go:187 > CB-Spider at http://localhost:1024/spider is not ready. Attempt 3/60
3:17AM INF main.go:187 > CB-Spider at http://localhost:1024/spider is not ready. Attempt 4/60
3:17AM INF main.go:187 > CB-Spider at http://localhost:1024/spider is not ready. Attempt 5/60
3:17AM INF main.go:187 > CB-Spider at http://localhost:1024/spider is not ready. Attempt 6/60

3:17AM INF main.go:184 > CB-Spider is now ready.



  ██████╗██████╗    ████████╗██████╗      
 ██╔════╝██╔══██╗   ╚══██╔══╝██╔══██╗     
 ██║     ██████╔╝█████╗██║   ██████╔╝     
 ██║     ██╔══██╗╚════╝██║   ██╔══██╗     
 ╚██████╗██████╔╝      ██║   ██████╔╝     
  ╚═════╝╚═════╝       ╚═╝   ╚═════╝      
                                         
 ██████╗ ███████╗ █████╗ ██████╗ ██╗   ██╗
 ██╔══██╗██╔════╝██╔══██╗██╔══██╗╚██╗ ██╔╝
 ██████╔╝█████╗  ███████║██║  ██║ ╚████╔╝ 
 ██╔══██╗██╔══╝  ██╔══██║██║  ██║  ╚██╔╝  
 ██║  ██║███████╗██║  ██║██████╔╝   ██║   
 ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝    ╚═╝   
 ```