### PR TITLE
Update k8sclusterinfo.yaml and add 'others' keyword

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -6,13 +6,66 @@
 #   <csp>: Name of the CSP
 #     nodegroupsWithCluster:
 #     version:
-#       - region: [region1, region2, all(special keyword)]
+#       - region: [region1, region2, common(special keyword: most of regions)]
+#
 
 k8scluster:
+  azure:
+    nodegroupsWithCluster: true
+    nodeImageDesignation: false
+    version:
+      - region: [westeurope,westus]
+        available:
+          - name: 1.29
+            id: 1.29.4
+          - name: 1.28
+            id: 1.28.9
+          - name: 1.27
+            id: 1.27.13
+      - region: [common]
+        available:
+          - name: 1.29
+            id: 1.29.5
+          - name: 1.28
+            id: 1.28.10
+          - name: 1.27
+            id: 1.27.14
+    rootDisk:
+      - region: [common]
+        type:
+          - name: default
+            id: default
+        size:
+          min: 10
+          max: 40
+  gcp:
+    nodegroupsWithCluster: true
+    nodeImageDesignation: true
+    version:
+      - region: [common]
+        available:
+          - name: 1.29
+            id: 1.29.6-gke.1038001
+          - name: 1.28
+            id: 1.28.11-gke.1019001
+          - name: 1.26
+            id: 1.27.14-gke.1059002
+    rootDisk:
+      - region: [common]
+        type:
+          - name: default
+            id: default
+        size:
+          min: 10
+          max: 40
   alibaba:
     nodegroupsWithCluster: false
+    nodeImageDesignation: true
     version:
-      - region: [ap-northeast-1,ap-northeast-2,ap-southeast-1,ap-southeast-3,ap-southeast-5,us-west-1,us-east-1,eu-central-1,eu-west-1,cn-beijing,cn-hongkong,cn-shanghai,cn-huhehaote,cn-heyuan,cn-wulanchabu,cn-guangzhou]
+      # ServiceUnavailable or NotSupportedSLB
+      - region: [me-east-1, cn-zhangjiakou, cn-hangzhou, cn-shenzhen, cn-chengdu, ap-south-1, ap-sourtheast-2]
+      # ap-northeast-1,ap-northeast-2,ap-southeast-1,ap-southeast-3,ap-southeast-5,us-west-1,us-east-1,eu-central-1,eu-west-1,cn-beijing,cn-hongkong,cn-shanghai,cn-huhehaote,cn-heyuan,cn-wulanchabu,cn-guangzhou
+      - region: [common] 
         available:
           - name: 1.30
             id: 1.30.1-aliyun.1
@@ -21,7 +74,7 @@ k8scluster:
           - name: 1.26
             id: 1.26.15-aliyun.1
     rootDisk:
-      - region: [all]
+      - region: [common]
         type:
           - name: cloud_essd
             id: cloud_essd
@@ -30,6 +83,7 @@ k8scluster:
           max: 40
   nhncloud:
     nodegroupsWithCluster: true
+    nodeImageDesignation: true
     version:
       - region: [kr1, kr2]
         available:
@@ -42,7 +96,7 @@ k8scluster:
           - name: 1.26
             id: v1.26.3
     rootDisk:
-      - region: [all]
+      - region: [common]
         type:
           - name: default
             id: default
@@ -51,8 +105,9 @@ k8scluster:
           max: 40
   tencent:
     nodegroupsWithCluster: false
+    nodeImageDesignation: true
     version:
-      - region: [all]
+      - region: [common]
         available:
           - name: 1.28
             id: 1.28.3
@@ -61,7 +116,7 @@ k8scluster:
           - name: 1.24
             id: 1.24.4
     rootDisk:
-      - region: [all]
+      - region: [common]
         type:
           - name: default
             id: default

--- a/src/core/common/common.go
+++ b/src/core/common/common.go
@@ -93,6 +93,8 @@ const (
 	StrK8s                        string = "k8s"
 	StrKubernetes                 string = "kubernetes"
 	StrContainer                  string = "container"
+	StrCommon                     string = "common"
+	StrEmpty                      string = "empty"
 	StrDefaultResourceName        string = "-systemdefault-"
 	// StrFirewallRule               string = "firewallRule"
 

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -1305,10 +1305,11 @@ func getK8sClusterDetail(providerName string) *K8sClusterDetail {
 // GetAvailableK8sClusterVersion is func to get available kubernetes cluster versions for provider and region from K8sClusterInfo
 func GetAvailableK8sClusterVersion(providerName string, regionName string) (*[]K8sClusterVersionDetailAvailable, error) {
 	//
-	// Check available K8sCluster version and node image in k8sclusterinfo.yaml
+	// Check available K8sCluster version in k8sclusterinfo.yaml
 	//
 
 	providerName = strings.ToLower(providerName)
+	regionName = strings.ToLower(regionName)
 
 	// Get K8sClusterDetail for providerName
 	k8sClusterDetail := getK8sClusterDetail(providerName)
@@ -1316,19 +1317,38 @@ func GetAvailableK8sClusterVersion(providerName string, regionName string) (*[]K
 		return nil, fmt.Errorf("unsupported provider(%s) for kubernetes cluster", providerName)
 	}
 
-	// Get Available Versions for regionName
+	// Check if 'regionName' exists
 	var availableVersion *[]K8sClusterVersionDetailAvailable = nil
 	for _, versionDetail := range k8sClusterDetail.Version {
 		for _, region := range versionDetail.Region {
 			region = strings.ToLower(region)
-			if region == "all" || region == regionName {
-				availableVersion = &versionDetail.Available
+			if strings.EqualFold(region, regionName) {
+				if len(versionDetail.Available) == 0 {
+					availableVersion = &[]K8sClusterVersionDetailAvailable{{StrEmpty, StrEmpty}}
+				} else {
+					availableVersion = &versionDetail.Available
+				}
 				return availableVersion, nil
 			}
 		}
 	}
 
-	return nil, fmt.Errorf("no available kubernetes cluster version for provider(%s):region(%s)", providerName, regionName)
+	// Check if 'common' exists
+	for _, versionDetail := range k8sClusterDetail.Version {
+		for _, region := range versionDetail.Region {
+			region = strings.ToLower(region)
+			if strings.EqualFold(region, StrCommon) {
+				if len(versionDetail.Available) == 0 {
+					availableVersion = &[]K8sClusterVersionDetailAvailable{{StrEmpty, StrEmpty}}
+				} else {
+					availableVersion = &versionDetail.Available
+				}
+				return availableVersion, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no entry for provider(%s):region(%s)", providerName, regionName)
 }
 
 // GetAvailableK8sClusterNodeImage is func to get available kubernetes cluster node images for provider and region from K8sClusterInfo
@@ -1338,6 +1358,7 @@ func GetAvailableK8sClusterNodeImage(providerName string, regionName string) (*[
 	//
 
 	providerName = strings.ToLower(providerName)
+	regionName = strings.ToLower(regionName)
 
 	// Get K8sClusterDetail for providerName
 	k8sClusterDetail := getK8sClusterDetail(providerName)
@@ -1345,13 +1366,34 @@ func GetAvailableK8sClusterNodeImage(providerName string, regionName string) (*[
 		return nil, fmt.Errorf("unsupported provider(%s) for kubernetes cluster", providerName)
 	}
 
-	// Get Available Node Image for regionName
+	// Check if 'regionName' exists
 	var availableNodeImage *[]K8sClusterNodeImageDetailAvailable = nil
 	for _, nodeImageDetail := range k8sClusterDetail.NodeImage {
 		for _, region := range nodeImageDetail.Region {
 			region = strings.ToLower(region)
-			if region == "all" || region == regionName {
-				availableNodeImage = &nodeImageDetail.Available
+			if strings.EqualFold(region, regionName) {
+				if len(nodeImageDetail.Available) == 0 {
+					availableNodeImage = &[]K8sClusterNodeImageDetailAvailable{{StrEmpty, StrEmpty}}
+					break
+				} else {
+					availableNodeImage = &nodeImageDetail.Available
+				}
+				return availableNodeImage, nil
+			}
+		}
+	}
+
+	// Check if 'common' exists
+	for _, nodeImageDetail := range k8sClusterDetail.NodeImage {
+		for _, region := range nodeImageDetail.Region {
+			region = strings.ToLower(region)
+			if strings.EqualFold(region, StrCommon) {
+				if len(nodeImageDetail.Available) == 0 {
+					availableNodeImage = &[]K8sClusterNodeImageDetailAvailable{{StrEmpty, StrEmpty}}
+					break
+				} else {
+					availableNodeImage = &nodeImageDetail.Available
+				}
 				return availableNodeImage, nil
 			}
 		}


### PR DESCRIPTION
assets/k8sclusterinfo.yaml의 내용 업데이트 및 others 키워드를 추가하여 특이한 리전과 일반 리전을 구분하여 처리할 수 있도록 하였습니다.