### PR TITLE
[k8scluster] fix nodegroup's name

### DIFF
--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -162,7 +162,8 @@ func CreateK8sCluster(nsId string, req *model.TbK8sClusterReq, option string) (m
 
 	var spNodeGroupList []model.SpiderNodeGroupReqInfo
 	for _, v := range req.K8sNodeGroupList {
-		err := common.CheckString(v.Name)
+		spName := v.Name
+		err := common.CheckString(spName)
 		if err != nil {
 			log.Err(err).Msg("Failed to Create a K8sCluster")
 			return emptyObj, err
@@ -192,7 +193,7 @@ func CreateK8sCluster(nsId string, req *model.TbK8sClusterReq, option string) (m
 		}
 
 		spNodeGroupList = append(spNodeGroupList, model.SpiderNodeGroupReqInfo{
-			Name:            common.GenUid(),
+			Name:            spName,
 			ImageName:       spImgName,
 			VMSpecName:      spSpecName,
 			RootDiskType:    v.RootDiskType,


### PR DESCRIPTION
PR은 노드그룹의 이름에 UID 대신 사용자 지정 이름을 사용하도록 수정합니다.
현재는 노드그룹을 별도의 객체로 관리하지 않고 있습니다.