### PR TITLE
Handle the missing vNet/subnets by the unexpected outside operations

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -111,7 +111,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.9.3
+    image: cloudbaristaorg/cb-spider:0.9.6
     container_name: cb-spider
     # build:
     #   context: ../cb-spider

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/rs/zerolog v1.32.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.18.2
-	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/echo-swagger v1.4.1
 	github.com/swaggo/swag v1.16.3
 	github.com/tidwall/gjson v1.17.1
@@ -33,7 +32,6 @@ require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
@@ -71,7 +69,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -8155,7 +8155,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Delete VNet",
+                "description": "Delete VNet\n- withsubnets: delete VNet and its subnets\n- refine: delete information of VNet and its subnets if there's no info/resource in Spider/CSP\n- force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP",
                 "consumes": [
                     "application/json"
                 ],
@@ -8165,7 +8165,7 @@ const docTemplate = `{
                 "tags": [
                     "[Infra Resource] Network Management"
                 ],
-                "summary": "Delete VNet",
+                "summary": "Delete VNet (supporting actions: withsubnet, refine, force)",
                 "operationId": "DelVNet",
                 "parameters": [
                     {
@@ -8185,12 +8185,13 @@ const docTemplate = `{
                     },
                     {
                         "enum": [
-                            "true",
-                            "false"
+                            "withsubnets",
+                            "refine",
+                            "force"
                         ],
                         "type": "string",
-                        "description": "Delete subnets as well",
-                        "name": "withSubnets",
+                        "description": "Action",
+                        "name": "action",
                         "in": "query"
                     }
                 ],
@@ -8212,7 +8213,7 @@ const docTemplate = `{
         },
         "/ns/{nsId}/resources/vNet/{vNetId}/subnet": {
             "get": {
-                "description": "List all subnets (metadata)",
+                "description": "List all subnets",
                 "consumes": [
                     "application/json"
                 ],
@@ -8222,7 +8223,7 @@ const docTemplate = `{
                 "tags": [
                     "[Infra Resource] Network Management"
                 ],
-                "summary": "List all subnets (metadata)",
+                "summary": "List all subnets",
                 "operationId": "GetAllSubnet",
                 "parameters": [
                     {
@@ -8325,7 +8326,7 @@ const docTemplate = `{
         },
         "/ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}": {
             "get": {
-                "description": "Get Subnet (metadata)",
+                "description": "Get Subnet",
                 "consumes": [
                     "application/json"
                 ],
@@ -8335,7 +8336,7 @@ const docTemplate = `{
                 "tags": [
                     "[Infra Resource] Network Management"
                 ],
-                "summary": "Get Subnet (metadata)",
+                "summary": "Get Subnet",
                 "operationId": "GetSubnet",
                 "parameters": [
                     {
@@ -8383,7 +8384,7 @@ const docTemplate = `{
                 }
             },
             "delete": {
-                "description": "Delete Subnet",
+                "description": "Delete Subnet\n- refine: delete information of subnet if there's no info/resource in Spider/CSP\n- force: delete subnet regardless of the status of info/resource in Spider/CSP",
                 "consumes": [
                     "application/json"
                 ],
@@ -8393,7 +8394,7 @@ const docTemplate = `{
                 "tags": [
                     "[Infra Resource] Network Management"
                 ],
-                "summary": "Delete Subnet",
+                "summary": "Delete Subnet (supporting actions: refine, force)",
                 "operationId": "DelSubnet",
                 "parameters": [
                     {
@@ -8417,6 +8418,16 @@ const docTemplate = `{
                         "name": "subnetId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "refine",
+                            "force"
+                        ],
+                        "type": "string",
+                        "description": "Action",
+                        "name": "action",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -8148,7 +8148,7 @@
                 }
             },
             "delete": {
-                "description": "Delete VNet",
+                "description": "Delete VNet\n- withsubnets: delete VNet and its subnets\n- refine: delete information of VNet and its subnets if there's no info/resource in Spider/CSP\n- force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP",
                 "consumes": [
                     "application/json"
                 ],
@@ -8158,7 +8158,7 @@
                 "tags": [
                     "[Infra Resource] Network Management"
                 ],
-                "summary": "Delete VNet",
+                "summary": "Delete VNet (supporting actions: withsubnet, refine, force)",
                 "operationId": "DelVNet",
                 "parameters": [
                     {
@@ -8178,12 +8178,13 @@
                     },
                     {
                         "enum": [
-                            "true",
-                            "false"
+                            "withsubnets",
+                            "refine",
+                            "force"
                         ],
                         "type": "string",
-                        "description": "Delete subnets as well",
-                        "name": "withSubnets",
+                        "description": "Action",
+                        "name": "action",
                         "in": "query"
                     }
                 ],
@@ -8205,7 +8206,7 @@
         },
         "/ns/{nsId}/resources/vNet/{vNetId}/subnet": {
             "get": {
-                "description": "List all subnets (metadata)",
+                "description": "List all subnets",
                 "consumes": [
                     "application/json"
                 ],
@@ -8215,7 +8216,7 @@
                 "tags": [
                     "[Infra Resource] Network Management"
                 ],
-                "summary": "List all subnets (metadata)",
+                "summary": "List all subnets",
                 "operationId": "GetAllSubnet",
                 "parameters": [
                     {
@@ -8318,7 +8319,7 @@
         },
         "/ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}": {
             "get": {
-                "description": "Get Subnet (metadata)",
+                "description": "Get Subnet",
                 "consumes": [
                     "application/json"
                 ],
@@ -8328,7 +8329,7 @@
                 "tags": [
                     "[Infra Resource] Network Management"
                 ],
-                "summary": "Get Subnet (metadata)",
+                "summary": "Get Subnet",
                 "operationId": "GetSubnet",
                 "parameters": [
                     {
@@ -8376,7 +8377,7 @@
                 }
             },
             "delete": {
-                "description": "Delete Subnet",
+                "description": "Delete Subnet\n- refine: delete information of subnet if there's no info/resource in Spider/CSP\n- force: delete subnet regardless of the status of info/resource in Spider/CSP",
                 "consumes": [
                     "application/json"
                 ],
@@ -8386,7 +8387,7 @@
                 "tags": [
                     "[Infra Resource] Network Management"
                 ],
-                "summary": "Delete Subnet",
+                "summary": "Delete Subnet (supporting actions: refine, force)",
                 "operationId": "DelSubnet",
                 "parameters": [
                     {
@@ -8410,6 +8411,16 @@
                         "name": "subnetId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "enum": [
+                            "refine",
+                            "force"
+                        ],
+                        "type": "string",
+                        "description": "Action",
+                        "name": "action",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -6093,23 +6093,38 @@ paths:
       x-codegen-request-body-name: vNetReq
     delete:
       tags:
-      - "[Infra Resource] Network Management"
-      summary: Delete all VNets
-      description: Delete all VNets
-      operationId: DelAllVNet
+      - '[Infra Resource] Network Management'
+  /ns/{nsId}/resources/vNet/{vNetId}:
+    delete:
+      consumes:
+      - application/json
+      description: |-
+        Delete VNet
+        - withsubnets: delete VNet and its subnets
+        - refine: delete information of VNet and its subnets if there's no info/resource in Spider/CSP
+        - force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP
+      operationId: DelVNet
       parameters:
       - name: nsId
         in: path
         description: Namespace ID
         required: true
-        schema:
-          type: string
-          default: default
-      - name: match
+        type: string
+      - description: VNet ID
+        in: path
+        name: vNetId
+        required: true
+        type: string
+      - description: Action
+        enum:
+        - withsubnets
+        - refine
+        - force
         in: query
-        description: Delete resources containing matched ID-substring only
-        schema:
-          type: string
+        name: action
+        type: string
+      produces:
+      - application/json
       responses:
         "200":
           description: OK
@@ -6119,12 +6134,9 @@ paths:
                 $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.SimpleMsg'
-  /ns/{nsId}/resources/vNet/{vNetId}:
-    get:
+          schema:
+            $ref: '#/definitions/model.SimpleMsg'
+      summary: 'Delete VNet (supporting actions: withsubnet, refine, force)'
       tags:
       - "[Infra Resource] Network Management"
       summary: Get VNet
@@ -6206,10 +6218,9 @@ paths:
                 $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/vNet/{vNetId}/subnet:
     get:
-      tags:
-      - "[Infra Resource] Network Management"
-      summary: List all subnets (metadata)
-      description: List all subnets (metadata)
+      consumes:
+      - application/json
+      description: List all subnets
       operationId: GetAllSubnet
       parameters:
       - name: nsId
@@ -6240,11 +6251,9 @@ paths:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.SimpleMsg'
-    post:
+          schema:
+            $ref: '#/definitions/model.SimpleMsg'
+      summary: List all subnets
       tags:
       - "[Infra Resource] Network Management"
       summary: Create Subnet
@@ -6294,9 +6303,62 @@ paths:
   /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}:
     get:
       tags:
-      - "[Infra Resource] Network Management"
-      summary: Get Subnet (metadata)
-      description: Get Subnet (metadata)
+      - '[Infra Resource] Network Management'
+  /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}:
+    delete:
+      consumes:
+      - application/json
+      description: |-
+        Delete Subnet
+        - refine: delete information of subnet if there's no info/resource in Spider/CSP
+        - force: delete subnet regardless of the status of info/resource in Spider/CSP
+      operationId: DelSubnet
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: vNetId
+        in: path
+        description: VNet ID
+        required: true
+        schema:
+          type: string
+      - name: subnetId
+        in: path
+        description: Subnet ID
+        required: true
+        type: string
+      - description: Action
+        enum:
+        - refine
+        - force
+        in: query
+        name: action
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSubnetInfo'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/model.SimpleMsg'
+      summary: 'Delete Subnet (supporting actions: refine, force)'
+      tags:
+      - '[Infra Resource] Network Management'
+    get:
+      consumes:
+      - application/json
+      description: Get Subnet
       operationId: GetSubnet
       parameters:
       - name: nsId
@@ -6324,58 +6386,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/model.TbSubnetInfo'
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.SimpleMsg'
+          schema:
+            $ref: '#/definitions/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.SimpleMsg'
-    delete:
+          schema:
+            $ref: '#/definitions/model.SimpleMsg'
+      summary: Get Subnet
       tags:
-      - "[Infra Resource] Network Management"
-      summary: Delete Subnet
-      description: Delete Subnet
-      operationId: DelSubnet
-      parameters:
-      - name: nsId
-        in: path
-        description: Namespace ID
-        required: true
-        schema:
-          type: string
-          default: default
-      - name: vNetId
-        in: path
-        description: VNet ID
-        required: true
-        schema:
-          type: string
-      - name: subnetId
-        in: path
-        description: Subnet ID
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.SimpleMsg'
-        "404":
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.SimpleMsg'
+      - '[Infra Resource] Network Management'
   /ns/{nsId}/sharedResource:
     post:
       tags:

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -6093,38 +6093,23 @@ paths:
       x-codegen-request-body-name: vNetReq
     delete:
       tags:
-      - '[Infra Resource] Network Management'
-  /ns/{nsId}/resources/vNet/{vNetId}:
-    delete:
-      consumes:
-      - application/json
-      description: |-
-        Delete VNet
-        - withsubnets: delete VNet and its subnets
-        - refine: delete information of VNet and its subnets if there's no info/resource in Spider/CSP
-        - force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP
-      operationId: DelVNet
+      - "[Infra Resource] Network Management"
+      summary: Delete all VNets
+      description: Delete all VNets
+      operationId: DelAllVNet
       parameters:
       - name: nsId
         in: path
         description: Namespace ID
         required: true
-        type: string
-      - description: VNet ID
-        in: path
-        name: vNetId
-        required: true
-        type: string
-      - description: Action
-        enum:
-        - withsubnets
-        - refine
-        - force
+        schema:
+          type: string
+          default: default
+      - name: match
         in: query
-        name: action
-        type: string
-      produces:
-      - application/json
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
       responses:
         "200":
           description: OK
@@ -6134,9 +6119,12 @@ paths:
                 $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: 'Delete VNet (supporting actions: withsubnet, refine, force)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/vNet/{vNetId}:
+    get:
       tags:
       - "[Infra Resource] Network Management"
       summary: Get VNet
@@ -6178,8 +6166,12 @@ paths:
     delete:
       tags:
       - "[Infra Resource] Network Management"
-      summary: Delete VNet
-      description: Delete VNet
+      summary: "Delete VNet (supporting actions: withsubnet, refine, force)"
+      description: |-
+        Delete VNet
+        - withsubnets: delete VNet and its subnets
+        - refine: delete information of VNet and its subnets if there's no info/resource in Spider/CSP
+        - force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP
       operationId: DelVNet
       parameters:
       - name: nsId
@@ -6195,14 +6187,15 @@ paths:
         required: true
         schema:
           type: string
-      - name: withSubnets
+      - name: action
         in: query
-        description: Delete subnets as well
+        description: Action
         schema:
           type: string
           enum:
-          - "true"
-          - "false"
+          - withsubnets
+          - refine
+          - force
       responses:
         "200":
           description: OK
@@ -6218,8 +6211,9 @@ paths:
                 $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/vNet/{vNetId}/subnet:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: List all subnets
       description: List all subnets
       operationId: GetAllSubnet
       parameters:
@@ -6251,9 +6245,11 @@ paths:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all subnets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    post:
       tags:
       - "[Infra Resource] Network Management"
       summary: Create Subnet
@@ -6303,61 +6299,8 @@ paths:
   /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}:
     get:
       tags:
-      - '[Infra Resource] Network Management'
-  /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}:
-    delete:
-      consumes:
-      - application/json
-      description: |-
-        Delete Subnet
-        - refine: delete information of subnet if there's no info/resource in Spider/CSP
-        - force: delete subnet regardless of the status of info/resource in Spider/CSP
-      operationId: DelSubnet
-      parameters:
-      - name: nsId
-        in: path
-        description: Namespace ID
-        required: true
-        schema:
-          type: string
-          default: default
-      - name: vNetId
-        in: path
-        description: VNet ID
-        required: true
-        schema:
-          type: string
-      - name: subnetId
-        in: path
-        description: Subnet ID
-        required: true
-        type: string
-      - description: Action
-        enum:
-        - refine
-        - force
-        in: query
-        name: action
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.TbSubnetInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: 'Delete Subnet (supporting actions: refine, force)'
-      tags:
-      - '[Infra Resource] Network Management'
-    get:
-      consumes:
-      - application/json
+      - "[Infra Resource] Network Management"
+      summary: Get Subnet
       description: Get Subnet
       operationId: GetSubnet
       parameters:
@@ -6386,18 +6329,69 @@ paths:
           content:
             application/json:
               schema:
+                $ref: '#/components/schemas/model.TbSubnetInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: "Delete Subnet (supporting actions: refine, force)"
+      description: |-
+        Delete Subnet
+        - refine: delete information of subnet if there's no info/resource in Spider/CSP
+        - force: delete subnet regardless of the status of info/resource in Spider/CSP
+      operationId: DelSubnet
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: vNetId
+        in: path
+        description: VNet ID
+        required: true
+        schema:
+          type: string
+      - name: subnetId
+        in: path
+        description: Subnet ID
+        required: true
+        schema:
+          type: string
+      - name: action
+        in: query
+        description: Action
+        schema:
+          type: string
+          enum:
+          - refine
+          - force
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get Subnet
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/sharedResource:
     post:
       tags:


### PR DESCRIPTION
(related to #1808)

**First of all, some parts in this PR need the next version of CB-Spider (so I opened this draft PR).**
Since it's not urgent, I'm going to wait for the next release.

**This PR includes the following updates:**
* Add RefineVNet() and RefineSubent(), which operates based on information managed by Tumblebug
* Add actions (refine, force) on the following APIs
  - `DELETE /ns/{nsId}/resources/vNet/{vNetId}?action=xxx`
  - `DELETE /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}?action=xxx`
* Add the API to get subnet
  - `GET /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}`
* Improve comments in overall vNet/subnet functions and handlers

**The following was considered for the "Refine" implementation:**
1. Assume that Tumblebug, Spider, and CSP have already lost the consistency of information.
2. The information managed by Tumblebug is the most reliable.
3. A mechanism that only logs warnings has been applied because various abnormal returns occurred.
(Don't worry when you meet many warnings 😅)
