### PR TITLE
Add remote command by labelSelector

### DIFF
--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -2267,6 +2267,12 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Label selector query. Example: env=production,tier=backend",
+                        "name": "labelSelector",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Custom request ID",
                         "name": "x-request-id",
                         "in": "header"

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -2260,6 +2260,12 @@
                     },
                     {
                         "type": "string",
+                        "description": "Label selector query. Example: env=production,tier=backend",
+                        "name": "labelSelector",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Custom request ID",
                         "name": "x-request-id",
                         "in": "header"

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -1695,6 +1695,11 @@ paths:
         schema:
           type: string
           default: g1-1
+      - name: labelSelector
+        in: query
+        description: "Label selector query. Example: env=production,tier=backend"
+        schema:
+          type: string
       - name: x-request-id
         in: header
         description: Custom request ID

--- a/src/core/infra/benchmark.go
+++ b/src/core/infra/benchmark.go
@@ -48,7 +48,7 @@ func InstallBenchmarkAgentToMci(nsId string, mciId string, req *model.MciCmdReq,
 	// Replace given parameter with the installation cmd
 	req.Command = append(req.Command, cmd)
 
-	sshCmdResult, err := RemoteCommandToMci(nsId, mciId, "", "", req)
+	sshCmdResult, err := RemoteCommandToMci(nsId, mciId, "", "", "", req)
 
 	if err != nil {
 		temp := []model.SshCmdResult{}

--- a/src/core/infra/loadbalance.go
+++ b/src/core/infra/loadbalance.go
@@ -142,7 +142,7 @@ func CreateMcSwNlb(nsId string, mciId string, req *model.TbNLBReq, option string
 
 	cmd = common.RuntimeConf.Nlbsw.CommandNlbApplyConfig
 	cmds = append(cmds, cmd)
-	output, err := RemoteCommandToMci(nsId, nlbMciId, "", "", &model.MciCmdReq{Command: cmds})
+	output, err := RemoteCommandToMci(nsId, nlbMciId, "", "", "", &model.MciCmdReq{Command: cmds})
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyObj, err

--- a/src/core/infra/orchestration.go
+++ b/src/core/infra/orchestration.go
@@ -277,7 +277,7 @@ func OrchestrationController() {
 						if len(autoAction.PostCommand.Command) != 0 {
 
 							log.Debug().Msgf("[Post Command to VM] %v", autoAction.PostCommand.Command)
-							_, cmdErr := RemoteCommandToMci(nsId, mciPolicyTmp.Id, common.ToLower(autoAction.VmDynamicReq.Name), "", &autoAction.PostCommand)
+							_, cmdErr := RemoteCommandToMci(nsId, mciPolicyTmp.Id, common.ToLower(autoAction.VmDynamicReq.Name), "", "", &autoAction.PostCommand)
 							if cmdErr != nil {
 								mciPolicyTmp.Policy[policyIndex].Status = model.AutoStatusError
 								UpdateMciPolicyInfo(nsId, mciPolicyTmp)

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -789,7 +789,7 @@ func CreateMci(nsId string, req *model.TbMciReq, option string) (*model.TbMciInf
 		log.Info().Msgf("Wait for 5 seconds for a safe bootstrapping.")
 		time.Sleep(5 * time.Second)
 		log.Info().Msgf("BootstrappingCommand: %+v", mciTmp.PostCommand)
-		output, err := RemoteCommandToMci(nsId, mciId, "", "", &mciTmp.PostCommand)
+		output, err := RemoteCommandToMci(nsId, mciId, "", "", "", &mciTmp.PostCommand)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 		}


### PR DESCRIPTION
This PR enables selective parallel execution of remote commands in MCI by utilizing **labels** to target specific VMs.