### PR TITLE
[k8scluster] enable gcp and update regions/versions

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -46,12 +46,16 @@ k8scluster:
     version:
       - region: [common]
         available:
+          - name: 1.30
+            id: 1.30.3-gke.1225000
           - name: 1.29
-            id: 1.29.6-gke.1038001
+            id: 1.29.7-gke.1104000
           - name: 1.28
-            id: 1.28.11-gke.1019001
-          - name: 1.26
-            id: 1.27.14-gke.1059002
+            id: 1.28.12-gke.1052000
+          - name: 1.27
+            id: 1.27.16-gke.1051000
+      - region: [africa-south1]
+        # addnodegroup unavailble
     rootDisk:
       - region: [common]
         type:

--- a/conf/cloud_conf.yaml
+++ b/conf/cloud_conf.yaml
@@ -34,7 +34,7 @@ cloud:
       timeout: "9"
       threshold: "3"
     k8scluster:
-      enable: "n"
+      enable: "y"
   alibaba:
     enable: "y"
     nlb:


### PR DESCRIPTION
본 PR은 GCP에서 k8scluster를 사용할 수 있도록 활성화하고 관련 리전 및 버전 정보를 업데이트합니다.