### PR TITLE
Add encryption decryption script for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,19 @@ To provisioning multi-cloud infrastructures with CB-TB, it is necessary to regis
           ClientSecret:
         ...
     ```
+    - Encrypt `credentials.yaml` into `credentials.yaml.enc`
+      To protect sensitive information, `credentials.yaml` is not used directly. Instead, it must be encrypted using `encCredential.sh`. The encrypted file `credentials.yaml.enc` is then used by `init.py`. This approach ensures that sensitive credentials are not stored in plain text.
+
+      If you need to update your credentials, decrypt the encrypted file using `decCredential.sh`, make the necessary changes to `credentials.yaml`, and then re-encrypt it.
+      - Encrypting Credentials
+        ```bash
+        scripts/init/encCredential.sh
+        ```
+      - Decrypting Credentials
+        ```bash
+        scripts/init/decCredential.sh
+        ```
+
 - Register all multi-cloud connection information and common resources
   - How to register
   

--- a/scripts/init/README.md
+++ b/scripts/init/README.md
@@ -15,6 +15,18 @@ The `init.py` script is designed to automate the process of registering credenti
 - The `python3-venv` package should be installed for running the script using `init.sh`.
 
 ## Usage
+
+### Encrypting Credentials
+Before running `init.py`, you must encrypt your `credentials.yaml` file to ensure the security of your sensitive information.
+
+1. Use the `encCredential.sh` script to encrypt your `credentials.yaml` file:
+```bash
+scripts/init/encCredential.sh
+```
+
+The `init.py` script will decrypt the `credentials.yaml.enc` file as needed to read the credentials. You may need to provide a password if the decryption key is not stored.
+
+
 ### Direct Execution
 ```bash
 pip3 install -r requirements.txt
@@ -42,9 +54,25 @@ Before running the script, ensure the following environment variables are set ac
 - `API_USERNAME`: Username for API authentication.
 - `API_PASSWORD`: Password for API authentication.
 
+## Security Considerations
+To protect sensitive information, `credentials.yaml` is not used directly. Instead, it must be encrypted using `encCredential.sh`. The encrypted file `credentials.yaml.enc` is then used by `init.py`. This approach ensures that sensitive credentials are not stored in plain text.
+
+If you need to update your credentials, decrypt the encrypted file using `decCredential.sh`, make the necessary changes to `credentials.yaml`, and then re-encrypt it.
+
+### Encrypting Credentials
+```bash
+scripts/init/encCredential.sh
+```
+
+### Decrypting Credentials
+```bash
+scripts/init/decCredential.sh
+```
 
 ## Related Files
 - `init.py`: Main Python script.
 - `requirements.txt`: Contains all Python dependencies.
 - `init.sh`: Bash script for setting up a Python virtual environment and running `init.py`.
 - `credentials.yaml`: Contains the credentials data to be registered with the Tumblebug server.
+- `encCredential.sh`: Script to encrypt `credentials.yaml`.
+- `decCredential.sh`: Script to decrypt `credentials.yaml.enc`.

--- a/scripts/init/decCredential.sh
+++ b/scripts/init/decCredential.sh
@@ -40,6 +40,8 @@ fi
 # Prompt for password or use the key file
 if [ -f "$KEY_FILE" ]; then
     TB_CRED_DECRYPT_KEY=$(cat "$KEY_FILE")
+    echo -e "\n${YELLOW}Using the temporary key file for decryption: ${CYAN}$KEY_FILE${NC}"
+    echo -e "${RED}Warning: It is not recommended to use temporary key file continuously. Please manage the key securely and delete the file after use.${NC}"
 else
     read -sp "Enter the password: " PASSWORD
     echo
@@ -64,6 +66,9 @@ if [ $? -eq 0 ]; then
     echo -e "(Encrypted file deleted: $ENCRYPTED_FILE)\n"
 else
     echo -e "\n${RED}Failed to decrypt the file. Exiting.${NC}\n"
+    if [ -f "$KEY_FILE" ]; then
+        echo -e "${RED}Failed to decrypt the file using the key file. Please delete the key file and retry with manual password input.${NC}"
+    fi
     echo -e "${RED}log: ${DECRYPT_OUTPUT}${NC}\n"
     rm -f "$TEMP_DECRYPTED_FILE"  # Remove the temporary file if decryption failed
     exit 1

--- a/scripts/init/decCredential.sh
+++ b/scripts/init/decCredential.sh
@@ -1,47 +1,56 @@
 #!/bin/bash
 
+# Define colors for output
+RED='\033[0;31m'
+LGREEN='\033[1;32m'
+PURPLE='\033[0;35m'
+NC='\033[0m' # No Color
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+
 CRED_FILE_NAME="credentials.yaml"
 CRED_PATH="$HOME/.cloud-barista"
 FILE_PATH="$CRED_PATH/$CRED_FILE_NAME"
 ENCRYPTED_FILE="$FILE_PATH.enc"
 TEMP_DECRYPTED_FILE="$FILE_PATH.tmp"
+KEY_FILE="$CRED_PATH/cred_key"
 
 # Check if OpenSSL is installed
 if ! command -v openssl &> /dev/null; then
-    echo "OpenSSL is not installed. Installation guide:"
-    echo "Ubuntu/Debian: sudo apt-get install openssl"
-    echo "CentOS/RHEL: sudo yum install openssl"
-    echo "Fedora: sudo dnf install openssl"
-    echo "Arch Linux: sudo pacman -S openssl"
+    echo -e "\n${RED}OpenSSL is not installed. Installation guide:${NC}"
+    echo -e "${LGREEN}Ubuntu/Debian:${NC} sudo apt-get install openssl"
+    echo -e "${LGREEN}CentOS/RHEL:${NC} sudo yum install openssl"
+    echo -e "${LGREEN}Fedora:${NC} sudo dnf install openssl"
+    echo -e "${LGREEN}Arch Linux:${NC} sudo pacman -S openssl\n"
     exit 1
 fi
 
 # Check if the file is already decrypted
 if [ -f "$FILE_PATH" ]; then
-    echo "The file is already decrypted."
+    echo -e "\n${RED}The file is already decrypted.${NC}\n"
     exit 0
 fi
 
 # Check if the encrypted file exists
 if [ ! -f "$ENCRYPTED_FILE" ]; then
-    echo "The encrypted file does not exist: $ENCRYPTED_FILE"
+    echo -e "\n${RED}The encrypted file does not exist: ${CYAN}$ENCRYPTED_FILE${NC}\n"
     exit 1
 fi
 
-# Prompt for password or use the environment variable
-if [ -z "$TB_CRED_DECRYPT_KEY" ]; then
+# Prompt for password or use the key file
+if [ -f "$KEY_FILE" ]; then
+    TB_CRED_DECRYPT_KEY=$(cat "$KEY_FILE")
+else
     read -sp "Enter the password: " PASSWORD
     echo
 
     if [ -z "$PASSWORD" ]; then
-        echo "Password is required."
+        echo -e "\n${RED}Password is required.${NC}\n"
         exit 1
     fi
 
-    # Set the environment variable for the decryption key
+    # Use the entered password
     TB_CRED_DECRYPT_KEY=$PASSWORD
-else
-    echo "Using key from environment variable TB_CRED_DECRYPT_KEY"
 fi
 
 # Decrypt the file to a temporary file, suppressing OpenSSL error messages
@@ -51,10 +60,12 @@ DECRYPT_OUTPUT=$(openssl enc -aes-256-cbc -d -pbkdf2 -in "$ENCRYPTED_FILE" -out 
 if [ $? -eq 0 ]; then
     mv "$TEMP_DECRYPTED_FILE" "$FILE_PATH"
     rm "$ENCRYPTED_FILE"
-    echo "File successfully decrypted: $FILE_PATH"
-    echo "Encrypted file deleted: $ENCRYPTED_FILE"
+    echo -e "\n${LGREEN}File successfully decrypted: ${CYAN}$FILE_PATH${NC}"
+    echo -e "(Encrypted file deleted: $ENCRYPTED_FILE)\n"
 else
-    echo "Failed to decrypt the file. Exiting."
+    echo -e "\n${RED}Failed to decrypt the file. Exiting.${NC}\n"
+    echo -e "${RED}log: ${DECRYPT_OUTPUT}${NC}\n"
     rm -f "$TEMP_DECRYPTED_FILE"  # Remove the temporary file if decryption failed
     exit 1
 fi
+

--- a/scripts/init/decCredential.sh
+++ b/scripts/init/decCredential.sh
@@ -13,7 +13,7 @@ CRED_PATH="$HOME/.cloud-barista"
 FILE_PATH="$CRED_PATH/$CRED_FILE_NAME"
 ENCRYPTED_FILE="$FILE_PATH.enc"
 TEMP_DECRYPTED_FILE="$FILE_PATH.tmp"
-KEY_FILE="$CRED_PATH/cred_key"
+KEY_FILE="$CRED_PATH/.tmp_enc_key"
 
 # Check if OpenSSL is installed
 if ! command -v openssl &> /dev/null; then

--- a/scripts/init/decCredential.sh
+++ b/scripts/init/decCredential.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+CRED_FILE_NAME="credentials.yaml"
+CRED_PATH="$HOME/.cloud-barista"
+FILE_PATH="$CRED_PATH/$CRED_FILE_NAME"
+ENCRYPTED_FILE="$FILE_PATH.enc"
+TEMP_DECRYPTED_FILE="$FILE_PATH.tmp"
+
+# Check if OpenSSL is installed
+if ! command -v openssl &> /dev/null; then
+    echo "OpenSSL is not installed. Installation guide:"
+    echo "Ubuntu/Debian: sudo apt-get install openssl"
+    echo "CentOS/RHEL: sudo yum install openssl"
+    echo "Fedora: sudo dnf install openssl"
+    echo "Arch Linux: sudo pacman -S openssl"
+    exit 1
+fi
+
+# Check if the file is already decrypted
+if [ -f "$FILE_PATH" ]; then
+    echo "The file is already decrypted."
+    exit 0
+fi
+
+# Check if the encrypted file exists
+if [ ! -f "$ENCRYPTED_FILE" ]; then
+    echo "The encrypted file does not exist: $ENCRYPTED_FILE"
+    exit 1
+fi
+
+# Prompt for password or use the environment variable
+if [ -z "$TB_CRED_DECRYPT_KEY" ]; then
+    read -sp "Enter the password: " PASSWORD
+    echo
+
+    if [ -z "$PASSWORD" ]; then
+        echo "Password is required."
+        exit 1
+    fi
+
+    # Set the environment variable for the decryption key
+    TB_CRED_DECRYPT_KEY=$PASSWORD
+else
+    echo "Using key from environment variable TB_CRED_DECRYPT_KEY"
+fi
+
+# Decrypt the file to a temporary file, suppressing OpenSSL error messages
+DECRYPT_OUTPUT=$(openssl enc -aes-256-cbc -d -pbkdf2 -in "$ENCRYPTED_FILE" -out "$TEMP_DECRYPTED_FILE" -pass pass:"$TB_CRED_DECRYPT_KEY" 2>&1)
+
+# Check if decryption was successful
+if [ $? -eq 0 ]; then
+    mv "$TEMP_DECRYPTED_FILE" "$FILE_PATH"
+    rm "$ENCRYPTED_FILE"
+    echo "File successfully decrypted: $FILE_PATH"
+    echo "Encrypted file deleted: $ENCRYPTED_FILE"
+else
+    echo "Failed to decrypt the file. Exiting."
+    rm -f "$TEMP_DECRYPTED_FILE"  # Remove the temporary file if decryption failed
+    exit 1
+fi

--- a/scripts/init/encCredential.sh
+++ b/scripts/init/encCredential.sh
@@ -13,7 +13,7 @@ CRED_PATH="$HOME/.cloud-barista"
 FILE_PATH="$CRED_PATH/$CRED_FILE_NAME"
 ENCRYPTED_FILE="$FILE_PATH.enc"
 TEMP_DECRYPTED_FILE="$FILE_PATH.tmp.dec"
-KEY_FILE="$CRED_PATH/cred_key"
+KEY_FILE="$CRED_PATH/.tmp_enc_key"
 SCRIPT_DIR=$(dirname "$(realpath "$0")")
 DECRYPT_SCRIPT_PATH="$SCRIPT_DIR/decCredential.sh"
 

--- a/scripts/init/encCredential.sh
+++ b/scripts/init/encCredential.sh
@@ -58,7 +58,8 @@ while true; do
 done
 
 # Prompt for password
-read -sp "Enter a password (press enter to generate a random key): " PASSWORD
+echo -e "Enter a password (press ${YELLOW}enter${NC} to generate a random key): \c"
+read -sp "" PASSWORD
 echo
 if [ -n "$PASSWORD" ]; then
     read -sp "Confirm the password: " PASSWORD_CONFIRM
@@ -76,9 +77,31 @@ if [ -n "$PASSWORD" ]; then
 else
     # Generate a random key
     TB_CRED_DECRYPT_KEY=$(openssl rand -base64 64 | tr -d '\n')
-    echo "$TB_CRED_DECRYPT_KEY" > "$KEY_FILE"
-    echo -e "\n${YELLOW}A random encryption key was generated and saved to ${CYAN}$KEY_FILE${NC}"
-    echo -e "${YELLOW}This file should be used temporarily. Please store the key securely.${NC}\n"
+    echo -e "${YELLOW}A random key has been generated for encryption.${NC}\n"
+    while true; do
+        echo -e "Do you want to ${YELLOW}save${NC} the key to a temporary file or ${LGREEN}print${NC} it to stdout? (${YELLOW}s${NC}/${LGREEN}p${NC}): \c"
+        read -e OUTPUT_OPTION
+        case $OUTPUT_OPTION in
+            s )
+                echo "$TB_CRED_DECRYPT_KEY" > "$KEY_FILE"
+                echo -e "\n${LGREEN}The encryption key has been saved to: ${CYAN}$KEY_FILE${NC}"
+                echo -e "${RED}Warning: It is not recommended to use this temporary file continuously. Please manage the key securely and delete the file after use.${NC}"
+                break
+                ;;
+            p )
+                echo -e "\n${LGREEN}Encryption Key: ${CYAN}$TB_CRED_DECRYPT_KEY${NC}"
+                echo -e "${RED}Warning: Please copy and manage the key securely. This key will not be shown again.${NC}"
+                # Delete the existing key file if any
+                if [ -f "$KEY_FILE" ]; then
+                    rm "$KEY_FILE"
+                fi
+                break
+                ;;
+            * )
+                echo -e "${RED}Please answer 's' for save or 'p' for print.${NC}"
+                ;;
+        esac
+    done
 fi
 
 # Encrypt the file
@@ -90,8 +113,8 @@ if [ $? -eq 0 ]; then
     if [ $? -eq 0 ] && cmp -s "$FILE_PATH" "$TEMP_DECRYPTED_FILE"; then
         rm "$TEMP_DECRYPTED_FILE"
         rm "$FILE_PATH"
-        echo -e "\n${LGREEN}File successfully encrypted: ${CYAN}$ENCRYPTED_FILE${NC}"
-        echo -e "${LGREEN}Original file deleted: ${CYAN}$FILE_PATH${NC}\n"
+        echo -e "\n${YELLOW}File successfully encrypted${NC}: ${CYAN}$ENCRYPTED_FILE${NC}"
+        echo -e "(Original file deleted: ${CYAN}$FILE_PATH${NC})\n"
         echo -e "${YELLOW}To edit the credentials,${NC}"
         echo -e "Use ${CYAN}$DECRYPT_SCRIPT_PATH${NC} to decrypt the file"
         echo -e "Then edit ${CYAN}$FILE_PATH${NC}\n"

--- a/scripts/init/encCredential.sh
+++ b/scripts/init/encCredential.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+CRED_FILE_NAME="credentials.yaml"
+CRED_PATH="$HOME/.cloud-barista"
+FILE_PATH="$CRED_PATH/$CRED_FILE_NAME"
+ENCRYPTED_FILE="$FILE_PATH.enc"
+TEMP_DECRYPTED_FILE="$FILE_PATH.tmp.dec"
+
+# Check if OpenSSL is installed
+if ! command -v openssl &> /dev/null; then
+    echo "OpenSSL is not installed. Installation guide:"
+    echo "Ubuntu/Debian: sudo apt-get install openssl"
+    echo "CentOS/RHEL: sudo yum install openssl"
+    echo "Fedora: sudo dnf install openssl"
+    echo "Arch Linux: sudo pacman -S openssl"
+    exit 1
+fi
+
+# Check if the file is already encrypted
+if [ -f "$ENCRYPTED_FILE" ]; then
+    echo "The file is already encrypted."
+    exit 0
+fi
+
+# Check if the file to be encrypted exists
+if [ ! -f "$FILE_PATH" ]; then
+    echo "The file to be encrypted does not exist: $FILE_PATH"
+    exit 1
+fi
+
+# Prompt to proceed with encryption
+read -p "Do you want to encrypt the file $FILE_PATH? (y/n): " CONFIRM
+if [ "$CONFIRM" != "y" ]; then
+    echo "Encryption process aborted."
+    exit 0
+fi
+
+# Prompt for password
+read -sp "Enter a password (press enter to generate a random key): " PASSWORD
+echo
+if [ -n "$PASSWORD" ]; then
+    read -sp "Confirm the password: " PASSWORD_CONFIRM
+    echo
+    if [ "$PASSWORD" != "$PASSWORD_CONFIRM" ]; then
+        echo "Passwords do not match. Encryption aborted."
+        exit 1
+    fi
+fi
+
+if [ -z "$PASSWORD" ]; then
+    # Generate a random key
+    TB_CRED_DECRYPT_KEY=$(openssl rand -base64 64 | tr -d '\n')
+else
+    TB_CRED_DECRYPT_KEY=$PASSWORD
+fi
+
+# Encrypt the file
+openssl enc -aes-256-cbc -salt -pbkdf2 -in "$FILE_PATH" -out "$ENCRYPTED_FILE" -pass pass:"$TB_CRED_DECRYPT_KEY"
+
+if [ $? -eq 0 ]; then
+    # Verify encryption by decrypting the file to a temporary file
+    openssl enc -aes-256-cbc -d -pbkdf2 -in "$ENCRYPTED_FILE" -out "$TEMP_DECRYPTED_FILE" -pass pass:"$TB_CRED_DECRYPT_KEY"
+    if [ $? -eq 0 ] && cmp -s "$FILE_PATH" "$TEMP_DECRYPTED_FILE"; then
+        rm "$TEMP_DECRYPTED_FILE"
+        rm "$FILE_PATH"
+        echo "File successfully encrypted: $ENCRYPTED_FILE"
+        echo "Original file deleted: $FILE_PATH"
+        if [ -z "$PASSWORD" ]; then
+            echo "Your encryption key is: $TB_CRED_DECRYPT_KEY"
+            echo "To decrypt the file, export the key as an environment variable:"
+            echo "export TB_CRED_DECRYPT_KEY=\"$TB_CRED_DECRYPT_KEY\""
+        fi
+    else
+        echo "Encryption verification failed."
+        if [ $? -ne 0 ]; then
+            echo "Decryption failed during verification."
+        else
+            echo "File comparison failed during verification."
+        fi
+        rm "$TEMP_DECRYPTED_FILE"
+    fi
+else
+    echo "Failed to encrypt the file."
+fi

--- a/scripts/init/encCredential.sh
+++ b/scripts/init/encCredential.sh
@@ -1,39 +1,61 @@
 #!/bin/bash
 
+# Define colors for output
+RED='\033[0;31m'
+LGREEN='\033[1;32m'
+PURPLE='\033[0;35m'
+NC='\033[0m' # No Color
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+
 CRED_FILE_NAME="credentials.yaml"
 CRED_PATH="$HOME/.cloud-barista"
 FILE_PATH="$CRED_PATH/$CRED_FILE_NAME"
 ENCRYPTED_FILE="$FILE_PATH.enc"
 TEMP_DECRYPTED_FILE="$FILE_PATH.tmp.dec"
+KEY_FILE="$CRED_PATH/cred_key"
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+DECRYPT_SCRIPT_PATH="$SCRIPT_DIR/decCredential.sh"
 
 # Check if OpenSSL is installed
 if ! command -v openssl &> /dev/null; then
-    echo "OpenSSL is not installed. Installation guide:"
-    echo "Ubuntu/Debian: sudo apt-get install openssl"
-    echo "CentOS/RHEL: sudo yum install openssl"
-    echo "Fedora: sudo dnf install openssl"
-    echo "Arch Linux: sudo pacman -S openssl"
+    echo -e "\n${RED}OpenSSL is not installed. Installation guide:${NC}"
+    echo -e "${LGREEN}Ubuntu/Debian:${NC} sudo apt-get install openssl"
+    echo -e "${LGREEN}CentOS/RHEL:${NC} sudo yum install openssl"
+    echo -e "${LGREEN}Fedora:${NC} sudo dnf install openssl"
+    echo -e "${LGREEN}Arch Linux:${NC} sudo pacman -S openssl\n"
     exit 1
 fi
 
 # Check if the file is already encrypted
 if [ -f "$ENCRYPTED_FILE" ]; then
-    echo "The file is already encrypted."
+    echo -e "\n${RED}The file is already encrypted.${NC}\n"
     exit 0
 fi
 
 # Check if the file to be encrypted exists
 if [ ! -f "$FILE_PATH" ]; then
-    echo "The file to be encrypted does not exist: $FILE_PATH"
+    echo -e "\n${RED}The file to be encrypted does not exist: ${CYAN}$FILE_PATH${NC}\n"
     exit 1
 fi
 
 # Prompt to proceed with encryption
-read -p "Do you want to encrypt the file $FILE_PATH? (y/n): " CONFIRM
-if [ "$CONFIRM" != "y" ]; then
-    echo "Encryption process aborted."
-    exit 0
-fi
+while true; do
+    echo -e "\nDo you want to encrypt the file ${CYAN}$FILE_PATH${NC}? (y/n): \c"
+    read -e CONFIRM
+    case $CONFIRM in
+        [Yy]* )
+            break
+            ;;
+        [Nn]* )
+            echo -e "\n${RED}Encryption process aborted.${NC}\n"
+            exit 0
+            ;;
+        * )
+            echo -e "\n${RED}Please answer yes or no.${NC}\n"
+            ;;
+    esac
+done
 
 # Prompt for password
 read -sp "Enter a password (press enter to generate a random key): " PASSWORD
@@ -42,16 +64,21 @@ if [ -n "$PASSWORD" ]; then
     read -sp "Confirm the password: " PASSWORD_CONFIRM
     echo
     if [ "$PASSWORD" != "$PASSWORD_CONFIRM" ]; then
-        echo "Passwords do not match. Encryption aborted."
+        echo -e "\n${RED}Passwords do not match. Encryption aborted.${NC}\n"
         exit 1
     fi
-fi
-
-if [ -z "$PASSWORD" ]; then
+    TB_CRED_DECRYPT_KEY=$PASSWORD
+    # Delete the existing key file if any
+    if [ -f "$KEY_FILE" ]; then
+        rm "$KEY_FILE"
+    fi
+    echo -e "\n${YELLOW}Remember the password you have entered. You will need it to decrypt the file.${NC}\n"
+else
     # Generate a random key
     TB_CRED_DECRYPT_KEY=$(openssl rand -base64 64 | tr -d '\n')
-else
-    TB_CRED_DECRYPT_KEY=$PASSWORD
+    echo "$TB_CRED_DECRYPT_KEY" > "$KEY_FILE"
+    echo -e "\n${YELLOW}A random encryption key was generated and saved to ${CYAN}$KEY_FILE${NC}"
+    echo -e "${YELLOW}This file should be used temporarily. Please store the key securely.${NC}\n"
 fi
 
 # Encrypt the file
@@ -63,22 +90,20 @@ if [ $? -eq 0 ]; then
     if [ $? -eq 0 ] && cmp -s "$FILE_PATH" "$TEMP_DECRYPTED_FILE"; then
         rm "$TEMP_DECRYPTED_FILE"
         rm "$FILE_PATH"
-        echo "File successfully encrypted: $ENCRYPTED_FILE"
-        echo "Original file deleted: $FILE_PATH"
-        if [ -z "$PASSWORD" ]; then
-            echo "Your encryption key is: $TB_CRED_DECRYPT_KEY"
-            echo "To decrypt the file, export the key as an environment variable:"
-            echo "export TB_CRED_DECRYPT_KEY=\"$TB_CRED_DECRYPT_KEY\""
-        fi
+        echo -e "\n${LGREEN}File successfully encrypted: ${CYAN}$ENCRYPTED_FILE${NC}"
+        echo -e "${LGREEN}Original file deleted: ${CYAN}$FILE_PATH${NC}\n"
+        echo -e "${YELLOW}To edit the credentials,${NC}"
+        echo -e "Use ${CYAN}$DECRYPT_SCRIPT_PATH${NC} to decrypt the file"
+        echo -e "Then edit ${CYAN}$FILE_PATH${NC}\n"
     else
-        echo "Encryption verification failed."
+        echo -e "\n${RED}Encryption verification failed.${NC}\n"
         if [ $? -ne 0 ]; then
-            echo "Decryption failed during verification."
+            echo -e "${RED}Decryption failed during verification.${NC}\n"
         else
-            echo "File comparison failed during verification."
+            echo -e "${RED}File comparison failed during verification.${NC}\n"
         fi
         rm "$TEMP_DECRYPTED_FILE"
     fi
 else
-    echo "Failed to encrypt the file."
+    echo -e "\n${RED}Failed to encrypt the file.${NC}\n"
 fi

--- a/scripts/init/init.py
+++ b/scripts/init/init.py
@@ -31,7 +31,7 @@ HEADERS = {'Authorization': AUTH, 'Content-Type': 'application/json'}
 CRED_FILE_NAME_ENC = "credentials.yaml.enc"
 CRED_PATH = os.path.join(os.path.expanduser('~'), '.cloud-barista')
 ENC_FILE_PATH = os.path.join(CRED_PATH, CRED_FILE_NAME_ENC)
-KEY_FILE = os.path.join(CRED_PATH, "cred_key")
+KEY_FILE = os.path.join(CRED_PATH, ".tmp_enc_key")
 
 expected_completion_time_seconds = 240
 


### PR DESCRIPTION
to enhance security.

### Force encrypting `credentials.yaml` into `credentials.yaml.enc`

To protect sensitive information, `credentials.yaml` is not used directly. Instead, it must be encrypted using `encCredential.sh`. The encrypted file `credentials.yaml.enc` is then used by `init.py`. This approach ensures that sensitive credentials are not stored in plain text.

If you need to update your credentials, decrypt the encrypted file using `decCredential.sh`, make the necessary changes to `credentials.yaml`, and then re-encrypt it.

- Encrypting Credentials
  ```bash
  scripts/init/encCredential.sh
   ```

- Decrypting Credentials
   ```bash
   scripts/init/decCredential.sh
   ```