### PR TITLE
Support GCP to Azure VPN by site-to-site VPN API

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -3527,7 +3527,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[VPN] Sites in MCIS (under development)"
+                    "[VPN] Sites in MCIS"
                 ],
                 "summary": "Get sites in MCIS",
                 "operationId": "GetSitesInMcis",
@@ -4499,7 +4499,7 @@ const docTemplate = `{
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "Get resource info of a site-to-site VPN (Currently, GCP-AWS is supported)",
-                "operationId": "GetVpnGcpToAws",
+                "operationId": "GetSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",
@@ -4574,7 +4574,7 @@ const docTemplate = `{
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "Check the status of a specific request by its ID",
-                "operationId": "GetRequestStatusOfGcpAwsVpn",
+                "operationId": "GetRequestStatusOfSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",
@@ -8524,7 +8524,7 @@ const docTemplate = `{
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "(To be provided) Update a site-to-site VPN",
-                "operationId": "PutVpnGcpToAws",
+                "operationId": "PutSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",
@@ -8599,7 +8599,7 @@ const docTemplate = `{
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "Create a site-to-site VPN (Currently, GCP-AWS is supported)",
-                "operationId": "PostVpnGcpToAws",
+                "operationId": "PostSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",
@@ -8674,7 +8674,7 @@ const docTemplate = `{
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "Delete a site-to-site VPN (Currently, GCP-AWS is supported)",
-                "operationId": "DeleteVpnGcpToAws",
+                "operationId": "DeleteSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -3520,7 +3520,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[VPN] Sites in MCIS (under development)"
+                    "[VPN] Sites in MCIS"
                 ],
                 "summary": "Get sites in MCIS",
                 "operationId": "GetSitesInMcis",
@@ -4492,7 +4492,7 @@
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "Get resource info of a site-to-site VPN (Currently, GCP-AWS is supported)",
-                "operationId": "GetVpnGcpToAws",
+                "operationId": "GetSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",
@@ -4567,7 +4567,7 @@
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "Check the status of a specific request by its ID",
-                "operationId": "GetRequestStatusOfGcpAwsVpn",
+                "operationId": "GetRequestStatusOfSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",
@@ -8517,7 +8517,7 @@
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "(To be provided) Update a site-to-site VPN",
-                "operationId": "PutVpnGcpToAws",
+                "operationId": "PutSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",
@@ -8592,7 +8592,7 @@
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "Create a site-to-site VPN (Currently, GCP-AWS is supported)",
-                "operationId": "PostVpnGcpToAws",
+                "operationId": "PostSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",
@@ -8667,7 +8667,7 @@
                     "[VPN] Site-to-site VPN (under development)"
                 ],
                 "summary": "Delete a site-to-site VPN (Currently, GCP-AWS is supported)",
-                "operationId": "DeleteVpnGcpToAws",
+                "operationId": "DeleteSiteToSiteVpn",
                 "parameters": [
                     {
                         "type": "string",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -5519,7 +5519,7 @@ paths:
             $ref: '#/definitions/common.SimpleMsg'
       summary: Get sites in MCIS
       tags:
-      - '[VPN] Sites in MCIS (under development)'
+      - '[VPN] Sites in MCIS'
   /ns/{nsId}/mcis/{mcisId}/subgroup:
     get:
       consumes:
@@ -6151,7 +6151,7 @@ paths:
       - application/json
       description: Get resource info of a site-to-site VPN (Currently, GCP-AWS is
         supported)
-      operationId: GetVpnGcpToAws
+      operationId: GetSiteToSiteVpn
       parameters:
       - default: ns01
         description: Namespace ID
@@ -6203,7 +6203,7 @@ paths:
       consumes:
       - application/json
       description: Check the status of a specific request by its ID
-      operationId: GetRequestStatusOfGcpAwsVpn
+      operationId: GetRequestStatusOfSiteToSiteVpn
       parameters:
       - default: ns01
         description: Namespace ID
@@ -8878,7 +8878,7 @@ paths:
       consumes:
       - application/json
       description: Delete a site-to-site VPN (Currently, GCP-AWS is supported)
-      operationId: DeleteVpnGcpToAws
+      operationId: DeleteSiteToSiteVpn
       parameters:
       - default: ns01
         description: Namespace ID
@@ -8924,7 +8924,7 @@ paths:
       consumes:
       - application/json
       description: Create a site-to-site VPN (Currently, GCP-AWS is supported)
-      operationId: PostVpnGcpToAws
+      operationId: PostSiteToSiteVpn
       parameters:
       - default: ns01
         description: Namespace ID
@@ -8976,7 +8976,7 @@ paths:
       consumes:
       - application/json
       description: (To be provided) Update a site-to-site VPN
-      operationId: PutVpnGcpToAws
+      operationId: PutSiteToSiteVpn
       parameters:
       - default: ns01
         description: Namespace ID

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -287,12 +287,12 @@ func RunServer(port string) {
 	// VPN Sites info
 	g.GET("/:nsId/mcis/:mcisId/site", rest_mcis.RestGetSitesInMcis)
 
-	// VPN Management
-	streamResponseGroup.POST("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestPostVpnGcpToAws)
-	g.GET("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestGetVpnGcpToAws)
-	streamResponseGroup.PUT("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestPutVpnGcpToAws)
-	streamResponseGroup.DELETE("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestDeleteVpnGcpToAws)
-	g.GET("/:nsId/mcis/:mcisId/vpn/:vpnId/request/:requestId", rest_mcis.RestGetRequestStatusOfGcpAwsVpn)
+	// Site-to-stie VPN management
+	streamResponseGroup.POST("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestPostSiteToSiteVpn)
+	g.GET("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestGetSiteToSiteVpn)
+	streamResponseGroup.PUT("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestPutSiteToSiteVpn)
+	streamResponseGroup.DELETE("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestDeleteSiteToSiteVpn)
+	g.GET("/:nsId/mcis/:mcisId/vpn/:vpnId/request/:requestId", rest_mcis.RestGetRequestStatusOfSiteToSiteVpn)
 	// TBD
 	// g.POST("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestPostVpnGcpToAws)
 	// g.PUT("/:nsId/mcis/:mcisId/vpn/:vpnId", rest_mcis.RestPutVpnGcpToAws)


### PR DESCRIPTION
* Add GCP to Azure VPN configuration
* Enhance the mechanism to check if the CSP set is valid
* Make it simple to check which CSP set it is.
* Test to CRUD a GCP to Azure VPN
* Update the handler name and API ID trivially