### PR TITLE
[k8scluster] support k8sclusterDynamic like mciDynamic

### DIFF
--- a/assets/cloudspec.csv
+++ b/assets/cloudspec.csv
@@ -565,11 +565,11 @@ IBM,jp-tok,bx2-2x8,0.096,34.18,,,,,,,,,,default,default,,,,,,vm
 IBM,us-east,bx2-2x8,0.096,34.18,,,,,,,,,,default,default,,,,,,vm
 IBM,us-south,bx2-2x8,0.096,34.18,,,,,,,,,,default,default,,,,,,vm
 TENCENT,all,S3.SMALL2,0.04,59.98,,,,,,,,,,default,default,,,,,,vm
-TENCENT,all,SA2.MEDIUM4,0.04,59.98,,,,,,,,,,default,default,,,,,,vm
-TENCENT,all,S2.MEDIUM4,0.04,59.98,,,,,,,,,,default,default,,,,,,vm
-TENCENT,all,S5.MEDIUM4,0.03,59.98,,,,,,,,,,default,default,,,,,,vm
-TENCENT,all,S3.MEDIUM8,0.04,59.98,,,,,,,,,,default,default,,,,,,vm
-TENCENT,all,S8.MEDIUM8,0.04,59.98,,,,,,,,,,default,default,,,,,,vm
+TENCENT,all,SA2.MEDIUM4,0.04,59.98,,,,,,,,,,default,default,,,,,,vm|k8s
+TENCENT,all,S2.MEDIUM4,0.04,59.98,,,,,,,,,,default,default,,,,,,vm|k8s
+TENCENT,all,S5.MEDIUM4,0.03,59.98,,,,,,,,,,default,default,,,,,,vm|k8s
+TENCENT,all,S3.MEDIUM8,0.04,59.98,,,,,,,,,,default,default,,,,,,vm|k8s
+TENCENT,all,S8.MEDIUM8,0.04,59.98,,,,,,,,,,default,default,,,,,,vm|k8s
 TENCENT,all,PNV4.7XLARGE116,1.71,64.18,,,,,,,,,,default,default,gpu,NVIDIA A10,1,24,,vm
 NCP,KR,SPSVRSSD00000005,,,,,,,,,,,,default,default,,,,,,vm
 NCP,KR,SPSVRSSD00000007,,,,,,,,,,,,default,default,,,,,,vm

--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -4,7 +4,9 @@
 # The file is in YAML format and contains the following fields:
 # k8scluster: Top level key
 #   <csp>: Name of the CSP
-#     nodeGroupsOnCreation:
+#     nodeGroupsOnCreation: [true/false]
+#     nodeImageDesignation: [true/false]
+#     requiredSubnetCount: [required number of subnets to create a kubernetes cluster, default value is 1]
 #     version:
 #       - region: [region1, region2, common(special keyword: most of regions)]
 #
@@ -13,6 +15,7 @@ k8scluster:
   azure:
     nodeGroupsOnCreation: true
     nodeImageDesignation: false
+    requiredSubnetCount: 1
     version:
       - region: [westeurope,westus]
         available:
@@ -43,6 +46,7 @@ k8scluster:
   gcp:
     nodeGroupsOnCreation: true
     nodeImageDesignation: true
+    requiredSubnetCount: 1
     version:
       - region: [common]
         available:
@@ -67,6 +71,7 @@ k8scluster:
   alibaba:
     nodeGroupsOnCreation: false
     nodeImageDesignation: true
+    requiredSubnetCount: 1
     version:
       # ServiceUnavailable or NotSupportedSLB
       - region: [me-east-1, cn-zhangjiakou, cn-hangzhou, cn-shenzhen, cn-chengdu, ap-south-1, ap-sourtheast-2]
@@ -90,6 +95,7 @@ k8scluster:
   nhncloud:
     nodeGroupsOnCreation: true
     nodeImageDesignation: true
+    requiredSubnetCount: 1
     version:
       - region: [kr1, kr2]
         available:
@@ -112,6 +118,7 @@ k8scluster:
   tencent:
     nodeGroupsOnCreation: false
     nodeImageDesignation: true
+    requiredSubnetCount: 1
     version:
       - region: [common]
         available:

--- a/src/api/rest/server/resource/k8scluster.go
+++ b/src/api/rest/server/resource/k8scluster.go
@@ -15,18 +15,20 @@ limitations under the License.
 package resource
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
+	"github.com/cloud-barista/cb-tumblebug/src/core/infra"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
 
-// RestGetAvailableK8sClusterVersion func is a rest api wrapper for GetAvailableK8sClusterVersion.
-// RestGetAvailableK8sClusterVersion godoc
-// @ID GetAvailableK8sClusterVersion
+// RestGetAvailableK8sVersion func is a rest api wrapper for GetAvailableK8sVersion.
+// RestGetAvailableK8sVersion godoc
+// @ID GetAvailableK8sVersion
 // @Summary Get available kubernetes cluster version
 // @Description Get available kubernetes cluster version
 // @Tags [Kubernetes] Cluster Management
@@ -37,19 +39,19 @@ import (
 // @Success 200 {object} model.K8sClusterVersionDetailAvailable
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /availableK8sClusterVersion [get]
-func RestGetAvailableK8sClusterVersion(c echo.Context) error {
+// @Router /availableK8sVersion [get]
+func RestGetAvailableK8sVersion(c echo.Context) error {
 
 	providerName := c.QueryParam("providerName")
 	regionName := c.QueryParam("regionName")
 
-	content, err := common.GetAvailableK8sClusterVersion(providerName, regionName)
+	content, err := common.GetAvailableK8sVersion(providerName, regionName)
 	return common.EndRequestWithLog(c, err, content)
 }
 
-// RestGetAvailableK8sClusterNodeImage func is a rest api wrapper for GetAvailableK8sClusterNodeImage.
-// RestGetAvailableK8sClusterNodeImage godoc
-// @ID GetAvailableK8sClusterNodeImage
+// RestGetAvailableK8sNodeImage func is a rest api wrapper for GetAvailableK8sNodeImage.
+// RestGetAvailableK8sNodeImage godoc
+// @ID GetAvailableK8sNodeImage
 // @Summary (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
 // @Description (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
 // @Tags [Kubernetes] Cluster Management
@@ -60,19 +62,19 @@ func RestGetAvailableK8sClusterVersion(c echo.Context) error {
 // @Success 200 {object} model.K8sClusterNodeImageDetailAvailable
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /availableK8sClusterNodeImage [get]
-func RestGetAvailableK8sClusterNodeImage(c echo.Context) error {
+// @Router /availableK8sNodeImage [get]
+func RestGetAvailableK8sNodeImage(c echo.Context) error {
 
 	providerName := c.QueryParam("providerName")
 	regionName := c.QueryParam("regionName")
 
-	content, err := common.GetAvailableK8sClusterNodeImage(providerName, regionName)
+	content, err := common.GetAvailableK8sNodeImage(providerName, regionName)
 	return common.EndRequestWithLog(c, err, content)
 }
 
-// RestCheckNodeGroupsOnK8sCreation func is a rest api wrapper for CheckNodeGroupsOnK8sCreation.
-// RestCheckNodeGroupsOnK8sCreation godoc
-// @ID CheckNodeGroupsOnK8sCreation
+// RestCheckK8sNodeGroupsOnK8sCreation func is a rest api wrapper for GetModelK8sNodeGroupsOnK8sCreation.
+// RestCheckK8sNodeGroupsOnK8sCreation godoc
+// @ID CheckK8sNodeGroupsOnK8sCreation
 // @Summary Check whether nodegroups are required during the k8scluster creation
 // @Description Check whether nodegroups are required during the k8scluster creation
 // @Tags [Kubernetes] Cluster Management
@@ -82,12 +84,54 @@ func RestGetAvailableK8sClusterNodeImage(c echo.Context) error {
 // @Success 200 {object} model.K8sClusterNodeGroupsOnCreation
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /checkNodeGroupsOnK8sCreation [get]
-func RestCheckNodeGroupsOnK8sCreation(c echo.Context) error {
+// @Router /checkK8sNodeGroupsOnK8sCreation [get]
+func RestCheckK8sNodeGroupsOnK8sCreation(c echo.Context) error {
 
 	providerName := c.QueryParam("providerName")
 
-	content, err := common.CheckNodeGroupsOnK8sCreation(providerName)
+	content, err := common.GetModelK8sNodeGroupsOnK8sCreation(providerName)
+	return common.EndRequestWithLog(c, err, content)
+}
+
+// RestCheckK8sNodeImageDesignation func is a rest api wrapper for GetK8sNodeImageDesignation.
+// RestCheckK8sNodeImageDesignation godoc
+// @ID CheckK8sNodeImageDesignation
+// @Summary Check whether node image designation is possible to create a k8scluster
+// @Description Check whether node image designation is possible to create a k8scluster
+// @Tags [Kubernetes] Cluster Management
+// @Accept  json
+// @Produce  json
+// @Param providerName query string true "Name of the CSP to retrieve"
+// @Success 200 {object} model.K8sClusterNodeImageDesignation
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /checkK8sNodeImageDesignation [get]
+func RestCheckK8sNodeImageDesignation(c echo.Context) error {
+
+	providerName := c.QueryParam("providerName")
+
+	content, err := common.GetModelK8sNodeImageDesignation(providerName)
+	return common.EndRequestWithLog(c, err, content)
+}
+
+// RestGetRequiredK8sSubnetCount func is a rest api wrapper for GetModelK8sRequiredSubnetCount.
+// RestGetRequiredK8sSubnetCount godoc
+// @ID GetRequiredK8sSubnetCount
+// @Summary Get the required subnet count to create a k8scluster
+// @Description Get the required subnet count to create a k8scluster
+// @Tags [Kubernetes] Cluster Management
+// @Accept  json
+// @Produce  json
+// @Param providerName query string true "Name of the CSP to retrieve"
+// @Success 200 {object} model.K8sClusterRequiredSubnetCount
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /requiredK8sSubnetCount [get]
+func RestGetRequiredK8sSubnetCount(c echo.Context) error {
+
+	providerName := c.QueryParam("providerName")
+
+	content, err := common.GetModelK8sRequiredSubnetCount(providerName)
 	return common.EndRequestWithLog(c, err, content)
 }
 
@@ -203,6 +247,7 @@ func RestPostK8sNodeGroup(c echo.Context) error {
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster-01)
 // @Param k8sNodeGroupName path string true "K8sNodeGroup Name" default(ng-01)
+// @Param option query string false "Option for K8sNodeGroup deletion" Enums(force)
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/k8scluster/{k8sClusterId}/k8snodegroup/{k8sNodeGroupName} [delete]
@@ -212,9 +257,9 @@ func RestDeleteK8sNodeGroup(c echo.Context) error {
 	k8sClusterId := c.Param("k8sClusterId")
 	k8sNodeGroupName := c.Param("k8sNodeGroupName")
 
-	forceFlag := c.QueryParam("force")
+	optionFlag := c.QueryParam("option")
 
-	res, err := resource.RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, forceFlag)
+	res, err := resource.RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, optionFlag)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		mapA := map[string]string{"message": err.Error()}
@@ -404,6 +449,7 @@ func RestGetAllK8sCluster(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster-01)
+// @Param option query string false "Option for K8sCluster deletion" Enums(force)
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/k8scluster/{k8sClusterId} [delete]
@@ -412,9 +458,9 @@ func RestDeleteK8sCluster(c echo.Context) error {
 	nsId := c.Param("nsId")
 	k8sClusterId := c.Param("k8sClusterId")
 
-	forceFlag := c.QueryParam("force")
+	optionFlag := c.QueryParam("option")
 
-	res, err := resource.DeleteK8sCluster(nsId, k8sClusterId, forceFlag)
+	res, err := resource.DeleteK8sCluster(nsId, k8sClusterId, optionFlag)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		mapA := map[string]string{"message": err.Error()}
@@ -440,6 +486,7 @@ func RestDeleteK8sCluster(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param match query string false "Delete resources containing matched ID-substring only" default()
+// @Param option query string false "Option for K8sCluster deletion" Enums(force)
 // @Success 200 {object} model.IdList
 // @Failure 404 {object} model.SimpleMsg
 // @Router /ns/{nsId}/k8scluster [delete]
@@ -447,10 +494,10 @@ func RestDeleteAllK8sCluster(c echo.Context) error {
 
 	nsId := c.Param("nsId")
 
-	forceFlag := c.QueryParam("force")
+	optionFlag := c.QueryParam("option")
 	subString := c.QueryParam("match")
 
-	output, err := resource.DeleteAllK8sCluster(nsId, subString, forceFlag)
+	output, err := resource.DeleteAllK8sCluster(nsId, subString, optionFlag)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		mapA := map[string]string{"message": err.Error()}
@@ -496,4 +543,124 @@ func RestPutUpgradeK8sCluster(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, content)
+}
+
+// RestPostK8sClusterDynamicCheckRequest godoc
+// @ID PostK8sClusterDynamicCheckRequest
+// @Summary Check available ConnectionConfig list for creating K8sCluster Dynamically
+// @Description Check available ConnectionConfig list before create K8sCluster Dynamically from common spec and image
+// @Tags [Kubernetes] Cluster Management
+// @Accept  json
+// @Produce  json
+// @Param k8sclusterReq body model.K8sClusterConnectionConfigCandidatesReq true "Details for K8sCluster dynamic request information"
+// @Success 200 {object} model.CheckK8sClusterDynamicReqInfo
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /k8sclusterDynamicCheckRequest [post]
+func RestPostK8sClusterDynamicCheckRequest(c echo.Context) error {
+
+	req := &model.K8sClusterConnectionConfigCandidatesReq{}
+	if err := c.Bind(req); err != nil {
+		return common.EndRequestWithLog(c, err, nil)
+	}
+
+	result, err := infra.CheckK8sClusterDynamicReq(req)
+	return common.EndRequestWithLog(c, err, result)
+}
+
+// RestPostK8sClusterDynamic godoc
+// @ID PostK8sClusterDynamic
+// @Summary Create K8sCluster Dynamically
+// @Description Create K8sCluster Dynamically from common spec and image
+// @Tags [Kubernetes] Cluster Management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(default)
+// @Param k8sclusterReq body model.TbK8sClusterDynamicReq true "Request body to provision K8sCluster dynamically. <br> Must include commonSpec and commonImage info. <br> (ex: {name: k8scluster-01, commonImage: azure+koreacentral+ubuntu22.04, commonSpec: azure+koreacentral+Standard_B2s}]}) <br> You can use /k8sclusterRecommendNode and /k8sclusterDynamicCheckRequest to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1570"
+// @Param option query string false "Option for K8sCluster creation" Enums(hold)
+// @Param x-request-id header string false "Custom request ID"
+// @Success 200 {object} model.TbK8sClusterInfo
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /ns/{nsId}/k8sclusterDynamic [post]
+func RestPostK8sClusterDynamic(c echo.Context) error {
+	reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+
+	nsId := c.Param("nsId")
+	optionFlag := c.QueryParam("option")
+
+	req := &model.TbK8sClusterDynamicReq{}
+	if err := c.Bind(req); err != nil {
+		log.Warn().Err(err).Msg("invalid request")
+		return common.EndRequestWithLog(c, err, nil)
+	}
+
+	result, err := infra.CreateK8sClusterDynamic(reqID, nsId, req, optionFlag)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to create K8sCluster dynamically")
+		return common.EndRequestWithLog(c, err, nil)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// RestGetControlK8sCluster godoc
+// @ID GetControlK8sCluster
+// @Summary Control the creation of K8sCluster (continue, withdraw)
+// @Description Control the creation of K8sCluster (continue, withdraw)
+// @Tags [Kubernetes] Cluster Management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(default)
+// @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster-01)
+// @Param action query string true "Action to K8sCluster" Enums(continue, withdraw)
+// @Success 200 {object} model.SimpleMsg
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /ns/{nsId}/control/k8scluster/{k8sClusterId} [get]
+func RestGetControlK8sCluster(c echo.Context) error {
+
+	nsId := c.Param("nsId")
+	k8sClusterId := c.Param("k8sClusterId")
+
+	action := c.QueryParam("action")
+	returnObj := model.SimpleMsg{}
+
+	if action == "continue" || action == "withdraw" {
+
+		resultString, err := resource.HandleK8sClusterAction(nsId, k8sClusterId, action)
+		if err != nil {
+			return common.EndRequestWithLog(c, err, returnObj)
+		}
+		returnObj.Message = resultString
+		return common.EndRequestWithLog(c, err, returnObj)
+
+	} else {
+		err := fmt.Errorf("'action' should be one of these: continue, withdraw")
+		return common.EndRequestWithLog(c, err, returnObj)
+	}
+}
+
+// RestRecommendNode godoc
+// @ID RecommendNode
+// @Summary Recommend K8sCluster's Node plan (filter and priority)
+// @Description Recommend K8sCluster's Node plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+// @Tags [Kubernetes] Cluster Management
+// @Accept  json
+// @Produce  json
+// @Param deploymentPlan body model.DeploymentPlan false "Recommend K8sCluster's Node plan (filter and priority)"
+// @Success 200 {object} []model.TbSpecInfo
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /k8sclusterRecommendNode [post]
+func RestRecommendNode(c echo.Context) error {
+
+	nsId := model.SystemCommonNs
+
+	u := &model.DeploymentPlan{}
+	if err := c.Bind(u); err != nil {
+		return common.EndRequestWithLog(c, err, nil)
+	}
+
+	content, err := infra.RecommendVm(nsId, *u)
+	return common.EndRequestWithLog(c, err, content)
 }

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -381,9 +381,11 @@ func RunServer() {
 	g.PUT("/:nsId/monitoring/status/mci/:mciId/vm/:vmId", rest_infra.RestPutMonitorAgentStatusInstalled)
 
 	// K8sCluster
-	e.GET("/tumblebug/availableK8sClusterVersion", rest_resource.RestGetAvailableK8sClusterVersion)
-	e.GET("/tumblebug/availableK8sClusterNodeImage", rest_resource.RestGetAvailableK8sClusterNodeImage)
-	e.GET("/tumblebug/checkNodeGroupsOnK8sCreation", rest_resource.RestCheckNodeGroupsOnK8sCreation)
+	e.GET("/tumblebug/availableK8sVersion", rest_resource.RestGetAvailableK8sVersion)
+	e.GET("/tumblebug/availableK8sNodeImage", rest_resource.RestGetAvailableK8sNodeImage)
+	e.GET("/tumblebug/checkK8sNodeGroupsOnK8sCreation", rest_resource.RestCheckK8sNodeGroupsOnK8sCreation)
+	e.GET("/tumblebug/checkK8sNodeImageDesignation", rest_resource.RestCheckK8sNodeImageDesignation)
+	e.GET("/tumblebug/requiredK8sSubnetCount", rest_resource.RestGetRequiredK8sSubnetCount)
 	g.POST("/:nsId/k8scluster", rest_resource.RestPostK8sCluster)
 	g.POST("/:nsId/k8scluster/:k8sClusterId/k8snodegroup", rest_resource.RestPostK8sNodeGroup)
 	g.DELETE("/:nsId/k8scluster/:k8sClusterId/k8snodegroup/:k8sNodeGroupName", rest_resource.RestDeleteK8sNodeGroup)
@@ -396,6 +398,11 @@ func RunServer() {
 	g.DELETE("/:nsId/k8scluster/:k8sClusterId", rest_resource.RestDeleteK8sCluster)
 	g.DELETE("/:nsId/k8scluster", rest_resource.RestDeleteAllK8sCluster)
 	g.PUT("/:nsId/k8scluster/:k8sClusterId/upgrade", rest_resource.RestPutUpgradeK8sCluster)
+
+	e.POST("/tumblebug/k8sclusterRecommendNode", rest_resource.RestRecommendNode)
+	e.POST("/tumblebug/k8sclusterDynamicCheckRequest", rest_resource.RestPostK8sClusterDynamicCheckRequest)
+	g.POST("/:nsId/k8sclusterDynamic", rest_resource.RestPostK8sClusterDynamic)
+	g.GET("/:nsId/control/k8scluster/:k8sClusterId", rest_resource.RestGetControlK8sCluster)
 
 	// Network Load Balancer
 	g.POST("/:nsId/mci/:mciId/mcSwNlb", rest_infra.RestPostMcNLB)

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -17,6 +17,7 @@ package infra
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -945,7 +946,7 @@ func CreateMciDynamic(reqID string, nsId string, req *model.TbMciDynamicReq, dep
 	// Check whether VM names meet requirement.
 	errStr := ""
 	for i, k := range vmRequest {
-		err = checkCommonResAvailable(&k)
+		err = checkCommonResAvailableForVmDynamicReq(&k)
 		if err != nil {
 			log.Error().Err(err).Msgf("[%d] Failed to find common resource for MCI provision", i)
 			errStr += "{[" + strconv.Itoa(i+1) + "] " + err.Error() + "} "
@@ -1012,8 +1013,8 @@ func CreateMciVmDynamic(nsId string, mciId string, req *model.TbVmDynamicReq) (*
 	return CreateMciGroupVm(nsId, mciId, vmReq, true)
 }
 
-// checkCommonResAvailable is func to check common resources availability
-func checkCommonResAvailable(req *model.TbVmDynamicReq) error {
+// checkCommonResAvailableForVmDynamicReq is func to check common resources availability for VmDynamicReq
+func checkCommonResAvailableForVmDynamicReq(req *model.TbVmDynamicReq) error {
 
 	vmRequest := req
 	// Check whether VM names meet requirement.
@@ -1618,4 +1619,372 @@ func CreateVm(wg *sync.WaitGroup, nsId string, mciId string, vmInfoData *model.T
 	}
 
 	return nil
+}
+
+func filterCheckMciDynamicReqInfoToCheckK8sClusterDynamicReqInfo(mciDReqInfo *model.CheckMciDynamicReqInfo) *model.CheckK8sClusterDynamicReqInfo {
+	k8sDReqInfo := model.CheckK8sClusterDynamicReqInfo{}
+
+	if mciDReqInfo != nil {
+		for _, k := range mciDReqInfo.ReqCheck {
+			if strings.Contains(k.Spec.InfraType, model.StrK8s) ||
+				strings.Contains(k.Spec.InfraType, model.StrKubernetes) {
+
+				imageListForK8s := []model.TbImageInfo{}
+				for _, i := range k.Image {
+					if strings.Contains(i.InfraType, model.StrK8s) ||
+						strings.Contains(i.InfraType, model.StrKubernetes) {
+						imageListForK8s = append(imageListForK8s, i)
+					}
+				}
+
+				nodeDReqInfo := model.CheckNodeDynamicReqInfo{
+					ConnectionConfigCandidates: k.ConnectionConfigCandidates,
+					Spec:                       k.Spec,
+					Image:                      imageListForK8s,
+					Region:                     k.Region,
+					SystemMessage:              k.SystemMessage,
+				}
+
+				k8sDReqInfo.ReqCheck = append(k8sDReqInfo.ReqCheck, nodeDReqInfo)
+			}
+		}
+	}
+
+	return &k8sDReqInfo
+}
+
+// CheckK8sClusterDynamicReq is func to check request info to create K8sCluster obeject and deploy requested Nodes in a dynamic way
+func CheckK8sClusterDynamicReq(req *model.K8sClusterConnectionConfigCandidatesReq) (*model.CheckK8sClusterDynamicReqInfo, error) {
+	if len(req.CommonSpecs) != 1 {
+		err := fmt.Errorf("Only one CommonSpec should be defined.")
+		log.Error().Err(err).Msg("")
+		return &model.CheckK8sClusterDynamicReqInfo{}, err
+	}
+
+	mciCCCReq := model.MciConnectionConfigCandidatesReq{
+		CommonSpecs: req.CommonSpecs,
+	}
+	mciDReqInfo, err := CheckMciDynamicReq(&mciCCCReq)
+
+	k8sDReqInfo := filterCheckMciDynamicReqInfoToCheckK8sClusterDynamicReqInfo(mciDReqInfo)
+
+	return k8sDReqInfo, err
+}
+
+func filterDigitsAndDots(input string) string {
+	re := regexp.MustCompile(`[^0-9.]`)
+	return re.ReplaceAllString(input, "")
+}
+
+func getK8sRecommendVersion(providerName, regionName, reqVersion string) (string, error) {
+	availableVersion, err := common.GetAvailableK8sVersion(providerName, regionName)
+	if err != nil {
+		err := fmt.Errorf("No available K8sCluster version.")
+		log.Error().Err(err).Msg("")
+		return "", err
+	}
+
+	recVersion := model.StrEmpty
+	versionIdList := []string{}
+	for _, verDetail := range *availableVersion {
+		versionIdList = append(versionIdList, verDetail.Id)
+		if strings.EqualFold(reqVersion, verDetail.Id) {
+			recVersion = verDetail.Id
+			break
+		} else {
+			availVersion := filterDigitsAndDots(verDetail.Id)
+			filteredReqVersion := filterDigitsAndDots(reqVersion)
+			if strings.HasPrefix(availVersion, filteredReqVersion) {
+				recVersion = availVersion
+				break
+			}
+		}
+	}
+
+	if strings.EqualFold(recVersion, model.StrEmpty) {
+		return "", fmt.Errorf("Available K8sCluster Version(k8sclusterinfo.yaml) for Provider/Region(%s/%s): %s",
+			providerName, regionName, strings.Join(versionIdList, ", "))
+	}
+
+	return recVersion, nil
+}
+
+// checkCommonResAvailableForK8sClusterDynamicReq is func to check common resources availability for K8sClusterDynamicReq
+func checkCommonResAvailableForK8sClusterDynamicReq(dReq *model.TbK8sClusterDynamicReq) error {
+	specInfo, err := resource.GetSpec(model.SystemCommonNs, dReq.CommonSpec)
+	if err != nil {
+		log.Error().Err(err).Msg("")
+		return err
+	}
+
+	connName := specInfo.ConnectionName
+	// If ConnectionName is specified by the request, Use ConnectionName from the request
+	if dReq.ConnectionName != "" {
+		connName = dReq.ConnectionName
+	}
+
+	// validate the GetConnConfig for spec
+	connConfig, err := common.GetConnConfig(connName)
+	if err != nil {
+		err := fmt.Errorf("Failed to get ConnectionName (" + connName + ") for Spec (" + dReq.CommonSpec + ") is not found.")
+		log.Error().Err(err).Msg("")
+		return err
+	}
+
+	niDesignation, err := common.GetK8sNodeImageDesignation(connConfig.ProviderName)
+	if err != nil {
+		log.Error().Err(err).Msg("")
+	}
+
+	if niDesignation == false {
+		// if node image designation is not supported by CSP, CommonImage should be "default" or ""(blank)
+		if !(strings.EqualFold(dReq.CommonImage, "default") || strings.EqualFold(dReq.CommonImage, "")) {
+			err := fmt.Errorf("The NodeImageDesignation is not supported by CSP(%s). CommonImage's value should be \"default\" or \"\"", connConfig.ProviderName)
+			log.Error().Err(err).Msg("")
+			return err
+		}
+	}
+
+	// In K8sCluster, allows dReq.CommonImage to be set to "default" or ""
+	if strings.EqualFold(dReq.CommonImage, "default") ||
+		strings.EqualFold(dReq.CommonImage, "") {
+		// do nothing
+	} else {
+		osType := strings.ReplaceAll(dReq.CommonImage, " ", "")
+		imageId := resource.GetProviderRegionZoneResourceKey(connConfig.ProviderName, connConfig.RegionDetail.RegionName, "", osType)
+		// incase of user provided image id completely (e.g. aws+ap-northeast-2+ubuntu22.04)
+		if strings.Contains(dReq.CommonImage, "+") {
+			imageId = dReq.CommonImage
+		}
+		_, err = resource.GetImage(model.SystemCommonNs, imageId)
+		if err != nil {
+			err := fmt.Errorf("Failed to get Image " + dReq.CommonImage + " from " + connName)
+			log.Error().Err(err).Msg("")
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getK8sClusterReqFromDynamicReq is func to get TbK8sClusterReq from TbK8sClusterDynamicReq
+func getK8sClusterReqFromDynamicReq(reqID string, nsId string, dReq *model.TbK8sClusterDynamicReq) (*model.TbK8sClusterReq, error) {
+	onDemand := true
+
+	emptyK8sReq := &model.TbK8sClusterReq{}
+	k8sReq := &model.TbK8sClusterReq{}
+	k8sngReq := &model.TbK8sNodeGroupReq{}
+
+	specInfo, err := resource.GetSpec(model.SystemCommonNs, dReq.CommonSpec)
+	if err != nil {
+		log.Err(err).Msg("")
+		return emptyK8sReq, err
+	}
+	k8sngReq.SpecId = specInfo.Id
+
+	k8sRecVersion, err := getK8sRecommendVersion(specInfo.ProviderName, specInfo.RegionName, dReq.Version)
+	if err != nil {
+		log.Err(err).Msg("")
+		return emptyK8sReq, err
+	}
+
+	// If ConnectionName is specified by the request, Use ConnectionName from the request
+	k8sReq.ConnectionName = specInfo.ConnectionName
+	if dReq.ConnectionName != "" {
+		k8sReq.ConnectionName = dReq.ConnectionName
+	}
+
+	// validate the GetConnConfig for spec
+	connection, err := common.GetConnConfig(k8sReq.ConnectionName)
+	if err != nil {
+		err := fmt.Errorf("Failed to Get ConnectionName (" + k8sReq.ConnectionName + ") for Spec (" + dReq.CommonSpec + ") is not found.")
+		log.Err(err).Msg("")
+		return emptyK8sReq, err
+	}
+
+	k8sNgOnCreation, err := common.GetK8sNodeGroupsOnK8sCreation(connection.ProviderName)
+	if err != nil {
+		log.Err(err).Msgf("Failed to Get Nodegroups on K8sCluster Creation")
+		return emptyK8sReq, err
+	}
+
+	// In K8sCluster, allows dReq.CommonImage to be set to "default" or ""
+	if strings.EqualFold(dReq.CommonImage, "default") ||
+		strings.EqualFold(dReq.CommonImage, "") {
+		// do nothing
+	} else {
+		osType := strings.ReplaceAll(dReq.CommonImage, " ", "")
+		k8sngReq.ImageId = resource.GetProviderRegionZoneResourceKey(connection.ProviderName, connection.RegionDetail.RegionName, "", osType)
+		// incase of user provided image id completely (e.g. aws+ap-northeast-2+ubuntu22.04)
+		if strings.Contains(dReq.CommonImage, "+") {
+			k8sngReq.ImageId = dReq.CommonImage
+		}
+		_, err = resource.GetImage(model.SystemCommonNs, k8sngReq.ImageId)
+		if err != nil {
+			err := fmt.Errorf("Failed to get the Image " + k8sngReq.ImageId + " from " + k8sReq.ConnectionName)
+			log.Err(err).Msg("")
+			return emptyK8sReq, err
+		}
+	}
+	// Default resource name has this pattern (nsId + "-shared-" + vmReq.ConnectionName)
+	resourceName := nsId + model.StrSharedResourceName + k8sReq.ConnectionName
+
+	common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Setting vNet:" + resourceName, Time: time.Now()})
+
+	k8sReq.VNetId = resourceName
+	_, err = resource.GetResource(nsId, model.StrVNet, k8sReq.VNetId)
+	if err != nil {
+		if !onDemand {
+			err := fmt.Errorf("Failed to get the vNet " + k8sReq.VNetId + " from " + k8sReq.ConnectionName)
+			log.Err(err).Msg("Failed to get the vNet")
+			return emptyK8sReq, err
+		}
+
+		common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Loading default vNet:" + resourceName, Time: time.Now()})
+
+		err2 := resource.CreateSharedResource(nsId, model.StrVNet, k8sReq.ConnectionName)
+		if err2 != nil {
+			log.Err(err2).Msg("Failed to create new default vNet " + k8sReq.VNetId + " from " + k8sReq.ConnectionName)
+			return emptyK8sReq, err2
+		} else {
+			log.Info().Msg("Created new default vNet: " + k8sReq.VNetId)
+		}
+	} else {
+		log.Info().Msg("Found and utilize default vNet: " + k8sReq.VNetId)
+	}
+	k8sReq.SubnetIds = append(k8sReq.SubnetIds, resourceName)
+	k8sReq.SubnetIds = append(k8sReq.SubnetIds, resourceName+"-01")
+
+	common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Setting SSHKey:" + resourceName, Time: time.Now()})
+
+	k8sngReq.SshKeyId = resourceName
+	_, err = resource.GetResource(nsId, model.StrSSHKey, k8sngReq.SshKeyId)
+	if err != nil {
+		if !onDemand {
+			err := fmt.Errorf("Failed to get the SSHKey " + k8sngReq.SshKeyId + " from " + k8sReq.ConnectionName)
+			log.Err(err).Msg("Failed to get the SSHKey")
+			return emptyK8sReq, err
+		}
+
+		common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Loading default SSHKey:" + resourceName, Time: time.Now()})
+
+		err2 := resource.CreateSharedResource(nsId, model.StrSSHKey, k8sReq.ConnectionName)
+		if err2 != nil {
+			log.Err(err2).Msg("Failed to create new default SSHKey " + k8sngReq.SshKeyId + " from " + k8sReq.ConnectionName)
+			return emptyK8sReq, err2
+		} else {
+			log.Info().Msg("Created new default SSHKey: " + k8sReq.VNetId)
+		}
+	} else {
+		log.Info().Msg("Found and utilize default SSHKey: " + k8sReq.VNetId)
+	}
+
+	common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Setting securityGroup:" + resourceName, Time: time.Now()})
+
+	securityGroup := resourceName
+	k8sReq.SecurityGroupIds = append(k8sReq.SecurityGroupIds, securityGroup)
+	_, err = resource.GetResource(nsId, model.StrSecurityGroup, securityGroup)
+	if err != nil {
+		if !onDemand {
+			err := fmt.Errorf("Failed to get the securityGroup " + securityGroup + " from " + k8sReq.ConnectionName)
+			log.Err(err).Msg("Failed to get the securityGroup")
+			return emptyK8sReq, err
+		}
+
+		common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Loading default securityGroup:" + resourceName, Time: time.Now()})
+
+		err2 := resource.CreateSharedResource(nsId, model.StrSecurityGroup, k8sReq.ConnectionName)
+		if err2 != nil {
+			log.Err(err2).Msg("Failed to create new default securityGroup " + securityGroup + " from " + k8sReq.ConnectionName)
+			return emptyK8sReq, err2
+		} else {
+			log.Info().Msg("Created new default securityGroup: " + securityGroup)
+		}
+	} else {
+		log.Info().Msg("Found and utilize default securityGroup: " + securityGroup)
+	}
+
+	k8sngReq.Name = dReq.NodeGroupName
+	if k8sngReq.Name == "" {
+		k8sngReq.Name = common.GenUid()
+	}
+	k8sngReq.RootDiskType = dReq.RootDiskType
+	k8sngReq.RootDiskSize = dReq.RootDiskSize
+	k8sngReq.OnAutoScaling = dReq.OnAutoScaling
+	k8sngReq.DesiredNodeSize = dReq.DesiredNodeSize
+	k8sngReq.MinNodeSize = dReq.MinNodeSize
+	k8sngReq.MaxNodeSize = dReq.MaxNodeSize
+
+	k8sReq.Description = dReq.Description
+	k8sReq.Name = dReq.Name
+	if k8sReq.Name == "" {
+		k8sReq.Name = common.GenUid()
+	}
+	k8sReq.Version = k8sRecVersion
+	if k8sNgOnCreation {
+		k8sReq.K8sNodeGroupList = append(k8sReq.K8sNodeGroupList, *k8sngReq)
+	} else {
+		log.Info().Msg("Need to Add NodeGroups To Use This K8sCluster")
+	}
+	k8sReq.Label = dReq.Label
+
+	common.PrintJsonPretty(k8sReq)
+	common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Prepared resources for K8sCluster:" + k8sReq.Name, Info: k8sReq, Time: time.Now()})
+
+	return k8sReq, nil
+}
+
+// CreateK8sClusterDynamic is func to create K8sCluster obeject and deploy requested K8sCluster and NodeGroup in a dynamic way
+func CreateK8sClusterDynamic(reqID string, nsId string, dReq *model.TbK8sClusterDynamicReq, deployOption string) (*model.TbK8sClusterInfo, error) {
+	emptyK8sCluster := &model.TbK8sClusterInfo{}
+	err := common.CheckString(nsId)
+	if err != nil {
+		log.Err(err).Msg("")
+		return emptyK8sCluster, err
+	}
+	check, err := resource.CheckK8sCluster(nsId, dReq.Name)
+	if err != nil {
+		log.Err(err).Msg("")
+		return emptyK8sCluster, err
+	}
+	if check {
+		err := fmt.Errorf("already exists")
+		log.Err(err).Msgf("Failed to Create K8sCluster(%s) Dynamically", dReq.Name)
+		return emptyK8sCluster, err
+	}
+
+	err = checkCommonResAvailableForK8sClusterDynamicReq(dReq)
+	if err != nil {
+		log.Err(err).Msgf("Failed to find common resource for K8sCluster provision")
+		return emptyK8sCluster, err
+	}
+
+	//If not, generate default resources dynamically.
+	k8sReq, err := getK8sClusterReqFromDynamicReq(reqID, nsId, dReq)
+	if err != nil {
+		log.Err(err).Msg("Failed to prefare resources for dynamic K8sCluster creation")
+		// Rollback created default resources
+		time.Sleep(5 * time.Second)
+		log.Info().Msg("Try rollback created default resources")
+		rollbackResult, rollbackErr := resource.DelAllSharedResources(nsId)
+		if rollbackErr != nil {
+			err = fmt.Errorf("Failed in rollback operation: %w", rollbackErr)
+		} else {
+			ids := strings.Join(rollbackResult.IdList, ", ")
+			err = fmt.Errorf("Rollback results [%s]: %w", ids, err)
+		}
+		return emptyK8sCluster, err
+	}
+
+	common.PrintJsonPretty(k8sReq)
+	common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Prepared all resources for provisioning K8sCluster:" + k8sReq.Name, Info: k8sReq, Time: time.Now()})
+	common.UpdateRequestProgress(reqID, common.ProgressInfo{Title: "Start provisioning", Time: time.Now()})
+
+	// Run create K8sCluster with the generated K8sCluster request (option != register)
+	option := "create"
+	if deployOption == "hold" {
+		option = "hold"
+	}
+
+	return resource.CreateK8sCluster(nsId, k8sReq, option)
 }

--- a/src/core/model/config.go
+++ b/src/core/model/config.go
@@ -61,9 +61,19 @@ type K8sClusterNodeGroupsOnCreation struct {
 	Result string `json:"result" example:"true"`
 }
 
+type K8sClusterNodeImageDesignation struct {
+	Result string `json:"result" example:"true"`
+}
+
+type K8sClusterRequiredSubnetCount struct {
+	Result string `json:"result" example:"1"`
+}
+
 // K8sClusterDetail is structure for kubernetes cluster detail information
 type K8sClusterDetail struct {
 	NodeGroupsOnCreation bool                        `mapstructure:"nodeGroupsOnCreation" json:"nodegroups_on_creation"`
+	NodeImageDesignation bool                        `mapstructure:"nodeImageDesignation" json:"node_image_designation"`
+	RequiredSubnetCount  int                         `mapstructure:"requiredSubnetCount" json:"required_subnet_count"`
 	Version              []K8sClusterVersionDetail   `mapstructure:"version" json:"versions"`
 	NodeImage            []K8sClusterNodeImageDetail `mapstructure:"nodeImage" json:"node_images"`
 	RootDisk             []K8sClusterRootDiskDetail  `mapstructure:"rootDisk" json:"root_disks"`

--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -96,6 +96,12 @@ type TbK8sClusterReq struct { // Tumblebug
 	// Fields for "Register existing K8sCluster" feature
 	// @description CspResourceId is required to register a k8s cluster from CSP (option=register)
 	CspResourceId string `json:"cspResourceId" example:"required when option is register"`
+
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
+
+	// SystemLabel is for describing the k8scluster in a keyword (any string can be used) for special System purpose
+	SystemLabel string `json:"systemLabel" example:"" default:""`
 }
 
 // 2023-11-13 https://github.com/cloud-barista/cb-spider/blob/fa4bd91fdaa6bb853ea96eca4a7b4f58a2abebf2/api-runtime/rest-runtime/ClusterRest.go#L441
@@ -449,4 +455,65 @@ type SpiderAddonsInfo struct {
 // TbK8sAddonsInfo is a struct to handle K8sCluster Addons information from the CB-Tumblebug's REST API response
 type TbK8sAddonsInfo struct {
 	KeyValueList []KeyValue `json:"keyValueList"`
+}
+
+// K8sClusterConnectionConfigCandidatesReq is struct for a request to check requirements to create a new K8sCluster instance dynamically (with default resource option)
+type K8sClusterConnectionConfigCandidatesReq struct {
+	// CommonSpec is field for id of a spec in common namespace
+	CommonSpecs []string `json:"commonSpec" validate:"required" example:"azure+koreacentral+Standard_B2s"`
+}
+
+// CheckK8sClusterDynamicReqInfo is struct to check requirements to create a new K8sCluster instance dynamically (with default resource option)
+type CheckK8sClusterDynamicReqInfo struct {
+	ReqCheck []CheckNodeDynamicReqInfo `json:"reqCheck" validate:"required"`
+}
+
+// CheckNodeDynamicReqInfo is struct to check requirements to create a new server instance dynamically (with default resource option)
+type CheckNodeDynamicReqInfo struct {
+
+	// ConnectionConfigCandidates will provide ConnectionConfig options
+	ConnectionConfigCandidates []string `json:"connectionConfigCandidates" default:""`
+
+	Spec   TbSpecInfo    `json:"spec" default:""`
+	Image  []TbImageInfo `json:"image" default:""`
+	Region RegionDetail  `json:"region" default:""`
+
+	// Latest system message such as error message
+	SystemMessage string `json:"systemMessage" example:"Failed because ..." default:""` // systeam-given string message
+
+}
+
+// TbK8sClusterDynamicReq is struct for requirements to create K8sCluster dynamically (with default resource option)
+type TbK8sClusterDynamicReq struct {
+	// K8sCluster name if it is not empty.
+	Name string `json:"name" validate:"required" example:"k8scluster-01"`
+
+	// K8s Clsuter version
+	Version string `json:"version" example:"1.29"`
+
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
+
+	Description string `json:"description" example:"Description"`
+
+	// NodeGroup name if it is not empty
+	NodeGroupName string `json:"nodeGroupName" example:"nodegroup-01"`
+
+	// CommonSpec is field for id of a spec in common namespace
+	CommonSpec string `json:"commonSpec" validate:"required" example:"azure+koreacentral+standard_b2s"`
+
+	// CommonImage is field for id of a image in common namespace
+	CommonImage string `json:"commonImage" validate:"required" example:"default, azure+koreacentrall+ubuntu20.04"`
+
+	RootDiskType string `json:"rootDiskType,omitempty" example:"default, TYPE1, ..." default:"default"`  // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_essd"], TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]
+	RootDiskSize string `json:"rootDiskSize,omitempty" example:"default, 30, 42, ..." default:"default"` // "default", Integer (GB): ["50", ..., "1000"]
+
+	OnAutoScaling   string `json:"onAutoScaling,omitempty" default:"true" example:"true"`
+	DesiredNodeSize string `json:"desiredNodeSize,omitempty" default:"1" example:"1"`
+	MinNodeSize     string `json:"minNodeSize,omitempty" default:"1" example:"1"`
+	MaxNodeSize     string `json:"maxNodeSize,omitempty" default:"2" example:"3"`
+
+	// if ConnectionName is given, the VM tries to use associtated credential.
+	// if not, it will use predefined ConnectionName in Spec objects
+	ConnectionName string `json:"connectionName,omitempty" default:"azure-koreacentral"`
 }


### PR DESCRIPTION
본 PR은 K8s를 대상으로 mciDynamic과 유사한 k8sclusterDynamic API를 제공하며, 일부 API 이름이 변경되었습니다.


o API changes
  - (rename) /tumblebug/availableK8sClusterVersion to availableK8sVersion
  - (rename) /tumblebug/availableK8sClusterNodeImage to availableK8sNodeImage
  - (rename) /checkNodeGroupsOnK8sCreation to checkK8sNodeGroupsOnK8sCreation
  - (add) /requiredK8sSubnetCount
    K8s 생성시 CSP별 필요한 서브넷 수의 차이를 파악하기 위해 assets/k8sclusterinfo.yaml에 이와 관련된 값을 기록하고 K8s 생성시 참조하고 있습니다.
  - (add) /k8sclusterDynamicCheckRequest
    /mciDynamicCheckRequest와 유사한 기능을 수행하며, 하나의 CommonSpec만을 허용합니다.
  - (add) /ns/{nsId}/k8sclusterDynamic
    /mciDynamic과 유사하게 K8sCluster 생성 요청시 shared resource를 자동으로 생성한 후 K8sCluster를 생성하며, hold 옵션을 사용하는 경우 K8sCluster 생성을 대기합니다.
  - (add) /ns/{nsId}/control/k8scluster/{k8sClusterId}
    생성 대기 중인 K8sCluster에 대해 생성을 시작할지(continue), 생성을 포기할지(withdraw)를 결정합니다.
  - (add) /k8sclusterRecommendNode
     /mciRecommendVm과 유사한 기능으로 K8sCluster를 지원할 수 있는 Spec들에 대해 조건 검색을 수행합니다.