### PR TITLE
Modify swaggo/swag `@securityDefinitions`

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -299,11 +299,12 @@ func setConfig() {
 
 // @BasePath /tumblebug
 
-// // @securityDefinitions.basic BasicAuth
+// @securityDefinitions.basic BasicAuth
+
 // @securityDefinitions.apikey Bearer
 // @in header
 // @name Authorization
-// @description Type "Bearer" followed by a space and JWT token (get token in http://localhost:8056/auth)
+// @description Type "Bearer" followed by a space and JWT token ([TBD] Get token in http://xxx.xxx.xxx.xxx:xxx/auth)
 func main() {
 
 	// giving a default value of "1323"


### PR DESCRIPTION
This PR will enable two authentication interfaces in Swagger UI as follows.

Ref: [How to use security annotations from swaggo/swag](https://github.com/swaggo/swag?tab=readme-ov-file#how-to-use-security-annotations)

[추가 설명]

: Authorize 클릭
<img src="https://github.com/user-attachments/assets/43176c94-db81-44a0-9540-c6373bed9773" width="100%"/>

: BasicAuth를 기본 활용
<img src="https://github.com/user-attachments/assets/b9bef6e8-b8d1-477f-a95f-e9e41753d444" width="60%"/>

: JWT test를 위한 API 에서 자물쇠 클릭 시
<img src="https://github.com/user-attachments/assets/a4aeb079-5d9b-404e-bd72-5d9203246762" width="100%"/>

: JWT 인증 관련 팝업(현 시점에 사용되지 않음)
<img src="https://github.com/user-attachments/assets/c5b88314-126e-4330-ac87-bf6d9a8bf860" width="60%"/>


위 Bearer 인증 부분은 인증 서버를 엔트포인트가 필요한 상황입니다. 데모 및 테스트 용으로 MC-IAM-MANAGER에서 공유된 서버를 기재해 놓을 수 있지만, 현 상황에서는 안전하지 않은 방법이라는 생각이 듭니다. 

따라서, '([TBD] Get token in http://xxx.xxx.xxx.xxx:xxx/auth)' 으로 뼈대만을 적용해 두고, 추후 아래 방안 중 적절한 것으로 추진하면 될 것 같습니다.
* 인증 서버 연동 및 정보 수정
* 인증 서버 연동 가이드 제공
