### PR TITLE
Update API docs for MCIS control

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -2044,7 +2044,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
+                            "type": "string"
                         }
                     },
                     "404": {
@@ -2128,7 +2128,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
+                            "type": "string"
                         }
                     },
                     "404": {

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -2037,7 +2037,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
+                            "type": "string"
                         }
                     },
                     "404": {
@@ -2121,7 +2121,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/common.SimpleMsg"
+                            "type": "string"
                         }
                     },
                     "404": {

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -4244,7 +4244,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/common.SimpleMsg'
+            type: string
         "404":
           description: Not Found
           schema:
@@ -4303,7 +4303,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/common.SimpleMsg'
+            type: string
         "404":
           description: Not Found
           schema:

--- a/src/api/rest/server/mcis/control.go
+++ b/src/api/rest/server/mcis/control.go
@@ -33,7 +33,7 @@ import (
 // @Param mcisId path string true "MCIS ID" default(mcis01)
 // @Param action query string true "Action to MCIS" Enums(suspend, resume, reboot, terminate, refine)
 // @Param force query string false "Force control to skip checking controllable status" Enums(false, true)
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {string} string
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/control/mcis/{mcisId} [get]
@@ -74,7 +74,7 @@ func RestGetControlMcis(c echo.Context) error {
 // @Param vmId path string true "VM ID" default(g1-1)
 // @Param action query string true "Action to MCIS" Enums(suspend, resume, reboot, terminate)
 // @Param force query string false "Force control to skip checking controllable status" Enums(false, true)
-// @Success 200 {object} common.SimpleMsg
+// @Success 200 {string} string
 // @Failure 404 {object} common.SimpleMsg
 // @Failure 500 {object} common.SimpleMsg
 // @Router /ns/{nsId}/control/mcis/{mcisId}/vm/{vmId} [get]


### PR DESCRIPTION
The MCIS control APIs return a string type as a success response as follows:
![image](https://github.com/cloud-barista/cb-tumblebug/assets/7975459/2560c6dc-c3de-47a5-a2b8-333ef6ecdbee)
![image](https://github.com/cloud-barista/cb-tumblebug/assets/7975459/94c45a0a-42aa-48f2-bdd7-7f391f807264)

The API docs for MCIS control need to be updated. (This PR should be closed if `common.SimpleMsg` is the correct response.)

The APIs:
  - `GET /ns/{nsId}/control/mcis/{mcisId}`
  - `GET /ns/{nsId}/control/mcis/{mcisId}/vm/{vmId}`
