### PR TITLE
(Show and discuss) Add Traefik TLS reverse proxy with self-signed certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,8 +48,9 @@ src/api/rest/docs/swagger.json
 src/api/rest/docs/swagger.yaml
 
 # Config file for CB-Tumblebug
-conf/
+conf/*
 conf/credentials.conf
+!conf/traefik.yaml
 
 # Runtime files
 src/benchmarking.csv

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,11 @@ bcrypt: ## Generate bcrypt hash for given password (usage: make bcrypt PASSWORD=
 	fi
 	@echo "$(PASSWORD)" | ./cmd/bcrypt/bcrypt
 
-certs: ## Generate self-signed certificates (usage: `make certs` or `make certs DOMAIN=mydomain.com`)
+certs: ## Generate self-signed certificates (usage: `make certs` or `make certs DOMAIN=mydomain.com IP=xxx.xxx.xxx.xxx CERT_DIR=~/.cloud-barista/certs`)
 	@echo "Generating self-signed certificates..."
+	@echo "DOMAIN=$(DOMAIN), IP=$(IP), CERT_DIR=$(CERT_DIR)"
 	chmod +x scripts/certs/generate-certs.sh; \
-	scripts/certs/generate-certs.sh $(DOMAIN)
+	scripts/certs/generate-certs.sh DOMAIN=$(DOMAIN) IP=$(IP) CERT_DIR=$(CERT_DIR) 
 
 help: ## Display this help screen
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,10 @@ bcrypt: ## Generate bcrypt hash for given password (usage: make bcrypt PASSWORD=
 	fi
 	@echo "$(PASSWORD)" | ./cmd/bcrypt/bcrypt
 
+certs: ## Generate self-signed certificates (usage: `make certs` or `make certs DOMAIN=mydomain.com`)
+	@echo "Generating self-signed certificates..."
+	chmod +x scripts/certs/generate-certs.sh; \
+	scripts/certs/generate-certs.sh $(DOMAIN)
+
 help: ## Display this help screen
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/conf/traefik.yaml
+++ b/conf/traefik.yaml
@@ -1,0 +1,49 @@
+## TRAEFIK CONFIGURATION FOR LOCAL SSL
+
+# Version check configuration
+global:
+  checkNewVersion: true
+
+# Set log level for debugging SSL issues
+log:
+  level: WARN # Options: ERROR, WARN, INFO, DEBUG
+  # level: INFO
+
+# Dashboard configuration for monitoring
+api:
+  insecure: true # Warning: Only for local testing / enable dashboard without SSL
+  dashboard: true
+
+# Health check endpoint
+ping: {}
+
+## Configure providers for SSL testing
+providers:
+  docker:
+    exposedByDefault: false
+    watch: true
+  file:
+    fileName: /etc/traefik/traefik.yaml
+    watch: true
+
+# Port configuration
+# 80  -> HTTP
+# 443 -> HTTPS with SSL
+entryPoints:
+  web:
+    address: :80
+    # HTTP to HTTPS redirect configuration
+    # http:
+    #   redirections:
+    #     entryPoint:
+    #       to: websecure
+    #       scheme: https
+    #       permanent: true
+  websecure:
+    address: :443
+
+## SSL CERTIFICATE CONFIGURATION
+tls:
+  certificates:
+    - certFile: /certs/cert.crt # Public certificate
+      keyFile: /certs/cert.key # Private key

--- a/conf/traefik.yaml
+++ b/conf/traefik.yaml
@@ -44,6 +44,16 @@ entryPoints:
 
 ## SSL CERTIFICATE CONFIGURATION
 tls:
+  # Default certificates or fallback certificates used when Traefik couldn't find a certificate for a domain
+  # stores:
+  #   default:
+  #     defaultCertificate:
+  #       certFile: /certs/cert.crt
+  #       keyFile: /certs/cert.key
+  # Certificates for specific domains
   certificates:
     - certFile: /certs/cert.crt # Public certificate
       keyFile: /certs/cert.key # Private key
+  # options:
+  #   default:
+  #     sniStrict: true # Only allow the case where the Server Name Indication (SNI) matches the hostname

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,21 @@ networks:
     driver: bridge
 
 services:
+  reverse-proxy:
+    image: "traefik:v3.3"
+    container_name: "traefik"
+    ports:
+      - 80:80
+      - 443:443
+      - 8080:8080
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./conf/traefik.yaml:/etc/traefik/traefik.yaml
+      - ${HOME}/.certs/:/certs/
+    networks:
+      - external_network
+      - internal_network
+
   # CB-Tumblebug
   cb-tumblebug:
     image: cloudbaristaorg/cb-tumblebug:0.10.6
@@ -146,21 +161,36 @@ services:
   cb-mapui:
     image: cloudbaristaorg/cb-mapui:0.10.2
     container_name: cb-mapui
+    labels:
+      # Explicitly tell Traefik to expose this container
+      - traefik.enable=true
+      # The domain the service will respond to
+      - traefik.http.routers.cb-mapui.rule=Host(`cb-mapui.localhost`)
+      # Allow request only from the predefined entry point named "web"
+      # - traefik.http.routers.cb-mapui.entrypoints=web
+      # Allow request only from the predefined entry point named "websecure"
+      - traefik.http.routers.cb-mapui.entrypoints=websecure
+      - traefik.http.routers.cb-mapui.tls=true
+      # Requests to the service are forwarded via HTTP
+      - traefik.http.services.cb-mapui.loadbalancer.server.scheme=http
+      # The port the service listens on
+      - traefik.http.services.cb-mapui.loadbalancer.server.port=1324
     # build:
     #   context: ../cb-mapui
     #   dockerfile: Dockerfile
     networks:
-      - external_network
+      - internal_network
+      - external_network # Keep this for the time being to support legacy access methods (http://localhost:1324)
     ports:
       - target: 1324
         published: 1324
         protocol: tcp
-    healthcheck: # for cb-mapui
-      test: ["CMD", "nc", "-vz", "localhost", "1324"]
-      interval: 1m
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+    # healthcheck:
+    #   test: ["CMD", "curl", "-f", "http://localhost:1324"]
+    #   interval: 30s
+    #   timeout: 5s
+    #   retries: 3
+    #   start_period: 10s
 
   # # mc-terrarium (PoC): resource extentions such as VPN for CB-Tumblebug by using OpenTofu
   # mc-terrarium:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./conf/traefik.yaml:/etc/traefik/traefik.yaml
-      - ${HOME}/.certs/:/certs/
+      - ${HOME}/.cloud-barista/certs/:/certs/
     networks:
       - external_network
       - internal_network
@@ -164,12 +164,15 @@ services:
     labels:
       # Explicitly tell Traefik to expose this container
       - traefik.enable=true
-      # The domain the service will respond to
+      # Define the rule for routing requests to this service
+      # Note - Multiple hosts are supported (e.g., traefik.http.routers.cb-mapui.rule=Host(`cb-mapui.localhost`) || Host(`xxx.xxx.xxx.xxx`))
+      # Warn - (Please be careful) Public IP can be used for the rule (e.g., Host(`xxx.xxx.xxx.xxx`))
       - traefik.http.routers.cb-mapui.rule=Host(`cb-mapui.localhost`)
       # Allow request only from the predefined entry point named "web"
       # - traefik.http.routers.cb-mapui.entrypoints=web
       # Allow request only from the predefined entry point named "websecure"
       - traefik.http.routers.cb-mapui.entrypoints=websecure
+      # Enable HTTPS
       - traefik.http.routers.cb-mapui.tls=true
       # Requests to the service are forwarded via HTTP
       - traefik.http.services.cb-mapui.loadbalancer.server.scheme=http

--- a/scripts/certs/generate-certs.sh
+++ b/scripts/certs/generate-certs.sh
@@ -4,53 +4,104 @@ IFS=$'\n\t'
 
 # SSL Certificate Generator for Local Testing
 # Creates self-signed certificates for use with Traefik
-# Supports localhost and custom domain testing
+# Supports localhost, custom domain, and IP (Private/Public)
 
 # Usage Examples:
-# For localhost testing: ./generate-certs.sh
-# For custom domain testing: ./generate-certs.sh yourdomain.com
+# Default (localhost + auto-detected IPs): ./generate-certs.sh
+# Custom directory: ./generate-certs.sh CERT_DIR=/path/to/certs
+# Custom domain: ./generate-certs.sh DOMAIN=yourdomain.com
+# Custom IP: ./generate-certs.sh IP=xxx.xxx.xxx.xxx
+# All: ./generate-certs.sh DOMAIN=yourdomain.com IP=xxx.xxx.xxx.xxx CERT_DIR=/path/to/certs
 
 # Output Files:
 # cert.key - SSL private key (KEEP SECURE)
 # cert.crt - SSL public certificate
 # cert.pem - Combined certificate and key (for import)
 
-# Set domain name
-DOMAIN_NAME=${1:-"localhost"}
-# Set cert directory
-CERT_DIR=${2:-"$HOME/.certs"}
+# Parse arguments
+for arg in "$@"; do
+  case "$arg" in
+    CERT_DIR=*) CERT_DIR="${arg#*=}" ;;
+    DOMAIN=*) DOMAIN="${arg#*=}" ;;
+    IP=*) IP="${arg#*=}" ;;
+  esac
+done
 
-if [ ! -f "${CERT_DIR}/cert.key" ]; then
+# Default values
+CERT_DIR="${CERT_DIR:-$HOME/.cloud-barista/certs}"
+DOMAIN="${DOMAIN:-localhost}"
+IP="${IP:-}"
 
-  cd "${CERT_DIR}"
-
-  if [ "$DOMAIN_NAME" = "localhost" ]; then
-    echo "No additional domains will be added to cert"
-    SAN_LIST="[SAN]\nsubjectAltName=DNS:localhost, DNS:*.localhost"
-    printf "%s" "$SAN_LIST"
-  else
-    echo "You supplied domain $DOMAIN_NAME"
-    SAN_LIST="[SAN]\nsubjectAltName=DNS:localhost, DNS:*.localhost, DNS:*.$DOMAIN_NAME, DNS:$DOMAIN_NAME"
-    printf "%s" "$SAN_LIST"
-  fi
-
-  openssl req \
-    -newkey rsa:2048 \
-    -x509 \
-    -nodes \
-    -keyout "cert.key" \
-    -new \
-    -out "cert.crt" \
-    -subj "/CN=compose-dev-tls Self-Signed" \
-    -addext "subjectAltName=DNS:localhost,DNS:*.localhost,DNS:$DOMAIN_NAME,DNS:*.$DOMAIN_NAME" \
-    -sha256 \
-    -days 3650
-
-  cat "cert.crt" "cert.key" > "cert.pem"
-  echo "new TLS self-signed certificate created"
-
-else
-
-  echo "certificate files already exist. Skipping"
-
+# Check if certificate files already exist
+if [ -f "${CERT_DIR}/cert.key" ]; then
+  echo "Certificate files already exist. Skipping"
+  exit 0
 fi
+
+# Create cert directory if it doesn't exist
+if [ ! -d "${CERT_DIR}" ]; then
+  mkdir -p "${CERT_DIR}"
+fi
+cd "${CERT_DIR}"
+
+echo "Generating certificate in $CERT_DIR for DOMAIN=${DOMAIN:-N/A}, IP=${IP:-N/A}"
+
+# Detect Private & Public IP if IP=self
+if [ "$IP" = "self" ]; then
+  PRIVATE_IP=$(ip addr show | grep -oP 'inet \K192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[0-1])\.\d+\.\d+' | head -n 1 || echo "")
+  PUBLIC_IP=$(curl -s ifconfig.me || echo "")
+
+  IP_LIST=()
+  [ -n "$PRIVATE_IP" ] && IP_LIST+=("$PRIVATE_IP")
+  [ -n "$PUBLIC_IP" ] && IP_LIST+=("$PUBLIC_IP")
+
+  IP=$(IFS=','; echo "${IP_LIST[*]}")
+  echo "Detected IP: $IP"
+fi
+
+# Build SAN list (localhost is always included)
+SAN_ENTRIES=("DNS:localhost" "DNS:*.localhost")
+
+# Add multiple domains if provided
+if [ -n "$DOMAIN" ]; then
+  IFS=',' read -ra DOMAINS <<< "$DOMAIN"
+  for dom in "${DOMAINS[@]}"; do
+    [ "$dom" != "localhost" ] && SAN_ENTRIES+=("DNS:$dom" "DNS:*.$dom")
+  done
+fi
+
+# Add multiple IPs if provided
+if [ -n "$IP" ]; then
+  IFS=',' read -ra IPS <<< "$IP"
+  for ip in "${IPS[@]}"; do
+    SAN_ENTRIES+=("IP:$ip")
+  done
+fi
+
+# Join SAN entries with commas (쉼표를 정확히 삽입)
+SAN_LIST="subjectAltName=$(IFS=','; echo "${SAN_ENTRIES[*]}")"
+
+echo "Subject Alternative Name (SAN) list: $SAN_LIST"
+
+# Generate self-signed certificate
+openssl req \
+  -newkey rsa:2048 \
+  -x509 \
+  -nodes \
+  -keyout "cert.key" \
+  -new \
+  -out "cert.crt" \
+  -subj "/CN=compose-dev-tls Self-Signed" \
+  -addext "$SAN_LIST" \
+  -sha256 \
+  -days 3650
+
+cat "cert.crt" "cert.key" > "cert.pem"
+chmod 600 "cert.key"
+echo "Certificate created successfully in $CERT_DIR."
+
+cat "cert.crt" "cert.key" > "cert.pem"
+echo "New TLS self-signed certificate created"
+
+# Secure the private key
+chmod 600 "cert.key"

--- a/scripts/certs/generate-certs.sh
+++ b/scripts/certs/generate-certs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# SSL Certificate Generator for Local Testing
+# Creates self-signed certificates for use with Traefik
+# Supports localhost and custom domain testing
+
+# Usage Examples:
+# For localhost testing: ./generate-certs.sh
+# For custom domain testing: ./generate-certs.sh yourdomain.com
+
+# Output Files:
+# cert.key - SSL private key (KEEP SECURE)
+# cert.crt - SSL public certificate
+# cert.pem - Combined certificate and key (for import)
+
+# Set domain name
+DOMAIN_NAME=${1:-"localhost"}
+# Set cert directory
+CERT_DIR=${2:-"$HOME/.certs"}
+
+if [ ! -f "${CERT_DIR}/cert.key" ]; then
+
+  cd "${CERT_DIR}"
+
+  if [ "$DOMAIN_NAME" = "localhost" ]; then
+    echo "No additional domains will be added to cert"
+    SAN_LIST="[SAN]\nsubjectAltName=DNS:localhost, DNS:*.localhost"
+    printf "%s" "$SAN_LIST"
+  else
+    echo "You supplied domain $DOMAIN_NAME"
+    SAN_LIST="[SAN]\nsubjectAltName=DNS:localhost, DNS:*.localhost, DNS:*.$DOMAIN_NAME, DNS:$DOMAIN_NAME"
+    printf "%s" "$SAN_LIST"
+  fi
+
+  openssl req \
+    -newkey rsa:2048 \
+    -x509 \
+    -nodes \
+    -keyout "cert.key" \
+    -new \
+    -out "cert.crt" \
+    -subj "/CN=compose-dev-tls Self-Signed" \
+    -addext "subjectAltName=DNS:localhost,DNS:*.localhost,DNS:$DOMAIN_NAME,DNS:*.$DOMAIN_NAME" \
+    -sha256 \
+    -days 3650
+
+  cat "cert.crt" "cert.key" > "cert.pem"
+  echo "new TLS self-signed certificate created"
+
+else
+
+  echo "certificate files already exist. Skipping"
+
+fi

--- a/scripts/certs/generate-certs.sh
+++ b/scripts/certs/generate-certs.sh
@@ -78,7 +78,7 @@ if [ -n "$IP" ]; then
   done
 fi
 
-# Join SAN entries with commas (쉼표를 정확히 삽입)
+# Join SAN entries with commas
 SAN_LIST="subjectAltName=$(IFS=','; echo "${SAN_ENTRIES[*]}")"
 
 echo "Subject Alternative Name (SAN) list: $SAN_LIST"


### PR DESCRIPTION
This PR will add Traefik TSL reverse proxy with self-signed certificates.

It's applied to CB-MapUI.

(Updates)
* Add `generate-certs.sh`
* Add `make certs`
* Add `traefik.yaml` for Traefik TLS setup
* Update `docker-compose.yaml`
  - Add Traefik service for TLS reverse proxy
  - Update cb-mapui configuration

(quick start)
```
make certs
make compose
```

(What's changing)
![image](https://github.com/user-attachments/assets/d857986e-66e6-4534-86b7-3c2ee1e96de7)
![image](https://github.com/user-attachments/assets/bf843607-9c82-4e4e-b2af-7c9c6759687a)
