### PR TITLE
CHORE: [k8scluster] update some regions of tencent as unavailable

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -147,16 +147,16 @@ k8scluster:
     nodeImageDesignation: true
     requiredSubnetCount: 1
     version:
-      # Unavailable (CanNotAccess)
-      - region: [ap-hongkong]
+      # ServiceUnavailable
+      - region: [ap-mumbai, eu-moscow, na-toronto]
+      # ServiceCanNotAccess
+      - region: [ap-beijing, ap-chengdu, ap-chongqing, ap-guangzhou, ap-hongkong, ap-nanjing, ap-shanghai]
       - region: [common]
         available:
+          - name: 1.30
+            id: 1.30.0
           - name: 1.28
             id: 1.28.3
-          - name: 1.26
-            id: 1.26.1
-          - name: 1.24
-            id: 1.24.4
     rootDisk:
       - region: [common]
         type:


### PR DESCRIPTION
본 PR은 중국 지역 리전에 대한 이외 지역에서의 접근 문제가 해결될 때까지 접근을 막기 위한 것입니다.
(참조: https://github.com/cloud-barista/cb-spider/issues/1386)

o Set some regions as unavailable
 - Clients in korea cannot access k8scluster of regions in china
o Update K8sCluster version for tencent