### PR TITLE
Expedite vm recommend filtering speed

### DIFF
--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -392,12 +392,19 @@ func FilterSpecsByRange(nsId string, filter model.FilterSpecsByRangeRequest) ([]
 		}
 	}
 
+	startTime := time.Now()
+
 	var specs []model.TbSpecInfo
 	err := session.Find(&specs)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to execute query")
 		return nil, err
 	}
+
+	elapsedTime := time.Since(startTime)
+	log.Info().
+		Dur("elapsedTime", elapsedTime).
+		Msg("ORM:session.Find(&specs)")
 
 	return specs, nil
 }

--- a/src/main.go
+++ b/src/main.go
@@ -146,6 +146,11 @@ func init() {
 		log.Info().Msg("Table customImage set successfully..")
 	}
 
+	err = addIndexes()
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot add indexes to the tables (ORM)")
+	}
+
 	setConfig()
 
 	_, err = common.GetNs(model.DefaultNamespace)
@@ -361,6 +366,37 @@ func setConfig() {
 	//fmt.Printf("RuntimeLatancyMap: %v\n\n", common.RuntimeLatancyMap)
 	//fmt.Printf("[RuntimeLatancyMapIndex]\n %v\n", common.RuntimeLatancyMapIndex)
 
+}
+
+// addIndexes adds indexes to the tables for faster search
+func addIndexes() error {
+
+	_, err := model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_namespace ON tb_spec_info (Namespace)")
+	if err != nil {
+		return err
+	}
+
+	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_vcpu ON tb_spec_info (VCPU)")
+	if err != nil {
+		return err
+	}
+
+	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_memorygib ON tb_spec_info (MemoryGiB)")
+	if err != nil {
+		return err
+	}
+
+	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_cspspecname ON tb_spec_info (CspSpecName)")
+	if err != nil {
+		return err
+	}
+
+	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_costperhour ON tb_spec_info (CostPerHour)")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Main Body


### PR DESCRIPTION
- mciRecommend 가 spec이 8만건 이상 등록되기 시작하면서, 성능 저하 발생. (약 12초 소요)

DB 인덱스 추가를 통해서, 속도향상 시킴. 

약 12초 -> 약 3.5초
(향후 추가 개선의 소지가 있음)