### PR TITLE
Add remote file transfer feature

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -8535,6 +8535,95 @@ const docTemplate = `{
                 }
             }
         },
+        "/ns/{nsId}/transferFile/mci/{mciId}": {
+            "post": {
+                "description": "Transfer a file to specified MCI to the specified path.\nThe file size should be less than 10MB.\nNot for gerneral file transfer but for specific purpose (small configuration files).",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[MC-Infra] MCI Remote Command"
+                ],
+                "summary": "Transfer a file to specified MCI",
+                "operationId": "PostFileToMci",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "default",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "mci01",
+                        "description": "MCI ID",
+                        "name": "mciId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "g1",
+                        "description": "subGroupId to apply the file transfer only for VMs in subGroup of MCI",
+                        "name": "subGroupId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "g1-1",
+                        "description": "vmId to apply the file transfer only for a VM in MCI",
+                        "name": "vmId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "/home/cb-user/",
+                        "description": "Target path where the file will be stored",
+                        "name": "path",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "The file to be uploaded (Max 10MB)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.MciSshCmdResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/object": {
             "get": {
                 "description": "Get value of an object",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -8529,6 +8529,95 @@
                 }
             }
         },
+        "/ns/{nsId}/transferFile/mci/{mciId}": {
+            "post": {
+                "description": "Transfer a file to specified MCI to the specified path.\nThe file size should be less than 10MB.\nNot for gerneral file transfer but for specific purpose (small configuration files).",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[MC-Infra] MCI Remote Command"
+                ],
+                "summary": "Transfer a file to specified MCI",
+                "operationId": "PostFileToMci",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "default",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "mci01",
+                        "description": "MCI ID",
+                        "name": "mciId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "default": "g1",
+                        "description": "subGroupId to apply the file transfer only for VMs in subGroup of MCI",
+                        "name": "subGroupId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "g1-1",
+                        "description": "vmId to apply the file transfer only for a VM in MCI",
+                        "name": "vmId",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "default": "/home/cb-user/",
+                        "description": "Target path where the file will be stored",
+                        "name": "path",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "The file to be uploaded (Max 10MB)",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Custom request ID",
+                        "name": "x-request-id",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.MciSshCmdResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/object": {
             "get": {
                 "description": "Get value of an object",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -6448,6 +6448,86 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/transferFile/mci/{mciId}:
+    post:
+      tags:
+      - "[MC-Infra] MCI Remote Command"
+      summary: Transfer a file to specified MCI
+      description: |-
+        Transfer a file to specified MCI to the specified path.
+        The file size should be less than 10MB.
+        Not for gerneral file transfer but for specific purpose (small configuration files).
+      operationId: PostFileToMci
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: subGroupId
+        in: query
+        description: subGroupId to apply the file transfer only for VMs in subGroup
+          of MCI
+        schema:
+          type: string
+          default: g1
+      - name: vmId
+        in: query
+        description: vmId to apply the file transfer only for a VM in MCI
+        schema:
+          type: string
+          default: g1-1
+      - name: x-request-id
+        in: header
+        description: Custom request ID
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+              - file
+              - path
+              type: object
+              properties:
+                path:
+                  type: string
+                  description: Target path where the file will be stored
+                  default: /home/cb-user/
+                file:
+                  type: string
+                  description: The file to be uploaded (Max 10MB)
+                  format: binary
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.MciSshCmdResult'
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /object:
     get:
       tags:

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -338,6 +338,7 @@ func RunServer(port string) {
 	g.GET("/:nsId/control/mci/:mciId/vm/:vmId", rest_infra.RestGetControlMciVm)
 
 	g.POST("/:nsId/cmd/mci/:mciId", rest_infra.RestPostCmdMci)
+	g.POST("/:nsId/transferFile/mci/:mciId", rest_infra.RestPostFileToMci)
 	g.PUT("/:nsId/mci/:mciId/vm/:targetVmId/bastion/:bastionVmId", rest_infra.RestSetBastionNodes)
 	g.DELETE("/:nsId/mci/:mciId/bastion/:bastionVmId", rest_infra.RestRemoveBastionNodes)
 	g.GET("/:nsId/mci/:mciId/vm/:targetVmId/bastion", rest_infra.RestGetBastionNodes)


### PR DESCRIPTION
## SCP(SSH) 기반의 원격 파일 전송 기능 추가

### 목적
- Cloud-Migrator 지원 기능
- 소스의 SW의 설정 파일 등을 목표 인프라로 전송(중계)해주는 보조 기능
  - 대용량 파일/DB 덤프 전송하기 위한 기능 아님
  - 파일 예시 (*.yaml, *.json, ENV, *.sh, *.py, …)

### 방식
- 중계 전송 방식
  - 사용자 -> CB-TB: REST API 기반 파일 업로드 (multipart/form-data)
  - CB-TB: 파일 임시 저장 (메모리)
  - CB-TB -> 목표 인프라: SSH 프로토콜 기반 파일 전송 (SCP)

### 제한 및 제약
- 최대 파일 크기 10MB (보안 및 안정성을 위해 제한함)
- 편의를 위한 최소 기능이며, 추가적인 자동화나 관리 기능을 제공하지 않음.
- OS 다양성 등을 지원하지 않음 (현: Linux만 지원)

### API
- POST: /ns/{nsId}/transferFile/mci/{mciId}

### 예시
```
curl -X 'POST' \
  'http://localhost:1323/tumblebug/ns/default/transferFile/mci/mc-zy6w8?subGroupId=g1&vmId=g1-1' \
  -H 'accept: application/json' \
  -H 'Content-Type: multipart/form-data' \
  -H 'Authorization: Basic ZGVmYXVsdDpkZWZhdWx0' \
  -F 'path=/home/cb-user/' \
  -F 'file=@240919-과제-Todolist.pdf;type=application/pdf'
```

(Swagger Dashboard로 파일 첨부 가능)
![image](https://github.com/user-attachments/assets/ebd69525-4c1b-4269-b50e-956b7e3690c6)

![image](https://github.com/user-attachments/assets/f2e27481-d34c-4e97-a640-32c790bb452a)

