### PR TITLE
[k8scluster] support empty/default imagename when adding k8snodegroup

### DIFF
--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -400,6 +400,8 @@ func AddK8sNodeGroup(nsId string, k8sClusterId string, u *model.TbK8sNodeGroupRe
 
 	spImgName := "" // Some CSPs do not require ImageName for creating a cluster
 	if u.ImageId == "" || u.ImageId == "default" {
+		spImgName = ""
+	} else {
 		spImgName, err = GetCspResourceName(nsId, model.StrImage, u.ImageId)
 		if spImgName == "" {
 			log.Err(err).Msg("Failed to Add K8sNodeGroup")


### PR DESCRIPTION
본 PR은 AddK8sNodeGroup 호출시 ""와 "default"인 이미지 이름을 사용할 수 있도록 지원합니다.