### PR TITLE
Support domestic CSPs testing (NHN, KT requires register feature)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.6
 
 require (
 	github.com/cloud-barista/cb-store v0.8.0
+	github.com/cloud-barista/mc-terrarium v0.0.7
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-playground/validator/v10 v10.17.0
 	github.com/go-resty/resty/v2 v2.11.0
@@ -30,7 +31,6 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/bwmarrin/snowflake v0.3.0 // indirect
 	github.com/cloud-barista/cb-log v0.8.0 // indirect
-	github.com/cloud-barista/mc-terrarium v0.0.7 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,14 +18,6 @@ github.com/cloud-barista/cb-log v0.8.0 h1:ArWCs1EgpoD3ZnBgcC4cAw5ufI/JHmFKfJswlv
 github.com/cloud-barista/cb-log v0.8.0/go.mod h1:nGgfTFMPwl1MpCO3FBjexUkNdOYA0BNJoyM9Pd0lMms=
 github.com/cloud-barista/cb-store v0.8.0 h1:0K47YEf+K3wx18D+m0XirlDbdTz229XxsTXw6WACjRA=
 github.com/cloud-barista/cb-store v0.8.0/go.mod h1:6NuA5TdeVRExd59ULXv6LEhm4EE0ODn9L820g4VqApo=
-github.com/cloud-barista/mc-terrarium v0.0.6-0.20240516022714-7bafe50e1df5 h1:4/OX/AF2/f4vtA4JrmAQKtjTDvZP0dcJjoChLNXAhUk=
-github.com/cloud-barista/mc-terrarium v0.0.6-0.20240516022714-7bafe50e1df5/go.mod h1:qey9GFrJidyJ3tVfeL/gcImgWLqsF64j/fVmBfaddDI=
-github.com/cloud-barista/mc-terrarium v0.0.6-0.20240516045927-43023b6a0e18 h1:tsBHD7Gh+Q0jpZ3NCh4jDM+ozlxFCfpMc2gto+G6tZQ=
-github.com/cloud-barista/mc-terrarium v0.0.6-0.20240516045927-43023b6a0e18/go.mod h1:qey9GFrJidyJ3tVfeL/gcImgWLqsF64j/fVmBfaddDI=
-github.com/cloud-barista/mc-terrarium v0.0.6 h1:6HKwnzJ1i3xRiFeboJhMMzTq/qvTt11adIBkmJrSV04=
-github.com/cloud-barista/mc-terrarium v0.0.6/go.mod h1:qey9GFrJidyJ3tVfeL/gcImgWLqsF64j/fVmBfaddDI=
-github.com/cloud-barista/mc-terrarium v0.0.7-0.20240605063928-b1786b261c06 h1:zAovyT3dYd77t2PkP2IsayYNQ3emxUyldDfmVBvRw6Y=
-github.com/cloud-barista/mc-terrarium v0.0.7-0.20240605063928-b1786b261c06/go.mod h1:qey9GFrJidyJ3tVfeL/gcImgWLqsF64j/fVmBfaddDI=
 github.com/cloud-barista/mc-terrarium v0.0.7 h1:rXBbAxZyOuwWx77xekrBylGVj9ZIOmHyYcPZkykpCag=
 github.com/cloud-barista/mc-terrarium v0.0.7/go.mod h1:qey9GFrJidyJ3tVfeL/gcImgWLqsF64j/fVmBfaddDI=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
@@ -295,8 +287,7 @@ github.com/swaggo/swag v1.16.3/go.mod h1:DImHIuOFXKpMFAQjcC7FG4m3Dg4+QuUgUzJmKjI
 github.com/syndtr/goleveldb v1.0.0 h1:fBdIW9lB4Iz0n9khmH8w27SJ3QEJ7+IgjPEwGSZiFdE=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
-github.com/tidwall/gjson v1.17.0 h1:/Jocvlh98kcTfpN2+JzGQWQcqrPQwDrVEMApx/M5ZwM=
-github.com/tidwall/gjson v1.17.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
 github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=

--- a/src/core/mcis/provisioning.go
+++ b/src/core/mcis/provisioning.go
@@ -1698,20 +1698,25 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo, option string) e
 		// Try lookup customImage
 		requestBody.ReqInfo.ImageName, err = common.GetCspResourceId(nsId, common.StrCustomImage, vmInfoData.ImageId)
 		if requestBody.ReqInfo.ImageName == "" || err != nil {
-			log.Warn().Msgf("Not found the Image: %s in nsId: %s, find it from SystemCommonNs", vmInfoData.ImageId, nsId)
+			log.Warn().Msgf("Not found %s from CustomImage in ns: %s, find it from UserImage", vmInfoData.ImageId, nsId)
 			errAgg := err.Error()
 			// If customImage doesn't exist, then try lookup image
 			requestBody.ReqInfo.ImageName, err = common.GetCspResourceId(nsId, common.StrImage, vmInfoData.ImageId)
 			if requestBody.ReqInfo.ImageName == "" || err != nil {
+				log.Warn().Msgf("Not found %s from UserImage in ns: %s, find CommonImage from SystemCommonNs", vmInfoData.ImageId, nsId)
 				errAgg += err.Error()
 				// If cannot find the resource, use common resource
 				requestBody.ReqInfo.ImageName, err = common.GetCspResourceId(common.SystemCommonNs, common.StrImage, vmInfoData.ImageId)
 				if requestBody.ReqInfo.ImageName == "" || err != nil {
 					errAgg += err.Error()
 					err = fmt.Errorf(errAgg)
-					log.Error().Err(err).Msg("")
+					log.Error().Err(err).Msgf("Not found %s both from ns %s and SystemCommonNs", vmInfoData.ImageId, nsId)
 					return err
+				} else {
+					log.Info().Msgf("Use the CommonImage: %s in SystemCommonNs", requestBody.ReqInfo.ImageName)
 				}
+			} else {
+				log.Info().Msgf("Use the UserImage: %s in ns: %s", requestBody.ReqInfo.ImageName, nsId)
 			}
 		} else {
 			customImageFlag = true
@@ -1807,7 +1812,7 @@ func CreateVm(nsId string, mcisId string, vmInfoData *TbVmInfo, option string) e
 	)
 
 	if err != nil {
-		log.Error().Err(err).Msg("")
+		log.Error().Err(err).Msg("Spider returned an error")
 		return err
 	}
 

--- a/src/testclient/scripts/8.mcis/add-subgroup-to-mcis.sh
+++ b/src/testclient/scripts/8.mcis/add-subgroup-to-mcis.sh
@@ -21,6 +21,19 @@
 	else
 		RootDiskSize="${DISK_SIZE[$INDEX,$REGION]}"
 	fi
+
+
+	# Get a Subnet from the vNet (10.25.10.1/24 condition is only for KT cloud vpc)
+	echo "- Get vNet ${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX} to designate a Subnet"
+	VNETINFO=$(curl -H "${AUTH}" -sX GET http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX})
+	SUBNETARRAY=$(jq -r '.subnetInfoList' <<<"$VNETINFO")
+	echo "$SUBNETARRAY"
+	SUBNETID=$(jq -r '.subnetInfoList[] | select(.IPv4_CIDR == "10.25.10.1/24") | .Id' <<<"$VNETINFO")
+	if [ -z "$SUBNETID" ]; then
+		SUBNETID=$(jq -r '.subnetInfoList[0].Id' <<<"$VNETINFO")
+	fi
+	echo "Designated Subnet ID (for testing only): $SUBNETID"
+
 	
 	curl -H "${AUTH}" -sX POST http://$TumblebugServer/tumblebug/ns/$NSID/mcis/$MCISID/vm -H 'Content-Type: application/json' -d \
 		'{
@@ -35,7 +48,7 @@
 				"'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'"
 			],
 			"vNetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
-			"subnetId": "'${CONN_CONFIG[$INDEX,$REGION]}'-'${POSTFIX}'",
+			"subnetId": "'${SUBNETID}'",
 			"description": "description",
 			"vmUserPassword": "",
 			"rootDiskType": "'${RootDiskType}'",

--- a/src/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud-domestic.sh
+++ b/src/testclient/scripts/sequentialFullTest/clean-mcir-ns-cloud-domestic.sh
@@ -69,7 +69,7 @@ function clean_sequence() {
 
 	fi
 
-	#if ! [ "${CSP}" == "nhncloud" ]; then
+	if ! [ "${CSP}" == "nhncloud" ]; then
 		echo '## 3. vNet: Delete'
 		OUTPUT=$(../3.vNet/delete-vNet.sh -c $CSP -r $REGION -n $POSTFIX -f $TestSetFile)
 		echo "${OUTPUT}"
@@ -99,7 +99,7 @@ function clean_sequence() {
 			done
 
 		fi
-	#fi
+	fi
 
 	#../2.configureTumblebug/delete-ns.sh $CSP $REGION $POSTFIX
 


### PR DESCRIPTION
- KTCloud VPC, NHNCloud 의 경우, 부득이하게 Network를 미리 생성하고 등록해야 함.
- Test Script에서 VM 생성시 Subnet ID를 입력해야 하지만, 외부에서 등록된 ID이고, 해당 ID가 변경될 수 있는 바, 테스트 스크립트에서는 조건부로 임의 Subnet ID를 선정하여 VM 프로비저닝을 지원하기로 함.


결과
- KTCloud VPC, NHNCloud: 테스트 스크립트(create-all)로 VM 생성 확인 완료.