### PR TITLE
Fix warning messages in config.go and client.go

### DIFF
--- a/src/core/common/client.go
+++ b/src/core/common/client.go
@@ -69,7 +69,7 @@ func limitConcurrentRequests(requestKey string, limit int) bool {
 	currentCount := count.(int)
 
 	if currentCount >= limit {
-		fmt.Printf("[%s] requests for %s \n", currentCount, requestKey)
+		fmt.Printf("[%d] requests for %s \n", currentCount, requestKey)
 		return false
 	}
 

--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -248,7 +248,10 @@ func GetConfig(id string) (model.ConfigInfo, error) {
 	res := model.ConfigInfo{}
 
 	check, err := CheckConfig(id)
-	errString := id + " config is not found from Key-value store. Envirionment variable will be used."
+
+	const errMsgFormat = "%s config is not found from Key-value store. Environment variable will be used."
+	errString := fmt.Sprintf(errMsgFormat, id)
+	// errString := id + " config is not found from Key-value store. Envirionment variable will be used."
 
 	if !check {
 		err := fmt.Errorf(errString)


### PR DESCRIPTION
- Fix non-constant format string warning in config.go fmt.Errorf calls
- Fix integer format specifier in client.go Printf statement