### PR TITLE
Add Get Label Info and remove direct string usage

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -1033,6 +1033,36 @@ const docTemplate = `{
                 }
             }
         },
+        "/labelInfo": {
+            "get": {
+                "description": "Return LabelTypes and system defined label keys with example",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra Resource] Common Utility"
+                ],
+                "summary": "Return LabelTypes and system defined label keys with example",
+                "operationId": "GetSystemLabelInfo",
+                "responses": {
+                    "200": {
+                        "description": "LabelTypes and System labels with example values",
+                        "schema": {
+                            "$ref": "#/definitions/model.SystemLabelInfo"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/loadAssets": {
             "get": {
                 "description": "Load Common Resources from internal asset files (Spec, Image)",
@@ -12017,6 +12047,23 @@ const docTemplate = `{
                 "countUndefined": {
                     "description": "CountUndefined is for counting Undefined",
                     "type": "integer"
+                }
+            }
+        },
+        "model.SystemLabelInfo": {
+            "type": "object",
+            "properties": {
+                "labelTypes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "systemLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -1027,6 +1027,36 @@
                 }
             }
         },
+        "/labelInfo": {
+            "get": {
+                "description": "Return LabelTypes and system defined label keys with example",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra Resource] Common Utility"
+                ],
+                "summary": "Return LabelTypes and system defined label keys with example",
+                "operationId": "GetSystemLabelInfo",
+                "responses": {
+                    "200": {
+                        "description": "LabelTypes and System labels with example values",
+                        "schema": {
+                            "$ref": "#/definitions/model.SystemLabelInfo"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/loadAssets": {
             "get": {
                 "description": "Load Common Resources from internal asset files (Spec, Image)",
@@ -12011,6 +12041,23 @@
                 "countUndefined": {
                     "description": "CountUndefined is for counting Undefined",
                     "type": "integer"
+                }
+            }
+        },
+        "model.SystemLabelInfo": {
+            "type": "object",
+            "properties": {
+                "labelTypes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "systemLabels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -776,6 +776,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
+  /labelInfo:
+    get:
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Return LabelTypes and system defined label keys with example
+      description: Return LabelTypes and system defined label keys with example
+      operationId: GetSystemLabelInfo
+      responses:
+        "200":
+          description: LabelTypes and System labels with example values
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SystemLabelInfo'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /loadAssets:
     get:
       tags:
@@ -8916,6 +8936,17 @@ components:
         countUndefined:
           type: integer
           description: CountUndefined is for counting Undefined
+    model.SystemLabelInfo:
+      type: object
+      properties:
+        labelTypes:
+          type: array
+          items:
+            type: string
+        systemLabels:
+          type: object
+          additionalProperties:
+            type: string
     model.TbAttachDetachDataDiskReq:
       required:
       - dataDiskId

--- a/src/api/rest/server/common/label/label.go
+++ b/src/api/rest/server/common/label/label.go
@@ -176,3 +176,32 @@ func RestGetResourcesByLabelSelector(c echo.Context) error {
 
 	return common.EndRequestWithLog(c, reqID, nil, response)
 }
+
+// RestGetSystemLabelInfo godoc
+// @ID GetSystemLabelInfo
+// @Summary Return LabelTypes and system defined label keys with example
+// @Description Return LabelTypes and system defined label keys with example
+// @Tags [Infra Resource] Common Utility
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} model.SystemLabelInfo "LabelTypes and System labels with example values"
+// @Failure 500 {object} model.SimpleMsg "Internal Server Error"
+// @Router /labelInfo [get]
+func RestGetSystemLabelInfo(c echo.Context) error {
+	reqID, idErr := common.StartRequestWithLog(c)
+	if idErr != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"message": idErr.Error()})
+	}
+
+	// Use the GetLabelConstantsMap function to get the system label constants
+	systemLabels := model.GetLabelConstantsMap()
+	labelTypes := model.GetLabelTypes()
+
+	// Wrap the map in SystemLabelInfo struct
+	systemLabelInfo := model.SystemLabelInfo{
+		SystemLabels: systemLabels,
+		LabelTypes:   labelTypes,
+	}
+
+	return common.EndRequestWithLog(c, reqID, nil, systemLabelInfo)
+}

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -289,6 +289,7 @@ func RunServer(port string) {
 	e.DELETE("/tumblebug/label/:labelType/:uid/:key", rest_label.RestRemoveLabel)
 	e.GET("/tumblebug/label/:labelType/:uid", rest_label.RestGetLabels)
 	e.GET("/tumblebug/resources/:labelType", rest_label.RestGetResourcesByLabelSelector)
+	e.GET("/tumblebug/labelInfo", rest_label.RestGetSystemLabelInfo)
 
 	//MCI Management
 	g.POST("/:nsId/mci", rest_infra.RestPostMci)

--- a/src/core/common/namespace.go
+++ b/src/core/common/namespace.go
@@ -90,13 +90,13 @@ func CreateNs(u *model.NsReq) (model.NsInfo, error) {
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":     model.StrManager,
-		"sys.namespace":   content.Id,
-		"sys.labelType":   model.StrNamespace,
-		"sys.id":          content.Id,
-		"sys.name":        content.Name,
-		"sys.uid":         content.Uid,
-		"sys.description": content.Description,
+		model.LabelManager:     model.StrManager,
+		model.LabelNamespace:   content.Id,
+		model.LabelLabelType:   model.StrNamespace,
+		model.LabelId:          content.Id,
+		model.LabelName:        content.Name,
+		model.LabelUid:         content.Uid,
+		model.LabelDescription: content.Description,
 	}
 	err = label.CreateOrUpdateLabel(model.StrNamespace, content.Uid, key, labels)
 	if err != nil {

--- a/src/core/infra/loadbalance.go
+++ b/src/core/infra/loadbalance.go
@@ -68,7 +68,7 @@ func CreateMcSwNlb(nsId string, mciId string, req *model.TbNLBReq, option string
 
 	// create a special MCI for (SW)NLB
 	labels := map[string]string{
-		"sys.description": "MCI for Global-NLB",
+		model.LabelDescription: "MCI for Global-NLB",
 	}
 	mciDynamicReq := model.TbMciDynamicReq{Name: nlbMciId, InstallMonAgent: "no", Label: labels}
 

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -125,7 +125,7 @@ func ListVmId(nsId string, mciId string) ([]string, error) {
 // ListVmByLabel is a function to list VM IDs by label
 func ListVmByLabel(nsId string, mciId string, labelKey string) ([]string, error) {
 	// Construct the label selector
-	labelSelector := labelKey + " exists" + "," + "sys.nsId=" + nsId + "," + "sys.mciId=" + mciId
+	labelSelector := labelKey + " exists" + "," + model.LabelNamespace + "=" + nsId + "," + model.LabelMciId + "=" + mciId
 
 	// Call GetResourcesByLabelSelector (returns []interface{})
 	resources, err := label.GetResourcesByLabelSelector(model.StrVM, labelSelector)

--- a/src/core/infra/orchestration.go
+++ b/src/core/infra/orchestration.go
@@ -225,7 +225,7 @@ func OrchestrationController() {
 					case autoAction.ActionType == model.AutoActionScaleOut:
 
 						labels := map[string]string{
-							"sys.deploymentType": model.LabelAutoGen,
+							model.LabelDeploymentType: model.StrAutoGen,
 						}
 						autoAction.VmDynamicReq.Label = labels
 						// append uid to given vm name to avoid duplicated vm ID.
@@ -289,7 +289,7 @@ func OrchestrationController() {
 
 						// ScaleIn MCI.
 						log.Debug().Msg("[Removing VM]")
-						vmList, vmListErr := ListVmByLabel(nsId, mciPolicyTmp.Id, model.LabelAutoGen)
+						vmList, vmListErr := ListVmByLabel(nsId, mciPolicyTmp.Id, model.StrAutoGen)
 						if vmListErr != nil {
 							mciPolicyTmp.Policy[policyIndex].Status = model.AutoStatusError
 							UpdateMciPolicyInfo(nsId, mciPolicyTmp)

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -503,13 +503,13 @@ func CreateMci(nsId string, req *model.TbMciReq, option string) (*model.TbMciInf
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":     model.StrManager,
-		"sys.namespace":   nsId,
-		"sys.labelType":   model.StrMCI,
-		"sys.id":          mciId,
-		"sys.name":        req.Name,
-		"sys.uid":         uid,
-		"sys.description": req.Description,
+		model.LabelManager:     model.StrManager,
+		model.LabelNamespace:   nsId,
+		model.LabelLabelType:   model.StrMCI,
+		model.LabelId:          mciId,
+		model.LabelName:        req.Name,
+		model.LabelUid:         uid,
+		model.LabelDescription: req.Description,
 	}
 	for key, value := range req.Label {
 		labels[key] = value
@@ -596,16 +596,16 @@ func CreateMci(nsId string, req *model.TbMciReq, option string) (*model.TbMciInf
 
 			// Store label info using CreateOrUpdateLabel
 			labels := map[string]string{
-				"sys.manager":        model.StrManager,
-				"sys.namespace":      nsId,
-				"sys.labelType":      model.StrSubGroup,
-				"sys.id":             subGroupInfoData.Id,
-				"sys.name":           subGroupInfoData.Name,
-				"sys.uid":            subGroupInfoData.Uid,
-				"sys.mciId":          mciId,
-				"sys.mciname":        req.Name,
-				"sys.mciUid":         uid,
-				"sys.mciDescription": req.Description,
+				model.LabelManager:        model.StrManager,
+				model.LabelNamespace:      nsId,
+				model.LabelLabelType:      model.StrSubGroup,
+				model.LabelId:             subGroupInfoData.Id,
+				model.LabelName:           subGroupInfoData.Name,
+				model.LabelUid:            subGroupInfoData.Uid,
+				model.LabelMciId:          mciId,
+				model.LabelMciName:        req.Name,
+				model.LabelMciUid:         uid,
+				model.LabelMciDescription: req.Description,
 			}
 			err = label.CreateOrUpdateLabel(model.StrSubGroup, uid, key, labels)
 			if err != nil {
@@ -793,7 +793,7 @@ func CreateSystemMciDynamic(option string) (*model.TbMciInfo, error) {
 	// special purpose MCI
 	req.Name = option
 	labels := map[string]string{
-		"sys.purpose": option,
+		model.LabelPurpose: option,
 	}
 	req.Label = labels
 	req.SystemLabel = option
@@ -1209,18 +1209,18 @@ func AddVmToMci(wg *sync.WaitGroup, nsId string, mciId string, vmInfoData *model
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrVM,
-		"sys.id":              vmInfoData.Id,
-		"sys.name":            vmInfoData.Name,
-		"sys.uid":             vmInfoData.Uid,
-		"sys.cspResourceId":   vmInfoData.CspResourceId,
-		"sys.cspResourceName": vmInfoData.CspResourceName,
-		"sys.subGroupId":      vmInfoData.SubGroupId,
-		"sys.mciId":           mciId,
-		"sys.createdTime":     vmInfoData.CreatedTime,
-		"sys.connectionName":  vmInfoData.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrVM,
+		model.LabelId:              vmInfoData.Id,
+		model.LabelName:            vmInfoData.Name,
+		model.LabelUid:             vmInfoData.Uid,
+		model.LabelCspResourceId:   vmInfoData.CspResourceId,
+		model.LabelCspResourceName: vmInfoData.CspResourceName,
+		model.LabelSubGroupId:      vmInfoData.SubGroupId,
+		model.LabelMciId:           mciId,
+		model.LabelCreatedTime:     vmInfoData.CreatedTime,
+		model.LabelConnectionName:  vmInfoData.ConnectionName,
 	}
 	for key, value := range vmInfoData.Label {
 		labels[key] = value

--- a/src/core/infra/utility.go
+++ b/src/core/infra/utility.go
@@ -978,7 +978,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciId string, op
 				req.Name = vm.Name
 			}
 			labels := map[string]string{
-				"sys.registered": "true",
+				model.LabelRegistered: "true",
 			}
 			vm.Label = labels
 

--- a/src/core/model/label.go
+++ b/src/core/model/label.go
@@ -30,3 +30,90 @@ type LabelInfo struct {
 type Label struct {
 	Labels map[string]string `json:"labels"`
 }
+
+// SystemLabelInfo is a struct to return LabelTypes and System label Keys
+type SystemLabelInfo struct {
+	LabelTypes   []string          `json:"labelTypes"`
+	SystemLabels map[string]string `json:"systemLabels"`
+}
+
+const (
+	LabelManager         string = "sys.manager"
+	LabelNamespace       string = "sys.namespace"
+	LabelLabelType       string = "sys.labelType"
+	LabelId              string = "sys.id"
+	LabelName            string = "sys.name"
+	LabelUid             string = "sys.uid"
+	LabelCspResourceId   string = "sys.cspResourceId"
+	LabelCspResourceName string = "sys.cspResourceName"
+	LabelMciId           string = "sys.mciId"
+	LabelMciName         string = "sys.mciName"
+	LabelMciUid          string = "sys.mciUid"
+	LabelMciDescription  string = "sys.mciDescription"
+	LabelSubGroupId      string = "sys.subGroupId"
+	LabelCreatedTime     string = "sys.createdTime"
+	LabelConnectionName  string = "sys.connectionName"
+	LabelDescription     string = "sys.description"
+	LabelRegistered      string = "sys.registered"
+	LabelPurpose         string = "sys.purpose"
+	LabelDeploymentType  string = "sys.deploymentType"
+	LabelDiskType        string = "sys.diskType"
+	LabelDiskSize        string = "sys.diskSize"
+	LabelVersion         string = "sys.version"
+	LabelVNetId          string = "sys.vNetId"
+	LabelIpv4_CIDR       string = "sys.ipv4_CIDR"
+	LabelZone            string = "sys.zone"
+	LabelStatus          string = "sys.status"
+	LabelCspVNetId       string = "sys.cspVNetId"
+	LabelCspVNetName     string = "sys.cspVNetName"
+	LabelCidr            string = "sys.cidr"
+)
+
+// GetLabelConstantsMap returns a map with label-related system constants as keys and their example values.
+func GetLabelConstantsMap() map[string]string {
+	return map[string]string{
+		LabelManager:         "cb-tumblebug",
+		LabelNamespace:       "default",
+		LabelLabelType:       StrMCI,
+		LabelId:              "mci-1234",
+		LabelName:            "mci-1234",
+		LabelUid:             "wef12awefadf1221edcf",
+		LabelCspResourceId:   "csp-vm-1234",
+		LabelCspResourceName: "csp-vm-1234",
+		LabelMciId:           "mci-1234",
+		LabelSubGroupId:      "sg-1234",
+		LabelCreatedTime:     "2021-01-01T00:00:00Z",
+		LabelConnectionName:  "connection-1234",
+		LabelDescription:     "Description",
+		LabelRegistered:      "true",
+		LabelPurpose:         "testing",
+		LabelDeploymentType:  "vm",
+		LabelDiskType:        "HDD",
+		LabelDiskSize:        "10",
+		LabelVersion:         "1.0",
+		LabelVNetId:          "vnet-1234",
+		LabelIpv4_CIDR:       "10.0.0.0/24",
+		LabelZone:            "zone-1",
+		LabelStatus:          "Running",
+		LabelCspVNetId:       "csp-vnet-1234",
+		LabelCspVNetName:     "csp-vnet-1234",
+		LabelCidr:            "10.0.0.0/24",
+	}
+}
+
+// GetLabelTypes returns a list of label types.
+func GetLabelTypes() []string {
+	return []string{
+		StrVNet,
+		StrSubnet,
+		StrDataDisk,
+		StrNLB,
+		StrVM,
+		StrMCI,
+		StrSubGroup,
+		StrK8s,
+		StrKubernetes,
+		StrContainer,
+		StrNamespace,
+	}
+}

--- a/src/core/model/mci.go
+++ b/src/core/model/mci.go
@@ -75,7 +75,7 @@ const (
 	StatusComplete string = "None"
 )
 
-const LabelAutoGen string = "sys.autogen"
+const StrAutoGen string = "autogen"
 
 // DefaultSystemLabel is const for string to specify the Default System Label
 const DefaultSystemLabel string = "Managed by CB-Tumblebug"

--- a/src/core/resource/datadisk.go
+++ b/src/core/resource/datadisk.go
@@ -169,19 +169,19 @@ func CreateDataDisk(nsId string, u *model.TbDataDiskReq, option string) (model.T
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrDataDisk,
-		"sys.id":              content.Id,
-		"sys.name":            content.Name,
-		"sys.uid":             content.Uid,
-		"sys.diskType":        content.DiskType,
-		"sys.diskSize":        content.DiskSize,
-		"sys.cspResourceId":   content.CspResourceId,
-		"sys.cspResourceName": content.CspResourceName,
-		"sys.description":     content.Description,
-		"sys.createdTime":     content.CreatedTime.String(),
-		"sys.connectionName":  content.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrDataDisk,
+		model.LabelId:              content.Id,
+		model.LabelName:            content.Name,
+		model.LabelUid:             content.Uid,
+		model.LabelDiskType:        content.DiskType,
+		model.LabelDiskSize:        content.DiskSize,
+		model.LabelCspResourceId:   content.CspResourceId,
+		model.LabelCspResourceName: content.CspResourceName,
+		model.LabelDescription:     content.Description,
+		model.LabelCreatedTime:     content.CreatedTime.String(),
+		model.LabelConnectionName:  content.ConnectionName,
 	}
 	err = label.CreateOrUpdateLabel(model.StrDataDisk, uid, Key, labels)
 	if err != nil {

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -294,18 +294,18 @@ func CreateK8sCluster(nsId string, req *model.TbK8sClusterReq, option string) (m
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrK8s,
-		"sys.id":              tbK8sCInfo.Id,
-		"sys.name":            tbK8sCInfo.Name,
-		"sys.uid":             tbK8sCInfo.Uid,
-		"sys.version":         tbK8sCInfo.CspViewK8sClusterDetail.Version,
-		"sys.cspResourceId":   tbK8sCInfo.CspResourceId,
-		"sys.cspResourceName": tbK8sCInfo.CspResourceName,
-		"sys.description":     tbK8sCInfo.Description,
-		"sys.createdTime":     tbK8sCInfo.CspViewK8sClusterDetail.CreatedTime.String(),
-		"sys.connectionName":  tbK8sCInfo.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrK8s,
+		model.LabelId:              tbK8sCInfo.Id,
+		model.LabelName:            tbK8sCInfo.Name,
+		model.LabelUid:             tbK8sCInfo.Uid,
+		model.LabelVersion:         tbK8sCInfo.CspViewK8sClusterDetail.Version,
+		model.LabelCspResourceId:   tbK8sCInfo.CspResourceId,
+		model.LabelCspResourceName: tbK8sCInfo.CspResourceName,
+		model.LabelDescription:     tbK8sCInfo.Description,
+		model.LabelCreatedTime:     tbK8sCInfo.CspViewK8sClusterDetail.CreatedTime.String(),
+		model.LabelConnectionName:  tbK8sCInfo.ConnectionName,
 	}
 	err = label.CreateOrUpdateLabel(model.StrK8s, uid, k, labels)
 	if err != nil {

--- a/src/core/resource/securitygroup.go
+++ b/src/core/resource/securitygroup.go
@@ -256,17 +256,17 @@ func CreateSecurityGroup(nsId string, u *model.TbSecurityGroupReq, option string
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrSecurityGroup,
-		"sys.id":              content.Id,
-		"sys.name":            content.Name,
-		"sys.uid":             content.Uid,
-		"sys.vNetId":          content.VNetId,
-		"sys.cspResourceId":   content.CspResourceId,
-		"sys.cspResourceName": content.CspResourceName,
-		"sys.description":     content.Description,
-		"sys.connectionName":  content.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrSecurityGroup,
+		model.LabelId:              content.Id,
+		model.LabelName:            content.Name,
+		model.LabelUid:             content.Uid,
+		model.LabelVNetId:          content.VNetId,
+		model.LabelCspResourceId:   content.CspResourceId,
+		model.LabelCspResourceName: content.CspResourceName,
+		model.LabelDescription:     content.Description,
+		model.LabelConnectionName:  content.ConnectionName,
 	}
 	err = label.CreateOrUpdateLabel(model.StrSecurityGroup, uid, Key, labels)
 	if err != nil {

--- a/src/core/resource/sshkey.go
+++ b/src/core/resource/sshkey.go
@@ -179,16 +179,16 @@ func CreateSshKey(nsId string, u *model.TbSshKeyReq, option string) (model.TbSsh
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrSSHKey,
-		"sys.id":              content.Id,
-		"sys.name":            content.Name,
-		"sys.uid":             content.Uid,
-		"sys.cspResourceId":   content.CspResourceId,
-		"sys.cspResourceName": content.CspResourceName,
-		"sys.description":     content.Description,
-		"sys.connectionName":  content.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrSSHKey,
+		model.LabelId:              content.Id,
+		model.LabelName:            content.Name,
+		model.LabelUid:             content.Uid,
+		model.LabelCspResourceId:   content.CspResourceId,
+		model.LabelCspResourceName: content.CspResourceName,
+		model.LabelDescription:     content.Description,
+		model.LabelConnectionName:  content.ConnectionName,
 	}
 	err = label.CreateOrUpdateLabel(model.StrSSHKey, uid, Key, labels)
 	if err != nil {

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -384,22 +384,22 @@ func CreateSubnet(nsId string, vNetId string, subnetReq *model.TbSubnetReq) (mod
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrSubnet,
-		"sys.id":              subnetInfo.Id,
-		"sys.name":            subnetInfo.Name,
-		"sys.uid":             subnetInfo.Uid,
-		"sys.cspResourceId":   subnetInfo.CspResourceId,
-		"sys.cspResourceName": subnetInfo.CspResourceName,
-		"sys.ipv4_CIDR":       subnetInfo.IPv4_CIDR,
-		"sys.zone":            subnetInfo.Zone,
-		"sys.status":          subnetInfo.Status,
-		"sys.vNetId":          vNetInfo.Id,
-		"sys.cspvNetId":       vNetInfo.CspResourceId,
-		"sys.cspvNetName":     vNetInfo.CspResourceName,
-		"sys.description":     subnetInfo.Description,
-		"sys.connectionName":  subnetInfo.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrSubnet,
+		model.LabelId:              subnetInfo.Id,
+		model.LabelName:            subnetInfo.Name,
+		model.LabelUid:             subnetInfo.Uid,
+		model.LabelCspResourceId:   subnetInfo.CspResourceId,
+		model.LabelCspResourceName: subnetInfo.CspResourceName,
+		model.LabelIpv4_CIDR:       subnetInfo.IPv4_CIDR,
+		model.LabelZone:            subnetInfo.Zone,
+		model.LabelStatus:          subnetInfo.Status,
+		model.LabelVNetId:          vNetInfo.Id,
+		model.LabelCspVNetId:       vNetInfo.CspResourceId,
+		model.LabelCspVNetName:     vNetInfo.CspResourceName,
+		model.LabelDescription:     subnetInfo.Description,
+		model.LabelConnectionName:  subnetInfo.ConnectionName,
 	}
 	err = label.CreateOrUpdateLabel(model.StrSubnet, uid, subnetKey, labels)
 	if err != nil {
@@ -673,7 +673,7 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string) (model.SimpleMsg,
 
 	// Store label info using CreateOrUpdateLabel
 	// labels := map[string]string{
-	// 	"sys.manager":  model.StrManager,
+	// 	model.LabelManager:  model.StrManager,
 	// 	"namespace": nsId,
 	// }
 	err = label.DeleteLabelObject(model.StrSubnet, subnetInfo.Uid)
@@ -891,22 +891,22 @@ func RegisterSubnet(nsId string, vNetId string, subnetReq *model.TbRegisterSubne
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrSubnet,
-		"sys.id":              subnetInfo.Id,
-		"sys.name":            subnetInfo.Name,
-		"sys.uid":             subnetInfo.Uid,
-		"sys.cspResourceId":   subnetInfo.CspResourceId,
-		"sys.cspResourceName": subnetInfo.CspResourceName,
-		"sys.ipv4_CIDR":       subnetInfo.IPv4_CIDR,
-		"sys.zone":            subnetInfo.Zone,
-		"sys.status":          subnetInfo.Status,
-		"sys.vNetId":          vNetInfo.Id,
-		"sys.cspvNetId":       vNetInfo.CspResourceId,
-		"sys.cspvNetName":     vNetInfo.CspResourceName,
-		"sys.description":     subnetInfo.Description,
-		"sys.connectionName":  subnetInfo.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrSubnet,
+		model.LabelId:              subnetInfo.Id,
+		model.LabelName:            subnetInfo.Name,
+		model.LabelUid:             subnetInfo.Uid,
+		model.LabelCspResourceId:   subnetInfo.CspResourceId,
+		model.LabelCspResourceName: subnetInfo.CspResourceName,
+		model.LabelIpv4_CIDR:       subnetInfo.IPv4_CIDR,
+		model.LabelZone:            subnetInfo.Zone,
+		model.LabelStatus:          subnetInfo.Status,
+		model.LabelVNetId:          vNetInfo.Id,
+		model.LabelCspVNetId:       vNetInfo.CspResourceId,
+		model.LabelCspVNetName:     vNetInfo.CspResourceName,
+		model.LabelDescription:     subnetInfo.Description,
+		model.LabelConnectionName:  subnetInfo.ConnectionName,
 	}
 	err = label.CreateOrUpdateLabel(model.StrSubnet, uid, vNetKey, labels)
 	if err != nil {
@@ -1080,7 +1080,7 @@ func DeregisterSubnet(nsId string, vNetId string, subnetId string) (model.Simple
 
 	// Store label info using CreateOrUpdateLabel
 	// labels := map[string]string{
-	// 	"sys.manager":  model.StrManager,
+	// 	model.LabelManager:  model.StrManager,
 	// 	"namespace": nsId,
 	// }
 

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -490,20 +490,20 @@ func CreateVNet(nsId string, vNetReq *model.TbVNetReq) (model.TbVNetInfo, error)
 
 		// Store label info using CreateOrUpdateLabel
 		labels := map[string]string{
-			"sys.manager":         model.StrManager,
-			"sys.namespace":       nsId,
-			"sys.labelType":       model.StrSubnet,
-			"sys.id":              subnetInfo.Id,
-			"sys.name":            subnetInfo.Name,
-			"sys.uid":             subnetInfo.Uid,
-			"sys.cspResourceId":   subnetInfo.CspResourceId,
-			"sys.cspResourceName": subnetInfo.CspResourceName,
-			"sys.cidr":            subnetInfo.IPv4_CIDR,
-			"sys.status":          subnetInfo.Status,
-			"sys.description":     subnetInfo.Description,
-			"sys.zone":            subnetInfo.Zone,
-			"sys.vNetId":          vNetInfo.Id,
-			"sys.connectionName":  vNetInfo.ConnectionName,
+			model.LabelManager:         model.StrManager,
+			model.LabelNamespace:       nsId,
+			model.LabelLabelType:       model.StrSubnet,
+			model.LabelId:              subnetInfo.Id,
+			model.LabelName:            subnetInfo.Name,
+			model.LabelUid:             subnetInfo.Uid,
+			model.LabelCspResourceId:   subnetInfo.CspResourceId,
+			model.LabelCspResourceName: subnetInfo.CspResourceName,
+			model.LabelCidr:            subnetInfo.IPv4_CIDR,
+			model.LabelStatus:          subnetInfo.Status,
+			model.LabelDescription:     subnetInfo.Description,
+			model.LabelZone:            subnetInfo.Zone,
+			model.LabelVNetId:          vNetInfo.Id,
+			model.LabelConnectionName:  vNetInfo.ConnectionName,
 		}
 		err = label.CreateOrUpdateLabel(model.StrSubnet, subnetInfo.Uid, subnetKey, labels)
 		if err != nil {
@@ -532,18 +532,18 @@ func CreateVNet(nsId string, vNetReq *model.TbVNetReq) (model.TbVNetInfo, error)
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrVNet,
-		"sys.id":              vNetInfo.Id,
-		"sys.name":            vNetInfo.Name,
-		"sys.uid":             vNetInfo.Uid,
-		"sys.cspResourceId":   vNetInfo.CspResourceId,
-		"sys.cspResourceName": vNetInfo.CspResourceName,
-		"sys.cidr":            vNetInfo.CidrBlock,
-		"sys.status":          vNetInfo.Status,
-		"sys.description":     vNetInfo.Description,
-		"sys.connectionName":  vNetInfo.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrVNet,
+		model.LabelId:              vNetInfo.Id,
+		model.LabelName:            vNetInfo.Name,
+		model.LabelUid:             vNetInfo.Uid,
+		model.LabelCspResourceId:   vNetInfo.CspResourceId,
+		model.LabelCspResourceName: vNetInfo.CspResourceName,
+		model.LabelCidr:            vNetInfo.CidrBlock,
+		model.LabelStatus:          vNetInfo.Status,
+		model.LabelDescription:     vNetInfo.Description,
+		model.LabelConnectionName:  vNetInfo.ConnectionName,
 	}
 	err = label.CreateOrUpdateLabel(model.StrVNet, vNetInfo.Uid, vNetKey, labels)
 	if err != nil {
@@ -793,7 +793,7 @@ func DeleteVNet(nsId string, vNetId string, withSubnets string) (model.SimpleMsg
 
 	// Remove label info using RemoveLabel
 	// labels := map[string]string{
-	// 	"sys.manager":  model.StrManager,
+	// 	model.LabelManager:  model.StrManager,
 	// 	"namespace": nsId,
 	// }
 	err = label.RemoveLabel(model.StrVNet, vNetInfo.Uid, vNetKey)
@@ -995,20 +995,20 @@ func RegisterVNet(nsId string, vNetRegisterReq *model.TbRegisterVNetReq) (model.
 
 		// Store label info using CreateOrUpdateLabel
 		labels := map[string]string{
-			"sys.manager":         model.StrManager,
-			"sys.namespace":       nsId,
-			"sys.labelType":       model.StrSubnet,
-			"sys.id":              subnetInfo.Id,
-			"sys.name":            subnetInfo.Name,
-			"sys.uid":             subnetInfo.Uid,
-			"sys.cspResourceId":   subnetInfo.CspResourceId,
-			"sys.cspResourceName": subnetInfo.CspResourceName,
-			"sys.cidr":            subnetInfo.IPv4_CIDR,
-			"sys.status":          subnetInfo.Status,
-			"sys.description":     subnetInfo.Description,
-			"sys.zone":            subnetInfo.Zone,
-			"sys.vNetId":          vNetInfo.Id,
-			"sys.connectionName":  vNetInfo.ConnectionName,
+			model.LabelManager:         model.StrManager,
+			model.LabelNamespace:       nsId,
+			model.LabelLabelType:       model.StrSubnet,
+			model.LabelId:              subnetInfo.Id,
+			model.LabelName:            subnetInfo.Name,
+			model.LabelUid:             subnetInfo.Uid,
+			model.LabelCspResourceId:   subnetInfo.CspResourceId,
+			model.LabelCspResourceName: subnetInfo.CspResourceName,
+			model.LabelCidr:            subnetInfo.IPv4_CIDR,
+			model.LabelStatus:          subnetInfo.Status,
+			model.LabelDescription:     subnetInfo.Description,
+			model.LabelZone:            subnetInfo.Zone,
+			model.LabelVNetId:          vNetInfo.Id,
+			model.LabelConnectionName:  vNetInfo.ConnectionName,
 		}
 		err = label.CreateOrUpdateLabel(model.StrSubnet, subnetInfo.Uid, subnetKey, labels)
 		if err != nil {
@@ -1056,18 +1056,18 @@ func RegisterVNet(nsId string, vNetRegisterReq *model.TbRegisterVNetReq) (model.
 
 	// Store label info using CreateOrUpdateLabel
 	labels := map[string]string{
-		"sys.manager":         model.StrManager,
-		"sys.namespace":       nsId,
-		"sys.labelType":       model.StrVNet,
-		"sys.id":              vNetInfo.Id,
-		"sys.name":            vNetInfo.Name,
-		"sys.uid":             vNetInfo.Uid,
-		"sys.cspResourceId":   vNetInfo.CspResourceId,
-		"sys.cspResourceName": vNetInfo.CspResourceName,
-		"sys.cidr":            vNetInfo.CidrBlock,
-		"sys.status":          vNetInfo.Status,
-		"sys.description":     vNetInfo.Description,
-		"sys.connectionName":  vNetInfo.ConnectionName,
+		model.LabelManager:         model.StrManager,
+		model.LabelNamespace:       nsId,
+		model.LabelLabelType:       model.StrVNet,
+		model.LabelId:              vNetInfo.Id,
+		model.LabelName:            vNetInfo.Name,
+		model.LabelUid:             vNetInfo.Uid,
+		model.LabelCspResourceId:   vNetInfo.CspResourceId,
+		model.LabelCspResourceName: vNetInfo.CspResourceName,
+		model.LabelCidr:            vNetInfo.CidrBlock,
+		model.LabelStatus:          vNetInfo.Status,
+		model.LabelDescription:     vNetInfo.Description,
+		model.LabelConnectionName:  vNetInfo.ConnectionName,
 	}
 	err = label.CreateOrUpdateLabel(model.StrVNet, vNetInfo.Uid, vNetKey, labels)
 	if err != nil {
@@ -1223,7 +1223,7 @@ func DeregisterVNet(nsId string, vNetId string, withSubnets string) (model.Simpl
 
 	// Remove label info using RemoveLabel
 	// labels := map[string]string{
-	// 	"sys.manager":  model.StrManager,
+	// 	model.LabelManager:  model.StrManager,
 	// 	"namespace": nsId,
 	// }
 	err = label.RemoveLabel(model.StrVNet, vNetInfo.Uid, vNetKey)


### PR DESCRIPTION
- GET /labelInfo 기능 추가: labelTypes, systemLables 리스트 정보를 제공하는 편의성 향상 API
- sys.xxxx 형태의 시스템 레이블을 string을 직접 사용하지 않도록 상수화

http://localhost:1323/tumblebug/labelInfo

응답 예시
```
{
  "labelTypes": [
    "vNet",
    "subnet",
    "dataDisk",
    "nlb",
    "vm",
    "mci",
    "subGroup",
    "k8s",
    "kubernetes",
    "container",
    "ns"
  ],
  "systemLabels": {
    "sys.cidr": "10.0.0.0/24",
    "sys.connectionName": "connection-1234",
    "sys.createdTime": "2021-01-01T00:00:00Z",
    "sys.cspResourceId": "csp-vm-1234",
    "sys.cspResourceName": "csp-vm-1234",
    "sys.cspVNetId": "csp-vnet-1234",
    "sys.cspVNetName": "csp-vnet-1234",
    "sys.deploymentType": "vm",
    "sys.description": "Description",
    "sys.diskSize": "10",
    "sys.diskType": "HDD",
    "sys.id": "mci-1234",
    "sys.ipv4_CIDR": "10.0.0.0/24",
    "sys.labelType": "mci",
    "sys.manager": "cb-tumblebug",
    "sys.mciId": "mci-1234",
    "sys.name": "mci-1234",
    "sys.namespace": "default",
    "sys.purpose": "testing",
    "sys.registered": "true",
    "sys.status": "Running",
    "sys.subGroupId": "sg-1234",
    "sys.uid": "wef12awefadf1221edcf",
    "sys.vNetId": "vnet-1234",
    "sys.version": "1.0",
    "sys.zone": "zone-1"
  }
}
```