### PR TITLE
Fix vm status transition check bug

### DIFF
--- a/src/core/infra/control.go
+++ b/src/core/infra/control.go
@@ -188,7 +188,7 @@ func HandleMciVmAction(nsId string, mciId string, vmId string, action string, fo
 		return err.Error(), err
 	}
 
-	log.Debug().Msg("[VM action: " + action)
+	log.Info().Msg("[VM control request] " + action)
 
 	mci, err := GetMciStatus(nsId, mciId)
 	if err != nil {
@@ -517,7 +517,9 @@ func CheckAllowedTransition(nsId string, mciId string, vmId model.OptionalParame
 
 		// duplicated action
 		if strings.EqualFold(vm.Status, targetStatus) {
-			return errors.New(action + " is not allowed for VM under " + vm.Status)
+			if !strings.EqualFold(action, model.ActionReboot) {
+				return errors.New(action + " is not allowed for VM under " + vm.Status)
+			}
 		}
 		// redundant action
 		if strings.EqualFold(vm.Status, model.StatusTerminated) {

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -255,7 +255,7 @@ func ListSubGroupId(nsId string, mciId string) ([]string, error) {
 		return nil, err
 	}
 
-	log.Debug().Msg("[ListSubGroupId]")
+	//log.Debug().Msg("[ListSubGroupId]")
 	key := common.GenMciKey(nsId, mciId, "")
 	key += "/"
 
@@ -608,7 +608,7 @@ func ListVmInfo(nsId string, mciId string, vmId string) (*model.TbVmInfo, error)
 	vmKeyValue, err := kvstore.GetKv(vmKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
-		err = fmt.Errorf("In CoreGetMciVmInfo(); kvstore.GetKv() returned an error.")
+		err = fmt.Errorf("kvstore.GetKv() returned an error.")
 		log.Error().Err(err).Msg("")
 		// return nil, err
 	}
@@ -635,7 +635,7 @@ func ListVmInfo(nsId string, mciId string, vmId string) (*model.TbVmInfo, error)
 
 // GetMciObject is func to retrieve MCI object from database (no current status update)
 func GetMciObject(nsId string, mciId string) (model.TbMciInfo, error) {
-	log.Debug().Msg("[GetMciObject]" + mciId)
+	//log.Debug().Msg("[GetMciObject]" + mciId)
 	key := common.GenMciKey(nsId, mciId, "")
 	keyValue, err := kvstore.GetKv(key)
 	if err != nil {

--- a/src/core/infra/utility.go
+++ b/src/core/infra/utility.go
@@ -167,7 +167,7 @@ func CheckVm(nsId string, mciId string, vmId string) (bool, error) {
 		log.Error().Err(err).Msg("")
 		return false, err
 	}
-	log.Debug().Msg("[Check vm] " + mciId + ", " + vmId)
+	//log.Debug().Msg("[Check vm] " + mciId + ", " + vmId)
 
 	key := common.GenMciKey(nsId, mciId, vmId)
 

--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -468,9 +468,9 @@ func ListResource(nsId string, resourceType string, filterKey string, filterVal 
 		return nil, err
 	}
 
-	log.Debug().Msg("[Get] " + resourceType + " list")
+	//log.Debug().Msg("[Get] " + resourceType + " list")
 	key := "/ns/" + nsId + "/resources/" + resourceType
-	log.Debug().Msg(key)
+	//log.Debug().Msg(key)
 
 	keyValue, err := kvstore.GetKvList(key)
 	keyValue = kvutil.FilterKvListBy(keyValue, key, 1)

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -1028,7 +1028,7 @@ func ListK8sClusterId(nsId string) ([]string, error) {
 
 // ListK8sCluster returns the list of TB K8sCluster objects of given nsId
 func ListK8sCluster(nsId string, filterKey string, filterVal string) (interface{}, error) {
-	log.Info().Msg("ListK8sCluster")
+	//log.Info().Msg("ListK8sCluster")
 
 	err := common.CheckString(nsId)
 	if err != nil {
@@ -1036,9 +1036,9 @@ func ListK8sCluster(nsId string, filterKey string, filterVal string) (interface{
 		return nil, err
 	}
 
-	log.Debug().Msg("[Get] K8sCluster list")
+	//log.Debug().Msg("[Get] K8sCluster list")
 	k := fmt.Sprintf("/ns/%s/k8scluster", nsId)
-	log.Debug().Msg(k)
+	//log.Debug().Msg(k)
 
 	/*
 	 * Get model.TbK8sClusterInfo objects from kvstore


### PR DESCRIPTION
Fix vm status transition check bug for rebooting.

		// duplicated action
		if strings.EqualFold(vm.Status, targetStatus) {
			if !strings.EqualFold(action, model.ActionReboot) {
				return errors.New(action + " is not allowed for VM under " + vm.Status)
			}
		}