### PR TITLE
[testscripts] update query param(action=withsubnets) in (force-)delete-vnet.sh

### DIFF
--- a/src/testclient/scripts/3.vNet/delete-vNet.sh
+++ b/src/testclient/scripts/3.vNet/delete-vNet.sh
@@ -3,7 +3,7 @@
 function CallTB() {
 	echo "- Delete vNet in ${ResourceRegionNativeName}"
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?withSubnets=true | jq ''
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?action=withsubnets | jq ''
 }
 
 #function delete_vNet() {

--- a/src/testclient/scripts/3.vNet/force-delete-vNet.sh
+++ b/src/testclient/scripts/3.vNet/force-delete-vNet.sh
@@ -3,7 +3,7 @@
 function CallTB() {
 	echo "- Delete vNet in ${ResourceRegionNativeName}"
 
-	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true&withSubnets=true | jq ''
+	curl -H "${AUTH}" -sX DELETE http://$TumblebugServer/tumblebug/ns/$NSID/resources/vNet/${CONN_CONFIG[$INDEX,$REGION]}-${POSTFIX}?force=true&action=withsubnets | jq ''
 }
 
 #function delete_vNet() {


### PR DESCRIPTION
본 PR는 테스트 스크립트 중 (force-)delete-vnet.sh에 변경된 query param(action=withsubnets)가 적용되도록 합니다.