### PR TITLE
Fix code scanning alert no. 507: Use of insecure HostKeyCallback implementation

### DIFF
--- a/src/core/infra/remoteCommand.go
+++ b/src/core/infra/remoteCommand.go
@@ -684,7 +684,17 @@ func runSCPWithBastion(bastionInfo model.SshInfo, targetInfo model.SshInfo, file
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(bastionSigner),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.FixedHostKey(bastionPublicKey),
+	}
+
+	// Read the allowed host key for the bastion host
+	bastionPublicKeyBytes, err := ioutil.ReadFile("bastion_hostkey.pub")
+	if err != nil {
+		return fmt.Errorf("failed to read bastion host key: %v", err)
+	}
+	bastionPublicKey, err := ssh.ParsePublicKey(bastionPublicKeyBytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse bastion host key: %v", err)
 	}
 
 	// Parse the private key for the target host
@@ -699,7 +709,17 @@ func runSCPWithBastion(bastionInfo model.SshInfo, targetInfo model.SshInfo, file
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(targetSigner),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.FixedHostKey(targetPublicKey),
+	}
+
+	// Read the allowed host key for the target host
+	targetPublicKeyBytes, err := ioutil.ReadFile("target_hostkey.pub")
+	if err != nil {
+		return fmt.Errorf("failed to read target host key: %v", err)
+	}
+	targetPublicKey, err := ssh.ParsePublicKey(targetPublicKeyBytes)
+	if err != nil {
+		return fmt.Errorf("failed to parse target host key: %v", err)
 	}
 
 	// Setup the bastion host connection


### PR DESCRIPTION
Fixes [https://github.com/cloud-barista/cb-tumblebug/security/code-scanning/507](https://github.com/cloud-barista/cb-tumblebug/security/code-scanning/507)

To fix the problem, we need to replace the insecure `HostKeyCallback` implementation with a secure one. The best way to do this is to use the `ssh.FixedHostKey` function, which validates the host key against a predefined allow list. This involves reading the allowed host key from a file and using it to create the `ssh.ClientConfig`.

1. Read the allowed host key from a file.
2. Parse the host key using `ssh.ParsePublicKey`.
3. Use the parsed key with `ssh.FixedHostKey` to set the `HostKeyCallback` field in `ssh.ClientConfig`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
