### PR TITLE
Add Subnet handing id generated by CSP to vNet info

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -10139,6 +10139,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "idFromCsp": {
+                    "type": "string"
+                },
                 "ipv4_CIDR": {
                     "type": "string"
                 },
@@ -10161,6 +10164,9 @@ const docTemplate = `{
             ],
             "properties": {
                 "description": {
+                    "type": "string"
+                },
+                "idFromCsp": {
                     "type": "string"
                 },
                 "ipv4_CIDR": {

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -10132,6 +10132,9 @@
                 "id": {
                     "type": "string"
                 },
+                "idFromCsp": {
+                    "type": "string"
+                },
                 "ipv4_CIDR": {
                     "type": "string"
                 },
@@ -10154,6 +10157,9 @@
             ],
             "properties": {
                 "description": {
+                    "type": "string"
+                },
+                "idFromCsp": {
                     "type": "string"
                 },
                 "ipv4_CIDR": {

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1051,6 +1051,8 @@ definitions:
         type: string
       id:
         type: string
+      idFromCsp:
+        type: string
       ipv4_CIDR:
         type: string
       keyValueList:
@@ -1066,6 +1068,8 @@ definitions:
   mcir.TbSubnetReq:
     properties:
       description:
+        type: string
+      idFromCsp:
         type: string
       ipv4_CIDR:
         type: string

--- a/src/core/mcir/subnet.go
+++ b/src/core/mcir/subnet.go
@@ -156,6 +156,7 @@ func CreateSubnet(nsId string, vNetId string, req TbSubnetReq, objectOnly bool) 
 	}
 	tbSubnetInfo.Id = req.Name
 	tbSubnetInfo.Name = req.Name
+	tbSubnetInfo.IdFromCsp = req.IdFromCsp
 
 	newVNet.SubnetInfoList = append(newVNet.SubnetInfoList, tbSubnetInfo)
 	Val, _ = json.Marshal(newVNet)

--- a/src/core/mcir/vnet.go
+++ b/src/core/mcir/vnet.go
@@ -116,6 +116,7 @@ type TbVNetInfo struct { // Tumblebug
 // TbSubnetReq is a struct that represents TB subnet object.
 type TbSubnetReq struct { // Tumblebug
 	Name         string `validate:"required"`
+	IdFromCsp    string
 	IPv4_CIDR    string `validate:"required"`
 	KeyValueList []common.KeyValue
 	Description  string
@@ -137,6 +138,7 @@ func TbSubnetReqStructLevelValidation(sl validator.StructLevel) {
 type TbSubnetInfo struct { // Tumblebug
 	Id           string
 	Name         string `validate:"required"`
+	IdFromCsp    string
 	IPv4_CIDR    string `validate:"required"`
 	BastionNodes []BastionNode
 	KeyValueList []common.KeyValue
@@ -274,6 +276,7 @@ func CreateVNet(nsId string, u *TbVNetReq, option string) (TbVNetInfo, error) {
 			log.Error().Err(err).Msg("")
 		}
 		tbSubnetReq.Name = v.IId.NameId
+		tbSubnetReq.IdFromCsp = v.IId.SystemId
 
 		_, err = CreateSubnet(nsId, content.Id, tbSubnetReq, true)
 		if err != nil {


### PR DESCRIPTION
fix #1576

Response body of /ns/{nsId}/resources/vNet/{vNetId}
```
{
  "id": "ns01-systemdefault-aws-ap-northeast-2",
  "name": "ns01-systemdefault-aws-ap-northeast-2",
  "connectionName": "aws-ap-northeast-2",
  "cidrBlock": "10.34.0.0/16",
  "subnetInfoList": [
    {
      "Id": "ns01-systemdefault-aws-ap-northeast-2",
      "Name": "ns01-systemdefault-aws-ap-northeast-2",
      "IdFromCsp": "subnet-01631ba5b3eccf9b5",
      "IPv4_CIDR": "10.34.0.0/18",
      "BastionNodes": [
        {
          "mcisId": "mc-hhh6d",
          "vmId": "g1-1"
        }
      ],
      "KeyValueList": [
        {
          "key": "VpcId",
          "value": "vpc-07915390e0d20f457"
        },
        {
          "key": "MapPublicIpOnLaunch",
          "value": "false"
        },
        {
          "key": "AvailableIpAddressCount",
          "value": "16379"
        },
        {
          "key": "AvailabilityZone",
          "value": "ap-northeast-2a"
        },
        {
          "key": "Status",
          "value": "available"
        }
      ],
      "Description": ""
    },
    {
      "Id": "ns01-systemdefault-aws-ap-northeast-2-01",
      "Name": "ns01-systemdefault-aws-ap-northeast-2-01",
      "IdFromCsp": "subnet-0967288b4ceb2d12a",
      "IPv4_CIDR": "10.34.64.0/18",
      "BastionNodes": null,
      "KeyValueList": [
        {
          "key": "VpcId",
          "value": "vpc-07915390e0d20f457"
        },
        {
          "key": "MapPublicIpOnLaunch",
          "value": "false"
        },
        {
          "key": "AvailableIpAddressCount",
          "value": "16379"
        },
        {
          "key": "AvailabilityZone",
          "value": "ap-northeast-2a"
        },
        {
          "key": "Status",
          "value": "available"
        }
      ],
      "Description": ""
    }
  ],
  "description": "Generated Default Resource",
  "cspVNetId": "vpc-07915390e0d20f457",
  "cspVNetName": "ns01-ns01-systemdefault-aws-ap-northeast-2",
  "status": "",
  "keyValueList": null,
  "associatedObjectList": [
    "/ns/ns01/mcis/mc-hhh6d/vm/g1-1"
  ],
  "isAutoGenerated": false,
  "systemLabel": ""
}
```

"IdFromCsp": "**subnet-01631ba5b3eccf9b5**",