### PR TITLE
CHORE: set tencent's ap-hongkong as service unavailable

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -147,6 +147,8 @@ k8scluster:
     nodeImageDesignation: true
     requiredSubnetCount: 1
     version:
+      # Unavailable (CanNotAccess)
+      - region: [ap-hongkong]
       - region: [common]
         available:
           - name: 1.28


### PR DESCRIPTION
본 PR은 Tencent ap-hongkong 리전의 K8sCluster에 접근이 되지 않도록 설정한다.
현재 ap-hongkong의 K8sCluster가 생성되기는 하지만 해당 Kubeconfig로 접근 불가능한 것으로 확인되었다.
* 관련 이슈: https://github.com/cloud-barista/cb-spider/issues/1386