### PR TITLE
Enhance speed and stability of spec init

### DIFF
--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -787,7 +787,7 @@ func RegisterCredential(req model.CredentialReq) (model.CredentialInfo, error) {
 				filteredConnections.Connectionconfig = append(filteredConnections.Connectionconfig, connConfig)
 			}
 		}
-		log.Info().Msgf("Filtered connection config count: %d", len(filteredConnections.Connectionconfig))
+		log.Info().Msgf("[%s] filtered connection config: %d", req.ProviderName, len(filteredConnections.Connectionconfig))
 		regionRepresentative := make(map[string]model.ConnConfig)
 		for _, connConfig := range allConnections.Connectionconfig {
 			prefix := req.ProviderName + "-" + connConfig.RegionDetail.RegionName

--- a/src/main.go
+++ b/src/main.go
@@ -372,27 +372,27 @@ func setConfig() {
 // addIndexes adds indexes to the tables for faster search
 func addIndexes() error {
 
-	_, err := model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_namespace ON tb_spec_info (Namespace)")
+	_, err := model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_namespace ON TbSpecInfo (Namespace)")
 	if err != nil {
 		return err
 	}
 
-	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_vcpu ON tb_spec_info (VCPU)")
+	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_vcpu ON TbSpecInfo (VCPU)")
 	if err != nil {
 		return err
 	}
 
-	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_memorygib ON tb_spec_info (MemoryGiB)")
+	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_memorygib ON TbSpecInfo (MemoryGiB)")
 	if err != nil {
 		return err
 	}
 
-	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_cspspecname ON tb_spec_info (CspSpecName)")
+	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_cspspecname ON TbSpecInfo (CspSpecName)")
 	if err != nil {
 		return err
 	}
 
-	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_costperhour ON tb_spec_info (CostPerHour)")
+	_, err = model.ORM.Exec("CREATE INDEX IF NOT EXISTS idx_costperhour ON TbSpecInfo (CostPerHour)")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix #1857

Bulk로 DB를 제어하도록 전반적으로 개선하였습니다. 
- 참고, 기존에 update를 bulk로 수행하는 기능이 없어서, 개별 레코드로 처리하였으나, 일단 전체 등록하고 중복을 전체 삭제하는 짱구를 굴려서 해결하였습니다.
- 향후 추가 개선 소지도 있습니다.

---

- 등록 속도는 약 2배 이상 증가되는 것으로 보이며
- "database is locked" 발생 가능성도 줄였습니다.