### PR TITLE
Remove redundant log messages

### DIFF
--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -102,7 +102,7 @@ func RunServer() {
 	APILogSkipPatterns := [][]string{
 		{"/tumblebug/api"},
 		{"/mci", "option=status"},
-		{"/k8scluster"},
+		{"/k8sCluster"},
 		{"/resources/vNet"},
 		{"/resources/securityGroup"},
 		{"/resources/vpn"},

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -1038,7 +1038,6 @@ func ListK8sClusterId(nsId string) ([]string, error) {
 	}
 
 	k := fmt.Sprintf("/ns/%s/", nsId)
-	log.Debug().Msg(k)
 
 	kv, err := kvstore.GetKvList(k)
 


### PR DESCRIPTION
- Remove redundant log messages in K8s clusters.