### PR TITLE
Add docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ log/
 *.log
 *.history
 
+# Ignore all docker-compose files created by users, except docker-compose.yaml
+*docker-compose*.yaml
+!docker-compose.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ log/
 *.log
 *.history
 
-# Ignore all docker-compose files created by users, except docker-compose.yaml
+# Ignore all docker-compose.yaml files created by users, except docker-compose.yaml
 *docker-compose*.yaml
 !docker-compose.yaml
+
+# (TBD) .env file for docker-compose
+# 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,9 @@ services:
     container_name: cb-spider
     platform: linux/amd64
     ports:
-      - "1024:1024"
-      - "2048:2048"
+      - target: 1024
+        published: 1024
+        protocol: tcp  
     volumes:
       # - ./conf/log_conf.yaml:/root/go/src/github.com/cloud-barista/cb-spider/conf/log_conf.yaml
       - ./conf/store_conf.yaml:/root/go/src/github.com/cloud-barista/cb-spider/conf/store_conf.yaml
@@ -15,30 +16,31 @@ services:
       - ./container-volume/cb-spider-container/log/:/root/go/src/github.com/cloud-barista/cb-spider/log/
     environment:
       - PLUGIN_SW=OFF
-      # - SERVER_ADDRESS=localhost
+      - SERVER_ADDRESS=localhost
       # if you leave these values empty, REST Auth will be disabled.
-      - API_USERNAME=
-      - API_PASSWORD=
+      # - API_USERNAME=
+      # - API_PASSWORD=
       - SPIDER_LOG_LEVEL=error
       - SPIDER_HISCALL_LOG_LEVEL=error
       - ID_TRANSFORM_MODE=ON
     healthcheck: # for CB-Spider
-      test: [ "CMD", "curl", "-f", "http://localhost:1323/tumblebug/readyz" ]
-      interval: 5s
-      timeout: 1s
+      test: [ "CMD", "curl", "-f", "http://localhost:1024/spider/readyz" ]
+      interval: 1m
+      timeout: 5s
       retries: 3
-      start_period: 5s
-
+      start_period: 10s
   # CB-Tumblebug
   cb-tumblebug:
     image: cloudbaristaorg/cb-tumblebug:0.9.0
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: cb-tumblebug
     platform: linux/amd64
     ports:
-      - "1323:1323"
+      - target: 1323
+        published: 1323
+        protocol: tcp
     depends_on: 
       - cb-spider
     volumes:
@@ -46,49 +48,54 @@ services:
       - ./container-volume/cb-tumblebug-container/meta_db/:/app/meta_db/
       - ./container-volume/cb-tumblebug-container/log/:/app/log/
     environment:
-      - SPIDER_CALL_METHOD=REST
+      # - CBTUMBLEBUG_ROOT=/app
+      # - CBSTORE_ROOT=/app
+      # - CBLOG_ROOT=/app
+      # - SPIDER_CALL_METHOD=REST
       - SPIDER_REST_URL=http://cb-spider:1024/spider
       # - DRAGONFLY_CALL_METHOD=REST
-      # - DRAGONFLY_REST_URL=http://cb-dragonfly:9090/dragonfly
-      - DB_URL=localhost:3306 
-      - DB_DATABASE=cb_tumblebug 
-      - DB_USER=cb_tumblebug 
-      - DB_PASSWORD=cb_tumblebug 
-      - ALLOW_ORIGINS=*
-      - ENABLE_AUTH=true
-      - API_USERNAME=default
-      - API_PASSWORD=default
-      - AUTOCONTROL_DURATION_MS=10000
+      - DRAGONFLY_REST_URL=http://cb-dragonfly:9090/dragonfly
+      # - DB_URL=localhost:3306 
+      # - DB_DATABASE=cb_tumblebug 
+      # - DB_USER=cb_tumblebug 
+      # - DB_PASSWORD=cb_tumblebug 
+      # - ALLOW_ORIGINS=*
+      # - ENABLE_AUTH=true
+      # - API_USERNAME=default
+      # - API_PASSWORD=default
+      # - AUTOCONTROL_DURATION_MS=10000
       - SELF_ENDPOINT=localhost:1323
-      - API_DOC_PATH=/app/src/api/rest/docs/swagger.json
-      - DEFAULT_NAMESPACE=ns01
-      - DEFAULT_CREDENTIALHOLDER=admin
-      - LOGFILE_PATH=$CBTUMBLEBUG_ROOT/log/tumblebug.log
-      - LOGFILE_MAXSIZE=10
-      - LOGFILE_MAXBACKUPS=3
-      - LOGFILE_MAXAGE=30
-      - LOGFILE_COMPRESS=false
-      - LOGLEVEL=debug
-      - LOGWRITER=both
-      - NODE_ENV=development
+      # - API_DOC_PATH=/app/src/api/rest/docs/swagger.json
+      # - DEFAULT_NAMESPACE=ns01
+      # - DEFAULT_CREDENTIALHOLDER=admin
+      # - LOGFILE_PATH=/app/log/tumblebug.log
+      # - LOGFILE_MAXSIZE=10
+      # - LOGFILE_MAXBACKUPS=3
+      # - LOGFILE_MAXAGE=30
+      # - LOGFILE_COMPRESS=false
+      # - LOGLEVEL=debug
+      # - LOGWRITER=both
+      # - NODE_ENV=development
     healthcheck: # for CB-Tumblebug
       test: [ "CMD", "curl", "-f", "http://localhost:1323/tumblebug/readyz" ]
-      interval: 5s
-      timeout: 1s
+      interval: 1m
+      timeout: 5s
       retries: 3
-      start_period: 5s
+      start_period: 10s
 
   # cb-mapui
   cb-mapui:
     image: cloudbaristaorg/cb-mapui:0.9.0
     container_name: cb-mapui
     ports:
-      - "1324:1324"
-    depends_on:
-      - cb-tumblebug
+      - target: 1324
+        published: 1324
+        protocol: tcp
+    # depends_on:
+    #   - cb-tumblebug
     healthcheck: # for cb-mapui
       test: ["CMD", "nc", "-vz", "localhost", "1324"]
-      interval: 5s
-      timeout: 1s
+      interval: 1m
+      timeout: 5s
       retries: 3
-      start_period: 5s
+      start_period: 10s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,94 @@
+version: "3.6"
+services:
+  # CB-Spider
+  cb-spider:
+    image: cloudbaristaorg/cb-spider:0.9.0
+    container_name: cb-spider
+    platform: linux/amd64
+    ports:
+      - "1024:1024"
+      - "2048:2048"
+    volumes:
+      # - ./conf/log_conf.yaml:/root/go/src/github.com/cloud-barista/cb-spider/conf/log_conf.yaml
+      - ./conf/store_conf.yaml:/root/go/src/github.com/cloud-barista/cb-spider/conf/store_conf.yaml
+      - ./container-volume/cb-spider-container/meta_db/:/root/go/src/github.com/cloud-barista/cb-spider/meta_db/
+      - ./container-volume/cb-spider-container/log/:/root/go/src/github.com/cloud-barista/cb-spider/log/
+    environment:
+      - PLUGIN_SW=OFF
+      # - SERVER_ADDRESS=localhost
+      # if you leave these values empty, REST Auth will be disabled.
+      - API_USERNAME=
+      - API_PASSWORD=
+      - SPIDER_LOG_LEVEL=error
+      - SPIDER_HISCALL_LOG_LEVEL=error
+      - ID_TRANSFORM_MODE=ON
+    healthcheck: # for CB-Spider
+      test: [ "CMD", "curl", "-f", "http://localhost:1323/tumblebug/readyz" ]
+      interval: 5s
+      timeout: 1s
+      retries: 3
+      start_period: 5s
+
+  # CB-Tumblebug
+  cb-tumblebug:
+    image: cloudbaristaorg/cb-tumblebug:0.9.0
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    container_name: cb-tumblebug
+    platform: linux/amd64
+    ports:
+      - "1323:1323"
+    depends_on: 
+      - cb-spider
+    volumes:
+      - ./conf/:/app/conf/
+      - ./container-volume/cb-tumblebug-container/meta_db/:/app/meta_db/
+      - ./container-volume/cb-tumblebug-container/log/:/app/log/
+    environment:
+      - SPIDER_CALL_METHOD=REST
+      - SPIDER_REST_URL=http://cb-spider:1024/spider
+      # - DRAGONFLY_CALL_METHOD=REST
+      # - DRAGONFLY_REST_URL=http://cb-dragonfly:9090/dragonfly
+      - DB_URL=localhost:3306 
+      - DB_DATABASE=cb_tumblebug 
+      - DB_USER=cb_tumblebug 
+      - DB_PASSWORD=cb_tumblebug 
+      - ALLOW_ORIGINS=*
+      - ENABLE_AUTH=true
+      - API_USERNAME=default
+      - API_PASSWORD=default
+      - AUTOCONTROL_DURATION_MS=10000
+      - SELF_ENDPOINT=localhost:1323
+      - API_DOC_PATH=/app/src/api/rest/docs/swagger.json
+      - DEFAULT_NAMESPACE=ns01
+      - DEFAULT_CREDENTIALHOLDER=admin
+      - LOGFILE_PATH=$CBTUMBLEBUG_ROOT/log/tumblebug.log
+      - LOGFILE_MAXSIZE=10
+      - LOGFILE_MAXBACKUPS=3
+      - LOGFILE_MAXAGE=30
+      - LOGFILE_COMPRESS=false
+      - LOGLEVEL=debug
+      - LOGWRITER=both
+      - NODE_ENV=development
+    healthcheck: # for CB-Tumblebug
+      test: [ "CMD", "curl", "-f", "http://localhost:1323/tumblebug/readyz" ]
+      interval: 5s
+      timeout: 1s
+      retries: 3
+      start_period: 5s
+
+  # cb-mapui
+  cb-mapui:
+    image: cloudbaristaorg/cb-mapui:0.9.0
+    container_name: cb-mapui
+    ports:
+      - "1324:1324"
+    depends_on:
+      - cb-tumblebug
+    healthcheck: # for cb-mapui
+      test: ["CMD", "nc", "-vz", "localhost", "1324"]
+      interval: 5s
+      timeout: 1s
+      retries: 3
+      start_period: 5s


### PR DESCRIPTION
* Add docker-compose.yaml to provide a stable set of subsystems
* Ignore all docker-compose files created by users, except docker-compose.yaml

Tumblebug users/contributors can make and use their copies from docker-compose.yaml.
(e.g,. `docker-compose -f my-docker-compose.yaml up`, `docker-compose -f docker-compose2.yaml up`, and so on)

docker-compose.yaml has been tested on the following environment.
- Ubuntu 22.04.3 LTS on Windows Subsystem for Linux 2 (WLS 2)
- Docker 27.0.3
- Docker Compose 1.29.2

Test completed
- Create and delete MCIS across AWS, Azure, and GCP on mapui

Please review the changes in this pull request :-)

Close #1661 
