### PR TITLE
Check if the CB-Tumblebug container is working without issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=builder /go/src/github.com/cloud-barista/cb-tumblebug/src/cb-tumbleb
 # Setting various environment variables required by the application
 ENV CBTUMBLEBUG_ROOT=/app \
     CBSTORE_ROOT=/app \
+    CBLOG_ROOT=/app \
     SPIDER_CALL_METHOD=REST \
     DRAGONFLY_CALL_METHOD=REST \
     SPIDER_REST_URL=http://cb-spider:1024/spider \


### PR DESCRIPTION
This PR will add CBLOG_ROOT to Dockerfile to make the CB-Tumblebug container work properly.

## What was done for testing

### Build CB-Tumblebug container locally
```bash
docker build --no-cache -t local-tb .
```

### Run CB-Spider container
```bash
cd $CBTUMBLEBUG_ROOT
source conf/setup.env
./scripts/runSpider.sh
``` 

### Run CB-Tumblebug container (locally built one)
```bash
sudo docker run --rm -p 1323:1323 \
                --network host \
                -v /home/ubuntu/dev/cloud-barista/cb-tumblebug/container-volume/cb-tumblebug-container:/app/meta_db \
                -e SPIDER_REST_URL=http://localhost:1024/spider -e DRAGONFLY_REST_URL=http://localhost:9090/dragonfly -e SELF_ENDPOINT=localhost:1323 \
                --name cb-tumblebug \
                local-tb
```
Note - `--network host` option is added because my environment is WSL2.


### By `init.sh`, register all multi-cloud connection information and common resources
```bash
cd $CBTUMBLEBUG_ROOT
source conf/setup.env
./scripts/init/init.sh
```

### Run CB-MapUI
```bash
cd $CBTUMBLEBUG_ROOT
source conf/setup.env
./scripts/runMapUI.sh
```

### On MapUI, click and create MCIS

Result: 

![image](https://github.com/cloud-barista/cb-tumblebug/assets/7975459/ae8be85c-b548-4c0e-aaa0-70baf688de8a)

Note - `suspend`, `terminate`, and `delete` MCIS works normally.

close #1540 