### PR TITLE
Speed up docker build time by using go build cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,12 @@ To provisioning multi-cloud infrastructures with CB-TB, it is necessary to regis
 
 - With CB-MapUI, you can create, view, and control Mutli-Cloud infra.
   - [CB-MapUI](https://github.com/cloud-barista/cb-mapui) is a project to visualize the deployment of MCI in a map GUI.
-  - Run the CB-MapUI container using the CB-TB script
-    ```bash
-    cd ~/go/src/github.com/cloud-barista/cb-tumblebug
-    ./scripts/runMapUI.sh
-    ```
+  - CB-MapUI also run with CB-Tumblebug by default (edit `dockercompose.yaml` to disable)
+    - If you run the CB-MapUI container using the CB-TB script, excute
+      ```bash
+      cd ~/go/src/github.com/cloud-barista/cb-tumblebug
+      ./scripts/runMapUI.sh
+      ```
   - Access via web browser at http://{HostIP}:1324
     ![image](https://github.com/cloud-barista/cb-mapui/assets/5966944/2423fbcd-0fdb-4511-85e2-488ba15ae8c0)
 
@@ -528,11 +529,11 @@ To provisioning multi-cloud infrastructures with CB-TB, it is necessary to regis
   
   ```bash
   cd ~/go/src/github.com/cloud-barista/cb-tumblebug
-  sudo docker compose up --build
+  sudo DOCKER_BUILDKIT=1 docker compose up --build
   ```
 
   This command will automatically build the CB-Tumblebug from the local source code
-  and start it within a Docker container, along with any other necessary services as defined in the `docker-compose.yml` file.
+  and start it within a Docker container, along with any other necessary services as defined in the `docker-compose.yml` file. `DOCKER_BUILDKIT=1` setting is used to speed up the build by using the go build cache technique.
 
 #### (2-2) Option 2: Run CB-Tumblebug from the Makefile
 

--- a/src/core/common/namespace.go
+++ b/src/core/common/namespace.go
@@ -21,8 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	//"github.com/cloud-barista/cb-tumblebug/src/core/mcir"
-	//"github.com/cloud-barista/cb-tumblebug/src/core/mci"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 

--- a/src/core/mci/benchmark.go
+++ b/src/core/mci/benchmark.go
@@ -19,17 +19,12 @@ import (
 	"fmt"
 	"io"
 
-	//"log"
 	"strconv"
 	"strings"
 
-	//csv file handling
-
 	"encoding/csv"
-	"os"
-
-	// REST API (echo)
 	"net/http"
+	"os"
 
 	"sync"
 

--- a/src/core/mci/control.go
+++ b/src/core/mci/control.go
@@ -20,16 +20,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	//"log"
-
 	"strings"
-	"time"
-
-	//csv file handling
-
-	// REST API (echo)
-
 	"sync"
+	"time"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/mcir"
@@ -39,7 +32,6 @@ import (
 )
 
 // MCI Control
-
 // ControlVmResult is struct for result of VM control
 type ControlVmResult struct {
 	VmId   string `json:"vmId"`

--- a/src/core/mci/manageInfo.go
+++ b/src/core/mci/manageInfo.go
@@ -19,18 +19,12 @@ import (
 	"fmt"
 	"reflect"
 
-	//"log"
 	"strconv"
 	"strings"
 	"time"
 
-	//csv file handling
-
 	"math/rand"
 	"sort"
-
-	// REST API (echo)
-
 	"sync"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"


### PR DESCRIPTION
- 기존 dockerfile은 golang의 build cache를 활용하지 못해서, 상시 관련 pkg를 다운로드 받는 등, 효율이 떨어지고 속도가 오래 걸렸음. docker buildx 키트를 활용하여, golang의 build cache를 활용할 수 있도록 개선
  - 기존 이미지 빌드 속도: 약 140초
  - 개선 이미지 빌드 속도: 약 20초

굿.