### PR TITLE
CHORE: [k8scluster] add sample storageclass yaml files

### DIFF
--- a/src/testclient/scripts/sequentialFullTest/cinder-sc.yaml
+++ b/src/testclient/scripts/sequentialFullTest/cinder-sc.yaml
@@ -1,0 +1,9 @@
+# https://docs.nhncloud.com/ko/Container/NKS/ko/user-guide/, 동적프로비저닝
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cinder-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: cinder.csi.openstack.org
+volumeBindingMode: WaitForFirstConsumer

--- a/src/testclient/scripts/sequentialFullTest/ebs-sc.yaml
+++ b/src/testclient/scripts/sequentialFullTest/ebs-sc.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+  encrypted: "true"


### PR DESCRIPTION
본 PR은 AWS와 NHNCloud를 대상으로 생성한 K8sCluster에는 활용 가능한 StorageClass가 등록되어 있지 않기 때문에 기본 StorageClass로 등록하기 위한 예시를 추가합니다.
동적 볼륨 프로비저닝 시험 등을 위해 활용될 수 있습니다.

https://github.com/cloud-barista/cb-spider/issues/1487#issuecomment-2774219898