### PR TITLE
Refine API request logging struct

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
 services:
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.9.14
+    image: cloudbaristaorg/cb-tumblebug:0.9.15
     container_name: cb-tumblebug
     build:
       context: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
 services:
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.9.13
+    image: cloudbaristaorg/cb-tumblebug:0.9.14
     container_name: cb-tumblebug
     build:
       context: .
@@ -145,7 +145,7 @@ services:
 
   # cb-mapui
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.9.7
+    image: cloudbaristaorg/cb-mapui:0.9.8
     container_name: cb-mapui
     # build:
     #   context: ../cb-mapui

--- a/src/api/rest/server/middlewares/zerologger.go
+++ b/src/api/rest/server/middlewares/zerologger.go
@@ -1,6 +1,7 @@
 package middlewares
 
 import (
+	"net/http"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -42,7 +43,7 @@ func Zerologger(skipPatterns [][]string) echo.MiddlewareFunc {
 		// HandleError:      true, // forwards error to the global error handler, so it can decide appropriate status code
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
 			if v.Error == nil {
-				if v.Method != "OPTIONS" {
+				if v.Method != http.MethodOptions {
 					log.Info().
 						Str("ID", v.RequestID).
 						Str("Method", v.Method).

--- a/src/api/rest/server/middlewares/zerologger.go
+++ b/src/api/rest/server/middlewares/zerologger.go
@@ -42,33 +42,35 @@ func Zerologger(skipPatterns [][]string) echo.MiddlewareFunc {
 		// HandleError:      true, // forwards error to the global error handler, so it can decide appropriate status code
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
 			if v.Error == nil {
-				log.Info().
-					Str("id", v.RequestID).
-					Str("client_ip", v.RemoteIP).
-					//Str("host", v.Host).
-					Str("method", v.Method).
-					Str("URI", v.URI).
-					//Str("user_agent", v.UserAgent).
-					Int("status", v.Status).
-					//Int64("latency", v.Latency.Nanoseconds()).
-					Str("latency_human", v.Latency.String()).
-					Str("bytes_in", v.ContentLength).
-					Int64("bytes_out", v.ResponseSize).
-					Msg("request")
+				if v.Method != "OPTIONS" {
+					log.Info().
+						Str("ID", v.RequestID).
+						Str("Method", v.Method).
+						Str("URI", v.URI).
+						Str("clientIP", v.RemoteIP).
+						//Str("host", v.Host).
+						//Str("user_agent", v.UserAgent).
+						Int("status", v.Status).
+						//Int64("latency", v.Latency.Nanoseconds()).
+						Str("latency", v.Latency.String()).
+						//Str("bytes_in", v.ContentLength).
+						//Int64("bytes_out", v.ResponseSize).
+						Msg("request")
+				}
 			} else {
 				log.Error().
 					Err(v.Error).
-					Str("id", v.RequestID).
-					Str("client_ip", v.RemoteIP).
-					// Str("host", v.Host).
-					Str("method", v.Method).
+					Str("ID", v.RequestID).
+					Str("Method", v.Method).
 					Str("URI", v.URI).
+					Str("clientIP", v.RemoteIP).
+					// Str("host", v.Host).
 					//Str("user_agent", v.UserAgent).
 					Int("status", v.Status).
 					// Int64("latency", v.Latency.Nanoseconds()).
-					Str("latency_human", v.Latency.String()).
-					Str("bytes_in", v.ContentLength).
-					Int64("bytes_out", v.ResponseSize).
+					Str("latency", v.Latency.String()).
+					//Str("bytes_in", v.ContentLength).
+					//Int64("bytes_out", v.ResponseSize).
 					Msg("request error")
 			}
 			return nil


### PR DESCRIPTION
- Request logging 활용도 향상을 위한 출력 구조 refine

개선

- 중복 소지가 있던 Method=OPTIONS 는 로깅에서 제외
- id, method 를 의도적으로 대문자로 변경하여, 우선 기록되도록 순서 변경
- byte in out 등 활용도가 낮은 항목 제외 등

```
cb-tumblebug       | ⇨ http server started on [::]:1323
cb-tumblebug       | 5:28AM INF src/api/rest/server/middlewares/zerologger.go:58 > request ID=1728019710091268611 Method=GET URI=/tumblebug/ns?option=id clientIP=10.0.2.2 latency="644.494µs" status=200
cb-tumblebug       | 5:28AM INF src/api/rest/server/middlewares/zerologger.go:58 > request ID=1728019710164470559 Method=GET URI=/tumblebug/ns/default/mci?option=id clientIP=10.0.2.2 latency=1.70523ms status=200
cb-tumblebug       | 5:28AM INF src/api/rest/server/middlewares/zerologger.go:58 > request ID=1728019710185217384 Method=GET URI=/tumblebug/ns/default/resources/vNet?option=id clientIP=10.0.2.2 latency=3.637388ms status=200
cb-tumblebug       | 5:28AM INF src/api/rest/server/middlewares/zerologger.go:58 > request ID=1728019710191162710 Method=GET URI=/tumblebug/ns/default/resources/securityGroup?option=id clientIP=10.0.2.2 latency=1.291026ms status=200
cb-tumblebug       | 5:28AM INF src/api/rest/server/middlewares/zerologger.go:58 > request ID=1728019710195235879 Method=GET URI=/tumblebug/ns/default/resources/sshKey?option=id clientIP=10.0.2.2 latency=6.497271ms status=200
cb-tumblebug       | 5:28AM INF src/api/rest/server/middlewares/zerologger.go:58 > request ID=1728019710859276801 Method=GET URI=/tumblebug/connConfig?filterVerified=true&filterRegionRepresentative=true clientIP=10.0.2.2 latency=20.881379ms status=200
cb-tumblebug       | 5:33AM INF src/api/rest/server/middlewares/zerologger.go:58 > request ID=1728020010807717742 Method=POST URI=/tumblebug/ns clientIP=10.0.2.2 latency=3.935357ms status=200
cb-tumblebug       | 5:33AM INF src/api/rest/server/middlewares/zerologger.go:58 > request ID=1728020031105813503 Method=DELETE URI=/tumblebug/ns/newns clientIP=10.0.2.2 latency=7.953928ms status=200
```

