### PR TITLE
[k8scluster] update valid specId example in TbK8sNodeGroupReq

### DIFF
--- a/src/core/mcis/k8scluster.go
+++ b/src/core/mcis/k8scluster.go
@@ -140,7 +140,7 @@ type SpiderNodeGroupReqInfo struct {
 type TbK8sNodeGroupReq struct {
 	Name         string `json:"name" example:"ng-01"`
 	ImageId      string `json:"imageId" example:"image-01"`
-	SpecId       string `json:"specId" example:"spec-01"`
+	SpecId       string `json:"specId" example:"Standard_B2s (temporarily, CSP's Spec Names are valid. It will be upgraded)"`
 	RootDiskType string `json:"rootDiskType" example:"cloud_essd" enum:"default, TYPE1, ..."` // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_ssd"], TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]
 	RootDiskSize string `json:"rootDiskSize" example:"40" enum:"default, 30, 42, ..."`        // "default", Integer (GB): ["50", ..., "1000"]
 	SshKeyId     string `json:"sshKeyId" example:"sshkey-01"`

--- a/src/testclient/scripts/13.k8scluster/add-k8snodegroup.sh
+++ b/src/testclient/scripts/13.k8scluster/add-k8snodegroup.sh
@@ -55,7 +55,7 @@ req=$(cat << EOF
 	{
 		"name": "${K8SNODEGROUPNAME}",
 		"imageId": "${NODEIMAGEID}",
-		"specId": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+                "specId": "${SPEC_NAME[$INDEX,$REGION]}",
 		"rootDiskType": "${RootDiskType}",
 		"rootDiskSize": "${RootDiskSize}",
 		"sshKeyId": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",

--- a/src/testclient/scripts/13.k8scluster/create-k8scluster.sh
+++ b/src/testclient/scripts/13.k8scluster/create-k8scluster.sh
@@ -69,7 +69,7 @@ else # Type-II CSP
                 "k8sNodeGroupList": [ {
                         "name": "${K8SNODEGROUPNAME}",
 			"imageId": "default",
-                        "specId": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",
+                        "specId": "${SPEC_NAME[$INDEX,$REGION]}",
                         "rootDiskType": "${RootDiskType}",
                         "rootDiskSize": "${RootDiskSize}",
                         "sshKeyId": "${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}",


### PR DESCRIPTION
SpecId 체계 개선 진행 전 임시로 CB-TB의 SpecId가 아닌 CSP Spec Name을 입력하도록 예제를 변경하였습니다.