### PR TITLE
Improve the `X-Request-Id` and Request Details handling mechanism

### DIFF
--- a/src/api/rest/server/common/config.go
+++ b/src/api/rest/server/common/config.go
@@ -44,23 +44,20 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /config/{configId} [delete]
 func RestInitConfig(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	if err := Validate(c, []string{"configId"}); err != nil {
 		log.Error().Err(err).Msg("")
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	err := common.InitConfig(c.Param("configId"))
 	if err != nil {
 		err := fmt.Errorf("Failed to init the config " + c.Param("configId"))
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	} else {
 		// return SendMessage(c, http.StatusOK, "The config "+c.Param("configId")+" has been initialized.")
 		content := map[string]string{"message": "The config " + c.Param("configId") + " has been initialized."}
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	}
 }
 
@@ -77,10 +74,7 @@ func RestInitConfig(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /config/{configId} [get]
 func RestGetConfig(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	if err := Validate(c, []string{"configId"}); err != nil {
 		log.Error().Err(err).Msg("")
 		return SendMessage(c, http.StatusBadRequest, err.Error())
@@ -89,9 +83,9 @@ func RestGetConfig(c echo.Context) error {
 	content, err := common.GetConfig(c.Param("configId"))
 	if err != nil {
 		err := fmt.Errorf("Failed to find the config " + c.Param("configId"))
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	} else {
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	}
 }
 
@@ -113,15 +107,12 @@ type RestGetAllConfigResponse struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /config [get]
 func RestGetAllConfig(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	var content RestGetAllConfigResponse
 
 	configList, err := common.ListConfig()
 	content.Config = configList
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestPostConfig godoc
@@ -137,18 +128,15 @@ func RestGetAllConfig(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /config [post]
 func RestPostConfig(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &model.ConfigReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	log.Debug().Msg("[Creating or Updating Config]")
 	content, err := common.UpdateConfig(u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -163,14 +151,11 @@ func RestPostConfig(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /config [delete]
 func RestInitAllConfig(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	err := common.InitAllConfig()
 	content := map[string]string{
 		"message": "All configs has been initialized"}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetRequest godoc

--- a/src/api/rest/server/common/label/label.go
+++ b/src/api/rest/server/common/label/label.go
@@ -16,7 +16,6 @@ package label
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/labstack/echo/v4"
 
@@ -40,10 +39,6 @@ import (
 // @Failure 500 {object} model.SimpleMsg "Internal Server Error"
 // @Router /label/{labelType}/{uid} [put]
 func RestCreateOrUpdateLabel(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	labelType := c.Param("labelType")
 	uid := c.Param("uid")
@@ -51,7 +46,7 @@ func RestCreateOrUpdateLabel(c echo.Context) error {
 	// Parse the incoming request body to get the labels
 	var labelReq model.Label
 	if err := c.Bind(&labelReq); err != nil {
-		return common.EndRequestWithLog(c, reqID, fmt.Errorf("Invalid request body"), nil)
+		return common.EndRequestWithLog(c, fmt.Errorf("Invalid request body"), nil)
 	}
 
 	// Get the resource key
@@ -60,10 +55,10 @@ func RestCreateOrUpdateLabel(c echo.Context) error {
 	// Create or update the label in the KV store
 	err := label.CreateOrUpdateLabel(labelType, uid, resourceKey, labelReq.Labels)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
-	return common.EndRequestWithLog(c, reqID, nil, map[string]string{"message": "Label created or updated successfully"})
+	return common.EndRequestWithLog(c, nil, map[string]string{"message": "Label created or updated successfully"})
 }
 
 // RestRemoveLabel godoc
@@ -81,10 +76,6 @@ func RestCreateOrUpdateLabel(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg "Internal Server Error"
 // @Router /label/{labelType}/{uid}/{key} [delete]
 func RestRemoveLabel(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	labelType := c.Param("labelType")
 	uid := c.Param("uid")
@@ -93,10 +84,10 @@ func RestRemoveLabel(c echo.Context) error {
 	// Remove the label from the KV store
 	err := label.RemoveLabel(labelType, uid, key)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
-	return common.EndRequestWithLog(c, reqID, nil, map[string]string{"message": "Label removed successfully"})
+	return common.EndRequestWithLog(c, nil, map[string]string{"message": "Label removed successfully"})
 }
 
 // RestGetLabels godoc
@@ -113,10 +104,6 @@ func RestRemoveLabel(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg "Internal Server Error"
 // @Router /label/{labelType}/{uid} [get]
 func RestGetLabels(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	labelType := c.Param("labelType")
 	uid := c.Param("uid")
@@ -124,10 +111,10 @@ func RestGetLabels(c echo.Context) error {
 	// Get the labels from the KV store
 	labelInfo, err := label.GetLabels(labelType, uid)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
-	return common.EndRequestWithLog(c, reqID, nil, labelInfo)
+	return common.EndRequestWithLog(c, nil, labelInfo)
 }
 
 // ResourcesResponse is a struct to wrap the results of a label selector query
@@ -155,10 +142,6 @@ type ResourcesResponse struct {
 // @Failure 500 {object} model.SimpleMsg "Internal Server Error"
 // @Router /resources/{labelType} [get]
 func RestGetResourcesByLabelSelector(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	labelType := c.Param("labelType")
 	labelSelector := c.QueryParam("labelSelector")
@@ -166,7 +149,7 @@ func RestGetResourcesByLabelSelector(c echo.Context) error {
 	// Get resources based on the label selector
 	resources, err := label.GetResourcesByLabelSelector(labelType, labelSelector)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	// Wrap the results in a JSON object
@@ -174,7 +157,7 @@ func RestGetResourcesByLabelSelector(c echo.Context) error {
 		Results: resources,
 	}
 
-	return common.EndRequestWithLog(c, reqID, nil, response)
+	return common.EndRequestWithLog(c, nil, response)
 }
 
 // RestGetSystemLabelInfo godoc
@@ -188,10 +171,6 @@ func RestGetResourcesByLabelSelector(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg "Internal Server Error"
 // @Router /labelInfo [get]
 func RestGetSystemLabelInfo(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusInternalServerError, map[string]string{"message": idErr.Error()})
-	}
 
 	// Use the GetLabelConstantsMap function to get the system label constants
 	systemLabels := model.GetLabelConstantsMap()
@@ -203,5 +182,5 @@ func RestGetSystemLabelInfo(c echo.Context) error {
 		LabelTypes:   labelTypes,
 	}
 
-	return common.EndRequestWithLog(c, reqID, nil, systemLabelInfo)
+	return common.EndRequestWithLog(c, nil, systemLabelInfo)
 }

--- a/src/api/rest/server/common/namespace.go
+++ b/src/api/rest/server/common/namespace.go
@@ -15,8 +15,6 @@ limitations under the License.
 package common
 
 import (
-	"net/http"
-
 	"github.com/labstack/echo/v4"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
@@ -24,21 +22,18 @@ import (
 )
 
 func RestCheckNs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	if err := Validate(c, []string{"nsId"}); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	nsId := c.Param("nsId")
 	err := common.CheckString(nsId)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 	content, err := common.CheckNs(nsId)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestDelAllNs godoc
@@ -52,13 +47,10 @@ func RestCheckNs(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns [delete]
 func RestDelAllNs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	err := common.DelAllNs()
 	content := map[string]string{"message": "All namespaces has been deleted"}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestDelNs godoc
@@ -73,17 +65,14 @@ func RestDelAllNs(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId} [delete]
 func RestDelNs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	if err := Validate(c, []string{"nsId"}); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	err := common.DelNs(c.Param("nsId"))
 	content := map[string]string{"message": "The ns " + c.Param("nsId") + " has been deleted"}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // JSONResult's data field will be overridden by the specific type
@@ -112,10 +101,7 @@ type RestGetAllNsResponse struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns [get]
 func RestGetAllNs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	optionFlag := c.QueryParam("option")
 
 	var content RestGetAllNsResponse
@@ -123,11 +109,11 @@ func RestGetAllNs(c echo.Context) error {
 		content := model.IdList{}
 		var err error
 		content.IdList, err = common.ListNsId()
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else {
 		nsList, err := common.ListNs()
 		content.Ns = nsList
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	}
 }
 
@@ -144,17 +130,13 @@ func RestGetAllNs(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId} [get]
 func RestGetNs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	if err := Validate(c, []string{"nsId"}); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := common.GetNs(c.Param("nsId"))
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestPostNs godoc
@@ -170,17 +152,14 @@ func RestGetNs(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns [post]
 func RestPostNs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &model.NsReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := common.CreateNs(u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -198,15 +177,12 @@ func RestPostNs(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId} [put]
 func RestPutNs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &model.NsReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := common.UpdateNs(c.Param("nsId"), u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/common/utility.go
+++ b/src/api/rest/server/common/utility.go
@@ -127,13 +127,8 @@ func RestCheckHTTPVersion(c echo.Context) error {
 // @Router /credential/publicKey [get]
 func RestGetPublicKeyForCredentialEncryption(c echo.Context) error {
 
-	reqID, err := common.StartRequestWithLog(c)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": err.Error()})
-	}
 	result, err := common.GetPublicKeyForCredentialEncryption()
-	return common.EndRequestWithLog(c, reqID, err, result)
-
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestRegisterCredential is a REST API handler for registering credentials.
@@ -149,17 +144,14 @@ func RestGetPublicKeyForCredentialEncryption(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /credential [post]
 func RestRegisterCredential(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &model.CredentialReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := common.RegisterCredential(*u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -177,14 +169,11 @@ func RestRegisterCredential(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /connConfig/{connConfigName} [get]
 func RestGetConnConfig(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	connConfigName := c.Param("connConfigName")
 
 	content, err := common.GetConnConfig(connConfigName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -204,10 +193,7 @@ func RestGetConnConfig(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /connConfig [get]
 func RestGetConnConfigList(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	filterCredentialHolder := c.QueryParam("filterCredentialHolder")
 	filterVerified := c.QueryParam("filterVerified")
 	filterRegionRepresentative := c.QueryParam("filterRegionRepresentative")
@@ -222,7 +208,7 @@ func RestGetConnConfigList(c echo.Context) error {
 	}
 
 	content, err := common.GetConnConfigList(filterCredentialHolder, filterVerifiedBool, filterRegionRepresentativeBool)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetProviderList func is a rest api wrapper for GetProviderList.
@@ -238,12 +224,9 @@ func RestGetConnConfigList(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /provider [get]
 func RestGetProviderList(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	content, err := common.GetProviderList()
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -262,15 +245,12 @@ func RestGetProviderList(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /provider/{providerName}/region/{regionName} [get]
 func RestGetRegion(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	providerName := c.Param("providerName")
 	regionName := c.Param("regionName")
 
 	content, err := common.GetRegion(providerName, regionName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetRegions func is a rest api wrapper for GetRegion.
@@ -287,14 +267,11 @@ func RestGetRegion(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /provider/{providerName}/region [get]
 func RestGetRegions(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	providerName := c.Param("providerName")
 
 	content, err := common.GetRegions(providerName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetRegionListFromCsp func is a rest api wrapper for RetrieveRegionListFromCsp.
@@ -310,12 +287,9 @@ func RestGetRegions(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /regionFromCsp [get]
 func RestGetRegionListFromCsp(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	content, err := common.RetrieveRegionListFromCsp()
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -332,12 +306,9 @@ func RestGetRegionListFromCsp(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /cloudInfo [get]
 func RestGetCloudInfo(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	content, err := common.GetCloudInfo()
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetK8sClusterInfo func is a rest api wrapper for K8sClsuterInfo.
@@ -353,12 +324,9 @@ func RestGetCloudInfo(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /k8sClusterInfo [get]
 func RestGetK8sClusterInfo(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	content, err := common.GetK8sClusterInfo()
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // ObjectList struct consists of object IDs
@@ -492,10 +460,7 @@ type RestInspectResourcesRequest struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /inspectResources [post]
 func RestInspectResources(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &RestInspectResourcesRequest{}
 	if err := c.Bind(u); err != nil {
 		return err
@@ -511,7 +476,7 @@ func RestInspectResources(c echo.Context) error {
 	// 	content, err = infra.InspectVMs(u.ConnectionName)
 	// }
 	content, err = infra.InspectResources(u.ConnectionName, u.ResourceType)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -527,12 +492,9 @@ func RestInspectResources(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /inspectResourcesOverview [get]
 func RestInspectResourcesOverview(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	content, err := infra.InspectResourcesOverview()
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // Request struct for RestRegisterCspNativeResources
@@ -557,19 +519,16 @@ type RestRegisterCspNativeResourcesRequest struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /registerCspResources [post]
 func RestRegisterCspNativeResources(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &RestRegisterCspNativeResourcesRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 	option := c.QueryParam("option")
 	mciFlag := c.QueryParam("mciFlag")
 
 	content, err := infra.RegisterCspNativeResources(u.NsId, u.ConnectionName, u.MciName, option, mciFlag)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -594,19 +553,16 @@ type RestRegisterCspNativeResourcesRequestAll struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /registerCspResourcesAll [post]
 func RestRegisterCspNativeResourcesAll(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &RestRegisterCspNativeResourcesRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 	option := c.QueryParam("option")
 	mciFlag := c.QueryParam("mciFlag")
 
 	content, err := infra.RegisterCspNativeResourcesAll(u.NsId, u.MciName, option, mciFlag)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestForwardAnyReqToAny godoc
@@ -621,14 +577,11 @@ func RestRegisterCspNativeResourcesAll(c echo.Context) error {
 // @Success 200 {object} map[string]interface{}
 // @Router /forward/{path} [post]
 func RestForwardAnyReqToAny(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	reqPath := c.Param("*")
 	reqPath, err := url.PathUnescape(reqPath)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	log.Info().Msgf("reqPath: %s", reqPath)
@@ -638,7 +591,7 @@ func RestForwardAnyReqToAny(c echo.Context) error {
 	if c.Request().Body != nil {
 		bodyBytes, err := io.ReadAll(c.Request().Body)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, fmt.Errorf("Failed to read request body: %v", err), nil)
+			return common.EndRequestWithLog(c, fmt.Errorf("Failed to read request body: %v", err), nil)
 		}
 		requestBody = bodyBytes
 	} else {
@@ -646,5 +599,5 @@ func RestForwardAnyReqToAny(c echo.Context) error {
 	}
 
 	content, err := common.ForwardRequestToAny(reqPath, method, requestBody)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/infra/benchmark.go
+++ b/src/api/rest/server/infra/benchmark.go
@@ -15,8 +15,6 @@ limitations under the License.
 package infra
 
 import (
-	"net/http"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -39,10 +37,6 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/installBenchmarkAgent/mci/{mciId} [post]
 func RestPostInstallBenchmarkAgentToMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
@@ -55,7 +49,7 @@ func RestPostInstallBenchmarkAgentToMci(c echo.Context) error {
 
 	resultArray, err := infra.InstallBenchmarkAgentToMci(nsId, mciId, req, option)
 	if err != nil {
-		common.EndRequestWithLog(c, reqID, err, nil)
+		common.EndRequestWithLog(c, err, nil)
 	}
 
 	content := model.MciSshCmdResult{}
@@ -63,7 +57,7 @@ func RestPostInstallBenchmarkAgentToMci(c echo.Context) error {
 		content.Results = append(content.Results, v)
 	}
 
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -87,10 +81,6 @@ type RestGetAllBenchmarkRequest struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/benchmarkAll/mci/{mciId} [post]
 func RestGetAllBenchmark(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
@@ -101,7 +91,7 @@ func RestGetAllBenchmark(c echo.Context) error {
 	}
 
 	content, err := infra.RunAllBenchmarks(nsId, mciId, req.Host)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetLatencyBenchmark godoc
@@ -118,15 +108,12 @@ func RestGetAllBenchmark(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/benchmarkLatency/mci/{mciId} [get]
 func RestGetBenchmarkLatency(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
 	content, err := infra.RunLatencyBenchmark(nsId, mciId, "")
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 type RestGetBenchmarkRequest struct {
@@ -149,10 +136,7 @@ type RestGetBenchmarkRequest struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/benchmark/mci/{mciId} [post]
 func RestGetBenchmark(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	action := c.QueryParam("action")
@@ -163,5 +147,5 @@ func RestGetBenchmark(c echo.Context) error {
 	}
 
 	content, err := infra.CoreGetBenchmark(nsId, mciId, action, req.Host)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/infra/control.go
+++ b/src/api/rest/server/infra/control.go
@@ -16,7 +16,6 @@ package infra
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
@@ -40,10 +39,7 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/control/mci/{mciId} [get]
 func RestGetControlMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
@@ -59,14 +55,14 @@ func RestGetControlMci(c echo.Context) error {
 
 		resultString, err := infra.HandleMciAction(nsId, mciId, action, forceOption)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, returnObj)
+			return common.EndRequestWithLog(c, err, returnObj)
 		}
 		returnObj.Message = resultString
-		return common.EndRequestWithLog(c, reqID, err, returnObj)
+		return common.EndRequestWithLog(c, err, returnObj)
 
 	} else {
 		err := fmt.Errorf("'action' should be one of these: suspend, resume, reboot, terminate, refine, continue, withdraw")
-		return common.EndRequestWithLog(c, reqID, err, returnObj)
+		return common.EndRequestWithLog(c, err, returnObj)
 	}
 }
 
@@ -87,10 +83,7 @@ func RestGetControlMci(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/control/mci/{mciId}/vm/{vmId} [get]
 func RestGetControlMciVm(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
@@ -108,14 +101,14 @@ func RestGetControlMciVm(c echo.Context) error {
 
 		resultString, err := infra.HandleMciVmAction(nsId, mciId, vmId, action, forceOption)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, returnObj)
+			return common.EndRequestWithLog(c, err, returnObj)
 		}
 		returnObj.Message = resultString
-		return common.EndRequestWithLog(c, reqID, err, returnObj)
+		return common.EndRequestWithLog(c, err, returnObj)
 
 	} else {
 		err := fmt.Errorf("'action' should be one of these: suspend, resume, reboot, terminate, refine")
-		return common.EndRequestWithLog(c, reqID, err, returnObj)
+		return common.EndRequestWithLog(c, err, returnObj)
 	}
 }
 
@@ -135,10 +128,7 @@ func RestGetControlMciVm(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/vm/{vmId}/snapshot [post]
 func RestPostMciVmSnapshot(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
@@ -150,7 +140,7 @@ func RestPostMciVmSnapshot(c echo.Context) error {
 
 	result, err := infra.CreateVmSnapshot(nsId, mciId, vmId, u.Name)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, model.SimpleMsg{Message: "Failed to create a snapshot"})
+		return common.EndRequestWithLog(c, err, model.SimpleMsg{Message: "Failed to create a snapshot"})
 	}
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }

--- a/src/api/rest/server/infra/loadbalance.go
+++ b/src/api/rest/server/infra/loadbalance.go
@@ -15,8 +15,6 @@ limitations under the License.
 package infra
 
 import (
-	"net/http"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -39,10 +37,7 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/nlb [post]
 func RestPostNLB(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
@@ -50,11 +45,11 @@ func RestPostNLB(c echo.Context) error {
 
 	u := &model.TbNLBReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := infra.CreateNLB(nsId, mciId, u, optionFlag)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestPostMcNLB godoc
@@ -72,20 +67,17 @@ func RestPostNLB(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/mcSwNlb [post]
 func RestPostMcNLB(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
 	u := &model.TbNLBReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := infra.CreateMcSwNlb(nsId, mciId, u, "")
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 /*
@@ -129,16 +121,13 @@ func RestPutNLB(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/nlb/{nlbId} [get]
 func RestGetNLB(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	resourceId := c.Param("resourceId")
 
 	res, err := infra.GetNLB(nsId, mciId, resourceId)
-	return common.EndRequestWithLog(c, reqID, err, res)
+	return common.EndRequestWithLog(c, err, res)
 }
 
 // Response structure for RestGetAllNLB
@@ -163,10 +152,7 @@ type RestGetAllNLBResponse struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/nlb [get]
 func RestGetAllNLB(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
@@ -178,12 +164,12 @@ func RestGetAllNLB(c echo.Context) error {
 		content := model.IdList{}
 		var err error
 		content.IdList, err = infra.ListNLBId(nsId, mciId)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else {
 
 		resourceList, err := infra.ListNLB(nsId, mciId, filterKey, filterVal)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 
 		var content struct {
@@ -191,7 +177,7 @@ func RestGetAllNLB(c echo.Context) error {
 		}
 
 		content.NLB = resourceList.([]model.TbNLBInfo) // type assertion (interface{} -> array)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	}
 }
 
@@ -209,10 +195,7 @@ func RestGetAllNLB(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/nlb/{nlbId} [delete]
 func RestDelNLB(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	resourceId := c.Param("resourceId")
@@ -221,7 +204,7 @@ func RestDelNLB(c echo.Context) error {
 
 	err := infra.DelNLB(nsId, mciId, resourceId, forceFlag)
 	content := map[string]string{"message": "The NLB " + resourceId + " has been deleted"}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestDelAllNLB godoc
@@ -238,10 +221,7 @@ func RestDelNLB(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/nlb [delete]
 func RestDelAllNLB(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
@@ -249,7 +229,7 @@ func RestDelAllNLB(c echo.Context) error {
 	subString := c.QueryParam("match")
 
 	content, err := infra.DelAllNLB(nsId, mciId, subString, forceFlag)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetNLBHealth godoc
@@ -267,16 +247,13 @@ func RestDelAllNLB(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/healthz [get]
 func RestGetNLBHealth(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	resourceId := c.Param("resourceId")
 
 	content, err := infra.GetNLBHealth(nsId, mciId, resourceId)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // The REST APIs below are for dev/test only
@@ -297,10 +274,7 @@ func RestGetNLBHealth(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm [post]
 func RestAddNLBVMs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	resourceId := c.Param("resourceId")
@@ -310,7 +284,7 @@ func RestAddNLBVMs(c echo.Context) error {
 		return err
 	}
 	content, err := infra.AddNLBVMs(nsId, mciId, resourceId, u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestRemoveNLBVMs godoc
@@ -328,10 +302,7 @@ func RestAddNLBVMs(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm [delete]
 func RestRemoveNLBVMs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	resourceId := c.Param("resourceId")
@@ -343,5 +314,5 @@ func RestRemoveNLBVMs(c echo.Context) error {
 
 	err := infra.RemoveNLBVMs(nsId, mciId, resourceId, u)
 	content := map[string]string{"message": "Removed VMs from the NLB " + resourceId}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/infra/manageInfo.go
+++ b/src/api/rest/server/infra/manageInfo.go
@@ -16,7 +16,6 @@ package infra
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
@@ -53,10 +52,6 @@ type JSONResult struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId} [get]
 func RestGetMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
@@ -70,12 +65,12 @@ func RestGetMci(c echo.Context) error {
 		content := model.IdList{}
 		var err error
 		content.IdList, err = infra.ListVmByFilter(nsId, mciId, filterKey, filterVal)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else if option == "status" {
 
 		result, err := infra.GetMciStatus(nsId, mciId)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 
 		var content struct {
@@ -83,17 +78,17 @@ func RestGetMci(c echo.Context) error {
 		}
 		content.Result = result
 
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 
 	} else if option == "accessinfo" {
 
 		result, err := infra.GetMciAccessInfo(nsId, mciId, accessInfoOption)
-		return common.EndRequestWithLog(c, reqID, err, result)
+		return common.EndRequestWithLog(c, err, result)
 
 	} else {
 
 		result, err := infra.GetMciInfo(nsId, mciId)
-		return common.EndRequestWithLog(c, reqID, err, result)
+		return common.EndRequestWithLog(c, err, result)
 
 	}
 }
@@ -122,10 +117,7 @@ type RestGetAllMciStatusResponse struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci [get]
 func RestGetAllMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	option := c.QueryParam("option")
 
@@ -134,34 +126,34 @@ func RestGetAllMci(c echo.Context) error {
 		content := model.IdList{}
 		var err error
 		content.IdList, err = infra.ListMciId(nsId)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else if option == "status" {
 		// return MCI Status objects (diffent with MCI objects)
 		result, err := infra.ListMciStatus(nsId)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 		content := RestGetAllMciStatusResponse{}
 		content.Mci = result
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else if option == "simple" {
 		// MCI in simple (without VM information)
 		result, err := infra.ListMciInfo(nsId, option)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 		content := RestGetAllMciResponse{}
 		content.Mci = result
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else {
 		// MCI in detail (with status information)
 		result, err := infra.ListMciInfo(nsId, "status")
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 		content := RestGetAllMciResponse{}
 		content.Mci = result
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	}
 }
 
@@ -199,16 +191,13 @@ func RestPutMci(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId} [delete]
 func RestDelMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	option := c.QueryParam("option")
 
 	content, err := infra.DelMci(nsId, mciId, option)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestDelAllMci godoc
@@ -224,16 +213,13 @@ func RestDelMci(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci [delete]
 func RestDelAllMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	option := c.QueryParam("option")
 
 	message, err := infra.DelAllMci(nsId, option)
 	result := model.SimpleMsg{Message: message}
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // TODO: swag does not support multiple response types (success 200) in an API.
@@ -255,10 +241,7 @@ func RestDelAllMci(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/vm/{vmId} [get]
 func RestGetMciVm(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
@@ -268,15 +251,15 @@ func RestGetMciVm(c echo.Context) error {
 	switch option {
 	case "status":
 		result, err := infra.GetMciVmStatus(nsId, mciId, vmId)
-		return common.EndRequestWithLog(c, reqID, err, result)
+		return common.EndRequestWithLog(c, err, result)
 
 	case "idsInDetail":
 		result, err := infra.GetVmIdNameInDetail(nsId, mciId, vmId)
-		return common.EndRequestWithLog(c, reqID, err, result)
+		return common.EndRequestWithLog(c, err, result)
 
 	default:
 		result, err := infra.ListVmInfo(nsId, mciId, vmId)
-		return common.EndRequestWithLog(c, reqID, err, result)
+		return common.EndRequestWithLog(c, err, result)
 	}
 }
 
@@ -316,10 +299,7 @@ func RestPutMciVm(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/vm/{vmId} [delete]
 func RestDelMciVm(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
@@ -329,11 +309,11 @@ func RestDelMciVm(c echo.Context) error {
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err := fmt.Errorf("Failed to delete the VM info")
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	result := map[string]string{"message": "Deleted the VM info"}
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestGetMciGroupVms godoc
@@ -352,10 +332,7 @@ func RestDelMciVm(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId} [get]
 func RestGetMciGroupVms(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	subgroupId := c.Param("subgroupId")
@@ -364,7 +341,7 @@ func RestGetMciGroupVms(c echo.Context) error {
 	content := model.IdList{}
 	var err error
 	content.IdList, err = infra.ListVmBySubGroup(nsId, mciId, subgroupId)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetMciGroupIds godoc
@@ -381,10 +358,7 @@ func RestGetMciGroupVms(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/subgroup [get]
 func RestGetMciGroupIds(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	//option := c.QueryParam("option")
@@ -392,5 +366,5 @@ func RestGetMciGroupIds(c echo.Context) error {
 	content := model.IdList{}
 	var err error
 	content.IdList, err = infra.ListSubGroupId(nsId, mciId)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/infra/monitoring.go
+++ b/src/api/rest/server/infra/monitoring.go
@@ -15,8 +15,6 @@ limitations under the License.
 package infra
 
 import (
-	"net/http"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -38,20 +36,17 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/monitoring/install/mci/{mciId} [post]
 func RestPostInstallMonitorAgentToMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
 	req := &model.MciCmdReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 	// mciTmpSystemLabel := model.DefaultSystemLabel
 	content, err := infra.InstallMonitorAgentToMci(nsId, mciId, model.StrMCI, req)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestPutMonitorAgentStatusInstalled godoc
@@ -69,10 +64,7 @@ func RestPostInstallMonitorAgentToMci(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/monitoring/status/mci/{mciId}/vm/{vmId} [put]
 func RestPutMonitorAgentStatusInstalled(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
@@ -80,11 +72,11 @@ func RestPutMonitorAgentStatusInstalled(c echo.Context) error {
 	// mciTmpSystemLabel := model.DefaultSystemLabel
 	err := infra.SetMonitoringAgentStatusInstalled(nsId, mciId, vmId)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	result, err := infra.ListVmInfo(nsId, mciId, vmId)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestGetMonitorData godoc
@@ -102,19 +94,16 @@ func RestPutMonitorAgentStatusInstalled(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/monitoring/mci/{mciId}/metric/{metric} [get]
 func RestGetMonitorData(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	metric := c.Param("metric")
 
 	req := &model.MciCmdReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := infra.GetMonitoringData(nsId, mciId, metric)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/infra/orchestration.go
+++ b/src/api/rest/server/infra/orchestration.go
@@ -16,7 +16,6 @@ package infra
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
@@ -40,20 +39,17 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/policy/mci/{mciId} [post]
 func RestPostMciPolicy(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
 	req := &model.MciPolicyReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := infra.CreateMciPolicy(nsId, mciId, req)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetMciPolicy godoc
@@ -70,10 +66,6 @@ func RestPostMciPolicy(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/policy/mci/{mciId} [get]
 func RestGetMciPolicy(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
@@ -81,14 +73,14 @@ func RestGetMciPolicy(c echo.Context) error {
 	result, err := infra.GetMciPolicyObject(nsId, mciId)
 	if err != nil {
 		errorMessage := fmt.Errorf("Error to find MciPolicyObject : " + mciId + "ERROR : " + err.Error())
-		return common.EndRequestWithLog(c, reqID, errorMessage, nil)
+		return common.EndRequestWithLog(c, errorMessage, nil)
 	}
 
 	if result.Id == "" {
 		errorMessage := fmt.Errorf("Failed to find MciPolicyObject : " + mciId)
-		return common.EndRequestWithLog(c, reqID, errorMessage, nil)
+		return common.EndRequestWithLog(c, errorMessage, nil)
 	}
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // Response structure for RestGetAllMciPolicy
@@ -109,21 +101,18 @@ type RestGetAllMciPolicyResponse struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/policy/mci [get]
 func RestGetAllMciPolicy(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	log.Debug().Msg("[Get MCI Policy List]")
 
 	result, err := infra.GetAllMciPolicyObject(nsId)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content := RestGetAllMciPolicyResponse{}
 	content.MciPolicy = result
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 /*
@@ -159,16 +148,13 @@ func RestPutMciPolicy(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/policy/mci/{mciId} [delete]
 func RestDelMciPolicy(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
 	err := infra.DelMciPolicy(nsId, mciId)
 	result := map[string]string{"message": "Deleted the MCI Policy info"}
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestDelAllMciPolicy godoc
@@ -183,11 +169,8 @@ func RestDelMciPolicy(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/policy/mci [delete]
 func RestDelAllMciPolicy(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	result, err := infra.DelAllMciPolicy(nsId)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }

--- a/src/api/rest/server/infra/provisioning.go
+++ b/src/api/rest/server/infra/provisioning.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
 )
 
 // RestPostMci godoc
@@ -37,20 +38,17 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci [post]
 func RestPostMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	req := &model.TbMciReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	option := "create"
 	result, err := infra.CreateMci(nsId, req, option)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestPostRegisterCSPNativeVM godoc
@@ -67,20 +65,17 @@ func RestPostMci(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/registerCspVm [post]
 func RestPostRegisterCSPNativeVM(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	req := &model.TbMciReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	option := "register"
 	result, err := infra.CreateMci(nsId, req, option)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestPostSystemMci godoc
@@ -96,19 +91,16 @@ func RestPostRegisterCSPNativeVM(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /systemMci [post]
 func RestPostSystemMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	option := c.QueryParam("option")
 
 	req := &model.TbMciDynamicReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	result, err := infra.CreateSystemMciDynamic(option)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestPostMciDynamic godoc
@@ -134,12 +126,14 @@ func RestPostMciDynamic(c echo.Context) error {
 
 	req := &model.TbMciDynamicReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		log.Warn().Err(err).Msg("invalid request")
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	result, err := infra.CreateMciDynamic(reqID, nsId, req, option)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		log.Error().Err(err).Msg("failed to create MCI dynamically")
+		return common.EndRequestWithLog(c, err, nil)
 	}
 	return c.JSON(http.StatusOK, result)
 }
@@ -159,20 +153,17 @@ func RestPostMciDynamic(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/vmDynamic [post]
 func RestPostMciVmDynamic(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
 	req := &model.TbVmDynamicReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	result, err := infra.CreateMciVmDynamic(nsId, mciId, req)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestPostMciDynamicCheckRequest godoc
@@ -188,17 +179,14 @@ func RestPostMciVmDynamic(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /mciDynamicCheckRequest [post]
 func RestPostMciDynamicCheckRequest(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	req := &model.MciConnectionConfigCandidatesReq{}
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	result, err := infra.CheckMciDynamicReq(req)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestPostMciVm godoc
@@ -216,19 +204,16 @@ func RestPostMciDynamicCheckRequest(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/vm [post]
 func RestPostMciVm(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
 	vmInfoData := &model.TbVmReq{}
 	if err := c.Bind(vmInfoData); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 	result, err := infra.CreateMciGroupVm(nsId, mciId, vmInfoData, true)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestPostMciSubGroupScaleOut godoc
@@ -247,19 +232,16 @@ func RestPostMciVm(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId} [post]
 func RestPostMciSubGroupScaleOut(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	subgroupId := c.Param("subgroupId")
 
 	scaleOutReq := &model.TbScaleOutSubGroupReq{}
 	if err := c.Bind(scaleOutReq); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	result, err := infra.ScaleOutMciSubGroup(nsId, mciId, subgroupId, scaleOutReq.NumVMsToAdd)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }

--- a/src/api/rest/server/infra/recommendation.go
+++ b/src/api/rest/server/infra/recommendation.go
@@ -15,8 +15,6 @@ limitations under the License.
 package infra
 
 import (
-	"net/http"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -36,19 +34,16 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /mciRecommendVm [post]
 func RestRecommendVm(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := model.SystemCommonNs
 
 	u := &model.DeploymentPlan{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := infra.RecommendVm(nsId, *u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 type RestPostMciRecommendResponse struct {

--- a/src/api/rest/server/infra/utility.go
+++ b/src/api/rest/server/infra/utility.go
@@ -15,18 +15,13 @@ limitations under the License.
 package infra
 
 import (
-	"net/http"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
 	"github.com/labstack/echo/v4"
 )
 
 func RestCheckMci(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
@@ -37,14 +32,11 @@ func RestCheckMci(c echo.Context) error {
 	}
 	content := JsonTemplate{}
 	content.Exists = exists
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 func RestCheckVm(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
@@ -56,5 +48,5 @@ func RestCheckVm(c echo.Context) error {
 	}
 	content := JsonTemplate{}
 	content.Exists = exists
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/middlewares/requestIdAndDetailsIssuer.go
+++ b/src/api/rest/server/middlewares/requestIdAndDetailsIssuer.go
@@ -19,10 +19,9 @@ func RequestIdAndDetailsIssuer(next echo.HandlerFunc) echo.HandlerFunc {
 		reqID := c.Request().Header.Get(echo.HeaderXRequestID)
 		if reqID == "" {
 			reqID = fmt.Sprintf("%d", time.Now().UnixNano())
+			// Set the generated request ID to the request header
+			c.Request().Header.Set(echo.HeaderXRequestID, reqID)
 		}
-
-		// Set Request on the context
-		c.Set("RequestID", reqID)
 
 		//log.Trace().Msgf("(Request ID middleware) Request ID: %s", reqID)
 		if _, ok := common.RequestMap.Load(reqID); ok {

--- a/src/api/rest/server/middlewares/responseBodyDump.go
+++ b/src/api/rest/server/middlewares/responseBodyDump.go
@@ -23,8 +23,8 @@ func ResponseBodyDump() echo.MiddlewareFunc {
 			// log.Debug().Msg("Start - BodyDump() middleware")
 
 			// Get the request ID
-			reqID := c.Get("RequestID").(string)
-			//log.Trace().Msgf("(BodyDump middleware) Request ID: %s", reqID)
+			reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+			// log.Debug().Msgf("(BodyDump middleware) Request ID: %s", reqID)
 
 			// Get the content type
 			contentType := c.Response().Header().Get(echo.HeaderContentType)

--- a/src/api/rest/server/resource/common.go
+++ b/src/api/rest/server/resource/common.go
@@ -16,7 +16,6 @@ package resource
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -36,10 +35,7 @@ type JSONResult struct {
 // RestDelAllResources is a common function to handle 'DelAllResources' REST API requests.
 // Dummy functions for Swagger exist in [resource/*.go]
 func RestDelAllResources(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	resourceType := strings.Split(c.Path(), "/")[5]
 	// c.Path(): /tumblebug/ns/:nsId/resources/spec/:specId
@@ -48,16 +44,13 @@ func RestDelAllResources(c echo.Context) error {
 	subString := c.QueryParam("match")
 
 	content, err := resource.DelAllResources(nsId, resourceType, subString, forceFlag)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestDelResource is a common function to handle 'DelResource' REST API requests.
 // Dummy functions for Swagger exist in [resource/*.go]
 func RestDelResource(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	resourceType := strings.Split(c.Path(), "/")[5]
@@ -71,7 +64,7 @@ func RestDelResource(c echo.Context) error {
 
 	err := resource.DelResource(nsId, resourceType, resourceId, forceFlag)
 	content := map[string]string{"message": "The " + resourceType + " " + resourceId + " has been deleted"}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // Todo: need to reimplment the following invalid function
@@ -99,16 +92,13 @@ func RestDelResource(c echo.Context) error {
 
 // 	err := model.DelChildResource(nsId, childResourceType, parentResourceId, childResourceId, forceFlag)
 // 	content := map[string]string{"message": "The " + childResourceType + " " + childResourceId + " has been deleted"}
-// 	return common.EndRequestWithLog(c, reqID, err, content)
+// 	return common.EndRequestWithLog(c, err, content)
 // }
 
 // RestGetAllResources is a common function to handle 'GetAllResources' REST API requests.
 // Dummy functions for Swagger exist in [resource/*.go]
 func RestGetAllResources(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	optionFlag := c.QueryParam("option")
@@ -122,13 +112,13 @@ func RestGetAllResources(c echo.Context) error {
 		content := model.IdList{}
 		var err error
 		content.IdList, err = resource.ListResourceId(nsId, resourceType)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else {
 
 		resourceList, err := resource.ListResource(nsId, resourceType, filterKey, filterVal)
 		if err != nil {
 			err := fmt.Errorf("Failed to list " + resourceType + "s; " + err.Error())
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 
 		switch resourceType {
@@ -138,52 +128,52 @@ func RestGetAllResources(c echo.Context) error {
 			}
 
 			content.Image = resourceList.([]model.TbImageInfo) // type assertion (interface{} -> array)
-			return common.EndRequestWithLog(c, reqID, err, content)
+			return common.EndRequestWithLog(c, err, content)
 		case model.StrCustomImage:
 			var content struct {
 				Image []model.TbCustomImageInfo `json:"customImage"`
 			}
 
 			content.Image = resourceList.([]model.TbCustomImageInfo) // type assertion (interface{} -> array)
-			return common.EndRequestWithLog(c, reqID, err, content)
+			return common.EndRequestWithLog(c, err, content)
 		case model.StrSecurityGroup:
 			var content struct {
 				SecurityGroup []model.TbSecurityGroupInfo `json:"securityGroup"`
 			}
 
 			content.SecurityGroup = resourceList.([]model.TbSecurityGroupInfo) // type assertion (interface{} -> array)
-			return common.EndRequestWithLog(c, reqID, err, content)
+			return common.EndRequestWithLog(c, err, content)
 		case model.StrSpec:
 			var content struct {
 				Spec []model.TbSpecInfo `json:"spec"`
 			}
 
 			content.Spec = resourceList.([]model.TbSpecInfo) // type assertion (interface{} -> array)
-			return common.EndRequestWithLog(c, reqID, err, content)
+			return common.EndRequestWithLog(c, err, content)
 		case model.StrSSHKey:
 			var content struct {
 				SshKey []model.TbSshKeyInfo `json:"sshKey"`
 			}
 
 			content.SshKey = resourceList.([]model.TbSshKeyInfo) // type assertion (interface{} -> array)
-			return common.EndRequestWithLog(c, reqID, err, content)
+			return common.EndRequestWithLog(c, err, content)
 		case model.StrVNet:
 			var content struct {
 				VNet []model.TbVNetInfo `json:"vNet"`
 			}
 
 			content.VNet = resourceList.([]model.TbVNetInfo) // type assertion (interface{} -> array)
-			return common.EndRequestWithLog(c, reqID, err, content)
+			return common.EndRequestWithLog(c, err, content)
 		case model.StrDataDisk:
 			var content struct {
 				DataDisk []model.TbDataDiskInfo `json:"dataDisk"`
 			}
 
 			content.DataDisk = resourceList.([]model.TbDataDiskInfo) // type assertion (interface{} -> array)
-			return common.EndRequestWithLog(c, reqID, err, content)
+			return common.EndRequestWithLog(c, err, content)
 		default:
 			err := fmt.Errorf("Not accepatble resourceType: " + resourceType)
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 
 		}
 	}
@@ -192,10 +182,7 @@ func RestGetAllResources(c echo.Context) error {
 // RestGetResource is a common function to handle 'GetResource' REST API requests.
 // Dummy functions for Swagger exist in [resource/*.go]
 func RestGetResource(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	resourceType := strings.Split(c.Path(), "/")[5]
@@ -209,9 +196,9 @@ func RestGetResource(c echo.Context) error {
 	result, err := resource.GetResource(nsId, resourceType, resourceId)
 	if err != nil {
 		errorMessage := fmt.Errorf("Failed to find " + resourceType + " " + resourceId)
-		return common.EndRequestWithLog(c, reqID, errorMessage, nil)
+		return common.EndRequestWithLog(c, errorMessage, nil)
 	}
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestCheckResource godoc
@@ -228,10 +215,7 @@ func RestGetResource(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/checkResource/{resourceType}/{resourceId} [get]
 func RestCheckResource(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	resourceType := c.Param("resourceType")
 	resourceId := c.Param("resourceId")
@@ -246,16 +230,13 @@ func RestCheckResource(c echo.Context) error {
 	content := JsonTemplate{}
 	content.Exists = exists
 
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestTestAddObjectAssociation is a REST API call handling function
 // to test "model.UpdateAssociatedObjectList" function with "add" argument.
 func RestTestAddObjectAssociation(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	//resourceType := strings.Split(c.Path(), "/")[5]
 	// c.Path(): /tumblebug/ns/:nsId/testAddObjectAssociation/:resourceType/:resourceId
@@ -266,16 +247,13 @@ func RestTestAddObjectAssociation(c echo.Context) error {
 
 	content, err := resource.UpdateAssociatedObjectList(nsId, resourceType, resourceId, model.StrAdd, "/test/vm/key")
 
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestTestDeleteObjectAssociation is a REST API call handling function
 // to test "model.UpdateAssociatedObjectList" function with "delete" argument.
 func RestTestDeleteObjectAssociation(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	//resourceType := strings.Split(c.Path(), "/")[5]
 	// c.Path(): /tumblebug/ns/:nsId/testDeleteObjectAssociation/:resourceType/:resourceId
@@ -285,16 +263,13 @@ func RestTestDeleteObjectAssociation(c echo.Context) error {
 	resourceId = strings.ReplaceAll(resourceId, "%2B", "+")
 
 	content, err := resource.UpdateAssociatedObjectList(nsId, resourceType, resourceId, model.StrDelete, "/test/vm/key")
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestTestGetAssociatedObjectCount is a REST API call handling function
 // to test "model.GetAssociatedObjectCount" function.
 func RestTestGetAssociatedObjectCount(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	//resourceType := strings.Split(c.Path(), "/")[5]
 	// c.Path(): /tumblebug/ns/:nsId/testGetAssociatedObjectCount/:resourceType/:resourceId
@@ -306,7 +281,7 @@ func RestTestGetAssociatedObjectCount(c echo.Context) error {
 	associatedObjectCount, err := resource.GetAssociatedObjectCount(nsId, resourceType, resourceId)
 	content := map[string]int{"associatedObjectCount": associatedObjectCount}
 
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestLoadAssets godoc
@@ -320,12 +295,9 @@ func RestTestGetAssociatedObjectCount(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /loadAssets [get]
 func RestLoadAssets(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	content, err := resource.LoadAssets()
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestCreateSharedResource godoc
@@ -342,10 +314,7 @@ func RestLoadAssets(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/sharedResource [post]
 func RestCreateSharedResource(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	resType := c.QueryParam("option")
 
@@ -354,7 +323,7 @@ func RestCreateSharedResource(c echo.Context) error {
 
 	err := resource.CreateSharedResource(nsId, resType, connectionName)
 	content := map[string]string{"message": "Done"}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestDelAllSharedResources godoc
@@ -369,14 +338,11 @@ func RestCreateSharedResource(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/sharedResources [delete]
 func RestDelAllSharedResources(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	content, err := resource.DelAllSharedResources(nsId)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 /*

--- a/src/api/rest/server/resource/customimage.go
+++ b/src/api/rest/server/resource/customimage.go
@@ -16,7 +16,6 @@ package resource
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -39,26 +38,23 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/customImage [post]
 func RestPostCustomImage(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	optionFlag := c.QueryParam("option")
 
 	if optionFlag != "register" {
 		err := fmt.Errorf("POST customImage can be called only with 'option=register'")
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	u := &model.TbCustomImageReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.RegisterCustomImageWithId(nsId, u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetCustomImage godoc

--- a/src/api/rest/server/resource/dataDisk.go
+++ b/src/api/rest/server/resource/dataDisk.go
@@ -16,7 +16,6 @@ package resource
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
@@ -41,10 +40,6 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/dataDisk [post]
 func RestPostDataDisk(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	nsId := c.Param("nsId")
 
@@ -52,11 +47,11 @@ func RestPostDataDisk(c echo.Context) error {
 
 	u := &model.TbDataDiskReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.CreateDataDisk(nsId, u, optionFlag)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestPutDataDisk godoc
@@ -74,21 +69,17 @@ func RestPostDataDisk(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/dataDisk/{dataDiskId} [put]
 func RestPutDataDisk(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	nsId := c.Param("nsId")
 	dataDiskId := c.Param("resourceId")
 
 	u := &model.TbDataDiskUpsizeReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.UpsizeDataDisk(nsId, dataDiskId, u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetDataDisk godoc
@@ -186,10 +177,7 @@ func RestDelAllDataDisk(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk [put]
 func RestPutVmDataDisk(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
@@ -201,13 +189,13 @@ func RestPutVmDataDisk(c echo.Context) error {
 	if forceStr != "" {
 		forceBool, err = strconv.ParseBool(forceStr)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, fmt.Errorf("Invalid force value: %s", forceStr), nil)
+			return common.EndRequestWithLog(c, fmt.Errorf("Invalid force value: %s", forceStr), nil)
 		}
 	}
 
 	u := &model.TbAttachDetachDataDiskReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	switch option {
@@ -215,11 +203,11 @@ func RestPutVmDataDisk(c echo.Context) error {
 		fallthrough
 	case model.DetachDataDisk:
 		result, err := infra.AttachDetachDataDisk(nsId, mciId, vmId, option, u.DataDiskId, forceBool)
-		return common.EndRequestWithLog(c, reqID, err, result)
+		return common.EndRequestWithLog(c, err, result)
 
 	default:
 		err := fmt.Errorf("Supported options: %s, %s, %s", model.AttachDataDisk, model.DetachDataDisk, model.AvailableDataDisk)
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 }
 
@@ -238,25 +226,22 @@ func RestPutVmDataDisk(c echo.Context) error {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk [post]
 func RestPostVmDataDisk(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
 
 	u := &model.TbDataDiskVmReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	result, err := infra.ProvisionDataDisk(nsId, mciId, vmId, u)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestGetVmDataDisk godoc
@@ -274,10 +259,7 @@ func RestPostVmDataDisk(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk [get]
 func RestGetVmDataDisk(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 	vmId := c.Param("vmId")
@@ -285,7 +267,7 @@ func RestGetVmDataDisk(c echo.Context) error {
 
 	result, err := infra.GetAvailableDataDisks(nsId, mciId, vmId, optionFlag)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	var content interface{}
@@ -299,5 +281,5 @@ func RestGetVmDataDisk(c echo.Context) error {
 		}
 	}
 
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/resource/firewallrule.go
+++ b/src/api/rest/server/resource/firewallrule.go
@@ -15,8 +15,6 @@ limitations under the License.
 package resource
 
 import (
-	"net/http"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
@@ -42,20 +40,17 @@ type TbFirewallRulesWrapper struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules [post]
 func RestPostFirewallRules(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	securityGroupId := c.Param("securityGroupId")
 
 	u := &TbFirewallRulesWrapper{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.CreateFirewallRules(nsId, securityGroupId, *&u.FirewallRules, false)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 /* function RestPutFirewallRules not yet implemented
@@ -118,18 +113,15 @@ type RestGetAllFirewallRulesResponse struct {
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules [delete]
 func RestDelFirewallRules(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	securityGroupId := c.Param("securityGroupId")
 
 	u := &TbFirewallRulesWrapper{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.DeleteFirewallRules(nsId, securityGroupId, *&u.FirewallRules)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/resource/image.go
+++ b/src/api/rest/server/resource/image.go
@@ -16,7 +16,6 @@ package resource
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -44,10 +43,7 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/image [post]
 func RestPostImage(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	action := c.QueryParam("action")
@@ -69,21 +65,21 @@ func RestPostImage(c echo.Context) error {
 		log.Debug().Msg("[Registering Image with info]")
 		u := &model.TbImageInfo{}
 		if err := c.Bind(u); err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 		content, err := resource.RegisterImageWithInfo(nsId, u, update)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else if action == "registerWithId" {
 		log.Debug().Msg("[Registering Image with ID]")
 		u := &model.TbImageReq{}
 		if err := c.Bind(u); err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 		content, err := resource.RegisterImageWithId(nsId, u, update, false)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 	} else {
 		err := fmt.Errorf("You must specify: action=registerWithInfo or action=registerWithId")
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 }
@@ -103,10 +99,7 @@ func RestPostImage(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/image/{imageId} [put]
 func RestPutImage(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	resourceId := c.Param("imageId")
 	resourceId = strings.ReplaceAll(resourceId, " ", "+")
@@ -114,11 +107,11 @@ func RestPutImage(c echo.Context) error {
 
 	u := &model.TbImageInfo{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.UpdateImage(nsId, resourceId, *u, false)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // Request structure for RestLookupImage
@@ -140,18 +133,15 @@ type RestLookupImageRequest struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /lookupImage [post]
 func RestLookupImage(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &RestLookupImageRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	log.Debug().Msg("[Lookup image]: " + u.CspImageName)
 	content, err := resource.LookupImage(u.ConnectionName, u.CspImageName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -168,18 +158,15 @@ func RestLookupImage(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /lookupImages [post]
 func RestLookupImageList(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &RestLookupImageRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	log.Debug().Msg("[Lookup images]")
 	content, err := resource.LookupImageList(u.ConnectionName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -196,15 +183,12 @@ func RestLookupImageList(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/fetchImages [post]
 func RestFetchImages(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	u := &RestLookupImageRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	var connConfigCount, imageCount uint
@@ -213,19 +197,19 @@ func RestFetchImages(c echo.Context) error {
 	if u.ConnectionName == "" {
 		connConfigCount, imageCount, err = resource.FetchImagesForAllConnConfigs(nsId)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 	} else {
 		connConfigCount = 1
 		imageCount, err = resource.FetchImagesForConnConfig(u.ConnectionName, nsId)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 	}
 
 	content := map[string]string{
 		"message": "Fetched " + fmt.Sprint(imageCount) + " images (from " + fmt.Sprint(connConfigCount) + " connConfigs)"}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetImage godoc
@@ -324,10 +308,7 @@ type RestSearchImageRequest struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/searchImage [post]
 func RestSearchImage(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	u := &RestSearchImageRequest{}
@@ -338,5 +319,5 @@ func RestSearchImage(c echo.Context) error {
 	content, err := resource.SearchImage(nsId, u.Keywords...)
 	result := RestGetAllImageResponse{}
 	result.Image = content
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }

--- a/src/api/rest/server/resource/k8scluster.go
+++ b/src/api/rest/server/resource/k8scluster.go
@@ -39,15 +39,12 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /availableK8sClusterVersion [get]
 func RestGetAvailableK8sClusterVersion(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	providerName := c.QueryParam("providerName")
 	regionName := c.QueryParam("regionName")
 
 	content, err := common.GetAvailableK8sClusterVersion(providerName, regionName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetAvailableK8sClusterNodeImage func is a rest api wrapper for GetAvailableK8sClusterNodeImage.
@@ -65,15 +62,12 @@ func RestGetAvailableK8sClusterVersion(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /availableK8sClusterNodeImage [get]
 func RestGetAvailableK8sClusterNodeImage(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	providerName := c.QueryParam("providerName")
 	regionName := c.QueryParam("regionName")
 
 	content, err := common.GetAvailableK8sClusterNodeImage(providerName, regionName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestCheckNodeGroupsOnK8sCreation func is a rest api wrapper for CheckNodeGroupsOnK8sCreation.
@@ -90,14 +84,11 @@ func RestGetAvailableK8sClusterNodeImage(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /checkNodeGroupsOnK8sCreation [get]
 func RestCheckNodeGroupsOnK8sCreation(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	providerName := c.QueryParam("providerName")
 
 	content, err := common.CheckNodeGroupsOnK8sCreation(providerName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestPostK8sCluster func is a rest api wrapper for CreateK8sCluster.

--- a/src/api/rest/server/resource/securitygroup.go
+++ b/src/api/rest/server/resource/securitygroup.go
@@ -15,8 +15,6 @@ limitations under the License.
 package resource
 
 import (
-	"net/http"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
@@ -38,21 +36,18 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/securityGroup [post]
 func RestPostSecurityGroup(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	optionFlag := c.QueryParam("option")
 
 	u := &model.TbSecurityGroupReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.CreateSecurityGroup(nsId, u, optionFlag)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 /*

--- a/src/api/rest/server/resource/spec.go
+++ b/src/api/rest/server/resource/spec.go
@@ -16,7 +16,6 @@ package resource
 
 import (
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 
@@ -44,10 +43,7 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/spec [post]
 func RestPostSpec(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	action := c.QueryParam("action")
@@ -62,19 +58,19 @@ func RestPostSpec(c echo.Context) error {
 		log.Debug().Msg("[Registering Spec with info]")
 		u := &model.TbSpecInfo{}
 		if err := c.Bind(u); err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 		content, err := resource.RegisterSpecWithInfo(nsId, u, update)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 
 	} else { // if action == "registerWithCspResourceId" { // The default mode.
 		log.Debug().Msg("[Registering Spec with cspSpecName]")
 		u := &model.TbSpecReq{}
 		if err := c.Bind(u); err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 		content, err := resource.RegisterSpecWithCspResourceId(nsId, u, update)
-		return common.EndRequestWithLog(c, reqID, err, content)
+		return common.EndRequestWithLog(c, err, content)
 
 	} /* else {
 		mapA := map[string]string{"message": "LookupSpec(specRequest) failed."}
@@ -98,10 +94,7 @@ func RestPostSpec(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/spec/{specId} [put]
 func RestPutSpec(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	specId := c.Param("resourceId")
 	specId = strings.ReplaceAll(specId, " ", "+")
@@ -109,11 +102,11 @@ func RestPutSpec(c echo.Context) error {
 
 	u := &model.TbSpecInfo{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.UpdateSpec(nsId, specId, *u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // Request structure for RestLookupSpec
@@ -135,18 +128,15 @@ type RestLookupSpecRequest struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /lookupSpec [post]
 func RestLookupSpec(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &RestLookupSpecRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	fmt.Println("[Lookup spec]: " + u.CspResourceId)
 	content, err := resource.LookupSpec(u.ConnectionName, u.CspResourceId)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -163,18 +153,15 @@ func RestLookupSpec(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /lookupSpecs [post]
 func RestLookupSpecList(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	u := &RestLookupSpecRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	log.Debug().Msg("[Lookup specs]")
 	content, err := resource.LookupSpecList(u.ConnectionName)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 
 }
 
@@ -191,15 +178,12 @@ func RestLookupSpecList(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/fetchSpecs [post]
 func RestFetchSpecs(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	u := &RestLookupSpecRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	var connConfigCount, specCount uint
@@ -208,19 +192,19 @@ func RestFetchSpecs(c echo.Context) error {
 	if u.ConnectionName == "" {
 		connConfigCount, specCount, err = resource.FetchSpecsForAllConnConfigs(nsId)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 	} else {
 		connConfigCount = 1
 		specCount, err = resource.FetchSpecsForConnConfig(u.ConnectionName, nsId)
 		if err != nil {
-			return common.EndRequestWithLog(c, reqID, err, nil)
+			return common.EndRequestWithLog(c, err, nil)
 		}
 	}
 
 	content := map[string]string{
 		"message": "Fetched " + fmt.Sprint(specCount) + " specs (from " + fmt.Sprint(connConfigCount) + " connConfigs)"}
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestFilterSpecsResponse is Response structure for RestFilterSpecs
@@ -242,22 +226,19 @@ type RestFilterSpecsResponse struct {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/filterSpecsByRange [post]
 func RestFilterSpecsByRange(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 
 	u := &model.FilterSpecsByRangeRequest{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	log.Debug().Msg("[Filter specs]")
 	content, err := resource.FilterSpecsByRange(nsId, *u)
 	result := RestFilterSpecsResponse{}
 	result.Spec = content
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestGetSpec godoc
@@ -274,10 +255,7 @@ func RestFilterSpecsByRange(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/spec/{specId} [get]
 func RestGetSpec(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	specId := c.Param("resourceId")
 	// make " " and "+" to be "+" (web utilizes "+" for " " in URL)
@@ -286,7 +264,7 @@ func RestGetSpec(c echo.Context) error {
 
 	log.Debug().Msg("[Get spec]" + specId)
 	result, err := resource.GetSpec(nsId, specId)
-	return common.EndRequestWithLog(c, reqID, err, result)
+	return common.EndRequestWithLog(c, err, result)
 }
 
 // RestDelSpec godoc

--- a/src/api/rest/server/resource/sshkey.go
+++ b/src/api/rest/server/resource/sshkey.go
@@ -15,8 +15,6 @@ limitations under the License.
 package resource
 
 import (
-	"net/http"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
@@ -38,10 +36,6 @@ import (
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/sshKey [post]
 func RestPostSshKey(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	nsId := c.Param("nsId")
 
@@ -49,11 +43,11 @@ func RestPostSshKey(c echo.Context) error {
 
 	u := &model.TbSshKeyReq{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.CreateSshKey(nsId, u, optionFlag)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestPutSshKey godoc
@@ -71,20 +65,17 @@ func RestPostSshKey(c echo.Context) error {
 // @Failure 500 {object} model.SimpleMsg
 // @Router /ns/{nsId}/resources/sshKey/{sshKeyId} [put]
 func RestPutSshKey(c echo.Context) error {
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
+
 	nsId := c.Param("nsId")
 	sshKeyId := c.Param("resourceId")
 
 	u := &model.TbSshKeyInfo{}
 	if err := c.Bind(u); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	content, err := resource.UpdateSshKey(nsId, sshKeyId, *u)
-	return common.EndRequestWithLog(c, reqID, err, content)
+	return common.EndRequestWithLog(c, err, content)
 }
 
 // RestGetSshKey godoc

--- a/src/api/rest/server/util/netuil.go
+++ b/src/api/rest/server/util/netuil.go
@@ -72,24 +72,20 @@ type RestPostUtilToDesignNetworkReponse struct {
 func RestPostUtilToDesignNetwork(c echo.Context) error {
 
 	// ID for API request tracing
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
 
 	// Bind the request body to SubnettingRequest struct
 	subnettingReq := new(netutil.SubnettingRequest)
 	if err := c.Bind(subnettingReq); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	// Subnetting as many as requested rules
 	networkConfig, err := netutil.SubnettingBy(*subnettingReq)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
-	return common.EndRequestWithLog(c, reqID, err, networkConfig)
+	return common.EndRequestWithLog(c, err, networkConfig)
 }
 
 type RestPostUtilToValidateNetworkRequest struct {
@@ -110,27 +106,21 @@ type RestPostUtilToValidateNetworkRequest struct {
 // @Router /util/net/validate [post]
 func RestPostUtilToValidateNetwork(c echo.Context) error {
 
-	// ID for API request tracing
-	reqID, idErr := common.StartRequestWithLog(c)
-	if idErr != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"message": idErr.Error()})
-	}
-
 	// Bind the request body to SubnettingRequest struct
 	req := new(netutil.NetworkConfig)
 	if err := c.Bind(req); err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	// Validate the network configuration
 	netConf := req.NetworkConfiguration
 	err := netutil.ValidateNetwork(netConf)
 	if err != nil {
-		return common.EndRequestWithLog(c, reqID, err, nil)
+		return common.EndRequestWithLog(c, err, nil)
 	}
 
 	okMessage := model.SimpleMsg{}
 	okMessage.Message = "Network configuration is valid."
 
-	return common.EndRequestWithLog(c, reqID, err, okMessage)
+	return common.EndRequestWithLog(c, err, okMessage)
 }

--- a/src/core/common/client.go
+++ b/src/core/common/client.go
@@ -299,32 +299,35 @@ func ExtractRequestInfo(r *http.Request) RequestInfo {
 	}
 }
 
-// StartRequestWithLog initializes request tracking details
-func StartRequestWithLog(c echo.Context) (string, error) {
-	reqID := c.Request().Header.Get("x-request-id")
-	if reqID == "" {
-		reqID = fmt.Sprintf("%d", time.Now().UnixNano())
-	}
-	if _, ok := RequestMap.Load(reqID); ok {
-		return reqID, fmt.Errorf("The x-request-id is already in use")
-	}
+// // StartRequestWithLog initializes request tracking details
+// func StartRequestWithLog(c echo.Context) (string, error) {
+// 	reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+// 	if reqID == "" {
+// 		reqID = fmt.Sprintf("%d", time.Now().UnixNano())
+// 	}
+// 	if _, ok := RequestMap.Load(reqID); ok {
+// 		return reqID, fmt.Errorf("the x-request-id is already in use")
+// 	}
 
-	details := RequestDetails{
-		StartTime:   time.Now(),
-		Status:      "Handling",
-		RequestInfo: ExtractRequestInfo(c.Request()),
-	}
-	RequestMap.Store(reqID, details)
-	return reqID, nil
-}
+// 	details := RequestDetails{
+// 		StartTime:   time.Now(),
+// 		Status:      "Handling",
+// 		RequestInfo: ExtractRequestInfo(c.Request()),
+// 	}
+// 	RequestMap.Store(reqID, details)
+// 	return reqID, nil
+// }
 
 // EndRequestWithLog updates the request details and sends the final response.
-func EndRequestWithLog(c echo.Context, reqID string, err error, responseData interface{}) error {
+func EndRequestWithLog(c echo.Context, err error, responseData interface{}) error {
+
+	reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+
 	if v, ok := RequestMap.Load(reqID); ok {
 		details := v.(RequestDetails)
 		details.EndTime = time.Now()
 
-		c.Response().Header().Set("X-Request-ID", reqID)
+		c.Response().Header().Set(echo.HeaderXRequestID, reqID)
 
 		if err != nil {
 			details.Status = "Error"


### PR DESCRIPTION
* Check `X-Request-Id` in request Header and set it if it's empty in the RequestIdAndDetailsIssuer middleware
* Remove or replace common.StartRequestWithLog()
  - Note: common.EndRequestWithLog() will be removed or replaced

There are a lot of changes, but most of them are similar :-)