### PR TITLE
Improve shared resource handling mechanism on MCI dynamic creation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
 services:
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.10.2
+    image: cloudbaristaorg/cb-tumblebug:0.10.3
     container_name: cb-tumblebug
     build:
       context: .


### PR DESCRIPTION
This PR will improve the shared resource handling mechanism on MCI dynamic creation.

* Remove distributed lock
* Check if there is a Shared Resource before creation
* Execute getVmReqFromDynamicReq() for the first request (i.e., vmRequest[0])
  - It's necessary to create Shared Resources securely.
* Then apply an in-parallel routine for the remaining vmRequest[1:]

( It will be staged once more... ;;; )