### PR TITLE
Add MC-Infra Post (bootstrapping) Command feature and add safety features for bastion SSH

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -14664,6 +14664,14 @@ const docTemplate = `{
                     "type": "string",
                     "example": "mci01"
                 },
+                "postCommand": {
+                    "description": "PostCommand is for the command to bootstrap the VMs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.MciCmdReq"
+                        }
+                    ]
+                },
                 "systemLabel": {
                     "description": "SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose",
                     "type": "string",
@@ -14729,6 +14737,14 @@ const docTemplate = `{
                 },
                 "placementAlgo": {
                     "type": "string"
+                },
+                "postCommand": {
+                    "description": "PostCommand is for the command to bootstrap the VMs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.MciCmdReq"
+                        }
+                    ]
                 },
                 "resourceType": {
                     "description": "ResourceType is the type of the resource",
@@ -14803,6 +14819,14 @@ const docTemplate = `{
                 },
                 "placementAlgo": {
                     "type": "string"
+                },
+                "postCommand": {
+                    "description": "PostCommand is for the command to bootstrap the VMs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.MciCmdReq"
+                        }
+                    ]
                 },
                 "systemLabel": {
                     "description": "SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -14657,6 +14657,14 @@
                     "type": "string",
                     "example": "mci01"
                 },
+                "postCommand": {
+                    "description": "PostCommand is for the command to bootstrap the VMs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.MciCmdReq"
+                        }
+                    ]
+                },
                 "systemLabel": {
                     "description": "SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose",
                     "type": "string",
@@ -14722,6 +14730,14 @@
                 },
                 "placementAlgo": {
                     "type": "string"
+                },
+                "postCommand": {
+                    "description": "PostCommand is for the command to bootstrap the VMs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.MciCmdReq"
+                        }
+                    ]
                 },
                 "resourceType": {
                     "description": "ResourceType is the type of the resource",
@@ -14796,6 +14812,14 @@
                 },
                 "placementAlgo": {
                     "type": "string"
+                },
+                "postCommand": {
+                    "description": "PostCommand is for the command to bootstrap the VMs",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.MciCmdReq"
+                        }
+                    ]
                 },
                 "systemLabel": {
                     "description": "SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -11014,6 +11014,11 @@ components:
         name:
           type: string
           example: mci01
+        postCommand:
+          type: object
+          description: PostCommand is for the command to bootstrap the VMs
+          allOf:
+          - $ref: '#/components/schemas/model.MciCmdReq'
         systemLabel:
           type: string
           description: SystemLabel is for describing the mci in a keyword (any string
@@ -11067,6 +11072,11 @@ components:
             type: string
         placementAlgo:
           type: string
+        postCommand:
+          type: object
+          description: PostCommand is for the command to bootstrap the VMs
+          allOf:
+          - $ref: '#/components/schemas/model.MciCmdReq'
         resourceType:
           type: string
           description: ResourceType is the type of the resource
@@ -11124,6 +11134,11 @@ components:
           example: mci01
         placementAlgo:
           type: string
+        postCommand:
+          type: object
+          description: PostCommand is for the command to bootstrap the VMs
+          allOf:
+          - $ref: '#/components/schemas/model.MciCmdReq'
         systemLabel:
           type: string
           description: SystemLabel is for describing the mci in a keyword (any string

--- a/src/core/model/mci.go
+++ b/src/core/model/mci.go
@@ -103,6 +103,9 @@ type TbMciReq struct {
 	Description   string `json:"description" example:"Made in CB-TB"`
 
 	Vm []TbVmReq `json:"vm" validate:"required"`
+
+	// PostCommand is for the command to bootstrap the VMs
+	PostCommand MciCmdReq `json:"postCommand" validate:"omitempty"`
 }
 
 // ResourceStatusInfo is struct for status information of a resource
@@ -151,6 +154,9 @@ type TbMciInfo struct {
 
 	// List of IDs for new VMs. Return IDs if the VMs are newly added. This field should be used for return body only.
 	NewVmList []string `json:"newVmList"`
+
+	// PostCommand is for the command to bootstrap the VMs
+	PostCommand MciCmdReq `json:"postCommand"`
 }
 
 // TbVmReq is struct to get requirements to create a new server instance
@@ -208,6 +214,9 @@ type TbMciDynamicReq struct {
 	Description string `json:"description" example:"Made in CB-TB"`
 
 	Vm []TbVmDynamicReq `json:"vm" validate:"required"`
+
+	// PostCommand is for the command to bootstrap the VMs
+	PostCommand MciCmdReq `json:"postCommand"`
 }
 
 // TbVmDynamicReq is struct to get requirements to create a new server instance dynamically (with default resource option)

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -1037,8 +1037,6 @@ func ListK8sClusterId(nsId string) ([]string, error) {
 		return nil, err
 	}
 
-	log.Debug().Msg("[ListK8sClusterId] ns: " + nsId)
-	// key := "/ns/" + nsId + "/"
 	k := fmt.Sprintf("/ns/%s/", nsId)
 	log.Debug().Msg(k)
 
@@ -1063,7 +1061,7 @@ func ListK8sClusterId(nsId string) ([]string, error) {
 
 // ListK8sCluster returns the list of TB K8sCluster objects of given nsId
 func ListK8sCluster(nsId string, filterKey string, filterVal string) (interface{}, error) {
-	log.Info().Msg("ListK8sCluster")
+	// log.Info().Msg("ListK8sCluster")
 
 	k8sIdList, err := ListK8sClusterId(nsId)
 	if err != nil {


### PR DESCRIPTION
This PR adds Post (bootstrapping) Command feature to MC-Infra provisioning.

Users can insert commands (scripts) that are executed remotely just after VMs in a MCI are launched.

```
cb-tumblebug       | {
cb-tumblebug       |   "name": "mc-573qa",
cb-tumblebug       |   "installMonAgent": "no",
cb-tumblebug       |   "label": null,
cb-tumblebug       |   "systemLabel": "",
cb-tumblebug       |   "description": "Made via cb-mapui",
cb-tumblebug       |   "vm": [
cb-tumblebug       |     {
cb-tumblebug       |       "name": "g1",
cb-tumblebug       |       "subGroupSize": "1",
cb-tumblebug       |       "label": null,
cb-tumblebug       |       "description": "mapui",
cb-tumblebug       |       "connectionName": "aws-ap-northeast-2",
cb-tumblebug       |       "specId": "aws+ap-northeast-2+t3a.nano",
cb-tumblebug       |       "imageId": "aws+ap-northeast-2+ubuntu22.04",
cb-tumblebug       |       "vNetId": "default-shared-aws-ap-northeast-2",
cb-tumblebug       |       "subnetId": "default-shared-aws-ap-northeast-2",
cb-tumblebug       |       "securityGroupIds": [
cb-tumblebug       |         "default-shared-aws-ap-northeast-2"
cb-tumblebug       |       ],
cb-tumblebug       |       "sshKeyId": "default-shared-aws-ap-northeast-2",
cb-tumblebug       |       "rootDiskType": "default",
cb-tumblebug       |       "rootDiskSize": "default",
cb-tumblebug       |       "dataDiskIds": null
cb-tumblebug       |     }
cb-tumblebug       |   ],
cb-tumblebug       |   "postCommand": {
cb-tumblebug       |     "userName": "cb-user",
cb-tumblebug       |     "command": [
cb-tumblebug       |       "hostname -I",
cb-tumblebug       |       "echo $SSH_CLIENT"
cb-tumblebug       |     ]
cb-tumblebug       |   }
cb-tumblebug       | }
```

```
cb-tumblebug       | 3:20PM INF src/core/infra/provisioning.go:791 > BootstrappingCommand: {UserName:cb-user Command:[hostname -I echo $SSH_CLIENT]}
cb-tumblebug       | 3:20PM DBG src/core/infra/remoteCommand.go:195 > [SSH] mc-573qa.g1-1(10.32.62.77) with userName: cb-user
cb-tumblebug       | 3:20PM DBG src/core/infra/remoteCommand.go:197 > [SSH] cmd[0]: hostname -I
cb-tumblebug       | 3:20PM DBG src/core/infra/remoteCommand.go:197 > [SSH] cmd[1]: echo $SSH_CLIENT
cb-tumblebug       | 3:20PM INF src/core/infra/remoteCommand.go:505 > Attempting to connect to target host 10.32.62.77:22 via bastion
cb-tumblebug       | 3:20PM DBG src/core/infra/remoteCommand.go:517 > [Check Target via Bastion] 10.32.62.77:22 (Attempt 1/5, Timeout: 0s)
cb-tumblebug       | 3:20PM WRN src/core/infra/remoteCommand.go:564 > Connection timeout. Attempt 1/5. Retrying in 5s... error="context deadline exceeded"
cb-tumblebug       | 3:20PM DBG src/core/resource/k8scluster.go:1041 > /ns/default/
cb-tumblebug       | 3:20PM INF src/api/rest/server/middlewares/zerologger.go:59 > request ID=1740583248748401807 Method=GET URI=/tumblebug/ns/default/k8sCluster clientIP=172.19.0.1 latency=43.014884ms status=200
cb-tumblebug       | 3:20PM DBG src/core/infra/remoteCommand.go:517 > [Check Target via Bastion] 10.32.62.77:22 (Attempt 2/5, Timeout: 30s)
cb-tumblebug       | 3:20PM INF src/core/infra/remoteCommand.go:551 > Successfully connected to target host on attempt 2
cb-tumblebug       | 3:20PM DBG src/core/infra/remoteCommand.go:576 > Establishing SSH connection to target host with user: cb-user
cb-tumblebug       | 3:20PM INF src/core/infra/remoteCommand.go:619 > SSH connection established successfully to 10.32.62.77:22 as user cb-user
cb-tumblebug       | 10.32.62.77 
cb-tumblebug       | 10.32.62.77 33970 22
cb-tumblebug       | 3:20PM DBG src/core/infra/remoteCommand.go:248 > [Begin] SSH Output
cb-tumblebug       | map[0:10.32.62.77 
cb-tumblebug       |  1:10.32.62.77 33970 22
cb-tumblebug       | ]
cb-tumblebug       | 3:20PM DBG src/core/infra/remoteCommand.go:250 > [End] SSH Output
cb-tumblebug       | {
cb-tumblebug       |   "results": [
cb-tumblebug       |     {
cb-tumblebug       |       "mciId": "mc-573qa",
cb-tumblebug       |       "vmId": "g1-1",
cb-tumblebug       |       "vmIp": "3.38.92.140",
cb-tumblebug       |       "command": {
cb-tumblebug       |         "0": "hostname -I",
cb-tumblebug       |         "1": "echo $SSH_CLIENT"
cb-tumblebug       |       },
cb-tumblebug       |       "stdout": {
cb-tumblebug       |         "0": "10.32.62.77 \n",
cb-tumblebug       |         "1": "10.32.62.77 33970 22\n"
cb-tumblebug       |       },
cb-tumblebug       |       "stderr": {
cb-tumblebug       |         "0": "",
cb-tumblebug       |         "1": ""
cb-tumblebug       |       },
cb-tumblebug       |       "err": null
cb-tumblebug       |     }
cb-tumblebug       |   ]
cb-tumblebug       | }
```