### PR TITLE
Apply veryshort Duration for caching internal GET requests

### DIFF
--- a/src/core/common/client.go
+++ b/src/core/common/client.go
@@ -41,6 +41,8 @@ var clientCache = sync.Map{}
 var clientRequestCounter = sync.Map{}
 
 const (
+	// VeryShortDuration is a duration for very short-term cache
+	VeryShortDuration = 1 * time.Second
 	// ShortDuration is a duration for short-term cache
 	ShortDuration = 2 * time.Second
 	// MediumDuration is a duration for medium-term cache

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -434,7 +434,7 @@ func CheckSpiderReady() error {
 		SetUseBody(requestBody),
 		&requestBody,
 		&callResult,
-		ShortDuration,
+		VeryShortDuration,
 	)
 
 	if err != nil {
@@ -472,8 +472,6 @@ func GetConnConfigList(filterCredentialHolder string, filterVerified bool, filte
 		return ConnConfigList{}, nil
 	}
 
-	log.Info().Msgf("Filtered connection config count: %d", len(filteredConnections.Connectionconfig))
-
 	// filter by credential holder
 	if filterCredentialHolder != "" {
 		for _, connConfig := range filteredConnections.Connectionconfig {
@@ -483,7 +481,6 @@ func GetConnConfigList(filterCredentialHolder string, filterVerified bool, filte
 		}
 		filteredConnections = tmpConnections
 		tmpConnections = ConnConfigList{}
-		log.Info().Msgf("Filtered connection config count: %d", len(filteredConnections.Connectionconfig))
 	}
 
 	// filter only verified
@@ -495,7 +492,6 @@ func GetConnConfigList(filterCredentialHolder string, filterVerified bool, filte
 		}
 		filteredConnections = tmpConnections
 		tmpConnections = ConnConfigList{}
-		log.Info().Msgf("Filtered connection config count: %d", len(filteredConnections.Connectionconfig))
 	}
 
 	// filter only region representative
@@ -507,9 +503,8 @@ func GetConnConfigList(filterCredentialHolder string, filterVerified bool, filte
 		}
 		filteredConnections = tmpConnections
 		tmpConnections = ConnConfigList{}
-		log.Info().Msgf("Filtered connection config count: %d", len(filteredConnections.Connectionconfig))
 	}
-
+	log.Info().Msgf("Filtered connection config count: %d", len(filteredConnections.Connectionconfig))
 	return filteredConnections, nil
 }
 

--- a/src/core/mcir/common.go
+++ b/src/core/mcir/common.go
@@ -317,7 +317,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 		common.SetUseBody(requestBody),
 		&requestBody,
 		&callResult,
-		common.ShortDuration,
+		common.VeryShortDuration,
 	)
 
 	if err != nil {
@@ -460,7 +460,7 @@ func DelChildResource(nsId string, resourceType string, parentResourceId string,
 		common.SetUseBody(requestBody),
 		&requestBody,
 		&callResult,
-		common.ShortDuration,
+		common.VeryShortDuration,
 	)
 
 	if err != nil {

--- a/src/core/mcis/cluster.go
+++ b/src/core/mcis/cluster.go
@@ -959,7 +959,7 @@ func RemoveNodeGroup(nsId string, clusterId string, nodeGroupName string, forceF
 		common.SetUseBody(requestBody),
 		&requestBody,
 		&ifRes,
-		common.ShortDuration,
+		common.VeryShortDuration,
 	)
 
 	if err != nil {
@@ -1049,7 +1049,7 @@ func SetAutoscaling(nsId string, clusterId string, nodeGroupName string, u *TbSe
 		common.SetUseBody(requestBody),
 		&requestBody,
 		&ifRes,
-		common.ShortDuration,
+		common.VeryShortDuration,
 	)
 
 	if err != nil {
@@ -1134,7 +1134,7 @@ func ChangeAutoscaleSize(nsId string, clusterId string, nodeGroupName string, u 
 		common.SetUseBody(requestBody),
 		&requestBody,
 		&spChangeAutoscaleSizeRes,
-		common.ShortDuration,
+		common.VeryShortDuration,
 	)
 
 	if err != nil {
@@ -1488,7 +1488,7 @@ func DeleteCluster(nsId string, clusterId string, forceFlag string) (bool, error
 		common.SetUseBody(requestBody),
 		&requestBody,
 		&ifRes,
-		common.ShortDuration,
+		common.VeryShortDuration,
 	)
 
 	if forceFlag == "true" {


### PR DESCRIPTION

Some GET requests are actionable request.
Should not actively Caching.

This PR make the duration shorten.