### PR TITLE
Change string label to structed label for mci

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -10916,9 +10916,11 @@ const docTemplate = `{
                     "example": "[yes, no]"
                 },
                 "label": {
-                    "description": "Label is for describing the mci in a keyword (any string can be used)",
-                    "type": "string",
-                    "example": "User custom label"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "masterIp": {
                     "type": "string",
@@ -12067,6 +12069,13 @@ const docTemplate = `{
                     "type": "string",
                     "example": "aws-ap-southeast-1"
                 },
+                "label": {
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "name": {
                     "description": "Name is human-readable string to represent the object",
                     "type": "string",
@@ -12525,6 +12534,13 @@ const docTemplate = `{
                     "type": "string",
                     "example": "aws-ap-southeast-1"
                 },
+                "label": {
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "name": {
                     "description": "Name is human-readable string to represent the object",
                     "type": "string",
@@ -12686,9 +12702,11 @@ const docTemplate = `{
                     "example": "no"
                 },
                 "label": {
-                    "description": "Label is for describing the mci in a keyword (any string can be used)",
-                    "type": "string",
-                    "example": "DynamicVM"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string",
@@ -12739,9 +12757,11 @@ const docTemplate = `{
                     "example": "yes"
                 },
                 "label": {
-                    "description": "Label is for describing the mci in a keyword (any string can be used)",
-                    "type": "string",
-                    "example": "User custom label"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "description": "Name is human-readable string to represent the object",
@@ -12819,9 +12839,11 @@ const docTemplate = `{
                     "example": "no"
                 },
                 "label": {
-                    "description": "Label is for describing the mci in a keyword (any string can be used)",
-                    "type": "string",
-                    "example": "custom tag"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string",
@@ -13813,8 +13835,11 @@ const docTemplate = `{
                     "example": "Description"
                 },
                 "label": {
-                    "type": "string",
-                    "example": "DynamicVM"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "description": "VM name or subGroup name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",
@@ -13907,7 +13932,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "label": {
-                    "type": "string"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "location": {
                     "$ref": "#/definitions/model.Location"
@@ -14053,7 +14081,11 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "label": {
-                    "type": "string"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "description": "VM name or subGroup name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -10910,9 +10910,11 @@
                     "example": "[yes, no]"
                 },
                 "label": {
-                    "description": "Label is for describing the mci in a keyword (any string can be used)",
-                    "type": "string",
-                    "example": "User custom label"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "masterIp": {
                     "type": "string",
@@ -12061,6 +12063,13 @@
                     "type": "string",
                     "example": "aws-ap-southeast-1"
                 },
+                "label": {
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "name": {
                     "description": "Name is human-readable string to represent the object",
                     "type": "string",
@@ -12519,6 +12528,13 @@
                     "type": "string",
                     "example": "aws-ap-southeast-1"
                 },
+                "label": {
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "name": {
                     "description": "Name is human-readable string to represent the object",
                     "type": "string",
@@ -12680,9 +12696,11 @@
                     "example": "no"
                 },
                 "label": {
-                    "description": "Label is for describing the mci in a keyword (any string can be used)",
-                    "type": "string",
-                    "example": "DynamicVM"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string",
@@ -12733,9 +12751,11 @@
                     "example": "yes"
                 },
                 "label": {
-                    "description": "Label is for describing the mci in a keyword (any string can be used)",
-                    "type": "string",
-                    "example": "User custom label"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "description": "Name is human-readable string to represent the object",
@@ -12813,9 +12833,11 @@
                     "example": "no"
                 },
                 "label": {
-                    "description": "Label is for describing the mci in a keyword (any string can be used)",
-                    "type": "string",
-                    "example": "custom tag"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string",
@@ -13807,8 +13829,11 @@
                     "example": "Description"
                 },
                 "label": {
-                    "type": "string",
-                    "example": "DynamicVM"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "description": "VM name or subGroup name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",
@@ -13901,7 +13926,10 @@
                     "type": "string"
                 },
                 "label": {
-                    "type": "string"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "location": {
                     "$ref": "#/definitions/model.Location"
@@ -14047,7 +14075,11 @@
                     "type": "string"
                 },
                 "label": {
-                    "type": "string"
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "description": "VM name or subGroup name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -8164,10 +8164,10 @@ components:
             \ ([yes/no] default:yes)"
           example: "[yes, no]"
         label:
-          type: string
-          description: Label is for describing the mci in a keyword (any string can
-            be used)
-          example: User custom label
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
         masterIp:
           type: string
           example: 32.201.134.113
@@ -8953,6 +8953,11 @@ components:
           type: string
           description: Id is unique identifier for the object
           example: aws-ap-southeast-1
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
         name:
           type: string
           description: Name is human-readable string to represent the object
@@ -9296,6 +9301,11 @@ components:
           type: string
           description: Id is unique identifier for the object
           example: aws-ap-southeast-1
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
         name:
           type: string
           description: Name is human-readable string to represent the object
@@ -9427,10 +9437,10 @@ components:
           - "yes"
           - "no"
         label:
-          type: string
-          description: Label is for describing the mci in a keyword (any string can
-            be used)
-          example: DynamicVM
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
         name:
           type: string
           example: mci01
@@ -9471,10 +9481,10 @@ components:
           - "yes"
           - "no"
         label:
-          type: string
-          description: Label is for describing the mci in a keyword (any string can
-            be used)
-          example: User custom label
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
         name:
           type: string
           description: Name is human-readable string to represent the object
@@ -9535,10 +9545,10 @@ components:
           - "yes"
           - "no"
         label:
-          type: string
-          description: Label is for describing the mci in a keyword (any string can
-            be used)
-          example: custom tag
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
         name:
           type: string
           example: mci01
@@ -10268,8 +10278,10 @@ components:
           type: string
           example: Description
         label:
-          type: string
-          example: DynamicVM
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
         name:
           type: string
           description: "VM name or subGroup name if is (not empty) && (> 0). If it\
@@ -10344,7 +10356,9 @@ components:
         imageId:
           type: string
         label:
-          type: string
+          type: object
+          additionalProperties:
+            type: string
         location:
           $ref: '#/components/schemas/model.Location'
         monAgentStatus:
@@ -10451,7 +10465,10 @@ components:
           type: string
           description: ImageType        string   `json:"imageType"`
         label:
-          type: string
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
         name:
           type: string
           description: "VM name or subGroup name if is (not empty) && (> 0). If it\

--- a/src/core/infra/loadbalance.go
+++ b/src/core/infra/loadbalance.go
@@ -67,8 +67,10 @@ func CreateMcSwNlb(nsId string, mciId string, req *model.TbNLBReq, option string
 	nlbMciId := mciId + nlbPostfix
 
 	// create a special MCI for (SW)NLB
-
-	mciDynamicReq := model.TbMciDynamicReq{Name: nlbMciId, InstallMonAgent: "no", Label: "McSwNlb"}
+	labels := map[string]string{
+		"sys.description": "MCI for Global-NLB",
+	}
+	mciDynamicReq := model.TbMciDynamicReq{Name: nlbMciId, InstallMonAgent: "no", Label: labels}
 
 	// get vm requst from cloud_conf.yaml
 	vmGroupName := "nlb"

--- a/src/core/infra/orchestration.go
+++ b/src/core/infra/orchestration.go
@@ -224,7 +224,10 @@ func OrchestrationController() {
 					switch {
 					case autoAction.ActionType == model.AutoActionScaleOut:
 
-						autoAction.VmDynamicReq.Label = model.LabelAutoGen
+						labels := map[string]string{
+							"sys.deploymentType": model.LabelAutoGen,
+						}
+						autoAction.VmDynamicReq.Label = labels
 						// append uid to given vm name to avoid duplicated vm ID.
 						autoAction.VmDynamicReq.Name = common.ToLower(autoAction.VmDynamicReq.Name) + "-" + common.GenUid()
 						//vmReqTmp := autoAction.Vm

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -485,7 +485,6 @@ func CreateMci(nsId string, req *model.TbMciReq, option string) (*model.TbMciInf
 		"targetAction":    targetAction,
 		"targetStatus":    targetStatus,
 		"installMonAgent": req.InstallMonAgent,
-		"label":           req.Label,
 		"systemLabel":     req.SystemLabel,
 	}
 	val, err := json.Marshal(mapA)
@@ -512,6 +511,10 @@ func CreateMci(nsId string, req *model.TbMciReq, option string) (*model.TbMciInf
 		"sys.uid":         uid,
 		"sys.description": req.Description,
 	}
+	for key, value := range req.Label {
+		labels[key] = value
+	}
+
 	err = label.CreateOrUpdateLabel(model.StrMCI, uid, key, labels)
 	if err != nil {
 		log.Error().Err(err).Msg("")
@@ -789,7 +792,10 @@ func CreateSystemMciDynamic(option string) (*model.TbMciInfo, error) {
 
 	// special purpose MCI
 	req.Name = option
-	req.Label = option
+	labels := map[string]string{
+		"sys.purpose": option,
+	}
+	req.Label = labels
 	req.SystemLabel = option
 	req.Description = option
 	req.InstallMonAgent = "no"
@@ -826,7 +832,7 @@ func CreateSystemMciDynamic(option string) (*model.TbMciInfo, error) {
 				recommendedSpec := specList[0].Id
 				vmReq.CommonSpec = recommendedSpec
 
-				vmReq.Label = vmReq.CommonSpec
+				vmReq.Label = labels
 				vmReq.Name = vmReq.CommonSpec
 
 				vmReq.RootDiskType = specList[0].RootDiskType
@@ -1215,6 +1221,9 @@ func AddVmToMci(wg *sync.WaitGroup, nsId string, mciId string, vmInfoData *model
 		"sys.mciId":           mciId,
 		"sys.createdTime":     vmInfoData.CreatedTime,
 		"sys.connectionName":  vmInfoData.ConnectionName,
+	}
+	for key, value := range vmInfoData.Label {
+		labels[key] = value
 	}
 	err = label.CreateOrUpdateLabel(model.StrVM, vmInfoData.Uid, key, labels)
 	if err != nil {

--- a/src/core/infra/utility.go
+++ b/src/core/infra/utility.go
@@ -977,7 +977,10 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciId string, op
 				// (if mciFlag == "n") create a mci for each vm
 				req.Name = vm.Name
 			}
-			vm.Label = "not defined"
+			labels := map[string]string{
+				"sys.registered": "true",
+			}
+			vm.Label = labels
 
 			vm.ImageId = "cannot retrieve"
 			vm.SpecId = "cannot retrieve"

--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -331,6 +331,9 @@ type TbK8sClusterInfo struct {
 	// Latest system message such as error message
 	SystemMessage string `json:"systemMessage" example:"Failed because ..." default:""` // systeam-given string message
 
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
+
 	// SystemLabel is for describing the Resource in a keyword (any string can be used) for special System purpose
 	SystemLabel string `json:"systemLabel" example:"Managed by CB-Tumblebug" default:""`
 
@@ -397,6 +400,9 @@ type TbK8sNodeGroupInfo struct {
 
 	// Name is human-readable string to represent the object
 	Name string `json:"name" example:"aws-ap-southeast-1"`
+
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
 
 	CspViewK8sNodeGroupDetail SpiderNodeGroupInfo `json:"cspViewK8sNodeGroupDetail,omitempty"`
 

--- a/src/core/model/mci.go
+++ b/src/core/model/mci.go
@@ -75,7 +75,7 @@ const (
 	StatusComplete string = "None"
 )
 
-const LabelAutoGen string = "AutoGen"
+const LabelAutoGen string = "sys.autogen"
 
 // DefaultSystemLabel is const for string to specify the Default System Label
 const DefaultSystemLabel string = "Managed by CB-Tumblebug"
@@ -93,8 +93,8 @@ type TbMciReq struct {
 	// InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
 	InstallMonAgent string `json:"installMonAgent" example:"no" default:"yes" enums:"yes,no"` // yes or no
 
-	// Label is for describing the mci in a keyword (any string can be used)
-	Label string `json:"label" example:"custom tag" default:""`
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
 
 	// SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose
 	SystemLabel string `json:"systemLabel" example:"" default:""`
@@ -129,8 +129,8 @@ type TbMciInfo struct {
 	// ConfigureCloudAdaptiveNetwork is an option to configure Cloud Adaptive Network (CLADNet) ([yes/no] default:yes)
 	ConfigureCloudAdaptiveNetwork string `json:"configureCloudAdaptiveNetwork" example:"yes" default:"no" enums:"yes,no"` // yes or no
 
-	// Label is for describing the mci in a keyword (any string can be used)
-	Label string `json:"label" example:"User custom label"`
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
 
 	// SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose
 	SystemLabel string `json:"systemLabel" example:"Managed by CB-Tumblebug" default:""`
@@ -157,7 +157,8 @@ type TbVmReq struct {
 	// if subGroupSize is (not empty) && (> 0), subGroup will be generated. VMs will be created accordingly.
 	SubGroupSize string `json:"subGroupSize" example:"3" default:""`
 
-	Label string `json:"label"`
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
 
 	Description string `json:"description" example:"Description"`
 
@@ -191,8 +192,8 @@ type TbMciDynamicReq struct {
 	// InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:yes)
 	InstallMonAgent string `json:"installMonAgent" example:"no" default:"no" enums:"yes,no"` // yes or no
 
-	// Label is for describing the mci in a keyword (any string can be used)
-	Label string `json:"label" example:"DynamicVM" default:""`
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
 
 	// SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose
 	SystemLabel string `json:"systemLabel" example:"" default:""`
@@ -210,7 +211,8 @@ type TbVmDynamicReq struct {
 	// if subGroupSize is (not empty) && (> 0), subGroup will be generated. VMs will be created accordingly.
 	SubGroupSize string `json:"subGroupSize" example:"3" default:"1"`
 
-	Label string `json:"label" example:"DynamicVM"`
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
 
 	Description string `json:"description" example:"Description"`
 
@@ -367,8 +369,8 @@ type TbVmInfo struct {
 	// Created time
 	CreatedTime string `json:"createdTime" example:"2022-11-10 23:00:00" default:""`
 
-	Label       string `json:"label"`
-	Description string `json:"description"`
+	Label       map[string]string `json:"label"`
+	Description string            `json:"description"`
 
 	Region         RegionInfo `json:"region"` // AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
 	PublicIP       string     `json:"publicIP"`
@@ -385,7 +387,7 @@ type TbVmInfo struct {
 	SpecId           string     `json:"specId"`
 	CspSpecName      string     `json:"cspSpecName"`
 	ImageId          string     `json:"imageId"`
-	CspImageName       string     `json:"cspImageName"`
+	CspImageName     string     `json:"cspImageName"`
 	VNetId           string     `json:"vNetId"`
 	CspVNetId        string     `json:"cspVNetId"`
 	SubnetId         string     `json:"subnetId"`
@@ -525,8 +527,8 @@ type MciStatusInfo struct {
 	MasterIp      string `json:"masterIp" example:"32.201.134.113"`
 	MasterSSHPort string `json:"masterSSHPort"`
 
-	// Label is for describing the mci in a keyword (any string can be used)
-	Label string `json:"label" example:"User custom label"`
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
 
 	// SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose
 	SystemLabel string `json:"systemLabel" example:"Managed by CB-Tumblebug" default:""`

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -287,16 +287,7 @@ func CreateK8sCluster(nsId string, req *model.TbK8sClusterReq, option string) (m
 		return tbK8sCInfo, err
 	}
 
-	kv, err := kvstore.GetKv(k)
-	if err != nil {
-		err = fmt.Errorf("In CreateK8sCluster(); kvstore.GetKv() returned an error: " + err.Error())
-		log.Err(err).Msg("")
-	}
-
-	log.Debug().Msg("<" + kv.Key + "> \n" + kv.Value)
-
-	storedTbK8sCInfo := model.TbK8sClusterInfo{}
-	err = json.Unmarshal([]byte(kv.Value), &storedTbK8sCInfo)
+	storedTbK8sCInfo, err := GetK8sCluster(nsId, tbK8sCInfo.Id)
 	if err != nil {
 		log.Err(err).Msg("")
 	}
@@ -894,6 +885,15 @@ func GetK8sCluster(nsId string, k8sClusterId string) (model.TbK8sClusterInfo, er
 			return emptyObj, err
 		}
 	*/
+
+	// add label info
+	labelInfo, err := label.GetLabels(model.StrK8s, tbK8sCInfo.Uid)
+	if err != nil {
+		log.Error().Err(err).Msg("Cannot get the label info")
+		return tbK8sCInfo, err
+	}
+	tbK8sCInfo.Label = labelInfo.Labels
+
 	return tbK8sCInfo, nil
 }
 


### PR DESCRIPTION
각 오브젝트의 기존 label string을 신규 Label 구조로 대체 (오브젝트 조회시에, label 조회 기능을 통해 내용 첨부하여 제공)

본 PR의 적용 대상
- mci, vm
- k8sCluster

나머지 오브젝트에 대해서는 향후 적용 예정.

MCI 조회 예시

![image](https://github.com/user-attachments/assets/b53478d0-061d-4a40-b9e4-2573c6145b39)


