### PR TITLE
Remove PrintCloudInfoTable during initialization

### DIFF
--- a/src/core/common/label/label.go
+++ b/src/core/common/label/label.go
@@ -362,6 +362,7 @@ func UpdateCSPResourceLabel(labelType, uid string, labels map[string]string, con
 		// this is a best-effort operation, so we don't return an error if it fails
 		// drop if we meet the first error
 		if err != nil {
+			log.Info().Err(err).Msg("Cannot update CSP label/tag")
 			break
 		}
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -212,7 +212,7 @@ func setConfig() {
 	// make all map keys lowercase
 	common.AdjustKeysToLowercase(&common.RuntimeCloudInfo)
 	// fmt.Printf("%+v\n", common.RuntimeCloudInfo)
-	common.PrintCloudInfoTable(common.RuntimeCloudInfo)
+	// common.PrintCloudInfoTable(common.RuntimeCloudInfo)
 
 	//
 	// Load k8sclusterinfo


### PR DESCRIPTION
- [Remove redundant prints at initialization](https://github.com/cloud-barista/cb-tumblebug/commit/456099427d784ebc3b9876fd75a02d13dfa38b0f)
- [Add error log for updating csp tags](https://github.com/cloud-barista/cb-tumblebug/commit/ab628143923330d6bc18eca66f5e4ce0c74f3ae7)