### PR TITLE
[k8scluster] update cloudimage.csv for alibaba

### DIFF
--- a/assets/cloudimage.csv
+++ b/assets/cloudimage.csv
@@ -94,7 +94,7 @@ GCP,all,https://www.googleapis.com/compute/v1/projects/windows-cloud/global/imag
 ALIBABA,all,ubuntu_18_04_x64_20G_alibase_20240223.vhd,Ubuntu 18.04,,,vm
 ALIBABA,all,ubuntu_20_04_x64_20G_alibase_20240723.vhd,Ubuntu 20.04,,,vm
 ALIBABA,all,ubuntu_22_04_x64_20G_alibase_20240710.vhd,Ubuntu 22.04,,,vm
-ALIBABA,all,aliyun_3_x64_20G_alibase_20240528.vhd,Alibaba Cloud Linux 3.2104,,,vm|k8s
+ALIBABA,all,aliyun_3_x64_20G_alibase_20240819.vhd,Alibaba Cloud Linux 3.2104,,,vm|k8s
 TENCENT,all,img-pi0ii46r,Ubuntu 18.04,,,vm|k8s
 TENCENT,all,img-22trbn9x,Ubuntu 20.04,,,vm|k8s
 TENCENT,all,img-487zeit5,Ubuntu 22.04,,,vm

--- a/src/api/rest/server/resource/k8scluster.go
+++ b/src/api/rest/server/resource/k8scluster.go
@@ -50,8 +50,8 @@ func RestGetAvailableK8sClusterVersion(c echo.Context) error {
 // RestGetAvailableK8sClusterNodeImage func is a rest api wrapper for GetAvailableK8sClusterNodeImage.
 // RestGetAvailableK8sClusterNodeImage godoc
 // @ID GetAvailableK8sClusterNodeImage
-// @Summary Get available kubernetes cluster node image
-// @Description Get available kubernetes cluster node image
+// @Summary (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
+// @Description (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
 // @Tags [Kubernetes] Cluster Management
 // @Accept  json
 // @Produce  json


### PR DESCRIPTION
본 PR은 alibaba용 cloud image 정보가 변경되어 업데이트합니다.
추가로 /availableK8sClusterNodeImage를 under development 상태로 표기합니다.