### PR TITLE
FEAT: [k8scluster] support k8snodegroupDynamic

### DIFF
--- a/conf/cloud_conf.yaml
+++ b/conf/cloud_conf.yaml
@@ -16,7 +16,7 @@ cloud:
       timeout: "-1"
       threshold: "3"
     k8scluster:
-      enable: "n"
+      enable: "y"
   azure:
     enable: "y"
     nlb:

--- a/src/api/rest/server/resource/k8scluster.go
+++ b/src/api/rest/server/resource/k8scluster.go
@@ -75,8 +75,8 @@ func RestGetAvailableK8sNodeImage(c echo.Context) error {
 // RestCheckK8sNodeGroupsOnK8sCreation func is a rest api wrapper for GetModelK8sNodeGroupsOnK8sCreation.
 // RestCheckK8sNodeGroupsOnK8sCreation godoc
 // @ID CheckK8sNodeGroupsOnK8sCreation
-// @Summary Check whether nodegroups are required during the k8scluster creation
-// @Description Check whether nodegroups are required during the k8scluster creation
+// @Summary Check whether nodegroups are required during the K8sCluster creation
+// @Description Check whether nodegroups are required during the K8sCluster creation
 // @Tags [Kubernetes] Cluster Management
 // @Accept  json
 // @Produce  json
@@ -96,8 +96,8 @@ func RestCheckK8sNodeGroupsOnK8sCreation(c echo.Context) error {
 // RestCheckK8sNodeImageDesignation func is a rest api wrapper for GetK8sNodeImageDesignation.
 // RestCheckK8sNodeImageDesignation godoc
 // @ID CheckK8sNodeImageDesignation
-// @Summary Check whether node image designation is possible to create a k8scluster
-// @Description Check whether node image designation is possible to create a k8scluster
+// @Summary Check whether node image designation is possible to create a K8sCluster
+// @Description Check whether node image designation is possible to create a K8sCluster
 // @Tags [Kubernetes] Cluster Management
 // @Accept  json
 // @Produce  json
@@ -117,8 +117,8 @@ func RestCheckK8sNodeImageDesignation(c echo.Context) error {
 // RestGetRequiredK8sSubnetCount func is a rest api wrapper for GetModelK8sRequiredSubnetCount.
 // RestGetRequiredK8sSubnetCount godoc
 // @ID GetRequiredK8sSubnetCount
-// @Summary Get the required subnet count to create a k8scluster
-// @Description Get the required subnet count to create a k8scluster
+// @Summary Get the required subnet count to create a K8sCluster
+// @Description Get the required subnet count to create a K8sCluster
 // @Tags [Kubernetes] Cluster Management
 // @Accept  json
 // @Produce  json
@@ -149,7 +149,7 @@ func RestGetRequiredK8sSubnetCount(c echo.Context) error {
 // @Success 200 {object} model.TbK8sClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster [post]
+// @Router /ns/{nsId}/k8sCluster [post]
 func RestPostK8sCluster(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -190,7 +190,7 @@ func RestPostK8sCluster(c echo.Context) error {
 // @Success 200 {object} model.TbK8sClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster/{k8sClusterId} [put]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId} [put]
 */
 func RestPutK8sCluster(c echo.Context) error {
 	// nsId := c.Param("nsId")
@@ -212,7 +212,7 @@ func RestPutK8sCluster(c echo.Context) error {
 // @Success 200 {object} model.TbK8sClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster/{k8sClusterId}/k8snodegroup [post]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup [post]
 func RestPostK8sNodeGroup(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -246,11 +246,11 @@ func RestPostK8sNodeGroup(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster-01)
-// @Param k8sNodeGroupName path string true "K8sNodeGroup Name" default(ng-01)
+// @Param k8sNodeGroupName path string true "K8sNodeGroup Name" default(k8snodegroup-01)
 // @Param option query string false "Option for K8sNodeGroup deletion" Enums(force)
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster/{k8sClusterId}/k8snodegroup/{k8sNodeGroupName} [delete]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName} [delete]
 func RestDeleteK8sNodeGroup(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -291,7 +291,7 @@ func RestDeleteK8sNodeGroup(c echo.Context) error {
 // @Success 200 {object} model.TbSetK8sNodeGroupAutoscalingRes
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster/{k8sClusterId}/k8snodegroup/{k8sNodeGroupName}/onautoscaling [put]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoScaling [put]
 func RestPutSetK8sNodeGroupAutoscaling(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -331,7 +331,7 @@ func RestPutSetK8sNodeGroupAutoscaling(c echo.Context) error {
 // @Success 200 {object} model.TbChangeK8sNodeGroupAutoscaleSizeRes
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster/{k8sClusterId}/k8snodegroup/{k8sNodeGroupName}/autoscalesize [put]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize [put]
 func RestPutChangeK8sNodeGroupAutoscaleSize(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -369,7 +369,7 @@ func RestPutChangeK8sNodeGroupAutoscaleSize(c echo.Context) error {
 // @Success 200 {object} model.TbK8sClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster/{k8sClusterId} [get]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId} [get]
 func RestGetK8sCluster(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -403,7 +403,7 @@ type RestGetAllK8sClusterResponse struct {
 // @Success 200 {object} JSONResult{[DEFAULT]=RestGetAllK8sClusterResponse,[ID]=model.IdList} "Different return structures by the given option param"
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster [get]
+// @Router /ns/{nsId}/k8sCluster [get]
 func RestGetAllK8sCluster(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -452,7 +452,7 @@ func RestGetAllK8sCluster(c echo.Context) error {
 // @Param option query string false "Option for K8sCluster deletion" Enums(force)
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster/{k8sClusterId} [delete]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId} [delete]
 func RestDeleteK8sCluster(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -489,7 +489,7 @@ func RestDeleteK8sCluster(c echo.Context) error {
 // @Param option query string false "Option for K8sCluster deletion" Enums(force)
 // @Success 200 {object} model.IdList
 // @Failure 404 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster [delete]
+// @Router /ns/{nsId}/k8sCluster [delete]
 func RestDeleteAllK8sCluster(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -521,7 +521,7 @@ func RestDeleteAllK8sCluster(c echo.Context) error {
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8scluster/{k8sClusterId}/upgrade [put]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade [put]
 func RestPutUpgradeK8sCluster(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -552,11 +552,11 @@ func RestPutUpgradeK8sCluster(c echo.Context) error {
 // @Tags [Kubernetes] Cluster Management
 // @Accept  json
 // @Produce  json
-// @Param k8sclusterReq body model.K8sClusterConnectionConfigCandidatesReq true "Details for K8sCluster dynamic request information"
+// @Param k8sClusterConnectionConfigCandidatesReq body model.K8sClusterConnectionConfigCandidatesReq true "Details for K8sCluster dynamic request information"
 // @Success 200 {object} model.CheckK8sClusterDynamicReqInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /k8sclusterDynamicCheckRequest [post]
+// @Router /k8sClusterDynamicCheckRequest [post]
 func RestPostK8sClusterDynamicCheckRequest(c echo.Context) error {
 
 	req := &model.K8sClusterConnectionConfigCandidatesReq{}
@@ -576,13 +576,13 @@ func RestPostK8sClusterDynamicCheckRequest(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
-// @Param k8sclusterReq body model.TbK8sClusterDynamicReq true "Request body to provision K8sCluster dynamically. <br> Must include commonSpec and commonImage info. <br> (ex: {name: k8scluster-01, commonImage: azure+koreacentral+ubuntu22.04, commonSpec: azure+koreacentral+Standard_B2s}]}) <br> You can use /k8sclusterRecommendNode and /k8sclusterDynamicCheckRequest to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
+// @Param k8sClusterDyanmicReq body model.TbK8sClusterDynamicReq true "Request body to provision K8sCluster dynamically. <br> Must include commonSpec and commonImage info. <br> (ex: {name: k8scluster-01, commonImage: azure+koreacentral+ubuntu22.04, commonSpec: azure+koreacentral+Standard_B2s}]}) <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
 // @Param option query string false "Option for K8sCluster creation" Enums(hold)
 // @Param x-request-id header string false "Custom request ID"
 // @Success 200 {object} model.TbK8sClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8sclusterDynamic [post]
+// @Router /ns/{nsId}/k8sClusterDynamic [post]
 func RestPostK8sClusterDynamic(c echo.Context) error {
 	reqID := c.Request().Header.Get(echo.HeaderXRequestID)
 
@@ -603,6 +603,42 @@ func RestPostK8sClusterDynamic(c echo.Context) error {
 	return c.JSON(http.StatusOK, result)
 }
 
+// RestPostK8sNodeGroupDynamic godoc
+// @ID PostK8sNodeGroupDynamic
+// @Summary Create K8sNodeGroup Dynamically
+// @Description Create K8sNodeGroup Dynamically from common spec and image
+// @Tags [Kubernetes] Cluster Management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(default)
+// @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster-01)
+// @Param k8sNodeGroupDynamicReq body model.TbK8sNodeGroupDynamicReq true "Request body to provision K8sNodeGroup dynamically. <br> Must include commonSpec and commonImage info. <br> (ex: {name: k8snodegroup-01, commonImage: azure+koreacentral+ubuntu22.04, commonSpec: azure+koreacentral+Standard_B2s}]}) <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
+// @Param x-request-id header string false "Custom request ID"
+// @Success 200 {object} model.TbK8sNodeGroupInfo
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic [post]
+func RestPostK8sNodeGroupDynamic(c echo.Context) error {
+	reqID := c.Request().Header.Get(echo.HeaderXRequestID)
+
+	nsId := c.Param("nsId")
+	k8sClusterId := c.Param("k8sClusterId")
+
+	req := &model.TbK8sNodeGroupDynamicReq{}
+	if err := c.Bind(req); err != nil {
+		log.Warn().Err(err).Msg("invalid request")
+		return common.EndRequestWithLog(c, err, nil)
+	}
+
+	log.Debug().Msgf("reqID: %s, nsId: %s, k8sClusterId: %s, req: %v\n", reqID, nsId, k8sClusterId, req)
+	result, err := infra.CreateK8sNodeGroupDynamic(reqID, nsId, k8sClusterId, req)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to create K8sNodeGroup dynamically")
+		return common.EndRequestWithLog(c, err, nil)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
 // RestGetControlK8sCluster godoc
 // @ID GetControlK8sCluster
 // @Summary Control the creation of K8sCluster (continue, withdraw)
@@ -616,7 +652,7 @@ func RestPostK8sClusterDynamic(c echo.Context) error {
 // @Success 200 {object} model.SimpleMsg
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/control/k8scluster/{k8sClusterId} [get]
+// @Router /ns/{nsId}/control/k8sCluster/{k8sClusterId} [get]
 func RestGetControlK8sCluster(c echo.Context) error {
 
 	nsId := c.Param("nsId")
@@ -651,7 +687,7 @@ func RestGetControlK8sCluster(c echo.Context) error {
 // @Success 200 {object} []model.TbSpecInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /k8sclusterRecommendNode [post]
+// @Router /k8sClusterRecommendNode [post]
 func RestRecommendK8sNode(c echo.Context) error {
 
 	nsId := model.SystemCommonNs

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -402,6 +402,7 @@ func RunServer() {
 	e.POST("/tumblebug/k8sclusterRecommendNode", rest_resource.RestRecommendK8sNode)
 	e.POST("/tumblebug/k8sclusterDynamicCheckRequest", rest_resource.RestPostK8sClusterDynamicCheckRequest)
 	g.POST("/:nsId/k8sclusterDynamic", rest_resource.RestPostK8sClusterDynamic)
+	g.POST("/:nsId/k8scluster/:k8sClusterId/k8snodegroupDynamic", rest_resource.RestPostK8sNodeGroupDynamic)
 	g.GET("/:nsId/control/k8scluster/:k8sClusterId", rest_resource.RestGetControlK8sCluster)
 
 	// Network Load Balancer

--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -131,7 +131,7 @@ type SpiderNodeGroupReqInfo struct {
 
 // TbK8sNodeGroupReq is a struct to handle requests related to K8sNodeGroup toward CB-Tumblebug.
 type TbK8sNodeGroupReq struct {
-	Name         string `json:"name" example:"ng-01"`
+	Name         string `json:"name" example:"k8snodegroup-01"`
 	ImageId      string `json:"imageId" example:"image-01"`
 	SpecId       string `json:"specId" example:"spec-01"`
 	RootDiskType string `json:"rootDiskType" example:"cloud_essd" enum:"default, TYPE1, ..."` // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_ssd"], TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]
@@ -143,6 +143,11 @@ type TbK8sNodeGroupReq struct {
 	DesiredNodeSize string `json:"desiredNodeSize" example:"1"`
 	MinNodeSize     string `json:"minNodeSize" example:"1"`
 	MaxNodeSize     string `json:"maxNodeSize" example:"3"`
+
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label"`
+
+	Description string `json:"description" example:"Description"`
 }
 
 // SpiderSetAutoscalingReq is a wrapper struct to create JSON body of 'Set Autoscaling On/Off' request.
@@ -489,15 +494,15 @@ type TbK8sClusterDynamicReq struct {
 	Name string `json:"name" validate:"required" example:"k8scluster-01"`
 
 	// K8s Clsuter version
-	Version string `json:"version" example:"1.29"`
+	Version string `json:"version,omitempty" example:"1.29"`
 
 	// Label is for describing the object by keywords
-	Label map[string]string `json:"label"`
+	Label map[string]string `json:"label,omitempty"`
 
-	Description string `json:"description" example:"Description"`
+	Description string `json:"description,omitempty" example:"Description"`
 
 	// NodeGroup name if it is not empty
-	NodeGroupName string `json:"nodeGroupName" example:"nodegroup-01"`
+	NodeGroupName string `json:"nodeGroupName,omitempty" example:"k8snodegroup-01"`
 
 	// CommonSpec is field for id of a spec in common namespace
 	CommonSpec string `json:"commonSpec" validate:"required" example:"tencent+ap-seoul+S2.MEDIUM4"`
@@ -516,4 +521,29 @@ type TbK8sClusterDynamicReq struct {
 	// if ConnectionName is given, the VM tries to use associtated credential.
 	// if not, it will use predefined ConnectionName in Spec objects
 	ConnectionName string `json:"connectionName,omitempty" default:"tencent-ap-seoul"`
+}
+
+// TbK8sNodeGroupDynamicReq is struct for requirements to create K8sNodeGroup dynamically (with default resource option)
+type TbK8sNodeGroupDynamicReq struct {
+	// K8sNodeGroup name if it is not empty.
+	Name string `json:"name" validate:"required" example:"k8snodegroup-01"`
+
+	// Label is for describing the object by keywords
+	Label map[string]string `json:"label,omitempty"`
+
+	Description string `json:"description,omitempty" example:"Description"`
+
+	// CommonSpec is field for id of a spec in common namespace
+	CommonSpec string `json:"commonSpec" validate:"required" example:"tencent+ap-seoul+S2.MEDIUM4"`
+
+	// CommonImage is field for id of a image in common namespace
+	CommonImage string `json:"commonImage" validate:"required" example:"default, tencent+ap-seoul+ubuntu20.04"`
+
+	RootDiskType string `json:"rootDiskType,omitempty" example:"default, TYPE1, ..." default:"default"`  // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_essd"], TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]
+	RootDiskSize string `json:"rootDiskSize,omitempty" example:"default, 30, 42, ..." default:"default"` // "default", Integer (GB): ["50", ..., "1000"]
+
+	OnAutoScaling   string `json:"onAutoScaling,omitempty" default:"true" example:"true"`
+	DesiredNodeSize string `json:"desiredNodeSize,omitempty" default:"1" example:"1"`
+	MinNodeSize     string `json:"minNodeSize,omitempty" default:"1" example:"1"`
+	MaxNodeSize     string `json:"maxNodeSize,omitempty" default:"2" example:"3"`
 }

--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -1884,14 +1884,21 @@ func CreateSharedResource(nsId string, resType string, connectionName string) er
 
 			// Consist 2 subnets (10.i.0.0/18, 10.i.64.0/18)
 			// Reserve spaces for tentative 2 subnets (10.i.128.0/18, 10.i.192.0/18)
+			zones, length, _ := GetFirstNZones(connectionName, 2)
 			subnetName := reqTmp.Name
 			subnetCidr := "10." + strconv.Itoa(sliceIndex) + ".0.0/18"
 			subnet := model.TbSubnetReq{Name: subnetName, IPv4_CIDR: subnetCidr}
+			if length > 0 {
+				subnet.Zone = zones[0]
+			}
 			reqTmp.SubnetInfoList = append(reqTmp.SubnetInfoList, subnet)
 
 			subnetName = reqTmp.Name + "-01"
 			subnetCidr = "10." + strconv.Itoa(sliceIndex) + ".64.0/18"
 			subnet = model.TbSubnetReq{Name: subnetName, IPv4_CIDR: subnetCidr}
+			if length > 1 {
+				subnet.Zone = zones[1]
+			}
 			reqTmp.SubnetInfoList = append(reqTmp.SubnetInfoList, subnet)
 
 			common.PrintJsonPretty(reqTmp)


### PR DESCRIPTION
본 PR은 k8sclusterDynamic API를 통해 생성한 k8scluster를 대상으로 k8snodegroup을 동적으로 생성할 수 있는 k8snodegroupDynamic API를 지원합니다.

o API changes
  - (add) /ns/{nsId}/k8snodegroupDynamic

o others
  - enable aws for k8scluster
  - fix some bugs related to k8sclusterDynamic
  - when creating shared subnets, try to assign different zone