### PR TITLE
[k8scluster] add CheckNodeGroupsOnK8sCreation API (no routed)

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -4,14 +4,14 @@
 # The file is in YAML format and contains the following fields:
 # k8scluster: Top level key
 #   <csp>: Name of the CSP
-#     nodegroupsWithCluster:
+#     nodeGroupsOnCreation:
 #     version:
 #       - region: [region1, region2, common(special keyword: most of regions)]
 #
 
 k8scluster:
   azure:
-    nodegroupsWithCluster: true
+    nodeGroupsOnCreation: true
     nodeImageDesignation: false
     version:
       - region: [westeurope,westus]
@@ -41,7 +41,7 @@ k8scluster:
           min: 10
           max: 40
   gcp:
-    nodegroupsWithCluster: true
+    nodeGroupsOnCreation: true
     nodeImageDesignation: true
     version:
       - region: [common]
@@ -61,7 +61,7 @@ k8scluster:
           min: 10
           max: 40
   alibaba:
-    nodegroupsWithCluster: false
+    nodeGroupsOnCreation: false
     nodeImageDesignation: true
     version:
       # ServiceUnavailable or NotSupportedSLB
@@ -84,7 +84,7 @@ k8scluster:
           min: 10
           max: 40
   nhncloud:
-    nodegroupsWithCluster: true
+    nodeGroupsOnCreation: true
     nodeImageDesignation: true
     version:
       - region: [kr1, kr2]
@@ -106,7 +106,7 @@ k8scluster:
           min: 10
           max: 40
   tencent:
-    nodegroupsWithCluster: false
+    nodeGroupsOnCreation: false
     nodeImageDesignation: true
     version:
       - region: [common]

--- a/src/api/rest/server/mcis/k8scluster.go
+++ b/src/api/rest/server/mcis/k8scluster.go
@@ -75,6 +75,30 @@ func RestGetAvailableK8sClusterNodeImage(c echo.Context) error {
 	return common.EndRequestWithLog(c, reqID, err, content)
 }
 
+// RestCheckNodeGroupsOnK8sCreation func is a rest api wrapper for CheckNodeGroupsOnK8sCreation.
+// RestCheckNodeGroupsOnK8sCreation godoc
+// @ID CheckNodeGroupsOnK8sCreation
+// @Summary Check whether nodegroups are required during the k8scluster creation
+// @Description Check whether nodegroups are required during the k8scluster creation
+// @Tags [Infra resource] K8sCluster management
+// @Accept  json
+// @Produce  json
+// @Param providerName query string true "Name of the CSP to retrieve"
+// @Success 200 {object} bool
+// @Failure 404 {object} common.SimpleMsg
+// @Failure 500 {object} common.SimpleMsg
+// @Router /checkNodeGroupsOnK8sCreation [get]
+func RestCheckNodeGroupsOnK8sCreation(c echo.Context) error {
+	reqID, idErr := common.StartRequestWithLog(c)
+	if idErr != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
+	}
+	providerName := c.QueryParam("providerName")
+
+	content, err := common.CheckNodeGroupsOnK8sCreation(providerName)
+	return common.EndRequestWithLog(c, reqID, err, content)
+}
+
 // RestPostK8sCluster func is a rest api wrapper for CreateK8sCluster.
 // RestPostK8sCluster godoc
 // @ID PostK8sCluster

--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -73,10 +73,10 @@ type K8sClusterInfo struct {
 
 // K8sClusterDetail is structure for kubernetes cluster detail information
 type K8sClusterDetail struct {
-	NodeGroupsWithCluster bool                        `mapstructure:"nodegroupsWithCluster" json:"nodegroups_with_cluster"`
-	Version               []K8sClusterVersionDetail   `mapstructure:"version" json:"versions"`
-	NodeImage             []K8sClusterNodeImageDetail `mapstructure:"nodeImage" json:"node_images"`
-	RootDisk              []K8sClusterRootDiskDetail  `mapstructure:"rootDisk" json:"root_disks"`
+	NodeGroupsOnCreation bool                        `mapstructure:"nodeGroupsOnCreation" json:"nodegroups_on_creation"`
+	Version              []K8sClusterVersionDetail   `mapstructure:"version" json:"versions"`
+	NodeImage            []K8sClusterNodeImageDetail `mapstructure:"nodeImage" json:"node_images"`
+	RootDisk             []K8sClusterRootDiskDetail  `mapstructure:"rootDisk" json:"root_disks"`
 }
 
 // K8sClusterVersionDetail is structure for kubernetes cluster version detail information

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -1329,6 +1329,23 @@ func GetAvailableK8sClusterNodeImage(providerName string, regionName string) (*[
 	return nil, fmt.Errorf("no available kubernetes cluster node image for region(%s) of provider(%s)", regionName, providerName)
 }
 
+// CheckNodeGroupsOnK8sCreation is func to check whether nodegroups are required during the k8scluster creation
+func CheckNodeGroupsOnK8sCreation(providerName string) (bool, error) {
+	//
+	// Check nodeGroupsOnCreation field in k8sclusterinfo.yaml
+	//
+
+	providerName = strings.ToLower(providerName)
+
+	// Get K8sClusterDetail for providerName
+	k8sClusterDetail := getK8sClusterDetail(providerName)
+	if k8sClusterDetail == nil {
+		return false, fmt.Errorf("unsupported provider(%s) for kubernetes cluster", providerName)
+	}
+
+	return k8sClusterDetail.NodeGroupsOnCreation, nil
+}
+
 /*
 func isValidSpecForK8sCluster(spec *mcir.TbSpecInfo) bool {
 	//


### PR DESCRIPTION
K8sCluster 생성시 노드 그룹 지정 여부를 확인할 수 있는 API를 추가합니다.
아직 테스트가 되지 않았기에 route에 등록하지 않은 상태입니다.