### PR TITLE
Allow 'default' image id for k8scluster

### DIFF
--- a/src/core/mcis/cluster.go
+++ b/src/core/mcis/cluster.go
@@ -566,7 +566,9 @@ func CreateCluster(nsId string, u *TbClusterReq, option string) (TbClusterInfo, 
 		}
 
 		spImgName := "" // Some CSPs do not require ImageName for creating a cluster
-		if v.ImageId != "" {
+		if v.ImageId == "" || v.ImageId == "default" {
+			spImgName = ""
+		} else {
 			spImgName, err = common.GetCspResourceId(nsId, common.StrImage, v.ImageId)
 			if spImgName == "" {
 				log.Error().Err(err).Msg("")


### PR DESCRIPTION
클러스터 생성시 image id에 default 값을 허용하여 공백으로 입력되도록 수정합니다.

https://github.com/cloud-barista/cb-spider/pull/1214#issuecomment-2162065250