### PR TITLE
fix to ensure to call requestdone() when requestkey is valid

### DIFF
--- a/src/core/common/client.go
+++ b/src/core/common/client.go
@@ -79,6 +79,9 @@ func limitConcurrentRequests(requestKey string, limit int) bool {
 // requestDone decreases the request counter
 func requestDone(requestKey string) {
 	count, _ := clientRequestCounter.Load(requestKey)
+	if count == nil {
+		return
+	}
 	currentCount := count.(int)
 
 	if currentCount > 0 {
@@ -193,12 +196,16 @@ func ExecuteHttpRequest[B any, T any](
 	}
 
 	if err != nil {
-		requestDone(requestKey)
+		if method == "GET" {
+			requestDone(requestKey)
+		}
 		return fmt.Errorf("[Error from: %s] Message: %s", url, err.Error())
 	}
 
 	if resp.IsError() {
-		requestDone(requestKey)
+		if method == "GET" {
+			requestDone(requestKey)
+		}
 		return fmt.Errorf("[Error from: %s] Status code: %s, Message: %s", url, resp.Status(), resp.Body())
 	}
 


### PR DESCRIPTION
CB-SP에서 에러를 리턴하는 경우도 왕왕(동일한 이름의 노드그룹 추가 등) 있기 때문에 requestkey 값을 확인한 후 requestDone()을 호출하도록 수정한 PR입니다.
method가 GET인 경우에 한정하여 requestDone()을 호출하는 방안도 있겠습니다.
의견 주시면 반영하도록 하겠습니다.

fix: #1557