### PR TITLE
Add new built-in function feature for remote cmd

### DIFF
--- a/src/core/mcis/manageInfo.go
+++ b/src/core/mcis/manageInfo.go
@@ -970,6 +970,10 @@ func GetVmCurrentPublicIp(nsId string, mcisId string, vmId string) (TbVmStatusIn
 	key := common.GenMcisKey(nsId, mcisId, vmId)
 	keyValue, err := common.CBStore.Get(key)
 	if err != nil || keyValue == nil {
+		if keyValue == nil {
+			log.Error().Err(err).Msgf("Not found: %s keyValue is nil", key)
+			return errorInfo, fmt.Errorf("Not found: %s keyValue is nil", key)
+		}
 		log.Error().Err(err).Msg("")
 		return errorInfo, err
 	}


### PR DESCRIPTION
- ref: 1438

## 원격 커맨드 요청 body를 통한, built-in function 기능 제공
- `$$Func` 로 키워드가 시작되는 경우, 빌트인 함수를 찾고 치환
  -  GetPublicIP(): MCIS의 특정 VM의 Public IP로 치환
  -  GetPublicIPs(): MCIS의 모든 VM들의 Public IP 리스트로 치환 (구분자 지정 가능)
- 리소스 지정 키워드 지원
  - target=`this`는, SSH가 실행되는 VM 또는 MCIS 자신을 의미함
  - target=`mcis`.`vm` VM을 지정하기 위해서 MCISID`.`VMID를 `.`로 이어서 입력함.
- 빌트인 함수내 파라미터 구분
  - `,`로 파라미터 구분
- 빌트인 함수내 기타 데코레이터 지원 
  - separator: 구분자 (특수문자가 있는 경우 `' '`로 감싸서 적용)
  - prefix: 앞에 붙는 스트링
  - postfix: 뒤에 붙는 스트링

## 예시
- echo $$Func(GetPublicIP(target=this)) --> 122.123.34.54
- echo $$Func(GetPublicIPs(target=this, separator=', ', prefix='http://')) --> http://122.123.34.54, http://121.23.34.5, http://121.23.134.203
- echo $$Func(GetPublicIPs(target=this, separator=', ', prefix='http://', postfix=':3000')) --> http://122.123.34.54:3000, http://121.23.34.5:3000, http://121.23.134.203:3000
- echo $$Func(GetPublicIPs(target=mcis01, separator=', ', prefix='http://', postfix=':3000')) --> http://122.123.34.54:3000, http://121.23.34.5:3000, http://121.23.134.203:3000

## GUI 지원
MapUI에서 기능 시험 가능

![image](https://github.com/cloud-barista/cb-tumblebug/assets/5966944/38348022-8955-41e7-856d-8ccbd9ecff09)

(결과)
mcisId:"mc-0p8tp"
vmId:"g1-1"
vmIp:"43.203.252.48"

command:Object
0:"echo 43.203.252.48"
1:"echo http://43.203.252.48:3000"
2:"echo http://43.203.252.48:3000"
3:"echo http://18.118.95.81:3000Xhttp://3.21.93.182:3000Xhttp://3.135.198.53:3000"

stdout:Object
0:"43.203.252.48"
1:"http://43.203.252.48:3000"
2:"http://43.203.252.48:3000"
3:"http://18.118.95.81:3000Xhttp://3.21.93.182:3000Xhttp://3.135.198.53:3000"