### PR TITLE
Add `kvstore` pkg and improve functionality 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - --log-outputs
       - stderr
     healthcheck:
-      test: [ "/usr/local/bin/etcd", "--version"]
+      test: [ "CMD", "/usr/local/bin/etcd", "--version"]
       interval: 1m
       timeout: 5s
       retries: 3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,46 @@
 version: "3.6"
 services:
+  # etcd
+  etcd:
+    image: gcr.io/etcd-development/etcd:v3.5.14
+    container_name: etcd-gcr-v3.5.14
+    ports:
+      - "2379:2379"
+      - "2380:2380"
+    volumes: 
+      - ./container-volume/etcd/data:/etcd-data
+    entrypoint: /usr/local/bin/etcd
+    command:
+      - --name
+      - s1
+      - --data-dir
+      - /etcd-data
+      - --listen-client-urls
+      - http://0.0.0.0:2379
+      - --advertise-client-urls
+      - http://0.0.0.0:2379
+      - --listen-peer-urls
+      - http://0.0.0.0:2380
+      - --initial-advertise-peer-urls
+      - http://0.0.0.0:2380
+      - --initial-cluster
+      - s1=http://0.0.0.0:2380
+      - --initial-cluster-token
+      - tkn
+      - --initial-cluster-state
+      - new
+      - --log-level
+      - info
+      - --logger
+      - zap
+      - --log-outputs
+      - stderr
+    healthcheck:
+      test: [ "/usr/local/bin/etcd", "--version"]
+      interval: 1m
+      timeout: 5s
+      retries: 3
+      start_period: 10s
   # CB-Spider
   cb-spider:
     image: cloudbaristaorg/cb-spider:0.9.0

--- a/src/api/rest/server/mcis/network.go
+++ b/src/api/rest/server/mcis/network.go
@@ -1358,7 +1358,7 @@ func RestGetRequestStatusOfSiteToSiteVpn(c echo.Context) error {
 	}
 
 	reqId := c.Param("requestId")
-	if vpnId == "" {
+	if reqId == "" {
 		err := fmt.Errorf("invalid request, request ID (requestId: %s) is required", reqId)
 		log.Warn().Msg(err.Error())
 		res := model.Response{

--- a/src/examples/kvstore/main.go
+++ b/src/examples/kvstore/main.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
+	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvutil"
+)
+
+func main() {
+	// EtcdStore configuration
+	config := kvstore.Config{
+		Endpoints:   []string{"localhost:2379"}, // Replace with your etcd server endpoints
+		DialTimeout: 5 * time.Second,
+	}
+
+	// Create EtcdStore instance (singleton)
+	ctx := context.Background()
+	etcd, err := kvstore.NewEtcd(ctx, config)
+	if err != nil {
+		log.Fatalf("Failed to create EtcdStore: %v", err)
+	}
+	defer etcd.Close()
+
+	ctx2 := context.Background() // Create context for etcd operations
+
+	// Basic CRUD operations test
+	fmt.Println("\n## Basic CRUD operations test")
+	ExampleBasicCRUDTest(ctx2, etcd)
+
+	// Race condition test
+	fmt.Println("\n## ExampleRaceConditionTest")
+	ExampleRaceConditionTest(ctx2, etcd)
+
+	// FilterKVsBy example
+	fmt.Println("\n## FilterKVsBy example")
+	ExampleFilterKVsBy()
+
+	// ExtractIDsFromKey example
+	fmt.Println("\n## ExtractIDsFromKey example")
+	ExampleExtractIDsFromKey()
+
+	// ContainsIDs example
+	fmt.Println("\n## ContainsIDs example")
+	ExampleContainsIDs()
+
+	// [May not needed] BuildKey example
+	// fmt.Println("\n## BuildKey example")
+	// ExampleBuildKey()
+
+	// Watch operations example
+	fmt.Println("\n## Watch operations example")
+
+	var wg sync.WaitGroup
+	ctx3, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// goroutine to watch a single key
+	wg.Add(1)
+	go watchSingleKey(ctx3, &wg, etcd)
+
+	// goroutine to watch keys
+	wg.Add(1)
+	go watchMultipleKeys(ctx3, &wg, etcd)
+
+	// goroutine to update values
+	wg.Add(1)
+	go changeValues(ctx3, &wg, etcd)
+
+	// Wait for 10 seconds and then cancel the context to stop the goroutines
+	time.Sleep(10 * time.Second)
+	cancel()
+
+	// Wait for all goroutines to finish
+	wg.Wait()
+
+	fmt.Println("\nAll operations completed successfully!")
+}
+
+func ExampleBasicCRUDTest(ctx context.Context, etcd kvstore.Store) {
+	key := "test_key"
+	value := "Hello, Etcd!"
+
+	// Put (Store) a key-value pair
+	err := etcd.PutWith(ctx, key, value)
+	if err != nil {
+		log.Fatalf("Failed to put key-value: %v", err)
+	}
+	fmt.Printf("Successfully put key '%s' with value '%s'\n", key, value)
+
+	// Get (Retrieve) the value
+	retrievedValue, err := etcd.GetWith(ctx, key)
+	if err != nil {
+		log.Fatalf("Failed to get value: %v", err)
+	}
+	fmt.Printf("Retrieved value for key '%s': %s\n", key, retrievedValue)
+
+	// Update the value
+	newValue := "Updated Etcd Value"
+	err = etcd.PutWith(ctx, key, newValue)
+	if err != nil {
+		log.Fatalf("Failed to update value: %v", err)
+	}
+	fmt.Printf("Successfully updated key '%s' with new value '%s'\n", key, newValue)
+
+	// Get (Retrieve) the updated value
+	retrievedValue, err = etcd.GetWith(ctx, key)
+	if err != nil {
+		log.Fatalf("Failed to get updated value: %v", err)
+	}
+	fmt.Printf("Retrieved updated value for key '%s': %s\n", key, retrievedValue)
+
+	// Delete the key-value pair
+	err = etcd.DeleteWith(ctx, key)
+	if err != nil {
+		log.Fatalf("Failed to delete key: %v", err)
+	}
+	fmt.Printf("Successfully deleted key '%s'\n", key)
+
+	// Verify deletion
+	_, err = etcd.GetWith(ctx, key)
+	if err != nil {
+		fmt.Printf("As expected, failed to get deleted key '%s': %v\n", key, err)
+	} else {
+		log.Fatalf("Unexpectedly succeeded in getting deleted key '%s'", key)
+	}
+}
+
+func ExampleRaceConditionTest(ctx context.Context, etcd kvstore.Store) {
+	fmt.Println("Starting race condition test...")
+
+	key := "race_test_key"
+	iterations := 100
+	goroutines := 5
+
+	// Initialize the key with 0
+	err := etcd.PutWith(ctx, key, "0")
+	if err != nil {
+		log.Fatalf("Failed to initialize key: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	// Start goroutines
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+
+			// Create a persistent session
+			session, err := etcd.NewSession(ctx)
+			if err != nil {
+				log.Fatalf("Failed to create etcd session: %v", err)
+			}
+			defer session.Close()
+
+			// Get Lock
+			lockKey := key
+			// lock, err := etcd.NewLock(ctx, session, lockKey)
+			lock, err := etcd.NewLock(ctx, session, lockKey)
+			if err != nil {
+				log.Fatalf("Failed to get lock: %v", err)
+			}
+
+			for j := 0; j < iterations; j++ {
+
+				err = lock.Lock(ctx)
+				if err != nil {
+					log.Printf("Failed to acquire lock: %v", err)
+					continue
+				}
+
+				// Get current value, increment, and put new value within the lock
+				value, err := etcd.GetWith(ctx, key)
+				if err != nil {
+					log.Printf("Failed to get value: %v", err)
+					// Unlock
+					err = lock.Unlock(ctx)
+					if err != nil {
+						log.Printf("Failed to release lock: %v", err)
+					}
+					continue
+				}
+
+				intValue, _ := strconv.Atoi(value)
+				newValue := fmt.Sprintf("%d", intValue+1)
+
+				err = etcd.PutWith(ctx, key, newValue)
+				if err != nil {
+					log.Printf("Failed to put value: %v", err)
+					// Unlock
+					err = lock.Unlock(ctx)
+					if err != nil {
+						log.Printf("Failed to release lock: %v", err)
+					}
+					continue
+				}
+				log.Printf("Put value: %s", newValue)
+
+				// Unlock
+				err = lock.Unlock(ctx)
+				if err != nil {
+					log.Printf("Failed to release lock: %v", err)
+					continue
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify the final value
+	finalValue, err := etcd.GetWith(ctx, key)
+	if err != nil {
+		log.Fatalf("Failed to get final value: %v", err)
+	}
+
+	expectedValue := goroutines * iterations
+	actualValue, _ := strconv.Atoi(finalValue)
+	if actualValue != expectedValue {
+		log.Fatalf("Race condition detected. Expected %d, but got %d", expectedValue, actualValue)
+	}
+
+	fmt.Printf("Race condition test finished. Final value: %s\n", finalValue)
+
+	// Clean up
+	etcd.DeleteWith(ctx, key)
+}
+
+// ExampleFilterKVsBy demonstrates the usage of the FilterKVsBy function
+// with various key values and different levels of depth.
+func ExampleFilterKVsBy() {
+	kvs := kvstore.KeyValueMap{
+		"/ns/ns01/mcis/mcis02":           "value1",
+		"/ns/ns01/mcis/mcis03":           "value2",
+		"/ns/ns04/mcis/mcis02":           "value3",
+		"/ns/ns01":                       "value4",
+		"/ns/ns04/mcis/mcis05/vpc/vpc01": "value5",
+		"/ns/ns01/mcis/mcis07":           "value6",
+	}
+
+	// Print all key-value pairs
+	fmt.Println("All key-value pairs:")
+	for key, value := range kvs {
+		fmt.Println(key, value)
+	}
+
+	// Case 1: Filter by ns=ns01 and mcis=id2
+	prefixkey1 := "/ns/ns01/mcis"
+	filteredKVs1 := kvutil.FilterKvMapBy(kvs, prefixkey1)
+	fmt.Println("Filtered by '/ns/ns01/mcis', Ouput 'ns/ns01/mcis/{mcisId}': ")
+	for key, value := range filteredKVs1 {
+		fmt.Println(key, value)
+	}
+	// Output: /ns/ns01/mcis/mcis02 value1
+	// Output: /ns/ns01/mcis/mcis03 value2
+	// Output: /ns/ns01/mcis/mcis07 value6
+
+	// Case 2: Filter by ns=ns01
+	prefixkey2 := "/ns"
+	filteredKVs2 := kvutil.FilterKvMapBy(kvs, prefixkey2)
+	fmt.Println("Filtered by '/ns', Ouput 'ns/{nsId}'")
+	for key, value := range filteredKVs2 {
+		fmt.Println(key, value)
+	}
+	// Output: /ns/ns01 value4
+
+	// Case 3: Filter by ns=ns04, mcis=mcis05, and vpc=vpc01
+	prefixkey3 := "/ns/ns04/mcis/mcis05/vpc"
+	filteredKVs3 := kvutil.FilterKvMapBy(kvs, prefixkey3)
+	fmt.Println("Filtered by '/ns/ns04/mcis/mcis05/vpc', Ouput '/ns/ns04/mcis/mcis05/vpc/{vpcId}'")
+	for key, value := range filteredKVs3 {
+		fmt.Println(key, value)
+	}
+	// Output: /ns/ns04/mcis/mcis05/vpc/vpc01 value5
+}
+
+func ExampleExtractIDsFromKey() {
+
+	key := "/ns/ns01/mcis/mcis02/vpc/vpc03"
+
+	ids, err := kvutil.ExtractIDsFromKey(key, "ns", "mcis", "vpc")
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+	fmt.Println("Key: ", key)
+	fmt.Println(ids)
+
+	key2 := "/ns/ns01/mcis/mcis02/SOMETHINGADDED/vpc/vpc03"
+
+	ids, err = kvutil.ExtractIDsFromKey(key2, "ns", "mcis", "vpc")
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Println("Key: ", key2)
+	fmt.Println(ids)
+	// Output: [ns01 id2 id3]
+}
+
+func ExampleContainsIDs() {
+
+	ids := map[string]string{
+		"ns":   "ns01",
+		"mcis": "mcis02",
+	}
+
+	key := "/ns/ns01/mcis/mcis02/vpc/vpc03"
+	contains := kvutil.ContainsIDs(key, ids)
+	fmt.Println("key: ", key)
+	fmt.Println("ids: ", ids)
+	fmt.Println("result: ", contains)
+
+	key2 := "/ns/ns01/mcis/mcis02/SOMETHINGADDED/vpc/vpc03"
+	contains = kvutil.ContainsIDs(key2, ids)
+	fmt.Println("key: ", key2)
+	fmt.Println("ids: ", ids)
+	fmt.Println("result: ", contains)
+	// Output: true
+}
+
+// [May not needed]
+// func ExampleBuildKey() {
+// 	ids := map[string]string{
+// 		"ns":   "ns01",
+// 		"mcis": "mcis02",
+// 		"vpc":  "vpc03",
+// 	}
+
+// 	key := kvstore.BuildKeyBy(ids)
+// 	fmt.Println(key)
+// 	// Output: /ns/ns01/mcis/mcis02/vpc/vpc03
+// }
+
+func watchSingleKey(ctx context.Context, wg *sync.WaitGroup, etcd kvstore.Store) {
+	defer wg.Done()
+	watchChan := etcd.WatchKeyWith(ctx, "mykey")
+	for {
+		select {
+		case resp, ok := <-watchChan:
+			if !ok {
+				fmt.Println("Watch channel closed")
+				return
+			}
+			for _, ev := range resp.Events {
+				fmt.Printf("(Single key watch) Type: %s Key: %s Value: %s\n", ev.Type, ev.Kv.Key, ev.Kv.Value)
+			}
+		case <-ctx.Done():
+			fmt.Println("Single key watch cancelled")
+			return
+		}
+	}
+}
+
+func watchMultipleKeys(ctx context.Context, wg *sync.WaitGroup, etcd kvstore.Store) {
+	defer wg.Done()
+	watchChan := etcd.WatchKeysWith(ctx, "myprefix")
+	for {
+		select {
+		case resp, ok := <-watchChan:
+			if !ok {
+				fmt.Println("Watch channel closed")
+				return
+			}
+			for _, ev := range resp.Events {
+				fmt.Printf("(Multiple keys watch) Type: %s Key: %s Value: %s\n", ev.Type, ev.Kv.Key, ev.Kv.Value)
+			}
+		case <-ctx.Done():
+			fmt.Println("Multiple keys watch cancelled")
+			return
+		}
+	}
+}
+
+func changeValues(ctx context.Context, wg *sync.WaitGroup, etcd kvstore.Store) {
+	defer wg.Done()
+	for i := 0; ; i++ {
+		select {
+		case <-ctx.Done():
+			fmt.Println("Change values cancelled")
+			return
+		default:
+			// Update value with a single key
+			err := etcd.PutWith(ctx, "mykey", fmt.Sprintf("value%d", i))
+			if err != nil {
+				log.Printf("Error putting mykey: %v", err)
+			}
+
+			// Update values with multiple keys
+			err = etcd.PutWith(ctx, fmt.Sprintf("myprefix/key%d", i), fmt.Sprintf("prefixvalue%d", i))
+			if err != nil {
+				log.Printf("Error putting myprefix/key%d: %v", i, err)
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+	}
+}

--- a/src/examples/kvstore/main.go
+++ b/src/examples/kvstore/main.go
@@ -258,8 +258,8 @@ func ExampleFilterKVsBy() {
 
 	// Case 1: Filter by ns=ns01 and mcis=id2
 	prefixkey1 := "/ns/ns01/mcis"
-	filteredKVs1 := kvutil.FilterKvMapBy(kvs, prefixkey1)
-	fmt.Println("Filtered by '/ns/ns01/mcis', Ouput 'ns/ns01/mcis/{mcisId}': ")
+	filteredKVs1 := kvutil.FilterKvMapBy(kvs, prefixkey1, 1)
+	fmt.Println("Filtered by '/ns/ns01/mcis', Output 'ns/ns01/mcis/{mcisId}': ")
 	for key, value := range filteredKVs1 {
 		fmt.Println(key, value)
 	}
@@ -269,8 +269,8 @@ func ExampleFilterKVsBy() {
 
 	// Case 2: Filter by ns=ns01
 	prefixkey2 := "/ns"
-	filteredKVs2 := kvutil.FilterKvMapBy(kvs, prefixkey2)
-	fmt.Println("Filtered by '/ns', Ouput 'ns/{nsId}'")
+	filteredKVs2 := kvutil.FilterKvMapBy(kvs, prefixkey2, 1)
+	fmt.Println("Filtered by '/ns', Output 'ns/{nsId}'")
 	for key, value := range filteredKVs2 {
 		fmt.Println(key, value)
 	}
@@ -278,8 +278,8 @@ func ExampleFilterKVsBy() {
 
 	// Case 3: Filter by ns=ns04, mcis=mcis05, and vpc=vpc01
 	prefixkey3 := "/ns/ns04/mcis/mcis05/vpc"
-	filteredKVs3 := kvutil.FilterKvMapBy(kvs, prefixkey3)
-	fmt.Println("Filtered by '/ns/ns04/mcis/mcis05/vpc', Ouput '/ns/ns04/mcis/mcis05/vpc/{vpcId}'")
+	filteredKVs3 := kvutil.FilterKvMapBy(kvs, prefixkey3, 1)
+	fmt.Println("Filtered by '/ns/ns04/mcis/mcis05/vpc', Output '/ns/ns04/mcis/mcis05/vpc/{vpcId}'")
 	for key, value := range filteredKVs3 {
 		fmt.Println(key, value)
 	}

--- a/src/kvstore/etcd/etcd.go
+++ b/src/kvstore/etcd/etcd.go
@@ -1,17 +1,18 @@
-package kvstore
+package etcd
 
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
+
+	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 )
 
-// Etcd represents an etcd.
-type Etcd struct {
+// EtcdStore represents an etcd.
+type EtcdStore struct {
 	cli *clientv3.Client
 	ctx context.Context
 }
@@ -22,60 +23,29 @@ type Config struct {
 	DialTimeout time.Duration
 }
 
-var (
-	instance *Etcd
-	once     sync.Once
-)
-
-// NewEtcd creates a new instance of EtcdStore (singleton).
+// NewEtcdStore creates a new instance of EtcdStore (singleton).
 // It initializes the etcd client with the provided configuration and ensures only one instance is created.
-func NewEtcd(ctx context.Context, config Config) (Store, error) {
-	var err error
-	once.Do(func() {
-		cli, cliErr := clientv3.New(clientv3.Config{
-			Endpoints:   config.Endpoints,
-			DialTimeout: config.DialTimeout,
-		})
-		if cliErr != nil {
-			err = fmt.Errorf("failed to create etcd client: %w", cliErr)
-			return
-		}
-
-		if ctx == nil {
-			ctx = context.Background()
-		}
-
-		instance = &Etcd{
-			cli: cli,
-			ctx: ctx,
-		}
+func NewEtcdStore(ctx context.Context, config Config) (kvstore.Store, error) {
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   config.Endpoints,
+		DialTimeout: config.DialTimeout,
 	})
-
 	if err != nil {
 		return nil, err
 	}
-	return instance, nil
-}
 
-// GetEtcd returns the singleton instance of EtcdStore.
-func GetEtcd() *Etcd {
-	return instance
-}
-
-// GetEtcdClient returns the singleton instance of EtcdStore.
-func GetEtcdClient() *clientv3.Client {
-	return instance.cli
+	return &EtcdStore{cli: cli}, nil
 }
 
 // OpenSession creates a new etcd session.
 // A session is needed for acquiring locks.
-func (s *Etcd) NewSession(ctx context.Context) (*concurrency.Session, error) {
+func (s *EtcdStore) NewSession(ctx context.Context) (*concurrency.Session, error) {
 	return concurrency.NewSession(s.cli)
 }
 
 // NewLock acquires a lock on the given key and returns the mutex.
 // It uses the provided session to ensure the lock's lifecycle is tied to the session.
-func (s *Etcd) NewLock(ctx context.Context, session *concurrency.Session, lockKey string) (*concurrency.Mutex, error) {
+func (s *EtcdStore) NewLock(ctx context.Context, session *concurrency.Session, lockKey string) (*concurrency.Mutex, error) {
 	mutex := concurrency.NewMutex(session, lockKey)
 	err := mutex.Lock(ctx)
 	if err != nil {
@@ -85,12 +55,12 @@ func (s *Etcd) NewLock(ctx context.Context, session *concurrency.Session, lockKe
 }
 
 // Put stores a key-value pair in etcd.
-func (s *Etcd) Put(key, value string) error {
+func (s *EtcdStore) Put(key, value string) error {
 	return s.PutWith(s.ctx, key, value)
 }
 
 // PutWith stores a key-value pair in etcd using the provided context.
-func (s *Etcd) PutWith(ctx context.Context, key, value string) error {
+func (s *EtcdStore) PutWith(ctx context.Context, key, value string) error {
 	_, err := s.cli.Put(ctx, key, value)
 	if err != nil {
 		return fmt.Errorf("failed to put key-value: %w", err)
@@ -99,12 +69,12 @@ func (s *Etcd) PutWith(ctx context.Context, key, value string) error {
 }
 
 // Get retrieves the value for a given key from etcd without using a context.
-func (s *Etcd) Get(key string) (string, error) {
+func (s *EtcdStore) Get(key string) (string, error) {
 	return s.GetWith(s.ctx, key)
 }
 
 // GetWith retrieves the value for a given key from etcd using the provided context.
-func (s *Etcd) GetWith(ctx context.Context, key string) (string, error) {
+func (s *EtcdStore) GetWith(ctx context.Context, key string) (string, error) {
 	resp, err := s.cli.Get(ctx, key)
 	if err != nil {
 		return "", fmt.Errorf("failed to get key: %w", err)
@@ -116,12 +86,12 @@ func (s *Etcd) GetWith(ctx context.Context, key string) (string, error) {
 }
 
 // GetListWith retrieves multiple values for keys with the given keyPrefix from etcd.
-func (s *Etcd) GetList(keyPrefix string) ([]string, error) {
+func (s *EtcdStore) GetList(keyPrefix string) ([]string, error) {
 	return s.GetListWith(s.ctx, keyPrefix)
 }
 
 // GetListWith retrieves multiple values for keys with the given keyPrefix from etcd using the provided context.
-func (s *Etcd) GetListWith(ctx context.Context, keyPrefix string) ([]string, error) {
+func (s *EtcdStore) GetListWith(ctx context.Context, keyPrefix string) ([]string, error) {
 	// ascending by key as a default sort order
 	optAscendByKey := clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)
 
@@ -139,32 +109,32 @@ func (s *Etcd) GetListWith(ctx context.Context, keyPrefix string) ([]string, err
 }
 
 // GetKv retrieves a key-value pair from etcd without using a context.
-func (s *Etcd) GetKv(key string) (KeyValue, error) {
+func (s *EtcdStore) GetKv(key string) (kvstore.KeyValue, error) {
 	return s.GetKvWith(s.ctx, key)
 }
 
 // GetKvWith retrieves a key-value pair from etcd using the provided context.
-func (s *Etcd) GetKvWith(ctx context.Context, key string) (KeyValue, error) {
+func (s *EtcdStore) GetKvWith(ctx context.Context, key string) (kvstore.KeyValue, error) {
 	resp, err := s.cli.Get(ctx, key)
 	if err != nil {
-		return KeyValue{}, fmt.Errorf("failed to get key: %w", err)
+		return kvstore.KeyValue{}, fmt.Errorf("failed to get key: %w", err)
 	}
 	if len(resp.Kvs) == 0 {
-		return KeyValue{}, fmt.Errorf("key not found: %s", key)
+		return kvstore.KeyValue{}, fmt.Errorf("key not found: %s", key)
 	}
 
-	kv := KeyValue{Key: string(resp.Kvs[0].Key), Value: string(resp.Kvs[0].Value)}
+	kv := kvstore.KeyValue{Key: string(resp.Kvs[0].Key), Value: string(resp.Kvs[0].Value)}
 
 	return kv, nil
 }
 
 // GetKvList retrieves multiple key-value pairs with the given keyPrefix from etcd.
-func (s *Etcd) GetKvList(keyPrefix string) ([]KeyValue, error) {
+func (s *EtcdStore) GetKvList(keyPrefix string) ([]kvstore.KeyValue, error) {
 	return s.GetKvListWith(s.ctx, keyPrefix)
 }
 
 // GetKvListWith retrieves multiple key-value pairs with the given keyPrefix from etcd using the provided context.
-func (s *Etcd) GetKvListWith(ctx context.Context, keyPrefix string) ([]KeyValue, error) {
+func (s *EtcdStore) GetKvListWith(ctx context.Context, keyPrefix string) ([]kvstore.KeyValue, error) {
 	// ascending by key as a default sort order
 	optAscendByKey := clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)
 
@@ -174,20 +144,20 @@ func (s *Etcd) GetKvListWith(ctx context.Context, keyPrefix string) ([]KeyValue,
 		return nil, fmt.Errorf("failed to get list with keyPrefix: %w", err)
 	}
 
-	kvs := make([]KeyValue, len(resp.Kvs))
+	kvs := make([]kvstore.KeyValue, len(resp.Kvs))
 	for _, kv := range resp.Kvs {
-		kvs = append(kvs, KeyValue{Key: string(kv.Key), Value: string(kv.Value)})
+		kvs = append(kvs, kvstore.KeyValue{Key: string(kv.Key), Value: string(kv.Value)})
 	}
 	return kvs, nil
 }
 
 // GetKvMap retrieves multiple key-value pairs with the given keyPrefix from etcd.
-func (s *Etcd) GetKvMap(keyPrefix string) (KeyValueMap, error) {
+func (s *EtcdStore) GetKvMap(keyPrefix string) (kvstore.KeyValueMap, error) {
 	return s.GetKvMapWith(s.ctx, keyPrefix)
 }
 
 // GetKvMapWith retrieves multiple key-value pairs with the given keyPrefix from etcd using the provided context.
-func (s *Etcd) GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap, error) {
+func (s *EtcdStore) GetKvMapWith(ctx context.Context, keyPrefix string) (kvstore.KeyValueMap, error) {
 	// ascending by key as a default sort order
 	optAscendByKey := clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)
 
@@ -197,7 +167,7 @@ func (s *Etcd) GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap,
 		return nil, fmt.Errorf("failed to get list with keyPrefix: %w", err)
 	}
 
-	kvs := make(KeyValueMap, len(resp.Kvs))
+	kvs := make(kvstore.KeyValueMap, len(resp.Kvs))
 	for _, kv := range resp.Kvs {
 		kvs[string(kv.Key)] = string(kv.Value)
 	}
@@ -205,12 +175,12 @@ func (s *Etcd) GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap,
 }
 
 // Delete removes a key-value pair from etcd without using a context.
-func (s *Etcd) Delete(key string) error {
+func (s *EtcdStore) Delete(key string) error {
 	return s.DeleteWith(s.ctx, key)
 }
 
 // DeleteWith removes a key-value pair from etcd using the provided context.
-func (s *Etcd) DeleteWith(ctx context.Context, key string) error {
+func (s *EtcdStore) DeleteWith(ctx context.Context, key string) error {
 	_, err := s.cli.Delete(ctx, key)
 	if err != nil {
 		return fmt.Errorf("failed to delete key: %w", err)
@@ -219,48 +189,48 @@ func (s *Etcd) DeleteWith(ctx context.Context, key string) error {
 }
 
 // GetSortedKvList retrieves multiple values for keys with the given keyPrefix, sortBy, and order from etcd.
-func (s *Etcd) GetSortedKvList(keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error) {
+func (s *EtcdStore) GetSortedKvList(keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]kvstore.KeyValue, error) {
 	return s.GetSortedKvListWith(s.ctx, keyPrefix, sortBy, order)
 }
 
 // GetSortedKvListWith retrieves multiple values for keys with  the given keyPrefix, sortBy, and order from etcd using the provided context.
-func (s *Etcd) GetSortedKvListWith(ctx context.Context, keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error) {
+func (s *EtcdStore) GetSortedKvListWith(ctx context.Context, keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]kvstore.KeyValue, error) {
 	sortOp := clientv3.WithSort(sortBy, order)
 	resp, err := s.cli.Get(ctx, keyPrefix, clientv3.WithPrefix(), sortOp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get list with keyPrefix: %w", err)
 	}
 
-	kvs := make([]KeyValue, len(resp.Kvs))
+	kvs := make([]kvstore.KeyValue, len(resp.Kvs))
 	for _, kv := range resp.Kvs {
-		kvs = append(kvs, KeyValue{Key: string(kv.Key), Value: string(kv.Value)})
+		kvs = append(kvs, kvstore.KeyValue{Key: string(kv.Key), Value: string(kv.Value)})
 	}
 	return kvs, nil
 }
 
 // WatchKey watches for changes on the given key.
-func (s *Etcd) WatchKey(key string) clientv3.WatchChan {
+func (s *EtcdStore) WatchKey(key string) clientv3.WatchChan {
 	return s.WatchKeyWith(s.ctx, key)
 }
 
 // WatchKeyWith watches for changes on the given key using the provided context.
-func (s *Etcd) WatchKeyWith(ctx context.Context, key string) clientv3.WatchChan {
+func (s *EtcdStore) WatchKeyWith(ctx context.Context, key string) clientv3.WatchChan {
 	return s.cli.Watch(ctx, key)
 }
 
 // WatchKeys watches for changes on keys with the given keyPrefix.
-func (s *Etcd) WatchKeys(keyPrefix string) clientv3.WatchChan {
+func (s *EtcdStore) WatchKeys(keyPrefix string) clientv3.WatchChan {
 	return s.WatchKeysWith(s.ctx, keyPrefix)
 }
 
 // WatchKeysWith watches for changes on keys with the given keyPrefix using the provided context.
-func (s *Etcd) WatchKeysWith(ctx context.Context, keyPrefix string) clientv3.WatchChan {
+func (s *EtcdStore) WatchKeysWith(ctx context.Context, keyPrefix string) clientv3.WatchChan {
 	return s.cli.Watch(ctx, keyPrefix, clientv3.WithPrefix())
 }
 
 // Close closes the etcd client.
 // This is necessary to release resources associated with the client.
-func (s *Etcd) Close() error {
+func (s *EtcdStore) Close() error {
 	return s.cli.Close()
 }
 

--- a/src/kvstore/etcd/etcd.go
+++ b/src/kvstore/etcd/etcd.go
@@ -34,7 +34,7 @@ func NewEtcdStore(ctx context.Context, config Config) (kvstore.Store, error) {
 		return nil, err
 	}
 
-	return &EtcdStore{cli: cli}, nil
+	return &EtcdStore{cli: cli, ctx: ctx}, nil
 }
 
 // OpenSession creates a new etcd session.
@@ -137,13 +137,13 @@ func (s *EtcdStore) GetKvList(keyPrefix string) ([]kvstore.KeyValue, error) {
 func (s *EtcdStore) GetKvListWith(ctx context.Context, keyPrefix string) ([]kvstore.KeyValue, error) {
 	// ascending by key as a default sort order
 	optAscendByKey := clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)
-	
+
 	// Get all key-value pairs with the given keyPrefix
 	resp, err := s.cli.Get(ctx, keyPrefix, clientv3.WithPrefix(), optAscendByKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get list with keyPrefix: %w", err)
 	}
-	
+
 	kvs := make([]kvstore.KeyValue, len(resp.Kvs))
 	for _, kv := range resp.Kvs {
 		kvs = append(kvs, kvstore.KeyValue{Key: string(kv.Key), Value: string(kv.Value)})
@@ -207,7 +207,6 @@ func (s *EtcdStore) DeleteWith(ctx context.Context, key string) error {
 	}
 	return nil
 }
-
 
 // WatchKey watches for changes on the given key.
 func (s *EtcdStore) WatchKey(key string) clientv3.WatchChan {

--- a/src/kvstore/kvstore/etcd.go
+++ b/src/kvstore/kvstore/etcd.go
@@ -1,0 +1,277 @@
+package kvstore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+)
+
+// Etcd represents an etcd.
+type Etcd struct {
+	cli *clientv3.Client
+	ctx context.Context
+}
+
+// Config holds the configuration for EtcdStore.
+type Config struct {
+	Endpoints   []string
+	DialTimeout time.Duration
+}
+
+var (
+	instance *Etcd
+	once     sync.Once
+)
+
+// NewEtcd creates a new instance of EtcdStore (singleton).
+// It initializes the etcd client with the provided configuration and ensures only one instance is created.
+func NewEtcd(ctx context.Context, config Config) (Store, error) {
+	var err error
+	once.Do(func() {
+		cli, cliErr := clientv3.New(clientv3.Config{
+			Endpoints:   config.Endpoints,
+			DialTimeout: config.DialTimeout,
+		})
+		if cliErr != nil {
+			err = fmt.Errorf("failed to create etcd client: %w", cliErr)
+			return
+		}
+
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		instance = &Etcd{
+			cli: cli,
+			ctx: ctx,
+		}
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return instance, nil
+}
+
+// GetEtcd returns the singleton instance of EtcdStore.
+func GetEtcd() *Etcd {
+	return instance
+}
+
+// GetEtcdClient returns the singleton instance of EtcdStore.
+func GetEtcdClient() *clientv3.Client {
+	return instance.cli
+}
+
+// OpenSession creates a new etcd session.
+// A session is needed for acquiring locks.
+func (s *Etcd) NewSession(ctx context.Context) (*concurrency.Session, error) {
+	return concurrency.NewSession(s.cli)
+}
+
+// NewLock acquires a lock on the given key and returns the mutex.
+// It uses the provided session to ensure the lock's lifecycle is tied to the session.
+func (s *Etcd) NewLock(ctx context.Context, session *concurrency.Session, lockKey string) (*concurrency.Mutex, error) {
+	mutex := concurrency.NewMutex(session, lockKey)
+	err := mutex.Lock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return mutex, nil
+}
+
+// Put stores a key-value pair in etcd.
+func (s *Etcd) Put(key, value string) error {
+	return s.PutWith(s.ctx, key, value)
+}
+
+// PutWith stores a key-value pair in etcd using the provided context.
+func (s *Etcd) PutWith(ctx context.Context, key, value string) error {
+	_, err := s.cli.Put(ctx, key, value)
+	if err != nil {
+		return fmt.Errorf("failed to put key-value: %w", err)
+	}
+	return nil
+}
+
+// Get retrieves the value for a given key from etcd without using a context.
+func (s *Etcd) Get(key string) (string, error) {
+	return s.GetWith(s.ctx, key)
+}
+
+// GetWith retrieves the value for a given key from etcd using the provided context.
+func (s *Etcd) GetWith(ctx context.Context, key string) (string, error) {
+	resp, err := s.cli.Get(ctx, key)
+	if err != nil {
+		return "", fmt.Errorf("failed to get key: %w", err)
+	}
+	if len(resp.Kvs) == 0 {
+		return "", fmt.Errorf("key not found: %s", key)
+	}
+	return string(resp.Kvs[0].Value), nil
+}
+
+// GetListWith retrieves multiple values for keys with the given keyPrefix from etcd.
+func (s *Etcd) GetList(keyPrefix string) ([]string, error) {
+	return s.GetListWith(s.ctx, keyPrefix)
+}
+
+// GetListWith retrieves multiple values for keys with the given keyPrefix from etcd using the provided context.
+func (s *Etcd) GetListWith(ctx context.Context, keyPrefix string) ([]string, error) {
+	// ascending by key as a default sort order
+	optAscendByKey := clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)
+
+	// Get all values with the given keyPrefix
+	resp, err := s.cli.Get(ctx, keyPrefix, clientv3.WithPrefix(), optAscendByKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get list with keyPrefix: %w", err)
+	}
+
+	values := make([]string, len(resp.Kvs))
+	for i, kv := range resp.Kvs {
+		values[i] = string(kv.Value)
+	}
+	return values, nil
+}
+
+// GetKv retrieves a key-value pair from etcd without using a context.
+func (s *Etcd) GetKv(key string) (KeyValue, error) {
+	return s.GetKvWith(s.ctx, key)
+}
+
+// GetKvWith retrieves a key-value pair from etcd using the provided context.
+func (s *Etcd) GetKvWith(ctx context.Context, key string) (KeyValue, error) {
+	resp, err := s.cli.Get(ctx, key)
+	if err != nil {
+		return KeyValue{}, fmt.Errorf("failed to get key: %w", err)
+	}
+	if len(resp.Kvs) == 0 {
+		return KeyValue{}, fmt.Errorf("key not found: %s", key)
+	}
+
+	kv := KeyValue{Key: string(resp.Kvs[0].Key), Value: string(resp.Kvs[0].Value)}
+
+	return kv, nil
+}
+
+// GetKvList retrieves multiple key-value pairs with the given keyPrefix from etcd.
+func (s *Etcd) GetKvList(keyPrefix string) ([]KeyValue, error) {
+	return s.GetKvListWith(s.ctx, keyPrefix)
+}
+
+// GetKvListWith retrieves multiple key-value pairs with the given keyPrefix from etcd using the provided context.
+func (s *Etcd) GetKvListWith(ctx context.Context, keyPrefix string) ([]KeyValue, error) {
+	// ascending by key as a default sort order
+	optAscendByKey := clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)
+
+	// Get all key-value pairs with the given keyPrefix
+	resp, err := s.cli.Get(ctx, keyPrefix, clientv3.WithPrefix(), optAscendByKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get list with keyPrefix: %w", err)
+	}
+
+	kvs := make([]KeyValue, len(resp.Kvs))
+	for _, kv := range resp.Kvs {
+		kvs = append(kvs, KeyValue{Key: string(kv.Key), Value: string(kv.Value)})
+	}
+	return kvs, nil
+}
+
+// GetKvMap retrieves multiple key-value pairs with the given keyPrefix from etcd.
+func (s *Etcd) GetKvMap(keyPrefix string) (KeyValueMap, error) {
+	return s.GetKvMapWith(s.ctx, keyPrefix)
+}
+
+// GetKvMapWith retrieves multiple key-value pairs with the given keyPrefix from etcd using the provided context.
+func (s *Etcd) GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap, error) {
+	// ascending by key as a default sort order
+	optAscendByKey := clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend)
+
+	// Get all key-value pairs with the given keyPrefix
+	resp, err := s.cli.Get(ctx, keyPrefix, clientv3.WithPrefix(), optAscendByKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get list with keyPrefix: %w", err)
+	}
+
+	kvs := make(KeyValueMap, len(resp.Kvs))
+	for _, kv := range resp.Kvs {
+		kvs[string(kv.Key)] = string(kv.Value)
+	}
+	return kvs, nil
+}
+
+// Delete removes a key-value pair from etcd without using a context.
+func (s *Etcd) Delete(key string) error {
+	return s.DeleteWith(s.ctx, key)
+}
+
+// DeleteWith removes a key-value pair from etcd using the provided context.
+func (s *Etcd) DeleteWith(ctx context.Context, key string) error {
+	_, err := s.cli.Delete(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to delete key: %w", err)
+	}
+	return nil
+}
+
+// GetSortedKvList retrieves multiple values for keys with the given keyPrefix, sortBy, and order from etcd.
+func (s *Etcd) GetSortedKvList(keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error) {
+	return s.GetSortedKvListWith(s.ctx, keyPrefix, sortBy, order)
+}
+
+// GetSortedKvListWith retrieves multiple values for keys with  the given keyPrefix, sortBy, and order from etcd using the provided context.
+func (s *Etcd) GetSortedKvListWith(ctx context.Context, keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error) {
+	sortOp := clientv3.WithSort(sortBy, order)
+	resp, err := s.cli.Get(ctx, keyPrefix, clientv3.WithPrefix(), sortOp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get list with keyPrefix: %w", err)
+	}
+
+	kvs := make([]KeyValue, len(resp.Kvs))
+	for _, kv := range resp.Kvs {
+		kvs = append(kvs, KeyValue{Key: string(kv.Key), Value: string(kv.Value)})
+	}
+	return kvs, nil
+}
+
+// WatchKey watches for changes on the given key.
+func (s *Etcd) WatchKey(key string) clientv3.WatchChan {
+	return s.WatchKeyWith(s.ctx, key)
+}
+
+// WatchKeyWith watches for changes on the given key using the provided context.
+func (s *Etcd) WatchKeyWith(ctx context.Context, key string) clientv3.WatchChan {
+	return s.cli.Watch(ctx, key)
+}
+
+// WatchKeys watches for changes on keys with the given keyPrefix.
+func (s *Etcd) WatchKeys(keyPrefix string) clientv3.WatchChan {
+	return s.WatchKeysWith(s.ctx, keyPrefix)
+}
+
+// WatchKeysWith watches for changes on keys with the given keyPrefix using the provided context.
+func (s *Etcd) WatchKeysWith(ctx context.Context, keyPrefix string) clientv3.WatchChan {
+	return s.cli.Watch(ctx, keyPrefix, clientv3.WithPrefix())
+}
+
+// Close closes the etcd client.
+// This is necessary to release resources associated with the client.
+func (s *Etcd) Close() error {
+	return s.cli.Close()
+}
+
+// // CloseSession closes the given etcd session.
+// // It's important to close sessions to release resources.
+// func (s *EtcdStore) CloseSession(session *concurrency.Session) error {
+// 	return session.Close()
+// }
+
+// // Unlock releases the given lock.
+// // It is important to release the lock to allow other clients to acquire it.
+// func (s *EtcdStore) Unlock(ctx context.Context, mutex *concurrency.Mutex) error {
+// 	return mutex.Unlock(ctx)
+// }

--- a/src/kvstore/kvstore/kvstore.go
+++ b/src/kvstore/kvstore/kvstore.go
@@ -2,18 +2,16 @@ package kvstore
 
 import (
 	"context"
+	"fmt"
+	"sync"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
-type KeyValue struct {
-	Key   string
-	Value string
-}
-
-// KeyValueMap represents a key-value pair.
-type KeyValueMap map[string]string
+// Extensibility: Abstraction and Polymorphism
+// Store interface for key-value operations, designed for extensibility.
+// Initially for etcd, but adaptable to other stores.
 
 // Store defines operations as an interface for key-value store.
 // This was mainly implemented for etcd, but can be extended to other key-value stores later.
@@ -43,4 +41,202 @@ type Store interface {
 	Close() error
 	// CloseSession(session *concurrency.Session) error
 	// Unlock(ctx context.Context, mutex *concurrency.Mutex) error
+}
+
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
+// KeyValueMap represents a key-value pair.
+type KeyValueMap map[string]string
+
+var (
+	globalStore Store
+	initOnce    sync.Once
+)
+
+// Package-level implementation for global Store management
+// Provides functions to initialize, access, and manipulate the global Store instance.
+// Ensures thread-safe operations and simplifies key-value store interactions.
+
+// InitializeStore initializes the global Store with the provided Store implementation
+func InitializeStore(store Store) error {
+	if store == nil {
+		return fmt.Errorf("provided store is nil")
+	}
+	initOnce.Do(func() {
+		globalStore = store
+	})
+	return nil
+}
+
+// getStore returns the initialized global Store
+func getStore() (Store, error) {
+	if globalStore == nil {
+		return nil, fmt.Errorf("store not initialized")
+	}
+	return globalStore, nil
+}
+
+// NewSession creates a new session
+func NewSession(ctx context.Context) (*concurrency.Session, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.NewSession(ctx)
+}
+
+// NewLock creates a new lock
+func NewLock(ctx context.Context, session *concurrency.Session, lockKey string) (*concurrency.Mutex, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.NewLock(ctx, session, lockKey)
+}
+
+// PutWith stores a key-value pair with context
+func PutWith(ctx context.Context, key, value string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	return store.PutWith(ctx, key, value)
+}
+
+// GetWith retrieves a value for a given key with context
+func GetWith(ctx context.Context, key string) (string, error) {
+	store, err := getStore()
+	if err != nil {
+		return "", err
+	}
+	return store.GetWith(ctx, key)
+}
+
+// GetListWith retrieves multiple values for keys with the given prefix with context
+func GetListWith(ctx context.Context, keyPrefix string) ([]string, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetListWith(ctx, keyPrefix)
+}
+
+// GetKv retrieves a key-value pair
+func GetKv(key string) (KeyValue, error) {
+	store, err := getStore()
+	if err != nil {
+		return KeyValue{}, err
+	}
+	return store.GetKv(key)
+}
+
+// GetKvWith retrieves a key-value pair with context
+func GetKvWith(ctx context.Context, key string) (KeyValue, error) {
+	store, err := getStore()
+	if err != nil {
+		return KeyValue{}, err
+	}
+	return store.GetKvWith(ctx, key)
+}
+
+// GetKvList retrieves multiple key-value pairs with the given prefix
+func GetKvList(keyPrefix string) ([]KeyValue, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetKvList(keyPrefix)
+}
+
+// GetKvListWith retrieves multiple key-value pairs with the given prefix with context
+func GetKvListWith(ctx context.Context, keyPrefix string) ([]KeyValue, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetKvListWith(ctx, keyPrefix)
+}
+
+// GetSortedKvList retrieves sorted key-value pairs with the given prefix
+func GetSortedKvList(keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetSortedKvList(keyPrefix, sortBy, order)
+}
+
+// GetSortedKvListWith retrieves sorted key-value pairs with the given prefix with context
+func GetSortedKvListWith(ctx context.Context, keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetSortedKvListWith(ctx, keyPrefix, sortBy, order)
+}
+
+// GetKvMap retrieves a map of key-value pairs with the given prefix
+func GetKvMap(keyPrefix string) (KeyValueMap, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetKvMap(keyPrefix)
+}
+
+// GetKvMapWith retrieves a map of key-value pairs with the given prefix with context
+func GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetKvMapWith(ctx, keyPrefix)
+}
+
+// DeleteWith removes a key-value pair with context
+func DeleteWith(ctx context.Context, key string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	return store.DeleteWith(ctx, key)
+}
+
+// WatchKey watches for changes on a specific key
+func WatchKey(key string) clientv3.WatchChan {
+	store, err := getStore()
+	if err != nil {
+		return nil
+	}
+	return store.WatchKey(key)
+}
+
+// WatchKeyWith watches for changes on a specific key with context
+func WatchKeyWith(ctx context.Context, key string) clientv3.WatchChan {
+	store, err := getStore()
+	if err != nil {
+		return nil
+	}
+	return store.WatchKeyWith(ctx, key)
+}
+
+// WatchKeys watches for changes on keys with the given prefix
+func WatchKeys(keyPrefix string) clientv3.WatchChan {
+	store, err := getStore()
+	if err != nil {
+		return nil
+	}
+	return store.WatchKeys(keyPrefix)
+}
+
+// WatchKeysWith watches for changes on keys with the given prefix with context
+func WatchKeysWith(ctx context.Context, keyPrefix string) clientv3.WatchChan {
+	store, err := getStore()
+	if err != nil {
+		return nil
+	}
+	return store.WatchKeysWith(ctx, keyPrefix)
 }

--- a/src/kvstore/kvstore/kvstore.go
+++ b/src/kvstore/kvstore/kvstore.go
@@ -1,0 +1,46 @@
+package kvstore
+
+import (
+	"context"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+)
+
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
+// KeyValueMap represents a key-value pair.
+type KeyValueMap map[string]string
+
+// Store defines operations as an interface for key-value store.
+// This was mainly implemented for etcd, but can be extended to other key-value stores later.
+type Store interface {
+	NewSession(ctx context.Context) (*concurrency.Session, error)
+	NewLock(ctx context.Context, session *concurrency.Session, lockKey string) (*concurrency.Mutex, error)
+	Put(key, value string) error
+	PutWith(ctx context.Context, key, value string) error
+	Get(key string) (string, error)
+	GetWith(ctx context.Context, key string) (string, error)
+	GetList(keyPrefix string) ([]string, error)
+	GetListWith(ctx context.Context, keyPrefix string) ([]string, error)
+	GetKv(key string) (KeyValue, error)
+	GetKvWith(ctx context.Context, key string) (KeyValue, error)
+	GetKvList(keyPrefix string) ([]KeyValue, error)
+	GetKvListWith(ctx context.Context, keyPrefix string) ([]KeyValue, error)
+	GetSortedKvList(keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error)
+	GetSortedKvListWith(ctx context.Context, keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error)
+	GetKvMap(keyPrefix string) (KeyValueMap, error)
+	GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap, error)
+	Delete(key string) error
+	DeleteWith(ctx context.Context, key string) error
+	WatchKey(key string) clientv3.WatchChan
+	WatchKeyWith(ctx context.Context, key string) clientv3.WatchChan
+	WatchKeys(keyPrefix string) clientv3.WatchChan
+	WatchKeysWith(ctx context.Context, keyPrefix string) clientv3.WatchChan
+	Close() error
+	// CloseSession(session *concurrency.Session) error
+	// Unlock(ctx context.Context, mutex *concurrency.Mutex) error
+}

--- a/src/kvstore/kvstore/kvstore.go
+++ b/src/kvstore/kvstore/kvstore.go
@@ -97,6 +97,15 @@ func NewLock(ctx context.Context, session *concurrency.Session, lockKey string) 
 	return store.NewLock(ctx, session, lockKey)
 }
 
+// Put stores a key-value pair
+func Put(key, value string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	return store.Put(key, value)
+}
+
 // PutWith stores a key-value pair with context
 func PutWith(ctx context.Context, key, value string) error {
 	store, err := getStore()
@@ -106,6 +115,15 @@ func PutWith(ctx context.Context, key, value string) error {
 	return store.PutWith(ctx, key, value)
 }
 
+// Get retrieves a value for a given key
+func Get(key string) (string, error) {
+	store, err := getStore()
+	if err != nil {
+		return "", err
+	}
+	return store.Get(key)
+}
+
 // GetWith retrieves a value for a given key with context
 func GetWith(ctx context.Context, key string) (string, error) {
 	store, err := getStore()
@@ -113,6 +131,15 @@ func GetWith(ctx context.Context, key string) (string, error) {
 		return "", err
 	}
 	return store.GetWith(ctx, key)
+}
+
+// GetList retrieves multiple values for keys with the given prefix
+func GetList(keyPrefix string) ([]string, error) {
+	store, err := getStore()
+	if err != nil {
+		return nil, err
+	}
+	return store.GetList(keyPrefix)
 }
 
 // GetListWith retrieves multiple values for keys with the given prefix with context
@@ -196,6 +223,15 @@ func GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap, error) {
 	return store.GetKvMapWith(ctx, keyPrefix)
 }
 
+// Detete removes a key-value pair
+func Delete(key string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	return store.Delete(key)
+}
+
 // DeleteWith removes a key-value pair with context
 func DeleteWith(ctx context.Context, key string) error {
 	store, err := getStore()
@@ -239,4 +275,13 @@ func WatchKeysWith(ctx context.Context, keyPrefix string) clientv3.WatchChan {
 		return nil
 	}
 	return store.WatchKeysWith(ctx, keyPrefix)
+}
+
+// Close closes the store
+func Close() error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	return store.Close()
 }

--- a/src/kvstore/kvutil/kvutil.go
+++ b/src/kvstore/kvutil/kvutil.go
@@ -1,0 +1,104 @@
+package kvutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
+)
+
+// FilterKvMapBy filters a KeyValue map based on the given prefix key.
+// It returns a new KeyValue map containing only the key-value pairs that match the prefix criteria.
+func FilterKvMapBy(kvs kvstore.KeyValueMap, prefixKey string) kvstore.KeyValueMap {
+	result := make(kvstore.KeyValueMap)
+	prefix := strings.TrimSuffix(prefixKey, "/")
+
+	for key, value := range kvs {
+		if strings.HasPrefix(key, prefix) && hasOnlyNextSegment(prefix, key) {
+			result[key] = value
+		}
+	}
+
+	return result
+}
+
+// FilterKvListBy filters a slice of KeyValue pairs based on the given prefix key.
+// It returns a new slice containing only the key-value pairs that match the prefix criteria.
+func FilterKvListBy(kvs []kvstore.KeyValue, prefixKey string) []kvstore.KeyValue {
+	result := make([]kvstore.KeyValue, 0)
+	prefix := strings.TrimSuffix(prefixKey, "/")
+
+	for _, kv := range kvs {
+		if strings.HasPrefix(kv.Key, prefix) && hasOnlyNextSegment(prefix, kv.Key) {
+			result = append(result, kv)
+		}
+	}
+
+	return result
+}
+
+// hasOnlyNextSegment checks if a key has only one additional key segment after the prefix key.
+func hasOnlyNextSegment(prefix, key string) bool {
+	// Trim the prefix from the key and split the remaining part
+	trimmed := strings.TrimPrefix(key, prefix)
+	trimmed = strings.Trim(trimmed, "/")
+	parts := strings.Split(trimmed, "/")
+
+	// Check if the key has only one additional key segment
+	return len(parts) == 1
+}
+
+// ExtractIDsFromKey extracts specific IDs from a given key based on the provided structure.
+// It returns a slice of extracted ID values in the order of provided ID types.
+// If any ID type is not found in the key, it returns an error.
+func ExtractIDsFromKey(key string, idTypes ...string) ([]string, error) {
+	parts := strings.Split(strings.Trim(key, "/"), "/")
+	if len(parts) < len(idTypes)*2 {
+		return nil, fmt.Errorf("key does not contain all requested ID types")
+	}
+
+	ids := make([]string, len(idTypes))
+	for i, idType := range idTypes {
+		index := indexOf(parts, idType)
+		if index == -1 || index+1 >= len(parts) {
+			return nil, fmt.Errorf("could not find ID for type: %s", idType)
+		}
+		ids[i] = parts[index+1]
+	}
+	return ids, nil
+}
+
+// ContainsIDs checks if a key contains specific ID values.
+// It returns true if the key contains all ID types and values specified in the ids map.
+func ContainsIDs(key string, ids map[string]string) bool {
+	parts := strings.Split(strings.Trim(key, "/"), "/")
+	for idType, idValue := range ids {
+		index := indexOf(parts, idType)
+		if index == -1 || index+1 >= len(parts) || parts[index+1] != idValue {
+			return false
+		}
+	}
+	return true
+}
+
+// [May not needed]
+// // BuildKeyBy constructs a key from given ID types and values.
+// // It returns a string representing the constructed key.
+// func BuildKeyBy(ids map[string]string) string {
+// 	var parts []string
+// 	for idType, idValue := range ids {
+// 		parts = append(parts, idType, idValue)
+// 	}
+// 	return "/" + strings.Join(parts, "/")
+// }
+
+// indexOf finds the index of a string in a slice.
+// It returns the index if found, or -1 if not found.
+func indexOf(slice []string, item string) int {
+	for i, s := range slice {
+		if s == item {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
This PR includes the following:
* Add `kvstore.go`, which defines interfaces, structs, and types
* Add `etcd.go`, which implements functions (corresponding to interfaces) to utilize etcd
* Add `kvutil.go`, which supports utility functions to handle KeyValue easily.
* Update `docker-compose.yaml` to deploy and run etcd container locally
* Add examples to test the pkgs

**cb-store를 etcd로 대체하기 위한 작업을 진행중에 있습니다.**
* 이를 위해, cb-store 및 CB-Tumblebug의 기존 KeyValue store 관련 코드 리뷰 및 설계 의도 파악을 선행했고요.
* 관련하여, `kvstore`, `kvutil` pkg를 추가하고 `docker-compose.yaml` 업데이트를 진행하고자 합니다.
* 이는, etcd의 본래 활용 방식을 최대한 유지하면서, 기능을 보완/개선하는 방향으로 설계 및 개발하였습니다. 

**기능상으로 볼 때, 아래와 같이 매칭 가능합니다.** 
| As-Is | To-Be |
| ----- | -------|
| CBStore.Get(Key) | etcd.GetKv(key) |
| CBStore.GetList(key, true) | etcd.GetKvList(keyPrefix) |
| CBStore.Put(key, string(val)) | etcd.Put(key,value) |
| CBStore.Delete(key) | etcd.Delete(key) |
| CBStore.Close() | etcd.Close() |

**다음은 etcd의 신규 기능 리스트 입니다.**
: context, dist-lock, watch 기능 등을 제공합니다.

NewSession(ctx context.Context) (*concurrency.Session, error)
NewLock(ctx context.Context, session *concurrency.Session, lockKey string) (*concurrency.Mutex, error)
PutWith(ctx context.Context, key, value string) error
Get(key string) (string, error)
GetWith(ctx context.Context, key string) (string, error)
GetList(keyPrefix string) ([]string, error)
GetListWith(ctx context.Context, keyPrefix string) ([]string, error)
GetKvWith(ctx context.Context, key string) (KeyValue, error)
GetKvListWith(ctx context.Context, keyPrefix string) ([]KeyValue, error)
GetSortedKvList(keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error)
GetSortedKvListWith(ctx context.Context, keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error)
GetKvMap(keyPrefix string) (KeyValueMap, error)
GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap, error)
DeleteWith(ctx context.Context, key string) error
WatchKey(key string) clientv3.WatchChan
WatchKeyWith(ctx context.Context, key string) clientv3.WatchChan
WatchKeys(keyPrefix string) clientv3.WatchChan
WatchKeysWith(ctx context.Context, keyPrefix string) clientv3.WatchChan

**kvutil에는 아래 두 파트와 관련된 기능들이 구현되어 있습니다.**
: 추가로 필요한 기능이 있다면 코멘트 남겨주시기 바랍니다 👂 

(cb-tumblebug/src/core/common/utility.go)
https://github.com/cloud-barista/cb-tumblebug/blob/357c008971ee34ad576c360ce31ba02469a3aeac/src/core/common/utility.go#L1180-L1258

(cb-store/utils/utils.go)
https://github.com/cloud-barista/cb-store/blob/master/utils/utils.go

**`src/example/kvstore/main.go` 에서 활용/테스트를 위한 예시를 확인하실 수 있습니다.**

**`docker-compose.yaml`에서 etcd 컨테이너의 로컬 구동을 지원합니다.**
: etcd 서비스를 개별 구동하기 위한 명령어가 아래와 같습니다.
```bash
docker-compose up -d etcd
```
