### PR TITLE
Update to `runTumblebug.sh` and check readiness without auth

### DIFF
--- a/scripts/runTumblebug.sh
+++ b/scripts/runTumblebug.sh
@@ -10,20 +10,51 @@ cd "$parent_path"
 
 # Get IP address which is accessable from outsite.
 # `https://api.ipify.org` is one of IP lookup services. If it is not available we need to change.
-echo "[Retrieve IP address that accessable from outside]"
-echo
-str=$(curl https://api.ipify.org)
-if [ -z "$str" ]
-then
-    echo "The result for IP lookup is empty."
-    echo "Set ENDPOINT=localhost"
-    str=localhost
+echo "[Retrieve IP address accessible from outside]"
+external_ip=$(curl -s https://api.ipify.org)
+
+if [[ -n "$external_ip" ]]; then
+    # If external IP retrieval was successful, prompt user to select the ENDPOINT
+    echo "Please select endpoints to be used:"
+    echo "1) Use External IP for all components: $external_ip"
+    echo "2) Use 'host.docker.internal' to communicate with Spider and Dragonfly containers, 'localhost' for Tumblebug"
+    read -p "Enter your choice (1 or 2): " user_choice
+
+
+    case $user_choice in
+        1)
+            SP_ENDPOINT=$external_ip
+            DF_ENDPOINT=$external_ip
+            TB_ENDPOINT=$external_ip
+            ;;
+        2)
+            SP_ENDPOINT="host.docker.internal"
+            DF_ENDPOINT="host.docker.internal"
+            TB_ENDPOINT="localhost"
+            ;;
+        *)
+            echo "Invalid choice, use 'host.docker.internal' and 'localhost' as the default."
+            SP_ENDPOINT="host.docker.internal"
+            DF_ENDPOINT="host.docker.internal"
+            TB_ENDPOINT="localhost"
+            ;;
+    esac
+else
+    # If external IP retrieval failed, default to localhost
+    echo "Failed to retrieve external IP, use 'host.docker.internal' and 'localhost' as the default."
+    SP_ENDPOINT="host.docker.internal"
+    DF_ENDPOINT="host.docker.internal"
+    TB_ENDPOINT="localhost"
 fi
-ENDPOINT=$str
+
 echo
-echo "This script assume CB-Spider container is running in the same host. ($ENDPOINT)"
+echo "This script assume CB-Spider container is running in the same host. ($external_ip)"
 echo
-CONTAINER_ENV="-e SPIDER_REST_URL=http://$ENDPOINT:1024/spider -e DRAGONFLY_REST_URL=http://$ENDPOINT:9090/dragonfly -e SELF_ENDPOINT=$ENDPOINT:1323"
+
+if [ "$user_choice" != "1" ]; then
+    CONTAINER_ENV="--add-host host.docker.internal:host-gateway -e SPIDER_REST_URL=http://$SP_ENDPOINT:1024/spider -e DRAGONFLY_REST_URL=http://$DF_ENDPOINT:9090/dragonfly -e SELF_ENDPOINT=$TB_ENDPOINT:1323"
+else
+    CONTAINER_ENV="-e SPIDER_REST_URL=http://$SP_ENDPOINT:1024/spider -e DRAGONFLY_REST_URL=http://$DF_ENDPOINT:9090/dragonfly -e SELF_ENDPOINT=$TB_ENDPOINT:1323"    
+fi
 
 ./runContainer.sh "$CONTAINER_NAME_READ" "$CONTAINER_VERSION" "$CONTAINER_PORT" "$CONTAINER_DATA_PATH" "$CONTAINER_ENV"
-

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -141,7 +141,7 @@ func RunServer(port string) {
 	if enableAuth {
 		e.Use(middleware.BasicAuthWithConfig(middleware.BasicAuthConfig{
 			Skipper: func(c echo.Context) bool {
-				if c.Path() == "/tumblebug/health" ||
+				if c.Path() == "/tumblebug/readyz" ||
 					c.Path() == "/tumblebug/httpVersion" {
 					return true
 				}


### PR DESCRIPTION
This PR includes two things:
1) Adding endpoint selection logic to `runTumblebug.sh`
2) Checking readiness without auth

Tumblebug users/developers can select the endpoints when running the Tumblebug container.

Option 1) Use the retrieved external IP and set the endpoints of SP, DF, TB as the previous
Option 2) Use `host.docker.internal` and `localhost`
- Note: `host.docker.internal` is used for TB container to communicate with SP/DF containers
- Note: `localhost` is used for Tumblebug `SELF_ENDPOINT` for serving APIs externally

Also, we can check TB readiness without auth.
