### PR TITLE
Add API usage helper for searchImage

### DIFF
--- a/src/api/rest/server/resource/image.go
+++ b/src/api/rest/server/resource/image.go
@@ -359,6 +359,7 @@ func RestSearchImage(c echo.Context) error {
 		u.ProviderName,
 		u.RegionName,
 		u.OSType,
+		string(u.OSArchitecture),
 		u.IsGPUImage,
 		u.IsKubernetesImage,
 		u.IsRegisteredByAsset,
@@ -367,7 +368,29 @@ func RestSearchImage(c echo.Context) error {
 	)
 
 	result := model.SearchImageResponse{}
-	result.Count = cnt
+	result.ImageCount = cnt
 	result.ImageList = content
 	return clientManager.EndRequestWithLog(c, err, result)
+}
+
+// RestSearchImageOptions godoc
+// @ID SearchImageOptions
+// @Get available image search request options
+// @Description Get all available options for image search fields
+// @Tags [Infra Resource] Image Management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(system)
+// @Success 200 {object} model.SearchImageRequestOptions
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /ns/{nsId}/resources/searchImageOptions [get]
+func RestSearchImageOptions(c echo.Context) error {
+
+	content, err := resource.SearchImageOptions()
+	if err != nil {
+		return clientManager.EndRequestWithLog(c, err, nil)
+	}
+
+	return clientManager.EndRequestWithLog(c, nil, content)
 }

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -483,6 +483,7 @@ func RunServer() {
 	g.POST("/:nsId/resources/fetchImagesAsync", rest_resource.RestFetchImagesAsync)
 	g.GET("/:nsId/resources/fetchImagesResult", rest_resource.RestGetFetchImagesAsyncResult)
 	g.POST("/:nsId/resources/searchImage", rest_resource.RestSearchImage)
+	g.GET("/:nsId/resources/searchImageOptions", rest_resource.RestSearchImageOptions)
 
 	g.POST("/:nsId/resources/securityGroup", rest_resource.RestPostSecurityGroup)
 	g.GET("/:nsId/resources/securityGroup/:resourceId", rest_resource.RestGetResource)

--- a/src/core/model/image.go
+++ b/src/core/model/image.go
@@ -122,20 +122,88 @@ type ImageFetchOption struct {
 
 // SearchImageRequest is struct for Search Image Request
 type SearchImageRequest struct {
-	ProviderName           string   `json:"providerName" example:"aws"`
-	RegionName             string   `json:"regionName" example:"us-east-1"`
-	OSType                 string   `json:"osType" example:"ubuntu 22.04" description:"Simplified OS name and version string. Space-separated for AND condition"`
-	IsGPUImage             *bool    `json:"isGPUImage" example:"false"`
-	IsKubernetesImage      *bool    `json:"isKubernetesImage" example:"false"`
-	IsRegisteredByAsset    *bool    `json:"isRegisteredByAsset" example:"false" description:"Whether the image is registered by asset or not."`
-	IncludeDeprecatedImage *bool    `json:"includeDeprecatedImage" example:"false" description:"Include deprecated images in the search results."`
-	DetailSearchKeys       []string `json:"detailSearchKeys" example:"sql,2022" description:"Keywords for searching images in detail"`
+
+	// Cloud Service Provider (ex: "aws", "azure", "gcp", etc.). Use GET /provider to get the list of available providers.
+	ProviderName string `json:"providerName" example:"aws"`
+
+	// Cloud Service Provider Region (ex: "us-east-1", "us-west-2", etc.). Use GET /provider/{providerName}/region to get the list of available regions.
+	RegionName string `json:"regionName" example:"us-east-1"`
+
+	// Simplified OS name and version string. Space-separated for AND condition (ex: "ubuntu 22.04", "windows 10", etc.).
+	OSType string `json:"osType" example:"ubuntu 22.04" description:"Simplified OS name and version string. Space-separated for AND condition"`
+
+	// The architecture of the operating system of the image. (ex: "x86_64", "arm64", etc.)
+	OSArchitecture OSArchitecture `json:"osArchitecture" gorm:"column:os_architecture" example:"x86_64" description:"The architecture of the operating system of the image."`
+
+	// Whether the image is ready for GPU usage or not.
+	// In usual, true means the image is ready for GPU usage with GPU drivers and libraries installed.
+	// If not specified, both true and false images will be included in the search results.
+	// Even if the image is not ready for GPU usage, it can be used with GPU by installing GPU drivers and libraries manually.
+	IsGPUImage *bool `json:"isGPUImage" example:"false"`
+
+	// Whether the image is specialized image only for Kubernetes nodes.
+	// If not specified, both true and false images will be included in the search results.
+	// Images that are not specialized for Kubernetes also can be used as Kubernetes nodes. It depends on CSPs.
+	IsKubernetesImage *bool `json:"isKubernetesImage" example:"false"`
+
+	// Whether the image is registered by CB-Tumblebug asset file or not.
+	IsRegisteredByAsset *bool `json:"isRegisteredByAsset" example:"false" description:"Whether the image is registered by asset or not."`
+
+	// Whether the search results should include deprecated images or not.
+	// If not specified, deprecated images will not be included in the search results.
+	// In usual, deprecated images are not recommended to use, but they can be used if necessary.
+	IncludeDeprecatedImage *bool `json:"includeDeprecatedImage" example:"false" description:"Include deprecated images in the search results."`
+
+	// Keywords for searching images in detail.
+	// Space-separated for AND condition (ex: "sql 2022", "ubuntu 22.04", etc.).
+	// Used for if the user wants to search images with specific keywords in their details.
+	DetailSearchKeys []string `json:"detailSearchKeys" example:"tensorflow,2.17" description:"Keywords for searching images in detail"`
+}
+
+// SearchImageRequestOptions is struct for Search Image Request
+type SearchImageRequestOptions struct {
+
+	// Cloud Service Provider (ex: "aws", "azure", "gcp", etc.). Use GET /provider to get the list of available providers.
+	ProviderName []string `json:"providerName"`
+
+	// Cloud Service Provider Region (ex: "us-east-1", "us-west-2", etc.). Use GET /provider/{providerName}/region to get the list of available regions.
+	RegionName []string `json:"regionName"`
+
+	// Simplified OS name and version string. Space-separated for AND condition (ex: "ubuntu 22.04", "windows 10", etc.).
+	OSType []string `json:"osType" description:"Simplified OS name and version string. Space-separated for AND condition"`
+
+	// The architecture of the operating system of the image. (ex: "x86_64", "arm64", etc.)
+	OSArchitecture []string `json:"osArchitecture" description:"The architecture of the operating system of the image."`
+
+	// Whether the image is ready for GPU usage or not.
+	// In usual, true means the image is ready for GPU usage with GPU drivers and libraries installed.
+	// If not specified, both true and false images will be included in the search results.
+	// Even if the image is not ready for GPU usage, it can be used with GPU by installing GPU drivers and libraries manually.
+	IsGPUImage []bool `json:"isGPUImage" description:"Whether the image is ready for GPU usage or not."`
+
+	// Whether the image is specialized image only for Kubernetes nodes.
+	// If not specified, both true and false images will be included in the search results.
+	// Images that are not specialized for Kubernetes also can be used as Kubernetes nodes. It depends on CSPs.
+	IsKubernetesImage []bool `json:"isKubernetesImage" description:"Whether the image is specialized image only for Kubernetes nodes."`
+
+	// Whether the image is registered by CB-Tumblebug asset file or not.
+	IsRegisteredByAsset []bool `json:"isRegisteredByAsset" description:"Whether the image is registered by asset or not."`
+
+	// Whether the search results should include deprecated images or not.
+	// If not specified, deprecated images will not be included in the search results.
+	// In usual, deprecated images are not recommended to use, but they can be used if necessary.
+	IncludeDeprecatedImage []bool `json:"includeDeprecatedImage" description:"Include deprecated images in the search results."`
+
+	// Keywords for searching images in detail.
+	// Space-separated for AND condition (ex: "sql 2022", "ubuntu 22.04", etc.).
+	// Used for if the user wants to search images with specific keywords in their details.
+	DetailSearchKeys [][]string `json:"detailSearchKeys" description:"Keywords for searching images in detail"`
 }
 
 // SearchImageResponse is struct for Search Image Request
 type SearchImageResponse struct {
-	Count     int           `json:"count"`
-	ImageList []TbImageInfo `json:"imageList"`
+	ImageCount int           `json:"imageCount"`
+	ImageList  []TbImageInfo `json:"imageList"`
 }
 
 // SpiderImageList is struct for Spider Image List


### PR DESCRIPTION
This PR provides

a new API: GET [/ns/{nsId}/resources/searchImageOptions](http://localhost:1324/swagger.html#/[Infra%20Resource]%20Image%20Management/SearchImageOptions)


to support: the POST [/ns/{nsId}/resources/searchImage](http://localhost:1324/swagger.html#/[Infra%20Resource]%20Image%20Management/SearchImage)

the new API will help users available options for image search fields.

output of the searchImageOptions is, for instance, as follows.

```json
{
  "providerName": [
    "alibaba",
    "aws",
    "azure",
    "gcp",
    "ibm",
    "ncpvpc",
    "nhncloud",
    "tencent"
  ],
  "regionName": [
    "af-south-1",
    "ap-east-1",
    "ap-northeast-1",
    "ap-northeast-2",
    "ap-northeast-3",
    "ap-south-1",
    "ap-south-2",
    "ap-southeast-1",
    "ap-southeast-2",
    "ap-southeast-3",
    "ap-southeast-4",
    "ap-southeast-5",
    "ap-southeast-6",
    "ap-southeast-7",
    "au-syd",
    "br-sao",
    "ca-central-1",
    "ca-tor",
    "ca-west-1",
    "cn-beijing",
    "cn-chengdu",
    "cn-fuzhou",
    "cn-guangzhou",
    "cn-hangzhou",
    "cn-heyuan",
    "cn-hongkong",
    "cn-huhehaote",
    "cn-nanjing",
    "cn-qingdao",
    "cn-shanghai",
    "cn-shenzhen",
    "cn-wuhan-lr",
    "cn-wulanchabu",
    "cn-zhangjiakou",
    "common",
    "eu-central-1",
    "eu-central-2",
    "eu-de",
    "eu-es",
    "eu-gb",
    "eu-north-1",
    "eu-south-1",
    "eu-south-2",
    "eu-west-1",
    "eu-west-2",
    "eu-west-3",
    "il-central-1",
    "jp-tok",
    "jp1",
    "jpn",
    "kr",
    "kr1",
    "kr2",
    "me-central-1",
    "me-east-1",
    "me-south-1",
    "sa-east-1",
    "sgn",
    "us-east",
    "us-east-1",
    "us-east-2",
    "us-south",
    "us-west-1",
    "us-west-2"
  ],
  "osType": [
    "Alibaba Cloud Linux 2",
    "Alibaba Cloud Linux 3",
    "Alibaba Cloud Linux 3.2104",
    "AlmaLinux 8",
    "AlmaLinux 9",
    "Amazon Linux",
    "Amazon Linux 2",
    "Amazon Linux 2023",
    "CentOS",
    "CentOS 7",
    "CentOS 8",
    "CentOS 9",
    "Debian 10",
    "Debian 11",
    "Debian 12",
    "Debian 9",
    "Fedora",
    "Fedora 35",
    "Fedora 37",
    "Fedora 38",
    "Fedora 39",
    "Red Hat Enterprise Linux",
    "Red Hat Enterprise Linux 7",
    "Red Hat Enterprise Linux 8",
    "Red Hat Enterprise Linux 9",
    "Rocky Linux 8",
    "Rocky Linux 9",
    "SUSE Linux Enterprise Server",
    "SUSE Linux Enterprise Server 12",
    "SUSE Linux Enterprise Server 15",
    "Tencent Linux 3",
    "Ubuntu",
    "Ubuntu 16.04",
    "Ubuntu 18.04",
    "Ubuntu 20.04",
    "Ubuntu 20.04 Container",
    "Ubuntu 22.04",
    "Ubuntu 22.04 Container",
    "Ubuntu 22.10",
    "Ubuntu 23.04",
    "Ubuntu 24.04",
    "Windows",
    "Windows 10",
    "Windows 11",
    "Windows 2016",
    "Windows 2019",
    "Windows 2022"
  ],
  "osArchitecture": [
    "arm64",
    "arm64_mac",
    "na",
    "x86_32",
    "x86_64",
    "x86_64_mac"
  ],
  "isGPUImage": [
    true,
    false
  ],
  "isKubernetesImage": [
    true,
    false
  ],
  "isRegisteredByAsset": [
    true,
    false
  ],
  "includeDeprecatedImage": [
    true,
    false
  ],
  "detailSearchKeys": [
    [
      "This is just an example",
      "omit this option if not needed",
      "requires more time to search"
    ],
    [
      "sql",
      "2022"
    ],
    [
      "tensorflow",
      "2.17"
    ]
  ]
}
```