### PR TITLE
Update label.go. Fix typo: replace 'lable' with 'label' #1838

### DIFF
--- a/src/core/common/label/label.go
+++ b/src/core/common/label/label.go
@@ -130,7 +130,7 @@ func RemoveLabel(labelType, uid, key string) error {
 }
 
 // GetLabels retrieves the labels for a resource identified by its uid.
-func GetLabels(labelType, uid string) (lable model.LabelInfo, err error) {
+func GetLabels(labelType, uid string) (label model.LabelInfo, err error) {
 	labelInfo := model.LabelInfo{}
 
 	// Construct the labelKey


### PR DESCRIPTION
I checked all the files looking for corrections in the types and this was the only one I found give me a feedback