### PR TITLE
Rename spec and image relatd fields

### DIFF
--- a/assets/cloudimage.csv
+++ b/assets/cloudimage.csv
@@ -1,4 +1,4 @@
-ProviderName,regionName,cspResourceId,OsType,description,supportedInstance,infraType
+providerName,regionName,cspImageName,osType,description,supportedInstance,infraType
 AWS,ap-southeast-1,ami-061eb2b23f9f8839c,Ubuntu 18.04,,,vm
 AWS,ap-northeast-1,ami-06b060f6dd92163e3,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,ap-southeast-1,ami-02ee763250491e04a,Ubuntu 22.04,,,vm

--- a/assets/cloudspec.csv
+++ b/assets/cloudspec.csv
@@ -1,4 +1,4 @@
-providerName,regionName,cspResourceId,CostPerHour,evaluationScore01,evaluationScore02,evaluationScore03,evaluationScore04,evaluationScore05,evaluationScore06,evaluationScore07,evaluationScore08,evaluationScore09,evaluationScore10,rootDiskType,rootDiskSize,acceleratorType,acceleratorModel,acceleratorCount,acceleratorMemoryGB,description,infraType
+providerName,regionName,cspSpecName,costPerHour,evaluationScore01,evaluationScore02,evaluationScore03,evaluationScore04,evaluationScore05,evaluationScore06,evaluationScore07,evaluationScore08,evaluationScore09,evaluationScore10,rootDiskType,rootDiskSize,acceleratorType,acceleratorModel,acceleratorCount,acceleratorMemoryGB,description,infraType
 ALIBABA,ap-northeast-2,ecs.g6e.large,0.12122,78.43,,,,,,,,,,cloud_essd,40,,,,,,vm
 ALIBABA,ap-northeast-2,ecs.g6e.xlarge,0.24244,78.43,,,,,,,,,,cloud_essd,40,,,,,,vm|k8s
 ALIBABA,ap-northeast-2,ecs.g6e.2xlarge,0.48488,78.43,,,,,,,,,,cloud_essd,40,,,,,,vm|k8s

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -1079,7 +1079,7 @@ const docTemplate = `{
                 "operationId": "LookupImage",
                 "parameters": [
                     {
-                        "description": "Specify connectionName \u0026 cspResourceId",
+                        "description": "Specify connectionName, cspImageName",
                         "name": "lookupImageReq",
                         "in": "body",
                         "required": true,
@@ -1173,7 +1173,7 @@ const docTemplate = `{
                 "operationId": "LookupSpec",
                 "parameters": [
                     {
-                        "description": "Specify connectionName \u0026 cspResourceId",
+                        "description": "Specify connectionName \u0026 cspSpecNameS",
                         "name": "lookupSpecReq",
                         "in": "body",
                         "required": true,
@@ -6358,7 +6358,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6504,7 +6504,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6610,8 +6610,8 @@ const docTemplate = `{
                         }
                     },
                     {
-                        "description": "Specify name, connectionName and cspResourceId to register an image object automatically",
-                        "name": "imageId",
+                        "description": "Specify (name, connectionName, cspImageName) to register an image object automatically",
+                        "name": "imageReq",
                         "in": "body",
                         "schema": {
                             "$ref": "#/definitions/model.TbImageReq"
@@ -6662,7 +6662,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6709,7 +6709,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6717,7 +6717,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Image ID ({providerName}+{regionName}+{imageName})",
+                        "description": "Image ID ({providerName}+{regionName}+{cspImageName})",
                         "name": "imageId",
                         "in": "path",
                         "required": true
@@ -6769,7 +6769,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6777,7 +6777,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Image ID ({providerName}+{regionName}+{imageName})",
+                        "description": "Image ID ({providerName}+{regionName}+{cspImageName})",
                         "name": "imageId",
                         "in": "path",
                         "required": true
@@ -6820,7 +6820,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6828,7 +6828,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Image ID ({providerName}+{regionName}+{imageName})",
+                        "description": "Image ID ({providerName}+{regionName}+{cspImageName})",
                         "name": "imageId",
                         "in": "path",
                         "required": true
@@ -6867,7 +6867,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -7351,8 +7351,8 @@ const docTemplate = `{
                         }
                     },
                     {
-                        "description": "Specify name, connectionName and cspResourceId to register a spec object automatically",
-                        "name": "specName",
+                        "description": "Specify n(ame, connectionName, cspSpecName) to register a spec object automatically",
+                        "name": "specReq",
                         "in": "body",
                         "schema": {
                             "$ref": "#/definitions/model.TbSpecReq"
@@ -7413,7 +7413,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Spec ID ({providerName}+{regionName}+{specName})",
+                        "description": "Spec ID ({providerName}+{regionName}+{cspSpecName})",
                         "name": "specId",
                         "in": "path",
                         "required": true
@@ -7473,7 +7473,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Spec ID ({providerName}+{regionName}+{specName})",
+                        "description": "Spec ID ({providerName}+{regionName}+{cspSpecName})",
                         "name": "specId",
                         "in": "path",
                         "required": true
@@ -7524,7 +7524,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Spec ID ({providerName}+{regionName}+{specName})",
+                        "description": "Spec ID ({providerName}+{regionName}+{cspSpecName})",
                         "name": "specId",
                         "in": "path",
                         "required": true
@@ -10343,7 +10343,7 @@ const docTemplate = `{
                 "costPerHour": {
                     "$ref": "#/definitions/model.Range"
                 },
-                "cspResourceId": {
+                "cspSpecName": {
                     "type": "string"
                 },
                 "description": {
@@ -11789,6 +11789,11 @@ const docTemplate = `{
         "model.TbChangeK8sNodeGroupAutoscaleSizeRes": {
             "type": "object",
             "properties": {
+                "cspImageName": {
+                    "description": "VM config.",
+                    "type": "string",
+                    "example": "image-01"
+                },
                 "cspResourceId": {
                     "description": "CspResourceId is resource identifier managed by CSP",
                     "type": "string",
@@ -11799,6 +11804,10 @@ const docTemplate = `{
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
+                "cspSpecName": {
+                    "type": "string",
+                    "example": "spec-01"
+                },
                 "desiredNodeSize": {
                     "type": "integer",
                     "example": 1
@@ -11807,11 +11816,6 @@ const docTemplate = `{
                     "description": "Id is unique identifier for the object",
                     "type": "string",
                     "example": "aws-ap-southeast-1"
-                },
-                "imageId": {
-                    "description": "VM config.",
-                    "type": "string",
-                    "example": "image-01"
                 },
                 "k8sNodes": {
                     "description": "id for nodes",
@@ -11854,10 +11858,6 @@ const docTemplate = `{
                 "rootDiskType": {
                     "type": "string",
                     "example": "cloud_essd"
-                },
-                "specId": {
-                    "type": "string",
-                    "example": "spec-01"
                 },
                 "sshKeyId": {
                     "type": "string",
@@ -12218,15 +12218,10 @@ const docTemplate = `{
                 "creationDate": {
                     "type": "string"
                 },
-                "cspResourceId": {
-                    "description": "CspResourceId is resource identifier managed by CSP",
+                "cspImageName": {
+                    "description": "CspImageName is name of the image given by CSP",
                     "type": "string",
                     "example": "csp-06eb41e14121c550a"
-                },
-                "cspResourceName": {
-                    "description": "CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.",
-                    "type": "string",
-                    "example": "we12fawefadf1221edcf"
                 },
                 "description": {
                     "type": "string"
@@ -12283,14 +12278,14 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "connectionName",
-                "cspResourceId",
+                "cspImageName",
                 "name"
             ],
             "properties": {
                 "connectionName": {
                     "type": "string"
                 },
-                "cspResourceId": {
+                "cspImageName": {
                     "type": "string"
                 },
                 "description": {
@@ -12534,6 +12529,11 @@ const docTemplate = `{
         "model.TbK8sNodeGroupInfo": {
             "type": "object",
             "properties": {
+                "cspImageName": {
+                    "description": "VM config.",
+                    "type": "string",
+                    "example": "image-01"
+                },
                 "cspResourceId": {
                     "description": "CspResourceId is resource identifier managed by CSP",
                     "type": "string",
@@ -12544,6 +12544,10 @@ const docTemplate = `{
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
+                "cspSpecName": {
+                    "type": "string",
+                    "example": "spec-01"
+                },
                 "desiredNodeSize": {
                     "type": "integer",
                     "example": 1
@@ -12552,11 +12556,6 @@ const docTemplate = `{
                     "description": "Id is unique identifier for the object",
                     "type": "string",
                     "example": "aws-ap-southeast-1"
-                },
-                "imageId": {
-                    "description": "VM config.",
-                    "type": "string",
-                    "example": "image-01"
                 },
                 "k8sNodes": {
                     "description": "id for nodes",
@@ -12600,10 +12599,6 @@ const docTemplate = `{
                     "type": "string",
                     "example": "cloud_essd"
                 },
-                "specId": {
-                    "type": "string",
-                    "example": "spec-01"
-                },
                 "sshKeyId": {
                     "type": "string",
                     "example": "sshkey-01"
@@ -12627,13 +12622,17 @@ const docTemplate = `{
         "model.TbK8sNodeGroupReq": {
             "type": "object",
             "properties": {
+                "cspImageName": {
+                    "type": "string",
+                    "example": "image-01"
+                },
+                "cspSpecName": {
+                    "type": "string",
+                    "example": "Standard_B2s (temporarily, CSP's Spec Names are valid. It will be upgraded)"
+                },
                 "desiredNodeSize": {
                     "type": "string",
                     "example": "1"
-                },
-                "imageId": {
-                    "type": "string",
-                    "example": "image-01"
                 },
                 "maxNodeSize": {
                     "type": "string",
@@ -12661,10 +12660,6 @@ const docTemplate = `{
                     "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
                     "type": "string",
                     "example": "cloud_essd"
-                },
-                "specId": {
-                    "type": "string",
-                    "example": "Standard_B2s (temporarily, CSP's Spec Names are valid. It will be upgraded)"
                 },
                 "sshKeyId": {
                     "type": "string",
@@ -13367,15 +13362,10 @@ const docTemplate = `{
                 "costPerHour": {
                     "type": "number"
                 },
-                "cspResourceId": {
-                    "description": "CspResourceId is resource identifier managed by CSP",
+                "cspSpecName": {
+                    "description": "CspSpecName is name of the spec given by CSP",
                     "type": "string",
                     "example": "csp-06eb41e14121c550a"
-                },
-                "cspResourceName": {
-                    "description": "CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.",
-                    "type": "string",
-                    "example": "we12fawefadf1221edcf"
                 },
                 "description": {
                     "type": "string"
@@ -13419,7 +13409,7 @@ const docTemplate = `{
                     "example": "aws-ap-southeast-1"
                 },
                 "infraType": {
-                    "description": "vm|k8s|kubernetes|container, etc.",
+                    "description": "InfraType can be one of vm|k8s|kubernetes|container, etc.",
                     "type": "string"
                 },
                 "isAutoGenerated": {
@@ -13483,20 +13473,22 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "connectionName",
-                "cspResourceId",
+                "cspSpecName",
                 "name"
             ],
             "properties": {
                 "connectionName": {
                     "type": "string"
                 },
-                "cspResourceId": {
+                "cspSpecName": {
+                    "description": "CspSpecName is name of the spec given by CSP",
                     "type": "string"
                 },
                 "description": {
                     "type": "string"
                 },
                 "name": {
+                    "description": "Name is human-readable string to represent the object, used to generate Id",
                     "type": "string"
                 }
             }
@@ -13635,8 +13627,8 @@ const docTemplate = `{
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
-                "cspVNetHandlingId": {
-                    "description": "CspVNetHandlingId is identifier to handle CSP vNet resource",
+                "cspVNetName": {
+                    "description": "CspVNetName is identifier to handle CSP vNet resource",
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
@@ -13892,7 +13884,7 @@ const docTemplate = `{
                     "type": "string",
                     "example": "2022-11-10 23:00:00"
                 },
-                "cspImageId": {
+                "cspImageName": {
                     "type": "string"
                 },
                 "cspResourceId": {
@@ -13905,7 +13897,7 @@ const docTemplate = `{
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
-                "cspSpecId": {
+                "cspSpecName": {
                     "type": "string"
                 },
                 "cspSshKeyId": {
@@ -14520,7 +14512,7 @@ const docTemplate = `{
                 "connectionName": {
                     "type": "string"
                 },
-                "cspResourceId": {
+                "cspImageName": {
                     "type": "string"
                 }
             }

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -1072,7 +1072,7 @@
                 "operationId": "LookupImage",
                 "parameters": [
                     {
-                        "description": "Specify connectionName \u0026 cspResourceId",
+                        "description": "Specify connectionName, cspImageName",
                         "name": "lookupImageReq",
                         "in": "body",
                         "required": true,
@@ -1166,7 +1166,7 @@
                 "operationId": "LookupSpec",
                 "parameters": [
                     {
-                        "description": "Specify connectionName \u0026 cspResourceId",
+                        "description": "Specify connectionName \u0026 cspSpecNameS",
                         "name": "lookupSpecReq",
                         "in": "body",
                         "required": true,
@@ -6351,7 +6351,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6497,7 +6497,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6603,8 +6603,8 @@
                         }
                     },
                     {
-                        "description": "Specify name, connectionName and cspResourceId to register an image object automatically",
-                        "name": "imageId",
+                        "description": "Specify (name, connectionName, cspImageName) to register an image object automatically",
+                        "name": "imageReq",
                         "in": "body",
                         "schema": {
                             "$ref": "#/definitions/model.TbImageReq"
@@ -6655,7 +6655,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6702,7 +6702,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6710,7 +6710,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Image ID ({providerName}+{regionName}+{imageName})",
+                        "description": "Image ID ({providerName}+{regionName}+{cspImageName})",
                         "name": "imageId",
                         "in": "path",
                         "required": true
@@ -6762,7 +6762,7 @@
                     },
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6770,7 +6770,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Image ID ({providerName}+{regionName}+{imageName})",
+                        "description": "Image ID ({providerName}+{regionName}+{cspImageName})",
                         "name": "imageId",
                         "in": "path",
                         "required": true
@@ -6813,7 +6813,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -6821,7 +6821,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Image ID ({providerName}+{regionName}+{imageName})",
+                        "description": "Image ID ({providerName}+{regionName}+{cspImageName})",
                         "name": "imageId",
                         "in": "path",
                         "required": true
@@ -6860,7 +6860,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "default",
+                        "default": "system",
                         "description": "Namespace ID",
                         "name": "nsId",
                         "in": "path",
@@ -7344,8 +7344,8 @@
                         }
                     },
                     {
-                        "description": "Specify name, connectionName and cspResourceId to register a spec object automatically",
-                        "name": "specName",
+                        "description": "Specify n(ame, connectionName, cspSpecName) to register a spec object automatically",
+                        "name": "specReq",
                         "in": "body",
                         "schema": {
                             "$ref": "#/definitions/model.TbSpecReq"
@@ -7406,7 +7406,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Spec ID ({providerName}+{regionName}+{specName})",
+                        "description": "Spec ID ({providerName}+{regionName}+{cspSpecName})",
                         "name": "specId",
                         "in": "path",
                         "required": true
@@ -7466,7 +7466,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Spec ID ({providerName}+{regionName}+{specName})",
+                        "description": "Spec ID ({providerName}+{regionName}+{cspSpecName})",
                         "name": "specId",
                         "in": "path",
                         "required": true
@@ -7517,7 +7517,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Spec ID ({providerName}+{regionName}+{specName})",
+                        "description": "Spec ID ({providerName}+{regionName}+{cspSpecName})",
                         "name": "specId",
                         "in": "path",
                         "required": true
@@ -10336,7 +10336,7 @@
                 "costPerHour": {
                     "$ref": "#/definitions/model.Range"
                 },
-                "cspResourceId": {
+                "cspSpecName": {
                     "type": "string"
                 },
                 "description": {
@@ -11782,6 +11782,11 @@
         "model.TbChangeK8sNodeGroupAutoscaleSizeRes": {
             "type": "object",
             "properties": {
+                "cspImageName": {
+                    "description": "VM config.",
+                    "type": "string",
+                    "example": "image-01"
+                },
                 "cspResourceId": {
                     "description": "CspResourceId is resource identifier managed by CSP",
                     "type": "string",
@@ -11792,6 +11797,10 @@
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
+                "cspSpecName": {
+                    "type": "string",
+                    "example": "spec-01"
+                },
                 "desiredNodeSize": {
                     "type": "integer",
                     "example": 1
@@ -11800,11 +11809,6 @@
                     "description": "Id is unique identifier for the object",
                     "type": "string",
                     "example": "aws-ap-southeast-1"
-                },
-                "imageId": {
-                    "description": "VM config.",
-                    "type": "string",
-                    "example": "image-01"
                 },
                 "k8sNodes": {
                     "description": "id for nodes",
@@ -11847,10 +11851,6 @@
                 "rootDiskType": {
                     "type": "string",
                     "example": "cloud_essd"
-                },
-                "specId": {
-                    "type": "string",
-                    "example": "spec-01"
                 },
                 "sshKeyId": {
                     "type": "string",
@@ -12211,15 +12211,10 @@
                 "creationDate": {
                     "type": "string"
                 },
-                "cspResourceId": {
-                    "description": "CspResourceId is resource identifier managed by CSP",
+                "cspImageName": {
+                    "description": "CspImageName is name of the image given by CSP",
                     "type": "string",
                     "example": "csp-06eb41e14121c550a"
-                },
-                "cspResourceName": {
-                    "description": "CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.",
-                    "type": "string",
-                    "example": "we12fawefadf1221edcf"
                 },
                 "description": {
                     "type": "string"
@@ -12276,14 +12271,14 @@
             "type": "object",
             "required": [
                 "connectionName",
-                "cspResourceId",
+                "cspImageName",
                 "name"
             ],
             "properties": {
                 "connectionName": {
                     "type": "string"
                 },
-                "cspResourceId": {
+                "cspImageName": {
                     "type": "string"
                 },
                 "description": {
@@ -12527,6 +12522,11 @@
         "model.TbK8sNodeGroupInfo": {
             "type": "object",
             "properties": {
+                "cspImageName": {
+                    "description": "VM config.",
+                    "type": "string",
+                    "example": "image-01"
+                },
                 "cspResourceId": {
                     "description": "CspResourceId is resource identifier managed by CSP",
                     "type": "string",
@@ -12537,6 +12537,10 @@
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
+                "cspSpecName": {
+                    "type": "string",
+                    "example": "spec-01"
+                },
                 "desiredNodeSize": {
                     "type": "integer",
                     "example": 1
@@ -12545,11 +12549,6 @@
                     "description": "Id is unique identifier for the object",
                     "type": "string",
                     "example": "aws-ap-southeast-1"
-                },
-                "imageId": {
-                    "description": "VM config.",
-                    "type": "string",
-                    "example": "image-01"
                 },
                 "k8sNodes": {
                     "description": "id for nodes",
@@ -12593,10 +12592,6 @@
                     "type": "string",
                     "example": "cloud_essd"
                 },
-                "specId": {
-                    "type": "string",
-                    "example": "spec-01"
-                },
                 "sshKeyId": {
                     "type": "string",
                     "example": "sshkey-01"
@@ -12620,13 +12615,17 @@
         "model.TbK8sNodeGroupReq": {
             "type": "object",
             "properties": {
+                "cspImageName": {
+                    "type": "string",
+                    "example": "image-01"
+                },
+                "cspSpecName": {
+                    "type": "string",
+                    "example": "Standard_B2s (temporarily, CSP's Spec Names are valid. It will be upgraded)"
+                },
                 "desiredNodeSize": {
                     "type": "string",
                     "example": "1"
-                },
-                "imageId": {
-                    "type": "string",
-                    "example": "image-01"
                 },
                 "maxNodeSize": {
                     "type": "string",
@@ -12654,10 +12653,6 @@
                     "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
                     "type": "string",
                     "example": "cloud_essd"
-                },
-                "specId": {
-                    "type": "string",
-                    "example": "Standard_B2s (temporarily, CSP's Spec Names are valid. It will be upgraded)"
                 },
                 "sshKeyId": {
                     "type": "string",
@@ -13360,15 +13355,10 @@
                 "costPerHour": {
                     "type": "number"
                 },
-                "cspResourceId": {
-                    "description": "CspResourceId is resource identifier managed by CSP",
+                "cspSpecName": {
+                    "description": "CspSpecName is name of the spec given by CSP",
                     "type": "string",
                     "example": "csp-06eb41e14121c550a"
-                },
-                "cspResourceName": {
-                    "description": "CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.",
-                    "type": "string",
-                    "example": "we12fawefadf1221edcf"
                 },
                 "description": {
                     "type": "string"
@@ -13412,7 +13402,7 @@
                     "example": "aws-ap-southeast-1"
                 },
                 "infraType": {
-                    "description": "vm|k8s|kubernetes|container, etc.",
+                    "description": "InfraType can be one of vm|k8s|kubernetes|container, etc.",
                     "type": "string"
                 },
                 "isAutoGenerated": {
@@ -13476,20 +13466,22 @@
             "type": "object",
             "required": [
                 "connectionName",
-                "cspResourceId",
+                "cspSpecName",
                 "name"
             ],
             "properties": {
                 "connectionName": {
                     "type": "string"
                 },
-                "cspResourceId": {
+                "cspSpecName": {
+                    "description": "CspSpecName is name of the spec given by CSP",
                     "type": "string"
                 },
                 "description": {
                     "type": "string"
                 },
                 "name": {
+                    "description": "Name is human-readable string to represent the object, used to generate Id",
                     "type": "string"
                 }
             }
@@ -13628,8 +13620,8 @@
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
-                "cspVNetHandlingId": {
-                    "description": "CspVNetHandlingId is identifier to handle CSP vNet resource",
+                "cspVNetName": {
+                    "description": "CspVNetName is identifier to handle CSP vNet resource",
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
@@ -13885,7 +13877,7 @@
                     "type": "string",
                     "example": "2022-11-10 23:00:00"
                 },
-                "cspImageId": {
+                "cspImageName": {
                     "type": "string"
                 },
                 "cspResourceId": {
@@ -13898,7 +13890,7 @@
                     "type": "string",
                     "example": "we12fawefadf1221edcf"
                 },
-                "cspSpecId": {
+                "cspSpecName": {
                     "type": "string"
                 },
                 "cspSshKeyId": {
@@ -14513,7 +14505,7 @@
                 "connectionName": {
                     "type": "string"
                 },
-                "cspResourceId": {
+                "cspImageName": {
                     "type": "string"
                 }
             }

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -480,7 +480,7 @@ definitions:
         type: string
       costPerHour:
         $ref: '#/definitions/model.Range'
-      cspResourceId:
+      cspSpecName:
         type: string
       description:
         type: string
@@ -1454,6 +1454,10 @@ definitions:
     type: object
   model.TbChangeK8sNodeGroupAutoscaleSizeRes:
     properties:
+      cspImageName:
+        description: VM config.
+        example: image-01
+        type: string
       cspResourceId:
         description: CspResourceId is resource identifier managed by CSP
         example: csp-06eb41e14121c550a
@@ -1463,16 +1467,15 @@ definitions:
           is internally used to handle the resource.
         example: we12fawefadf1221edcf
         type: string
+      cspSpecName:
+        example: spec-01
+        type: string
       desiredNodeSize:
         example: 1
         type: integer
       id:
         description: Id is unique identifier for the object
         example: aws-ap-southeast-1
-        type: string
-      imageId:
-        description: VM config.
-        example: image-01
         type: string
       k8sNodes:
         description: id for nodes
@@ -1504,9 +1507,6 @@ definitions:
         type: string
       rootDiskType:
         example: cloud_essd
-        type: string
-      specId:
-        example: spec-01
         type: string
       sshKeyId:
         example: sshkey-01
@@ -1771,14 +1771,9 @@ definitions:
         type: string
       creationDate:
         type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
+      cspImageName:
+        description: CspImageName is name of the image given by CSP
         example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
         type: string
       description:
         type: string
@@ -1824,7 +1819,7 @@ definitions:
     properties:
       connectionName:
         type: string
-      cspResourceId:
+      cspImageName:
         type: string
       description:
         type: string
@@ -1832,7 +1827,7 @@ definitions:
         type: string
     required:
     - connectionName
-    - cspResourceId
+    - cspImageName
     - name
     type: object
   model.TbK8sAccessInfo:
@@ -2012,6 +2007,10 @@ definitions:
     - TbK8sClusterDeleting
   model.TbK8sNodeGroupInfo:
     properties:
+      cspImageName:
+        description: VM config.
+        example: image-01
+        type: string
       cspResourceId:
         description: CspResourceId is resource identifier managed by CSP
         example: csp-06eb41e14121c550a
@@ -2021,16 +2020,15 @@ definitions:
           is internally used to handle the resource.
         example: we12fawefadf1221edcf
         type: string
+      cspSpecName:
+        example: spec-01
+        type: string
       desiredNodeSize:
         example: 1
         type: integer
       id:
         description: Id is unique identifier for the object
         example: aws-ap-southeast-1
-        type: string
-      imageId:
-        description: VM config.
-        example: image-01
         type: string
       k8sNodes:
         description: id for nodes
@@ -2063,9 +2061,6 @@ definitions:
       rootDiskType:
         example: cloud_essd
         type: string
-      specId:
-        example: spec-01
-        type: string
       sshKeyId:
         example: sshkey-01
         type: string
@@ -2082,11 +2077,15 @@ definitions:
     type: object
   model.TbK8sNodeGroupReq:
     properties:
+      cspImageName:
+        example: image-01
+        type: string
+      cspSpecName:
+        example: Standard_B2s (temporarily, CSP's Spec Names are valid. It will be
+          upgraded)
+        type: string
       desiredNodeSize:
         example: "1"
-        type: string
-      imageId:
-        example: image-01
         type: string
       maxNodeSize:
         example: "3"
@@ -2111,10 +2110,6 @@ definitions:
           "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_ssd"],
           TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]'
         example: cloud_essd
-        type: string
-      specId:
-        example: Standard_B2s (temporarily, CSP's Spec Names are valid. It will be
-          upgraded)
         type: string
       sshKeyId:
         example: sshkey-01
@@ -2639,14 +2634,9 @@ definitions:
         type: string
       costPerHour:
         type: number
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
+      cspSpecName:
+        description: CspSpecName is name of the spec given by CSP
         example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
         type: string
       description:
         type: string
@@ -2677,7 +2667,7 @@ definitions:
         example: aws-ap-southeast-1
         type: string
       infraType:
-        description: vm|k8s|kubernetes|container, etc.
+        description: InfraType can be one of vm|k8s|kubernetes|container, etc.
         type: string
       isAutoGenerated:
         type: boolean
@@ -2725,15 +2715,18 @@ definitions:
     properties:
       connectionName:
         type: string
-      cspResourceId:
+      cspSpecName:
+        description: CspSpecName is name of the spec given by CSP
         type: string
       description:
         type: string
       name:
+        description: Name is human-readable string to represent the object, used to
+          generate Id
         type: string
     required:
     - connectionName
-    - cspResourceId
+    - cspSpecName
     - name
     type: object
   model.TbSshKeyInfo:
@@ -2837,8 +2830,8 @@ definitions:
           is internally used to handle the resource.
         example: we12fawefadf1221edcf
         type: string
-      cspVNetHandlingId:
-        description: CspVNetHandlingId is identifier to handle CSP vNet resource
+      cspVNetName:
+        description: CspVNetName is identifier to handle CSP vNet resource
         example: we12fawefadf1221edcf
         type: string
       description:
@@ -3035,7 +3028,7 @@ definitions:
         description: Created time
         example: "2022-11-10 23:00:00"
         type: string
-      cspImageId:
+      cspImageName:
         type: string
       cspResourceId:
         description: CspResourceId is resource identifier managed by CSP
@@ -3046,7 +3039,7 @@ definitions:
           is internally used to handle the resource.
         example: we12fawefadf1221edcf
         type: string
-      cspSpecId:
+      cspSpecName:
         type: string
       cspSshKeyId:
         type: string
@@ -3478,7 +3471,7 @@ definitions:
     properties:
       connectionName:
         type: string
-      cspResourceId:
+      cspImageName:
         type: string
     type: object
   resource.RestLookupSpecRequest:
@@ -4245,7 +4238,7 @@ paths:
       description: Lookup image
       operationId: LookupImage
       parameters:
-      - description: Specify connectionName & cspResourceId
+      - description: Specify connectionName, cspImageName
         in: body
         name: lookupImageReq
         required: true
@@ -4307,7 +4300,7 @@ paths:
       description: Lookup spec
       operationId: LookupSpec
       parameters:
-      - description: Specify connectionName & cspResourceId
+      - description: Specify connectionName & cspSpecNameS
         in: body
         name: lookupSpecReq
         required: true
@@ -7853,7 +7846,7 @@ paths:
       description: Fetch images
       operationId: FetchImages
       parameters:
-      - default: default
+      - default: system
         description: Namespace ID
         in: path
         name: nsId
@@ -7951,7 +7944,7 @@ paths:
       description: Delete all images
       operationId: DelAllImage
       parameters:
-      - default: default
+      - default: system
         description: Namespace ID
         in: path
         name: nsId
@@ -7982,7 +7975,7 @@ paths:
       description: List all images or images' ID
       operationId: GetAllImage
       parameters:
-      - default: default
+      - default: system
         description: Namespace ID
         in: path
         name: nsId
@@ -8053,10 +8046,10 @@ paths:
         name: imageInfo
         schema:
           $ref: '#/definitions/model.TbImageInfo'
-      - description: Specify name, connectionName and cspResourceId to register an
-          image object automatically
+      - description: Specify (name, connectionName, cspImageName) to register an image
+          object automatically
         in: body
-        name: imageId
+        name: imageReq
         schema:
           $ref: '#/definitions/model.TbImageReq'
       - default: false
@@ -8089,13 +8082,13 @@ paths:
       description: Delete image
       operationId: DelImage
       parameters:
-      - default: default
+      - default: system
         description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: Image ID ({providerName}+{regionName}+{imageName})
+      - description: Image ID ({providerName}+{regionName}+{cspImageName})
         in: path
         name: imageId
         required: true
@@ -8120,13 +8113,13 @@ paths:
       description: Get image
       operationId: GetImage
       parameters:
-      - default: default
+      - default: system
         description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: Image ID ({providerName}+{regionName}+{imageName})
+      - description: Image ID ({providerName}+{regionName}+{cspImageName})
         in: path
         name: imageId
         required: true
@@ -8161,13 +8154,13 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/model.TbImageInfo'
-      - default: default
+      - default: system
         description: Namespace ID
         in: path
         name: nsId
         required: true
         type: string
-      - description: Image ID ({providerName}+{regionName}+{imageName})
+      - description: Image ID ({providerName}+{regionName}+{cspImageName})
         in: path
         name: imageId
         required: true
@@ -8197,7 +8190,7 @@ paths:
       description: Search image
       operationId: SearchImage
       parameters:
-      - default: default
+      - default: system
         description: Namespace ID
         in: path
         name: nsId
@@ -8525,10 +8518,10 @@ paths:
         name: specInfo
         schema:
           $ref: '#/definitions/model.TbSpecInfo'
-      - description: Specify name, connectionName and cspResourceId to register a
-          spec object automatically
+      - description: Specify n(ame, connectionName, cspSpecName) to register a spec
+          object automatically
         in: body
-        name: specName
+        name: specReq
         schema:
           $ref: '#/definitions/model.TbSpecReq'
       - default: false
@@ -8567,7 +8560,7 @@ paths:
         name: nsId
         required: true
         type: string
-      - description: Spec ID ({providerName}+{regionName}+{specName})
+      - description: Spec ID ({providerName}+{regionName}+{cspSpecName})
         in: path
         name: specId
         required: true
@@ -8598,7 +8591,7 @@ paths:
         name: nsId
         required: true
         type: string
-      - description: Spec ID ({providerName}+{regionName}+{specName})
+      - description: Spec ID ({providerName}+{regionName}+{cspSpecName})
         in: path
         name: specId
         required: true
@@ -8639,7 +8632,7 @@ paths:
         name: nsId
         required: true
         type: string
-      - description: Spec ID ({providerName}+{regionName}+{specName})
+      - description: Spec ID ({providerName}+{regionName}+{cspSpecName})
         in: path
         name: specId
         required: true

--- a/src/api/rest/server/resource/image.go
+++ b/src/api/rest/server/resource/image.go
@@ -37,7 +37,7 @@ import (
 // @Param action query string true "registeringMethod" Enums(registerWithInfo, registerWithId)
 // @Param nsId path string true "Namespace ID" default(system)
 // @Param imageInfo body model.TbImageInfo false "Specify details of a image object (cspResourceName, guestOS, description, ...) manually"
-// @Param imageId body model.TbImageReq false "Specify name, connectionName and cspResourceId to register an image object automatically"
+// @Param imageReq body model.TbImageReq false "Specify (name, connectionName, cspImageName) to register an image object automatically"
 // @Param update query boolean false "Force update to existing image object" default(false)
 // @Success 200 {object} model.TbImageInfo
 // @Failure 404 {object} model.SimpleMsg
@@ -96,8 +96,8 @@ func RestPostImage(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param imageInfo body model.TbImageInfo true "Details for an image object"
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param imageId path string true "Image ID ({providerName}+{regionName}+{imageName})"
+// @Param nsId path string true "Namespace ID" default(system)
+// @Param imageId path string true "Image ID ({providerName}+{regionName}+{cspImageName})"
 // @Success 200 {object} model.TbImageInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
@@ -124,7 +124,7 @@ func RestPutImage(c echo.Context) error {
 // Request structure for RestLookupImage
 type RestLookupImageRequest struct {
 	ConnectionName string `json:"connectionName"`
-	CspResourceId  string `json:"cspResourceId"`
+	CspImageName   string `json:"cspImageName"`
 }
 
 // RestLookupImage godoc
@@ -134,7 +134,7 @@ type RestLookupImageRequest struct {
 // @Tags [Infra Resource] Image Management
 // @Accept  json
 // @Produce  json
-// @Param lookupImageReq body RestLookupImageRequest true "Specify connectionName & cspResourceId"
+// @Param lookupImageReq body RestLookupImageRequest true "Specify connectionName, cspImageName"
 // @Success 200 {object} model.SpiderImageInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
@@ -149,8 +149,8 @@ func RestLookupImage(c echo.Context) error {
 		return common.EndRequestWithLog(c, reqID, err, nil)
 	}
 
-	log.Debug().Msg("[Lookup image]: " + u.CspResourceId)
-	content, err := resource.LookupImage(u.ConnectionName, u.CspResourceId)
+	log.Debug().Msg("[Lookup image]: " + u.CspImageName)
+	content, err := resource.LookupImage(u.ConnectionName, u.CspImageName)
 	return common.EndRequestWithLog(c, reqID, err, content)
 
 }
@@ -190,7 +190,7 @@ func RestLookupImageList(c echo.Context) error {
 // @Tags [Infra Resource] Image Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
+// @Param nsId path string true "Namespace ID" default(system)
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
@@ -235,8 +235,8 @@ func RestFetchImages(c echo.Context) error {
 // @Tags [Infra Resource] Image Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param imageId path string true "Image ID ({providerName}+{regionName}+{imageName})"
+// @Param nsId path string true "Namespace ID" default(system)
+// @Param imageId path string true "Image ID ({providerName}+{regionName}+{cspImageName})"
 // @Success 200 {object} model.TbImageInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
@@ -258,7 +258,7 @@ type RestGetAllImageResponse struct {
 // @Tags [Infra Resource] Image Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
+// @Param nsId path string true "Namespace ID" default(system)
 // @Param option query string false "Option" Enums(id)
 // @Param filterKey query string false "Field key for filtering (ex:guestOS)"
 // @Param filterVal query string false "Field value for filtering (ex: Ubuntu18.04)"
@@ -278,8 +278,8 @@ func RestGetAllImage(c echo.Context) error {
 // @Tags [Infra Resource] Image Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param imageId path string true "Image ID ({providerName}+{regionName}+{imageName})"
+// @Param nsId path string true "Namespace ID" default(system)
+// @Param imageId path string true "Image ID ({providerName}+{regionName}+{cspImageName})"
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/image/{imageId} [delete]
@@ -295,7 +295,7 @@ func RestDelImage(c echo.Context) error {
 // @Tags [Infra Resource] Image Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
+// @Param nsId path string true "Namespace ID" default(system)
 // @Param match query string false "Delete resources containing matched ID-substring only" default()
 // @Success 200 {object} model.IdList
 // @Failure 404 {object} model.SimpleMsg
@@ -317,7 +317,7 @@ type RestSearchImageRequest struct {
 // @Tags [Infra Resource] Image Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
+// @Param nsId path string true "Namespace ID" default(system)
 // @Param keywords body RestSearchImageRequest true "Keywords"
 // @Success 200 {object} RestGetAllImageResponse
 // @Failure 404 {object} model.SimpleMsg

--- a/src/api/rest/server/resource/spec.go
+++ b/src/api/rest/server/resource/spec.go
@@ -37,7 +37,7 @@ import (
 // @Param action query string true "registeringMethod" Enums(registerWithInfo, registerWithCspResourceId)
 // @Param nsId path string true "Namespace ID" default(system)
 // @Param specInfo body model.TbSpecInfo false "Specify details of a spec object (vCPU, memoryGiB, ...) manually"
-// @Param specName body model.TbSpecReq false "Specify name, connectionName and cspResourceId to register a spec object automatically"
+// @Param specReq body model.TbSpecReq false "Specify n(ame, connectionName, cspSpecName) to register a spec object automatically"
 // @Param update query boolean false "Force update to existing spec object" default(false)
 // @Success 200 {object} model.TbSpecInfo
 // @Failure 404 {object} model.SimpleMsg
@@ -68,7 +68,7 @@ func RestPostSpec(c echo.Context) error {
 		return common.EndRequestWithLog(c, reqID, err, content)
 
 	} else { // if action == "registerWithCspResourceId" { // The default mode.
-		log.Debug().Msg("[Registering Spec with CspResourceId]")
+		log.Debug().Msg("[Registering Spec with cspSpecName]")
 		u := &model.TbSpecReq{}
 		if err := c.Bind(u); err != nil {
 			return common.EndRequestWithLog(c, reqID, err, nil)
@@ -92,7 +92,7 @@ func RestPostSpec(c echo.Context) error {
 // @Produce  json
 // @Param specInfo body model.TbSpecInfo true "Details for an spec object"
 // @Param nsId path string true "Namespace ID" default(system)
-// @Param specId path string true "Spec ID ({providerName}+{regionName}+{specName})"
+// @Param specId path string true "Spec ID ({providerName}+{regionName}+{cspSpecName})"
 // @Success 200 {object} model.TbSpecInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
@@ -129,7 +129,7 @@ type RestLookupSpecRequest struct {
 // @Tags [Infra Resource] Spec Management
 // @Accept  json
 // @Produce  json
-// @Param lookupSpecReq body RestLookupSpecRequest true "Specify connectionName & cspResourceId"
+// @Param lookupSpecReq body RestLookupSpecRequest true "Specify connectionName & cspSpecNameS"
 // @Success 200 {object} model.SpiderSpecInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
@@ -268,7 +268,7 @@ func RestFilterSpecsByRange(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(system)
-// @Param specId path string true "Spec ID ({providerName}+{regionName}+{specName})"
+// @Param specId path string true "Spec ID ({providerName}+{regionName}+{cspSpecName})"
 // @Success 200 {object} model.TbSpecInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
@@ -297,7 +297,7 @@ func RestGetSpec(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(system)
-// @Param specId path string true "Spec ID ({providerName}+{regionName}+{specName})"
+// @Param specId path string true "Spec ID ({providerName}+{regionName}+{cspSpecName})"
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/spec/{specId} [delete]

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -1436,8 +1436,8 @@ func CreateVm(nsId string, mciId string, vmInfoData *model.TbVmInfo, option stri
 	vmInfoData.RootDeviceName = callResult.RootDeviceName
 	vmInfoData.NetworkInterface = callResult.NetworkInterface
 
-	vmInfoData.CspSpecId = callResult.VMSpecName
-	vmInfoData.CspImageId = callResult.ImageIId.SystemId
+	vmInfoData.CspSpecName = callResult.VMSpecName
+	vmInfoData.CspImageName = callResult.ImageIId.SystemId
 	vmInfoData.CspVNetId = callResult.VpcIID.SystemId
 	vmInfoData.CspSubnetId = callResult.SubnetIID.SystemId
 	vmInfoData.CspSshKeyId = callResult.KeyPairIId.SystemId

--- a/src/core/model/image.go
+++ b/src/core/model/image.go
@@ -36,7 +36,7 @@ type SpiderImageInfo struct {
 type TbImageReq struct {
 	Name           string `json:"name" validate:"required"`
 	ConnectionName string `json:"connectionName" validate:"required"`
-	CspResourceId  string `json:"cspResourceId" validate:"required"`
+	CspImageName   string `json:"cspImageName" validate:"required"`
 	Description    string `json:"description"`
 }
 
@@ -46,10 +46,9 @@ type TbImageInfo struct {
 	Id string `json:"id" example:"aws-ap-southeast-1"`
 	// Uid is universally unique identifier for the object, used for labelSelector
 	Uid string `json:"uid,omitempty" example:"wef12awefadf1221edcf"`
-	// CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.
-	CspResourceName string `json:"cspResourceName,omitempty" example:"we12fawefadf1221edcf"`
-	// CspResourceId is resource identifier managed by CSP
-	CspResourceId string `json:"cspResourceId,omitempty" example:"csp-06eb41e14121c550a"`
+
+	// CspImageName is name of the image given by CSP
+	CspImageName string `json:"cspImageName,omitempty" example:"csp-06eb41e14121c550a"`
 
 	// Name is human-readable string to represent the object
 	Name                 string     `json:"name" example:"aws-ap-southeast-1"`

--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -127,8 +127,8 @@ type SpiderNodeGroupReqInfo struct {
 // TbK8sNodeGroupReq is a struct to handle requests related to K8sNodeGroup toward CB-Tumblebug.
 type TbK8sNodeGroupReq struct {
 	Name         string `json:"name" example:"ng-01"`
-	ImageId      string `json:"imageId" example:"image-01"`
-	SpecId       string `json:"specId" example:"Standard_B2s (temporarily, CSP's Spec Names are valid. It will be upgraded)"`
+	CspImageName string `json:"cspImageName" example:"image-01"`
+	CspSpecName  string `json:"cspSpecName" example:"Standard_B2s (temporarily, CSP's Spec Names are valid. It will be upgraded)"`
 	RootDiskType string `json:"rootDiskType" example:"cloud_essd" enum:"default, TYPE1, ..."` // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_ssd"], TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]
 	RootDiskSize string `json:"rootDiskSize" example:"40" enum:"default, 30, 42, ..."`        // "default", Integer (GB): ["50", ..., "1000"]
 	SshKeyId     string `json:"sshKeyId" example:"sshkey-01"`
@@ -396,8 +396,8 @@ type TbK8sNodeGroupInfo struct {
 	Name string `json:"name" example:"aws-ap-southeast-1"`
 
 	// VM config.
-	ImageId      string `json:"imageId" example:"image-01"`
-	SpecId       string `json:"specId" example:"spec-01"`
+	CspImageName string `json:"cspImageName" example:"image-01"`
+	CspSpecName  string `json:"cspSpecName" example:"spec-01"`
 	RootDiskType string `json:"rootDiskType" example:"cloud_essd"`
 	RootDiskSize string `json:"rootDiskSize" example:"40"`
 	SshKeyId     string `json:"sshKeyId" example:"sshkey-01"`

--- a/src/core/model/mci.go
+++ b/src/core/model/mci.go
@@ -383,9 +383,9 @@ type TbVmInfo struct {
 	ConnectionName   string     `json:"connectionName"`
 	ConnectionConfig ConnConfig `json:"connectionConfig"`
 	SpecId           string     `json:"specId"`
-	CspSpecId        string     `json:"cspSpecId"`
+	CspSpecName      string     `json:"cspSpecName"`
 	ImageId          string     `json:"imageId"`
-	CspImageId       string     `json:"cspImageId"`
+	CspImageName       string     `json:"cspImageName"`
 	VNetId           string     `json:"vNetId"`
 	CspVNetId        string     `json:"cspVNetId"`
 	SubnetId         string     `json:"subnetId"`

--- a/src/core/model/spec.go
+++ b/src/core/model/spec.go
@@ -49,11 +49,13 @@ type SpiderGpuInfo struct {
 }
 
 // TbSpecReq is a struct to handle 'Register spec' request toward CB-Tumblebug.
-type TbSpecReq struct { // Tumblebug
+type TbSpecReq struct {
+	// Name is human-readable string to represent the object, used to generate Id
 	Name           string `json:"name" validate:"required"`
 	ConnectionName string `json:"connectionName" validate:"required"`
-	CspResourceId  string `json:"cspResourceId" validate:"required"`
-	Description    string `json:"description"`
+	// CspSpecName is name of the spec given by CSP
+	CspSpecName string `json:"cspSpecName" validate:"required"`
+	Description string `json:"description"`
 }
 
 // TbSpecInfo is a struct that represents TB spec object.
@@ -62,10 +64,9 @@ type TbSpecInfo struct { // Tumblebug
 	Id string `json:"id" example:"aws-ap-southeast-1"`
 	// Uid is universally unique identifier for the object, used for labelSelector
 	Uid string `json:"uid,omitempty" example:"wef12awefadf1221edcf"`
-	// CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.
-	CspResourceName string `json:"cspResourceName,omitempty" example:"we12fawefadf1221edcf"`
-	// CspResourceId is resource identifier managed by CSP
-	CspResourceId string `json:"cspResourceId,omitempty" example:"csp-06eb41e14121c550a"`
+
+	// CspSpecName is name of the spec given by CSP
+	CspSpecName string `json:"cspSpecName,omitempty" example:"csp-06eb41e14121c550a"`
 
 	// Name is human-readable string to represent the object
 	Name           string `json:"name" example:"aws-ap-southeast-1"`
@@ -73,7 +74,7 @@ type TbSpecInfo struct { // Tumblebug
 	ConnectionName string `json:"connectionName,omitempty"`
 	ProviderName   string `json:"providerName,omitempty"`
 	RegionName     string `json:"regionName,omitempty"`
-	// vm|k8s|kubernetes|container, etc.
+	// InfraType can be one of vm|k8s|kubernetes|container, etc.
 	InfraType             string   `json:"infraType,omitempty"`
 	OsType                string   `json:"osType,omitempty"`
 	VCPU                  uint16   `json:"vCPU,omitempty"`
@@ -115,7 +116,7 @@ type FilterSpecsByRangeRequest struct {
 	ConnectionName      string `json:"connectionName"`
 	ProviderName        string `json:"providerName"`
 	RegionName          string `json:"regionName"`
-	CspResourceId       string `json:"cspResourceId"`
+	CspSpecName         string `json:"cspSpecName"`
 	InfraType           string `json:"infraType"`
 	OsType              string `json:"osType"`
 	VCPU                Range  `json:"vCPU"`

--- a/src/core/model/subnet.go
+++ b/src/core/model/subnet.go
@@ -49,8 +49,8 @@ type TbSubnetInfo struct { // Tumblebug
 	// Name is human-readable string to represent the object
 	Name           string `json:"name" example:"aws-ap-southeast-1"`
 	ConnectionName string `json:"connectionName"`
-	// CspVNetHandlingId is identifier to handle CSP vNet resource
-	CspVNetHandlingId string `json:"cspVNetHandlingId,omitempty" example:"we12fawefadf1221edcf"`
+	// CspVNetName is identifier to handle CSP vNet resource
+	CspVNetName string `json:"cspVNetName,omitempty" example:"we12fawefadf1221edcf"`
 	// CspVNetId is vNet resource identifier managed by CSP
 	CspVNetId    string        `json:"cspResourceId,omitempty" example:"csp-45eb41e14121c550a"`
 	Status       string        `json:"status"`

--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -1466,7 +1466,7 @@ func LoadAssets() (model.IdList, error) {
 
 		providerName := strings.ToLower(row[0])
 		regionName := strings.ToLower(row[1])
-		specReqTmp.CspResourceId = row[2]
+		specReqTmp.CspSpecName = row[2]
 		rootDiskType := row[14]
 		rootDiskSize := row[15]
 		acceleratorType := row[16]
@@ -1482,7 +1482,7 @@ func LoadAssets() (model.IdList, error) {
 		description := row[20]
 		infraType := strings.ToLower(row[21])
 
-		specReqTmp.Name = GetProviderRegionZoneResourceKey(providerName, regionName, "", specReqTmp.CspResourceId)
+		specReqTmp.Name = GetProviderRegionZoneResourceKey(providerName, regionName, "", specReqTmp.CspSpecName)
 
 		//get connetion for lookup (if regionName is "all", use providerName only)
 		validRepresentativeConnectionMapKey := providerName + "-" + regionName
@@ -1508,7 +1508,7 @@ func LoadAssets() (model.IdList, error) {
 				log.Trace().Msgf("[%d] register Common Spec: %s", i, specReqTmp.Name)
 
 				// Register Spec object
-				searchKey := GetProviderRegionZoneResourceKey(providerName, regionName, "", specReqTmp.CspResourceId)
+				searchKey := GetProviderRegionZoneResourceKey(providerName, regionName, "", specReqTmp.CspSpecName)
 				_, ok := specMap.Load(searchKey)
 				if ok {
 					// spiderSpec := value.(SpiderSpecInfo)
@@ -1605,7 +1605,7 @@ func LoadAssets() (model.IdList, error) {
 			// row6: infraType
 			providerName := strings.ToLower(row[0])
 			regionName := strings.ToLower(row[1])
-			imageReqTmp.CspResourceId = row[2]
+			imageReqTmp.CspImageName = row[2]
 			osType := strings.ReplaceAll(row[3], " ", "")
 			description := row[4]
 			infraType := strings.ToLower(row[6])
@@ -1637,7 +1637,7 @@ func LoadAssets() (model.IdList, error) {
 
 					_, err1 := RegisterImageWithId(model.SystemCommonNs, &imageReqTmp, true, true)
 					if err1 != nil {
-						log.Info().Msgf("Provider: %s, Region: %s, CspResourceId: %s Error: %s", providerName, regionName, imageReqTmp.CspResourceId, err1.Error())
+						log.Info().Msgf("Provider: %s, Region: %s, CspResourceId: %s Error: %s", providerName, regionName, imageReqTmp.CspImageName, err1.Error())
 						regiesteredStatus += "  [Failed] " + err1.Error()
 					} else {
 						// Update registered image object with OsType info
@@ -1962,14 +1962,14 @@ func GetCspResourceName(nsId string, resourceType string, resourceId string) (st
 		if err != nil {
 			return "", err
 		}
-		return specInfo.CspResourceId, nil
+		return specInfo.CspSpecName, nil
 	}
 	if resourceType == model.StrImage {
 		imageInfo, err := GetImage(nsId, resourceId)
 		if err != nil {
 			return "", err
 		}
-		return imageInfo.CspResourceId, nil
+		return imageInfo.CspImageName, nil
 	}
 
 	key := common.GenResourceKey(nsId, resourceType, resourceId)

--- a/src/core/resource/image.go
+++ b/src/core/resource/image.go
@@ -62,8 +62,7 @@ func ConvertSpiderImageToTumblebugImage(spiderImage model.SpiderImageInfo) (mode
 		tumblebugImage.Name = spiderImage.IId.NameId
 	}
 
-	tumblebugImage.CspResourceId = spiderImage.IId.NameId
-	tumblebugImage.CspResourceName = common.LookupKeyValueList(spiderImage.KeyValueList, "Name")
+	tumblebugImage.CspImageName = spiderImage.IId.NameId
 	tumblebugImage.Description = common.LookupKeyValueList(spiderImage.KeyValueList, "Description")
 	tumblebugImage.CreationDate = common.LookupKeyValueList(spiderImage.KeyValueList, "CreationDate")
 	tumblebugImage.GuestOS = spiderImage.GuestOS
@@ -99,14 +98,14 @@ func RegisterImageWithId(nsId string, u *model.TbImageReq, update bool, RDBonly 
 		}
 	}
 
-	res, err := LookupImage(u.ConnectionName, u.CspResourceId)
+	res, err := LookupImage(u.ConnectionName, u.CspImageName)
 	if err != nil {
 		log.Trace().Err(err).Msg("")
 		return content, err
 	}
 	if res.IId.NameId == "" {
 		err := fmt.Errorf("CB-Spider returned empty IId.NameId without Error: %s", u.ConnectionName)
-		log.Error().Err(err).Msgf("Cannot LookupImage %s %v", u.CspResourceId, res)
+		log.Error().Err(err).Msgf("Cannot LookupImage %s %v", u.CspImageName, res)
 		return content, err
 	}
 
@@ -166,11 +165,11 @@ func RegisterImageWithInfo(nsId string, content *model.TbImageInfo, update bool)
 		log.Error().Err(err).Msg("")
 		return model.TbImageInfo{}, err
 	}
-	err = common.CheckString(content.Name)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return model.TbImageInfo{}, err
-	}
+	// err = common.CheckString(content.Name)
+	// if err != nil {
+	// 	log.Error().Err(err).Msg("")
+	// 	return model.TbImageInfo{}, err
+	// }
 	check, err := CheckResource(nsId, resourceType, content.Name)
 
 	if !update {
@@ -493,7 +492,7 @@ func GetImage(nsId string, imageKey string) (model.TbImageInfo, error) {
 	}
 
 	// ex: img-487zeit5
-	image = model.TbImageInfo{Namespace: nsId, CspResourceId: imageKey}
+	image = model.TbImageInfo{Namespace: nsId, CspImageName: imageKey}
 	has, err = model.ORM.Where("LOWER(Namespace) = ? AND LOWER(CspResourceId) = ?", nsId, imageKey).Get(&image)
 	if err != nil {
 		log.Info().Err(err).Msgf("Failed to get image %s by CspResourceId", imageKey)

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -169,10 +169,10 @@ func CreateK8sCluster(nsId string, req *model.TbK8sClusterReq, option string) (m
 		}
 
 		spImgName := "" // Some CSPs do not require ImageName for creating a k8s cluster
-		if v.ImageId == "" || v.ImageId == "default" {
+		if v.CspImageName == "" || v.CspImageName == "default" {
 			spImgName = ""
 		} else {
-			spImgName, err = GetCspResourceName(nsId, model.StrImage, v.ImageId)
+			spImgName, err = GetCspResourceName(nsId, model.StrImage, v.CspImageName)
 			if spImgName == "" {
 				log.Err(err).Msg("Failed to Create a K8sCluster")
 				return emptyObj, err
@@ -185,7 +185,7 @@ func CreateK8sCluster(nsId string, req *model.TbK8sClusterReq, option string) (m
 		// 	return emptyObj, err
 		// }
 		// spSpecName := specInfo.CspResourceId
-		spSpecName := v.SpecId
+		spSpecName := v.CspSpecName
 
 		spKpName, err := GetCspResourceName(nsId, model.StrSSHKey, v.SshKeyId)
 		if spKpName == "" {
@@ -402,8 +402,8 @@ func AddK8sNodeGroup(nsId string, k8sClusterId string, u *model.TbK8sNodeGroupRe
 	}
 
 	spImgName := "" // Some CSPs do not require ImageName for creating a cluster
-	if u.ImageId != "" {
-		spImgName, err = GetCspResourceName(nsId, model.StrImage, u.ImageId)
+	if u.CspImageName != "" {
+		spImgName, err = GetCspResourceName(nsId, model.StrImage, u.CspImageName)
 		if spImgName == "" {
 			log.Err(err).Msg("Failed to Add K8sNodeGroup")
 			return emptyObj, err
@@ -416,7 +416,7 @@ func AddK8sNodeGroup(nsId string, k8sClusterId string, u *model.TbK8sNodeGroupRe
 	// 	return emptyObj, err
 	// }
 	// spSpecName := specInfo.CspResourceId
-	spSpecName := u.SpecId
+	spSpecName := u.CspSpecName
 
 	spKpName, err := GetCspResourceName(nsId, model.StrSSHKey, u.SshKeyId)
 	if spKpName == "" {
@@ -1343,8 +1343,8 @@ func convertSpiderNetworkInfoToTbK8sClusterNetworkInfo(spNetworkInfo model.Spide
 
 func convertSpiderNodeGroupInfoToTbK8sNodeGroupInfo(spNodeGroupInfo *model.SpiderNodeGroupInfo) model.TbK8sNodeGroupInfo {
 	tbNodeId := spNodeGroupInfo.IId.SystemId
-	tbImageId := spNodeGroupInfo.ImageIID.SystemId
-	tbSpecId := spNodeGroupInfo.VMSpecName
+	tbCspImageName := spNodeGroupInfo.ImageIID.SystemId
+	tbCspSpecName := spNodeGroupInfo.VMSpecName
 	tbRootDiskType := spNodeGroupInfo.RootDiskType
 	tbRootDiskSize := spNodeGroupInfo.RootDiskSize
 	tbSshKeyId := spNodeGroupInfo.KeyPairIID.SystemId
@@ -1362,8 +1362,8 @@ func convertSpiderNodeGroupInfoToTbK8sNodeGroupInfo(spNodeGroupInfo *model.Spide
 	tbKeyValueList := convertSpiderKeyValueListToTbKeyValueList(spNodeGroupInfo.KeyValueList)
 	tbK8sNodeGroupInfo := model.TbK8sNodeGroupInfo{
 		Id:              tbNodeId,
-		ImageId:         tbImageId,
-		SpecId:          tbSpecId,
+		CspImageName:    tbCspImageName,
+		CspSpecName:     tbCspSpecName,
 		RootDiskType:    tbRootDiskType,
 		RootDiskSize:    tbRootDiskSize,
 		SshKeyId:        tbSshKeyId,

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -55,7 +55,7 @@ func ConvertSpiderSpecToTumblebugSpec(spiderSpec model.SpiderSpecInfo) (model.Tb
 	tumblebugSpec := model.TbSpecInfo{}
 
 	tumblebugSpec.Name = spiderSpec.Name
-	tumblebugSpec.CspResourceId = spiderSpec.Name
+	tumblebugSpec.CspSpecName = spiderSpec.Name
 	tumblebugSpec.RegionName = spiderSpec.Region
 	tempUint64, _ := strconv.ParseUint(spiderSpec.VCpu.Count, 10, 16)
 	tumblebugSpec.VCPU = uint16(tempUint64)
@@ -229,16 +229,16 @@ func RegisterSpecWithCspResourceId(nsId string, u *model.TbSpecReq, update bool)
 		return content, err
 	}
 
-	res, err := LookupSpec(u.ConnectionName, u.CspResourceId)
+	res, err := LookupSpec(u.ConnectionName, u.CspSpecName)
 	if err != nil {
-		log.Error().Err(err).Msgf("Cannot LookupSpec ConnectionName(%s), CspResourceId(%s)", u.ConnectionName, u.CspResourceId)
+		log.Error().Err(err).Msgf("Cannot LookupSpec ConnectionName(%s), CspResourceId(%s)", u.ConnectionName, u.CspSpecName)
 		return content, err
 	}
 
 	content.Namespace = nsId
 	content.Id = u.Name
 	content.Name = u.Name
-	content.CspResourceId = res.Name
+	content.CspSpecName = res.Name
 	content.ConnectionName = u.ConnectionName
 	content.AssociatedObjectList = []string{}
 	tempUint64, _ := strconv.ParseUint(res.VCpu.Count, 10, 16)
@@ -337,7 +337,7 @@ func GetSpec(nsId string, specKey string) (model.TbSpecInfo, error) {
 	}
 
 	// ex: img-487zeit5
-	spec = model.TbSpecInfo{Namespace: nsId, CspResourceId: specKey}
+	spec = model.TbSpecInfo{Namespace: nsId, CspSpecName: specKey}
 	has, err = model.ORM.Where("LOWER(Namespace) = ? AND LOWER(CspResourceId) = ?", nsId, specKey).Get(&spec)
 	if err != nil {
 		log.Info().Err(err).Msgf("Failed to get spec %s by CspResourceId", specKey)

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -253,7 +253,7 @@ func CreateSubnet(nsId string, vNetId string, subnetReq *model.TbSubnetReq) (mod
 	subnetInfo.ResourceType = resourceType
 	subnetInfo.ConnectionName = vNetInfo.ConnectionName
 	subnetInfo.CspVNetId = vNetInfo.CspResourceId
-	subnetInfo.CspVNetHandlingId = vNetInfo.CspResourceName
+	subnetInfo.CspVNetName = vNetInfo.CspResourceName
 
 	// Set status to 'Configuring'
 	subnetInfo.Status = string(NetworkOnConfiguring)
@@ -608,7 +608,7 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string) (model.SimpleMsg,
 	spReqt.ConnectionName = subnetInfo.ConnectionName
 
 	// API to delete a subnet
-	url := fmt.Sprintf("%s/vpc/%s/subnet/%s", model.SpiderRestUrl, subnetInfo.CspVNetHandlingId, subnetInfo.CspResourceName)
+	url := fmt.Sprintf("%s/vpc/%s/subnet/%s", model.SpiderRestUrl, subnetInfo.CspVNetName, subnetInfo.CspResourceName)
 
 	var spResp spiderBooleanInfoResp
 
@@ -767,7 +767,7 @@ func RegisterSubnet(nsId string, vNetId string, subnetReq *model.TbRegisterSubne
 	subnetInfo.Uid = uid
 	subnetInfo.ConnectionName = vNetInfo.ConnectionName
 	subnetInfo.CspVNetId = vNetInfo.CspResourceId
-	subnetInfo.CspVNetHandlingId = vNetInfo.CspResourceName
+	subnetInfo.CspVNetName = vNetInfo.CspResourceName
 
 	// Set status to 'Registering'
 	subnetInfo.Status = string(NetworkOnRegistering)
@@ -1012,7 +1012,7 @@ func DeregisterSubnet(nsId string, vNetId string, subnetId string) (model.Simple
 	// [Via Spider] Deregister the subnet
 	spReqt := spiderSubnetUnregisterRequest{}
 	spReqt.ConnectionName = subnetInfo.ConnectionName
-	spReqt.ReqInfo.VPCName = subnetInfo.CspVNetHandlingId
+	spReqt.ReqInfo.VPCName = subnetInfo.CspVNetName
 
 	// API to deregister subnet
 	url := fmt.Sprintf("%s/regsubne/%s", model.SpiderRestUrl, subnetInfo.CspResourceName)

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -434,7 +434,7 @@ func CreateVNet(nsId string, vNetReq *model.TbVNetReq) (model.TbVNetInfo, error)
 				vNetInfo.SubnetInfoList[i].ResourceType = model.StrSubnet
 				vNetInfo.SubnetInfoList[i].ConnectionName = vNetInfo.ConnectionName
 				vNetInfo.SubnetInfoList[i].CspVNetId = spResp.IId.SystemId
-				vNetInfo.SubnetInfoList[i].CspVNetHandlingId = spResp.IId.NameId
+				vNetInfo.SubnetInfoList[i].CspVNetName = spResp.IId.NameId
 				vNetInfo.SubnetInfoList[i].Status = string(NetworkAvailable)
 				vNetInfo.SubnetInfoList[i].CspResourceId = spSubnetInfo.IId.SystemId
 				vNetInfo.SubnetInfoList[i].CspResourceName = spSubnetInfo.IId.NameId
@@ -963,18 +963,18 @@ func RegisterVNet(nsId string, vNetRegisterReq *model.TbRegisterVNetReq) (model.
 	//       since the order may differ different between slices
 	for i, spSubnetInfo := range spResp.SubnetInfoList {
 		subnetInfo := model.TbSubnetInfo{
-			Id:                fmt.Sprintf("reg-subnet-%02d", i+1),
-			Name:              fmt.Sprintf("reg-subnet-%02d", i+1),
-			Uid:               common.GenUid(),
-			ConnectionName:    vNetInfo.ConnectionName,
-			Status:            string(NetworkUnknown),
-			CspResourceId:     spSubnetInfo.IId.SystemId,
-			CspResourceName:   spSubnetInfo.IId.NameId,
-			CspVNetId:         spResp.IId.SystemId,
-			CspVNetHandlingId: spResp.IId.NameId,
-			KeyValueList:      spSubnetInfo.KeyValueList,
-			Zone:              spSubnetInfo.Zone,
-			IPv4_CIDR:         spSubnetInfo.IPv4_CIDR,
+			Id:              fmt.Sprintf("reg-subnet-%02d", i+1),
+			Name:            fmt.Sprintf("reg-subnet-%02d", i+1),
+			Uid:             common.GenUid(),
+			ConnectionName:  vNetInfo.ConnectionName,
+			Status:          string(NetworkUnknown),
+			CspResourceId:   spSubnetInfo.IId.SystemId,
+			CspResourceName: spSubnetInfo.IId.NameId,
+			CspVNetId:       spResp.IId.SystemId,
+			CspVNetName:     spResp.IId.NameId,
+			KeyValueList:    spSubnetInfo.KeyValueList,
+			Zone:            spSubnetInfo.Zone,
+			IPv4_CIDR:       spSubnetInfo.IPv4_CIDR,
 			// todo: restore the tag list later
 			// TagList:        spSubnetInfo.TagList,
 		}


### PR DESCRIPTION
cspResourceId -> cspImageName
cspResourceId -> cspSpecName

명시적으로 csp 라는 표현을 붙여서, 혼동을 방지하고자 하였습니다. 
또한 pair로 있던 cspXXXId 는 TB에서 assets에 해당하는 spec과 image에 경우에는 도입하지 않도록 field에서 삭제하였습니다. (다른 리소스 군은 2개의 pair를 지니고 있음)