### PR TITLE
Expedite and enhance image fetching mechanism

### DIFF
--- a/assets/cloudimage.csv
+++ b/assets/cloudimage.csv
@@ -82,15 +82,16 @@ AWS,af-south-1,ami-03dfab9c5b8844b77,Windows Server 2012 R2,,,vm
 AWS,eu-south-1,ami-0f274cb646afd3475,Ubuntu 18.04,,,vm
 AWS,eu-south-1,ami-0fdd5958b81f36e68,Ubuntu 22.04,,,vm
 AWS,eu-south-1,ami-0c49c6227e9c03e66,Windows Server 2012 R2,,,vm
-AZURE,all,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202404080,Ubuntu 20.04,,,vm
-AZURE,all,Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202404090,Ubuntu 22.04,,,vm
-AZURE,all,Debian:debian-10:10:0.20240204.1647,Debian 10,,,vm
-AZURE,all,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:9600.21620.231004,Windows Server 2012 R2,,,vm
-GCP,all,https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20240307b,Ubuntu 20.04,,,vm
-GCP,all,https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20240319,Ubuntu 22.04,,,vm
-GCP,all,https://www.googleapis.com/compute/v1/projects/debian-cloud/global/debian-10-buster-v20221102,Debian 10,,,vm
+AZURE,all,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202505200,Ubuntu 20.04,,,vm
+AZURE,all,Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210,Ubuntu 22.04,,,vm
+AZURE,all,Debian:debian-11:11:0.20250528.2126,Debian 10,,,vm
+AZURE,all,Debian:debian-10:10:0.20240430.1733,Debian 11,,,vm
+AZURE,all,MicrosoftWindowsServer:WindowsServer:2019-Datacenter:17763.7322.250524,Windows 2019,,,vm
+GCP,all,https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250530,Ubuntu 20.04,,,vm
+GCP,all,https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250530,Ubuntu 22.04,,,vm
+GCP,all,https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-v20250513,Debian 11,,,vm
 GCP,all,https://www.googleapis.com/compute/v1/projects/deeplearning-platform-release/global/images/tf-2-15-cu121-v20240417-debian-11,Debian 11,"Google, Deep Learning VM for TensorFlow 2.15 with CUDA 12.1, M120, Debian 11, Python 3.10, with TensorFlow 2.15 for CUDA 12.1 with Intel MKL-DNN preinstalled",,vm
-GCP,all,https://www.googleapis.com/compute/v1/projects/windows-cloud/global/images/windows-server-2012-r2-dc-v20221014,Windows Server 2012 R2,,,vm
+GCP,all,https://www.googleapis.com/compute/v1/projects/windows-cloud/global/images/windows-server-2019-dc-v20250515,Windows 2019,,,vm
 ALIBABA,all,ubuntu_18_04_x64_20G_alibase_20240223.vhd,Ubuntu 18.04,,,vm
 ALIBABA,all,ubuntu_20_04_x64_20G_alibase_20250415.vhd,Ubuntu 20.04,,,vm
 ALIBABA,all,ubuntu_22_04_x64_20G_alibase_20250415.vhd,Ubuntu 22.04,,,vm

--- a/assets/extractionpatterns.yaml
+++ b/assets/extractionpatterns.yaml
@@ -80,20 +80,12 @@ extractionPatterns:
     - "cuda"
     - "nvidia"
     - "deep learning"
-    - "ml."
-    - "accelerated"
-    - "tesla"
-    - "a100"
-    - "t4"
-    - "v100"
-    - "p100"
+    - "tensorflow"
+    - "pytorch"
+    - "keras"
+    - "caffe"
+    - "machine learning"
     - "optimized-for-ml"
-    - "nc"  # Azure NC-series
-    - "nd"  # Azure ND-series
-    - "nv"  # Azure NV-series
-    - "g2"  # NCP g2 instance
-    - "heterogeneous"
-    - "compute-optimized-with-gpu"
   
   # Kubernetes image identification patterns (case-insensitive, any match = Kubernetes)
   k8sPatterns:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,7 +88,8 @@ services:
       retries: 3
       start_period: 10s
 
-  # cb-tumblebug-etcd
+  # CB-Tumblebug ETCD
+  # This is used for storing CB-Tumblebug metadata.
   cb-tumblebug-etcd:
     image: gcr.io/etcd-development/etcd:v3.5.14
     container_name: cb-tumblebug-etcd
@@ -134,7 +135,8 @@ services:
       retries: 3
       start_period: 10s
 
-  # PostgreSQL for CB-Tumblebug
+  # CB-Tumblebug PostgreSQL
+  # This is used for storing CB-Tumblebug Spec and Image.
   cb-tumblebug-postgres:
     image: postgres:16-alpine
     container_name: cb-tumblebug-postgres
@@ -155,78 +157,6 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
-
-  # pgAdmin Dashboard for PostgreSQL
-  cb-tumblebug-pgadmin:
-    image: dpage/pgadmin4:latest
-    container_name: cb-tumblebug-pgadmin
-    restart: always
-    networks:
-      - internal_network
-      - external_network
-    ports:
-      - 5050:80
-    volumes:
-      - ./container-volume/cb-tumblebug-container/meta_db/pgadmin:/var/lib/pgadmin
-    environment:
-      - PGADMIN_DEFAULT_EMAIL=admin@cloud-barista.org
-      - PGADMIN_DEFAULT_PASSWORD=cb_tumblebug
-      - PGADMIN_CONFIG_SERVER_MODE=True
-      - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
-      - PGADMIN_CONFIG_CONSOLE_LOG_LEVEL=40
-      - PGADMIN_CONFIG_FILE_LOG_LEVEL=40
-      - PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION=False
-      - PGADMIN_CONFIG_SESSION_EXPIRATION_TIME=1440
-      - PGADMIN_CONFIG_ENABLE_PSQL=False
-      - PGADMIN_CONFIG_ENABLE_CONSOLE_LOGGING=False
-      - PGADMIN_CONFIG_ENABLE_FILE_LOGGING=False      
-      - PGADMIN_SERVER_JSON={"Servers":{"1":{"Name":"CB-Tumblebug PostgreSQL","Group":"Cloud-Barista","Host":"cb-tumblebug-postgres","Port":5432,"MaintenanceDB":"cb_tumblebug","Username":"cb_tumblebug","SSLMode":"prefer","Password":"cb_tumblebug"}}}
-    user: "0:0"
-    depends_on:
-      - cb-tumblebug-postgres
-    logging:
-      driver: "none"
-
-  # Metabase - Lightweight data visualization tool
-  cb-tumblebug-metabase:
-    image: metabase/metabase:latest
-    container_name: cb-tumblebug-metabase
-    restart: always
-    networks:
-      - internal_network
-      - external_network
-    ports:
-      - 3000:3000
-    environment:
-      # - MB_DB_TYPE=postgres
-      # - MB_DB_DBNAME=cb_tumblebug
-      # - MB_DB_PORT=5432
-      # - MB_DB_USER=cb_tumblebug
-      # - MB_DB_PASS=cb_tumblebug
-      # - MB_DB_HOST=cb-tumblebug-postgres
-      - MB_ADMIN_EMAIL=admin@cloud-barista.org
-      - MB_ADMIN_FIRST_NAME=Cloud
-      - MB_ADMIN_LAST_NAME=Barista
-      - MB_ADMIN_PASSWORD=cb_tumblebug11
-      - MB_SITE_NAME=CB-Tumblebug Analytics
-      - MB_SITE_LOCALE=en
-      - JAVA_TIMEZONE=Asia/Seoul
-      - MB_LOGGER_LEVEL=ERROR
-      - MB_JETTY_REQUEST_LOGS_ENABLED=false
-      - MB_JETTY_ALLOWED_HOSTS=localhost
-      - MB_LOGGING_LEVEL=ERROR      
-    volumes:
-      - ./container-volume/cb-tumblebug-container/meta_db/metabase-data:/metabase-data
-    depends_on:
-      cb-tumblebug-postgres:
-        condition: service_healthy
-    user: "0:0"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 60s
 
   # CB-Spider
   cb-spider:
@@ -261,9 +191,10 @@ services:
       retries: 3
       start_period: 10s
 
-  # cb-mapui
+  # CB-MapUI
+  # This is the Map-based client for CB-Tumblebug.
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.10.3
+    image: cloudbaristaorg/cb-mapui:0.10.5
     container_name: cb-mapui
     labels:
       # Explicitly tell Traefik to expose this container
@@ -396,3 +327,81 @@ services:
   #     timeout: 10s
   #     retries: 3
   #     start_period: 10s
+
+  # # CB-Tumblebug Metabase Dashboard for PostgreSQL
+  # # Enable this service to manage the PostgreSQL database of CB-Tumblebug.
+  # cb-tumblebug-metabase:
+  #   image: metabase/metabase:latest
+  #   container_name: cb-tumblebug-metabase
+  #   restart: always
+  #   networks:
+  #     - internal_network
+  #     - external_network
+  #   ports:
+  #     - 3000:3000
+  #   environment:
+  #     # - MB_DB_TYPE=postgres
+  #     # - MB_DB_DBNAME=cb_tumblebug
+  #     # - MB_DB_PORT=5432
+  #     # - MB_DB_USER=cb_tumblebug
+  #     # - MB_DB_PASS=cb_tumblebug
+  #     # - MB_DB_HOST=cb-tumblebug-postgres
+  #     - MB_ADMIN_EMAIL=admin@cloud-barista.org
+  #     - MB_ADMIN_PASSWORD=cb_tumblebug11      
+  #     - MB_ADMIN_FIRST_NAME=Cloud
+  #     - MB_ADMIN_LAST_NAME=Barista
+  #     - MB_SITE_NAME=CB-Tumblebug Analytics
+  #     - MB_SITE_LOCALE=en
+  #     - JAVA_TIMEZONE=Asia/Seoul
+  #     - MB_JETTY_REQUEST_LOGS_ENABLED=false
+  #     - MB_JETTY_ALLOWED_HOSTS=localhost
+  #     - MB_LOGGER_LEVEL=OFF
+  #     - MB_LOGGING_LEVEL=OFF  
+  #     - MB_EMOJI_IN_LOGS=false   
+      
+  #   volumes:
+  #     - ./container-volume/cb-tumblebug-container/meta_db/metabase-data:/metabase-data
+  #   depends_on:
+  #     cb-tumblebug-postgres:
+  #       condition: service_healthy
+  #   user: "0:0"
+  #   logging:
+  #     driver: "none"    
+  #   healthcheck:
+  #     test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+  #     interval: 30s
+  #     timeout: 5s
+  #     retries: 3
+  #     start_period: 60s
+
+  # # CB-Tumblebug pgAdmin Dashboard for PostgreSQL
+  # # Enable this service to manage the PostgreSQL database of CB-Tumblebug.
+  # cb-tumblebug-pgadmin:
+  #   image: dpage/pgadmin4:latest
+  #   container_name: cb-tumblebug-pgadmin
+  #   restart: always
+  #   networks:
+  #     - internal_network
+  #     - external_network
+  #   ports:
+  #     - 5050:80
+  #   volumes:
+  #     - ./container-volume/cb-tumblebug-container/meta_db/pgadmin:/var/lib/pgadmin
+  #   environment:
+  #     - PGADMIN_DEFAULT_EMAIL=admin@cloud-barista.org
+  #     - PGADMIN_DEFAULT_PASSWORD=cb_tumblebug
+  #     - PGADMIN_CONFIG_SERVER_MODE=True
+  #     - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
+  #     - PGADMIN_CONFIG_CONSOLE_LOG_LEVEL=40
+  #     - PGADMIN_CONFIG_FILE_LOG_LEVEL=40
+  #     - PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION=False
+  #     - PGADMIN_CONFIG_SESSION_EXPIRATION_TIME=1440
+  #     - PGADMIN_CONFIG_ENABLE_PSQL=False
+  #     - PGADMIN_CONFIG_ENABLE_CONSOLE_LOGGING=False
+  #     - PGADMIN_CONFIG_ENABLE_FILE_LOGGING=False      
+  #     - PGADMIN_SERVER_JSON={"Servers":{"1":{"Name":"CB-Tumblebug PostgreSQL","Group":"Cloud-Barista","Host":"cb-tumblebug-postgres","Port":5432,"MaintenanceDB":"cb_tumblebug","Username":"cb_tumblebug","SSLMode":"prefer","Password":"cb_tumblebug"}}}
+  #   user: "0:0"
+  #   depends_on:
+  #     - cb-tumblebug-postgres
+  #   logging:
+  #     driver: "none"

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -401,8 +401,8 @@ func RegisterSpecWithInfoInBulk(specList []model.TbSpecInfo) error {
 			return err
 		}
 
-		log.Info().Msgf("Bulk upsert success: batch %d-%d, affected: %d records",
-			i, end-1, result.RowsAffected)
+		// log.Info().Msgf("Bulk upsert success: batch %d-%d, affected: %d records",
+		// 	i, end-1, result.RowsAffected)
 	}
 
 	// Re-enable foreign key constraints

--- a/src/main.go
+++ b/src/main.go
@@ -45,6 +45,7 @@ import (
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	gormLogger "gorm.io/gorm/logger"
 )
 
 // init for main
@@ -120,8 +121,10 @@ func init() {
 		strings.Split(model.DBUrl, ":")[1],
 	)
 
-	//err = common.OpenSQL("../meta_db/dat/cbtumblebug.s3db") // commented out to move to use XORM
-	model.ORM, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	// Use GORM's default logger in silent mode to avoid verbose output
+	model.ORM, err = gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: gormLogger.Default.LogMode(gormLogger.Silent),
+	})
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to connect to PostgreSQL database")
 	} else {


### PR DESCRIPTION
## Expedite and enhance image fetching mechanism
- Update assets/cloudimage.csv and Improve assets/extractionpatterns.yaml
- Expedite image fetching speed by selectively assign parallelism
- Provide both sync and async mechanisms for the image fetching 
- Provide a method to check fetching status and prevent duplicated requests

## Update docker-compose
- use cb-mapui:0.10.5 and disable pgAdmin and Metabase by default in docker-compose.yaml (they are for cb-tb developers only)
