### PR TITLE
feat: [k8scluster] support to transfer file to k8scluster's container

### DIFF
--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -417,6 +417,7 @@ func RunServer() {
 	g.GET("/:nsId/control/k8sCluster/:k8sClusterId", rest_resource.RestGetControlK8sCluster)
 
 	g.POST("/:nsId/cmd/k8sCluster/:k8sClusterId", rest_resource.RestPostCmdK8sCluster)
+	g.POST("/:nsId/transferFile/k8sCluster/:k8sClusterId", rest_resource.RestPostFileToK8sCluster)
 
 	// Network Load Balancer
 	g.POST("/:nsId/mci/:mciId/mcSwNlb", rest_infra.RestPostMcNLB)

--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -555,8 +555,13 @@ type TbK8sClusterContainerCmdReq struct {
 
 // TbK8sClusterContainerCmdResult is struct for K8sClusterContainerCmd Result
 type TbK8sClusterContainerCmdResult struct {
-	Command map[int]string `json:"command"`
-	Stdout  map[int]string `json:"stdout"`
-	Stderr  map[int]string `json:"stderr"`
-	Err     error          `json:"err"`
+	Command string `json:"command"`
+	Stdout  string `json:"stdout"`
+	Stderr  string `json:"stderr"`
+	Err     error  `json:"err"`
+}
+
+// TbK8sClusterContainerCmdResultMap is struct maps for K8sClusterContainerCmd Result
+type TbK8sClusterContainerCmdResults struct {
+	Results []*TbK8sClusterContainerCmdResult `json:"results"`
 }


### PR DESCRIPTION
본 PR은 MCI에서 제공하는 transferFile API와 유사하게 K8Cluster 내 Container를 대상으로 임의의 파일을 전송하는 API를 추가합니다. 따라서 전송 가능한 파일 용량은 최대 10MB 이내로 제한되어 있으며, kubectl cp 기능과 동일하게 tar 기능이 사용되었습니다.

@hanizang77 