### PR TITLE
Fix #1876: Remove the redundant code for fmt.Print

### DIFF
--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -149,10 +149,6 @@ func UpdateConfig(u *model.ConfigReq) (model.ConfigInfo, error) {
 	}
 	keyValue, _ := kvstore.GetKv(key)
 
-	fmt.Println("UpdateConfig(); ===========================")
-	fmt.Println("UpdateConfig(); Key: " + keyValue.Key + "\nValue: " + keyValue.Value)
-	fmt.Println("UpdateConfig(); ===========================")
-
 	UpdateGlobalVariable(content.Id)
 
 	return content, nil

--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -147,7 +147,6 @@ func UpdateConfig(u *model.ConfigReq) (model.ConfigInfo, error) {
 		log.Error().Err(err).Msg("")
 		return content, err
 	}
-	keyValue, _ := kvstore.GetKv(key)
 
 	UpdateGlobalVariable(content.Id)
 


### PR DESCRIPTION
Hello,
Hope you're doing well
As per the request mentioned in issue #1876, I have simple removed the redundant log statement that has been mentioned
If at all I missed something or implemented code changes incorrectly, then do let me know
Sincere apologies for any inconvenience or misunderstanding

Thanks and Regards,
Mohit Kambli