### PR TITLE
FIX: [k8scluster] update k8scluster infor from CB-SP for ListK8sCluster()

### DIFF
--- a/src/api/rest/server/resource/k8scluster.go
+++ b/src/api/rest/server/resource/k8scluster.go
@@ -291,7 +291,7 @@ func RestDeleteK8sNodeGroup(c echo.Context) error {
 // @Success 200 {object} model.TbSetK8sNodeGroupAutoscalingRes
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoScaling [put]
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling [put]
 func RestPutSetK8sNodeGroupAutoscaling(c echo.Context) error {
 
 	nsId := c.Param("nsId")

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -386,24 +386,24 @@ func RunServer() {
 	e.GET("/tumblebug/checkK8sNodeGroupsOnK8sCreation", rest_resource.RestCheckK8sNodeGroupsOnK8sCreation)
 	e.GET("/tumblebug/checkK8sNodeImageDesignation", rest_resource.RestCheckK8sNodeImageDesignation)
 	e.GET("/tumblebug/requiredK8sSubnetCount", rest_resource.RestGetRequiredK8sSubnetCount)
-	g.POST("/:nsId/k8scluster", rest_resource.RestPostK8sCluster)
-	g.POST("/:nsId/k8scluster/:k8sClusterId/k8snodegroup", rest_resource.RestPostK8sNodeGroup)
-	g.DELETE("/:nsId/k8scluster/:k8sClusterId/k8snodegroup/:k8sNodeGroupName", rest_resource.RestDeleteK8sNodeGroup)
-	g.PUT("/:nsId/k8scluster/:k8sClusterId/k8snodegroup/:k8sNodeGroupName/onautoscaling", rest_resource.RestPutSetK8sNodeGroupAutoscaling)
-	g.PUT("/:nsId/k8scluster/:k8sClusterId/k8snodegroup/:k8sNodeGroupName/autoscalesize", rest_resource.RestPutChangeK8sNodeGroupAutoscaleSize)
-	g.GET("/:nsId/k8scluster/:k8sClusterId", rest_resource.RestGetK8sCluster, middleware.TimeoutWithConfig(timeoutConfig),
+	g.POST("/:nsId/k8sCluster", rest_resource.RestPostK8sCluster)
+	g.POST("/:nsId/k8sCluster/:k8sClusterId/k8sNodeGroup", rest_resource.RestPostK8sNodeGroup)
+	g.DELETE("/:nsId/k8sCluster/:k8sClusterId/k8sNodeGroup/:k8sNodeGroupName", rest_resource.RestDeleteK8sNodeGroup)
+	g.PUT("/:nsId/k8sCluster/:k8sClusterId/k8sNodeGroup/:k8sNodeGroupName/onAutoscaling", rest_resource.RestPutSetK8sNodeGroupAutoscaling)
+	g.PUT("/:nsId/k8sCluster/:k8sClusterId/k8sNodeGroup/:k8sNodeGroupName/autoscaleSize", rest_resource.RestPutChangeK8sNodeGroupAutoscaleSize)
+	g.GET("/:nsId/k8sCluster/:k8sClusterId", rest_resource.RestGetK8sCluster, middleware.TimeoutWithConfig(timeoutConfig),
 		middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(2)))
-	g.GET("/:nsId/k8scluster", rest_resource.RestGetAllK8sCluster, middleware.TimeoutWithConfig(timeoutConfig),
+	g.GET("/:nsId/k8sCluster", rest_resource.RestGetAllK8sCluster, middleware.TimeoutWithConfig(timeoutConfig),
 		middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(2)))
-	g.DELETE("/:nsId/k8scluster/:k8sClusterId", rest_resource.RestDeleteK8sCluster)
-	g.DELETE("/:nsId/k8scluster", rest_resource.RestDeleteAllK8sCluster)
-	g.PUT("/:nsId/k8scluster/:k8sClusterId/upgrade", rest_resource.RestPutUpgradeK8sCluster)
+	g.DELETE("/:nsId/k8sCluster/:k8sClusterId", rest_resource.RestDeleteK8sCluster)
+	g.DELETE("/:nsId/k8sCluster", rest_resource.RestDeleteAllK8sCluster)
+	g.PUT("/:nsId/k8sCluster/:k8sClusterId/upgrade", rest_resource.RestPutUpgradeK8sCluster)
 
-	e.POST("/tumblebug/k8sclusterRecommendNode", rest_resource.RestRecommendK8sNode)
-	e.POST("/tumblebug/k8sclusterDynamicCheckRequest", rest_resource.RestPostK8sClusterDynamicCheckRequest)
-	g.POST("/:nsId/k8sclusterDynamic", rest_resource.RestPostK8sClusterDynamic)
-	g.POST("/:nsId/k8scluster/:k8sClusterId/k8snodegroupDynamic", rest_resource.RestPostK8sNodeGroupDynamic)
-	g.GET("/:nsId/control/k8scluster/:k8sClusterId", rest_resource.RestGetControlK8sCluster)
+	e.POST("/tumblebug/k8sClusterRecommendNode", rest_resource.RestRecommendK8sNode)
+	e.POST("/tumblebug/k8sClusterDynamicCheckRequest", rest_resource.RestPostK8sClusterDynamicCheckRequest)
+	g.POST("/:nsId/k8sClusterDynamic", rest_resource.RestPostK8sClusterDynamic)
+	g.POST("/:nsId/k8sCluster/:k8sClusterId/k8sNodeGroupDynamic", rest_resource.RestPostK8sNodeGroupDynamic)
+	g.GET("/:nsId/control/k8sCluster/:k8sClusterId", rest_resource.RestGetControlK8sCluster)
 
 	// Network Load Balancer
 	g.POST("/:nsId/mci/:mciId/mcSwNlb", rest_infra.RestPostMcNLB)

--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -304,8 +304,8 @@ type TbK8sClusterInfo struct {
 	// ResourceType is the type of the resource
 	ResourceType string `json:"resourceType"`
 
-	// Id is unique identifier for the object
-	Id string `json:"id" example:"aws-ap-southeast-1"`
+	// Id is unique identifier for the object, same as Name
+	Id string `json:"id" example:"k8scluster-01"`
 	// Uid is universally unique identifier for the object, used for labelSelector
 	Uid string `json:"uid,omitempty" example:"wef12awefadf1221edcf"`
 	// CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.
@@ -314,7 +314,7 @@ type TbK8sClusterInfo struct {
 	CspResourceId string `json:"cspResourceId,omitempty" example:"csp-06eb41e14121c550a"`
 
 	// Name is human-readable string to represent the object
-	Name           string `json:"name" example:"aws-ap-southeast-1"`
+	Name           string `json:"name" example:"k8scluster-01"`
 	ConnectionName string `json:"connectionName" example:"alibaba-ap-northeast-2"`
 
 	// ConnectionConfig shows connection info to cloud service provider

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -1081,8 +1081,8 @@ func ListK8sCluster(nsId string, filterKey string, filterVal string) (interface{
 
 	if kv != nil {
 		for _, v := range kv {
-			tbK8sCInfo := model.TbK8sClusterInfo{}
-			err = json.Unmarshal([]byte(v.Value), &tbK8sCInfo)
+			storedTbK8sCInfo := model.TbK8sClusterInfo{}
+			err = json.Unmarshal([]byte(v.Value), &storedTbK8sCInfo)
 			if err != nil {
 				log.Err(err).Msg("Failed to List K8sCluster")
 				return nil, err
@@ -1096,7 +1096,14 @@ func ListK8sCluster(nsId string, filterKey string, filterVal string) (interface{
 					continue
 				}
 			}
-			tbK8sCInfoList = append(tbK8sCInfoList, tbK8sCInfo)
+
+			tbK8sCInfo, err := GetK8sCluster(nsId, storedTbK8sCInfo.Id)
+			if err != nil {
+				log.Err(err).Msg("Failed to List K8sCluster")
+				continue
+			}
+
+			tbK8sCInfoList = append(tbK8sCInfoList, *tbK8sCInfo)
 		}
 	}
 


### PR DESCRIPTION
본 PR은 ListK8sCluster() API 호출시 최신 정보 확인을 위해 CB-SP에 직접 관련 정보를 요청합니다.

fixes #1933