### PR TITLE
Make init.sh works for ubuntu 18.04 as well

### DIFF
--- a/scripts/init/README.md
+++ b/scripts/init/README.md
@@ -10,7 +10,7 @@ The `init.py` script is designed to automate the process of registering credenti
 - **Resource Loading**: Initiates the loading of common specs and images into Tumblebug.
 
 ## Prerequisites
-- Python 3.x installed
+- Python 3.7.5 or higher is installed
 - Python packages listed in `requirements.txt`
 - The `python3-venv` package should be installed for running the script using `init.sh`.
 

--- a/scripts/init/init.sh
+++ b/scripts/init/init.sh
@@ -3,13 +3,30 @@
 SCRIPT_DIR=$(cd $(dirname "$0") && pwd)
 
 # Python version check
+REQUIRED_VERSION="3.7.5"
+
 PYTHON_VERSION=$(python3 --version | cut -d' ' -f2)
 echo "Detected Python version: $PYTHON_VERSION"
 PYTHON_MAJOR=$(echo $PYTHON_VERSION | cut -d. -f1)
 PYTHON_MINOR=$(echo $PYTHON_VERSION | cut -d. -f2)
+PYTHON_PATCH=$(echo $PYTHON_VERSION | cut -d. -f3)
+
+# Check if the Python3 version is 3.7.5 or higher
+REQUIRED_MAJOR=3
+REQUIRED_MINOR=7
+REQUIRED_PATCH=5
+
+if [[ $PYTHON_MAJOR -gt $REQUIRED_MAJOR ]] || \
+   [[ $PYTHON_MAJOR -eq $REQUIRED_MAJOR && $PYTHON_MINOR -gt $REQUIRED_MINOR ]] || \
+   [[ $PYTHON_MAJOR -eq $REQUIRED_MAJOR && $PYTHON_MINOR -eq $REQUIRED_MINOR && $PYTHON_PATCH -ge $REQUIRED_PATCH ]]; then
+    echo "Python version is sufficient."
+else
+    echo "This script requires Python $REQUIRED_MAJOR.$REQUIRED_MINOR.$REQUIRED_PATCH or higher. Please upgrade the version"
+    exit 1
+fi
 
 # Check if venv module is available and python3-venv is installed
-if ! python3 -c "import venv" &> /dev/null; then
+if ! python3 -c "import venv ensurepip" &> /dev/null; then
     if ! dpkg -s python${PYTHON_MAJOR}.${PYTHON_MINOR}-venv &> /dev/null; then
         echo "python3-venv package for Python ${PYTHON_MAJOR}.${PYTHON_MINOR} is not installed. Installing..."
         sudo apt update

--- a/scripts/init/requirements.txt
+++ b/scripts/init/requirements.txt
@@ -2,7 +2,7 @@
 requests==2.31.0
 
 # Used for parsing and creating YAML files
-PyYAML==6.0.1
+PyYAML==6.0
 
 # Used for displaying progress bars
 tqdm==4.66.3

--- a/scripts/runSpider.sh
+++ b/scripts/runSpider.sh
@@ -4,8 +4,9 @@ CONTAINER_NAME_READ="CB-Spider"
 CONTAINER_VERSION="0.8.13"
 CONTAINER_PORT="-p 1024:1024 -p 2048:2048"
 CONTAINER_DATA_PATH="/root/go/src/github.com/cloud-barista/cb-spider/meta_db"
+CONTAINER_ENV="-e SERVER_ADDRESS=localhost"
 
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 cd "$parent_path"
 
-./runContainer.sh "$CONTAINER_NAME_READ" "$CONTAINER_VERSION" "$CONTAINER_PORT" "$CONTAINER_DATA_PATH"
+./runContainer.sh "$CONTAINER_NAME_READ" "$CONTAINER_VERSION" "$CONTAINER_PORT" "$CONTAINER_DATA_PATH" "$CONTAINER_ENV"


### PR DESCRIPTION
fix #1547

- `if ! python3 -c "import venv ensurepip" &> /dev/null; then ` will fix #1547
- Define minimal python3 version
- runSpider will provide env variable to make spider runs in localhost.