### PR TITLE
Refactor label removal to use DeleteLabelObject function

### DIFF
--- a/src/core/common/label/label.go
+++ b/src/core/common/label/label.go
@@ -103,6 +103,12 @@ func RemoveLabel(labelType, uid, key string) error {
 		return err
 	}
 
+	if labelData == "" {
+		err = fmt.Errorf("does not exist, label object for %s", labelKey)
+		log.Warn().Msg(err.Error())
+		return err
+	}
+
 	var labelInfo model.LabelInfo
 	err = json.Unmarshal([]byte(labelData), &labelInfo)
 	if err != nil {

--- a/src/core/resource/sqlDb.go
+++ b/src/core/resource/sqlDb.go
@@ -942,8 +942,8 @@ func DeleteSqlDb(nsId string, sqlDbId string) (model.SimpleMsg, error) {
 		return emptyRet, err
 	}
 
-	// Remove label info using RemoveLabel
-	err = label.RemoveLabel(model.StrSqlDB, sqlDBInfo.Uid, sqlDbKey)
+	// Remove label info using DeleteLabelObject
+	err = label.DeleteLabelObject(model.StrSqlDB, sqlDBInfo.Uid)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -908,12 +908,12 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 		return emptyRet, err
 	}
 
-	// Remove label info using RemoveLabel
+	// Remove label info using DeleteLabelObject
 	// labels := map[string]string{
 	// 	model.LabelManager:  model.StrManager,
 	// 	"namespace": nsId,
 	// }
-	err = label.RemoveLabel(model.StrVNet, vNetInfo.Uid, vNetKey)
+	err = label.DeleteLabelObject(model.StrVNet, vNetInfo.Uid)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -1066,7 +1066,7 @@ func RefineVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 			// return emptyRet, err
 		}
 
-		err = label.RemoveLabel(model.StrSubnet, vNetInfo.Uid, subnetKv.Key)
+		err = label.DeleteLabelObject(model.StrSubnet, vNetInfo.Uid)
 		if err != nil {
 			log.Warn().Err(err).Msg("")
 			// return emptyRet, err
@@ -1080,12 +1080,12 @@ func RefineVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 		// return emptyRet, err
 	}
 
-	// Remove label info using RemoveLabel
+	// Remove label info using DeleteLabelObject
 	// labels := map[string]string{
 	// 	"sys.manager":  model.StrManager,
 	// 	"namespace": nsId,
 	// }
-	err = label.RemoveLabel(model.StrVNet, vNetInfo.Uid, vNetKey)
+	err = label.DeleteLabelObject(model.StrVNet, vNetInfo.Uid)
 	if err != nil {
 		log.Warn().Err(err).Msg("")
 		// return emptyRet, err
@@ -1536,12 +1536,12 @@ func DeregisterVNet(nsId string, vNetId string, withSubnets string) (model.Simpl
 		return emptyRet, err
 	}
 
-	// Remove label info using RemoveLabel
+	// Remove label info using DeleteLabelObject
 	// labels := map[string]string{
 	// 	model.LabelManager:  model.StrManager,
 	// 	"namespace": nsId,
 	// }
-	err = label.RemoveLabel(model.StrVNet, vNetInfo.Uid, vNetKey)
+	err = label.DeleteLabelObject(model.StrVNet, vNetInfo.Uid)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err

--- a/src/core/resource/vpn.go
+++ b/src/core/resource/vpn.go
@@ -1178,8 +1178,8 @@ func DeleteSiteToSiteVPN(nsId string, mciId string, vpnId string) (model.SimpleM
 		return emptyRet, err
 	}
 
-	// Remove label info using RemoveLabel
-	err = label.RemoveLabel(model.StrVPN, vpnInfo.Uid, vpnKey)
+	// Remove label info using DeleteLabelObject
+	err = label.DeleteLabelObject(model.StrVPN, vpnInfo.Uid)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err


### PR DESCRIPTION
This PR will mainly replace RemoveLabel() with DeleteLabelObject(). It's related to the last part of resource deletion functions.


@seokho-son 

Could you please check if DeleteLabelObject() function is appropriate for the resource deletion function? 

Which do you prefer between `error` or `nil` for the return value when the label object doesn't exist in RemoveLabel()?

close #1928 