### PR TITLE
Combine fetch images and update images from asset

### DIFF
--- a/assets/cloudimage.csv
+++ b/assets/cloudimage.csv
@@ -3,95 +3,70 @@ AWS,ap-southeast-1,ami-061eb2b23f9f8839c,Ubuntu 18.04,,,vm
 AWS,ap-northeast-1,ami-06b060f6dd92163e3,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,ap-southeast-1,ami-02ee763250491e04a,Ubuntu 22.04,,,vm
 AWS,ap-southeast-1,ami-0d55f20871d03244b,Debian 10,,,vm
-AWS,ap-southeast-1,ami-06ff89fde394bfd6d,Windows Server 2012 R2,,,vm
 AWS,ca-central-1,ami-0d0eaed20348a3389,Ubuntu 18.04,,,vm
 AWS,ca-central-1,ami-0163eef3f762a1e37,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,ca-central-1,ami-0b6937ac543fe96d7,Ubuntu 22.04,,,vm
 AWS,ca-central-1,ami-0b572790c607396bb,Debian 10,,,vm
-AWS,ca-central-1,ami-08bb451e17239bc35,Windows Server 2012 R2,,,vm
 AWS,us-west-1,ami-0dd655843c87b6930,Ubuntu 18.04,,,vm
 AWS,us-west-1,ami-0710bb577045071ff,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,us-west-1,ami-085284d24fe829cd0,Ubuntu 22.04,,,vm
 AWS,us-west-1,ami-0a2a0146cce54add1,Debian 10,,,vm
-AWS,us-west-1,ami-007ecccd0b872e690,Windows Server 2012 R2,,,vm
 AWS,us-east-1,ami-085925f297f89fce1,Ubuntu 18.04,,,vm
 AWS,us-east-1,ami-032346ab877c418af,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,us-east-1,ami-052efd3df9dad4825,Ubuntu 22.04,,,vm
 AWS,us-east-1,ami-0e3370550517d663c,Debian 10,,,vm
-AWS,us-east-1,ami-0a115baff5798ce9f,Windows Server 2012 R2,,,vm
 AWS,ap-northeast-1,ami-0cd744adeca97abb1,Ubuntu 18.04,,,vm
 AWS,ap-northeast-1,ami-08eec9ed020969fb6,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,ap-northeast-1,ami-07200fa04af91f087,Ubuntu 22.04,,,vm
 AWS,ap-northeast-1,ami-039ed92b1a75d78cc,Debian 10,,,vm
-AWS,ap-northeast-1,ami-006b8cbbcbb9386e7,Windows Server 2012 R2,,,vm
 AWS,ap-northeast-1,ami-0bded5720a0796acb,Ubuntu 20.04,Deep Learning OSS Nvidia Driver AMI GPU TensorFlow 2.15 (Ubuntu 20.04) 20240423,G4dn G5 G6 Gr6 P4 P4de P5,vm
 AWS,ap-south-1,ami-0123b531fc646552f,Ubuntu 18.04,,,vm
 AWS,ap-south-1,ami-0b2ec65899cc867ef,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,ap-south-1,ami-068257025f72f470d,Ubuntu 22.04,,,vm
 AWS,ap-south-1,ami-01c4fc7cb18b931d3,Debian 10,,,vm
-AWS,ap-south-1,ami-0c267eb626faf52fc,Windows Server 2012 R2,,,vm
 AWS,ap-southeast-2,ami-00a54827eb7ffcd3c,Ubuntu 18.04,,,vm
 AWS,ap-southeast-2,ami-090c5c0d13f82b2a1,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,ap-southeast-2,ami-0e040c48614ad1327,Ubuntu 22.04,,,vm
-AWS,ap-southeast-2,ami-0b059f50f9974fc49,Windows Server 2012 R2,,,vm
 AWS,eu-west-2,ami-0be057a22c63962cb,Ubuntu 18.04,,,vm
 AWS,eu-west-2,ami-0cf5d174a5c8791f1,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,eu-west-2,ami-0fb391cce7a602d1f,Ubuntu 22.04,,,vm
-AWS,eu-west-2,ami-0fc22514827f2e7de,Windows Server 2012 R2,,,vm
 AWS,us-east-2,ami-01e7ca2ef94a0ae86,Ubuntu 18.04,,,vm
 AWS,us-east-2,ami-094be4c7f1e506a7a,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,us-east-2,ami-02f3416038bdb17fb,Ubuntu 22.04,,,vm
-AWS,us-east-2,ami-0eb31daebdf3775ac,Windows Server 2012 R2,,,vm
 AWS,us-east-2,ami-0ad87058f66b00409,Debian 10,,,vm
 AWS,us-east-2,ami-028faa7f1b7384e6e,Ubuntu 20.04,Deep Learning OSS Nvidia Driver AMI GPU TensorFlow 2.15 (Ubuntu 20.04) 20240423,G4dn G5 G6 Gr6 P4 P4de P5,vm
 AWS,us-west-2,ami-02701bcdc5509e57b,Ubuntu 18.04,,,vm
 AWS,us-west-2,ami-0d70546e43a941d70,Ubuntu 22.04,,,vm
-AWS,us-west-2,ami-0be1488bb453a4e59,Windows Server 2012 R2,,,vm
 AWS,ap-northeast-3,ami-0e958e6a9363c29ad,Ubuntu 18.04,,,vm
 AWS,ap-northeast-3,ami-096d800410995ae84,Ubuntu 22.04,,,vm
-AWS,ap-northeast-3,ami-0f8631249f16ca5c0,Windows Server 2012 R2,,,vm
 AWS,eu-central-1,ami-0e0102e3ff768559b,Ubuntu 18.04,,,vm
 AWS,eu-central-1,ami-065deacbcaac64cf2,Ubuntu 22.04,,,vm
-AWS,eu-central-1,ami-08bf6933faf9f2610,Windows Server 2012 R2,,,vm
 AWS,eu-west-1,ami-06fd78dc2f0b69910,Ubuntu 18.04,,,vm
 AWS,eu-west-1,ami-0d75513e7706cf2d9,Ubuntu 22.04,,,vm
-AWS,eu-west-1,ami-01ebc54e4d18b85ef,Windows Server 2012 R2,,,vm
 AWS,eu-west-3,ami-0a0d71ff90f62f72a,Ubuntu 18.04,,,vm
 AWS,eu-west-3,ami-09e513e9eacab10c1,Ubuntu 22.04,,,vm
-AWS,eu-west-3,ami-0da74102f47e3c02a,Windows Server 2012 R2,,,vm
 AWS,eu-north-1,ami-0f269726c071d0e96,Ubuntu 18.04,,,vm
 AWS,eu-north-1,ami-0440e5026412ff23f,Ubuntu 22.04,,,vm
-AWS,eu-north-1,ami-028b9d976ede1a204,Windows Server 2012 R2,,,vm
 AWS,sa-east-1,ami-0bd91caaa9bc42cf3,Ubuntu 18.04,,,vm
 AWS,sa-east-1,ami-08ae71fd7f1449df1,Ubuntu 22.04,,,vm
-AWS,sa-east-1,ami-0f96e31470b42a40c,Windows Server 2012 R2,,,vm
 AWS,ap-northeast-2,ami-00379ec40a3e30f87,Ubuntu 18.04,,,vm
 AWS,ap-northeast-2,ami-08b2c3a9f2695e351,Ubuntu 20.04,Ubuntu Server 20.04 LTS (HVM) with SQL Server 2022 Standard,,vm
 AWS,ap-northeast-2,ami-058165de3b7202099,Ubuntu 22.04,,,vm
-AWS,ap-northeast-2,ami-0ec892301ee1c788c,Windows Server 2012 R2,,,vm
 AWS,ap-east-1,ami-036915aa0cb1d91a1,Ubuntu 18.04,,,vm
 AWS,ap-east-1,ami-0ecb6d8435affe2b6,Ubuntu 22.04,,,vm
-AWS,ap-east-1,ami-046ab0ba1e9a60ff6,Windows Server 2012 R2,,,vm
 AWS,me-south-1,ami-026dde872642a6ffe,Ubuntu 18.04,,,vm
 AWS,me-south-1,ami-0c9b2924fcd9b73a4,Ubuntu 22.04,,,vm
 AWS,me-south-1,ami-08ca9d63b8d4ec276,Debian 10,,,vm
-AWS,me-south-1,ami-098a156f95e80a167,Windows Server 2012 R2,,,vm
 AWS,af-south-1,ami-0e4b4778694305983,Ubuntu 18.04,,,vm
 AWS,af-south-1,ami-080bc3824e96f9b8d,Ubuntu 22.04,,,vm
-AWS,af-south-1,ami-03dfab9c5b8844b77,Windows Server 2012 R2,,,vm
 AWS,eu-south-1,ami-0f274cb646afd3475,Ubuntu 18.04,,,vm
 AWS,eu-south-1,ami-0fdd5958b81f36e68,Ubuntu 22.04,,,vm
-AWS,eu-south-1,ami-0c49c6227e9c03e66,Windows Server 2012 R2,,,vm
 AZURE,all,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202505200,Ubuntu 20.04,,,vm
 AZURE,all,Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210,Ubuntu 22.04,,,vm
 AZURE,all,Debian:debian-11:11:0.20250528.2126,Debian 10,,,vm
 AZURE,all,Debian:debian-10:10:0.20240430.1733,Debian 11,,,vm
 AZURE,all,MicrosoftWindowsServer:WindowsServer:2019-Datacenter:17763.7322.250524,Windows 2019,,,vm
-GCP,all,https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20250530,Ubuntu 20.04,,,vm
-GCP,all,https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250530,Ubuntu 22.04,,,vm
-GCP,all,https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-11-bullseye-v20250513,Debian 11,,,vm
 GCP,all,https://www.googleapis.com/compute/v1/projects/deeplearning-platform-release/global/images/tf-2-15-cu121-v20240417-debian-11,Debian 11,"Google, Deep Learning VM for TensorFlow 2.15 with CUDA 12.1, M120, Debian 11, Python 3.10, with TensorFlow 2.15 for CUDA 12.1 with Intel MKL-DNN preinstalled",,vm
-GCP,all,https://www.googleapis.com/compute/v1/projects/windows-cloud/global/images/windows-server-2019-dc-v20250515,Windows 2019,,,vm
 ALIBABA,all,ubuntu_18_04_x64_20G_alibase_20240223.vhd,Ubuntu 18.04,,,vm
 ALIBABA,all,ubuntu_20_04_x64_20G_alibase_20250415.vhd,Ubuntu 20.04,,,vm
 ALIBABA,all,ubuntu_22_04_x64_20G_alibase_20250415.vhd,Ubuntu 22.04,,,vm
@@ -99,21 +74,6 @@ ALIBABA,all,aliyun_3_x64_20G_alibase_20250117.vhd,Alibaba Cloud Linux 3.2104,,,v
 TENCENT,all,img-pi0ii46r,Ubuntu 18.04,,,vm|k8s
 TENCENT,all,img-22trbn9x,Ubuntu 20.04,,,vm|k8s
 TENCENT,all,img-487zeit5,Ubuntu 22.04,,,vm
-TENCENT,all,img-bpsjtw7n,Windows Server 2012 R2,,,vm
-IBM,us-south,r006-9de77234-3189-42f8-982d-f2266477cfe0,Ubuntu 18.04,,,vm
-IBM,us-south,r006-b4d8d8d4-7768-4a1b-9434-9483ca821a0d,Windows Server 2012 R2,,,vm
-IBM,br-sao,r042-92d1cd12-f014-4b9a-abf8-c5ca6494a9e5,Ubuntu 18.04,,,vm
-IBM,br-sao,r042-d932aff6-577b-40c9-b1c0-59820b847089,Ubuntu 22.04,Ubuntu Linux 22.04 Jammy Jellyfish Minimal Install (s390x),,vm
-IBM,ca-tor,r038-e92647cf-8be9-438a-b94c-251cc86bc99a,Ubuntu 18.04,,,vm
-IBM,us-east,r014-dc446598-a1b5-41c3-a1d6-add3afaf264e,Ubuntu 18.04,,,vm
-IBM,eu-de,r010-1f68eb2d-f35c-4959-8f4b-2b2f9cf78102,Ubuntu 18.04,,,vm
-IBM,eu-de,r010-450355ae-7f70-48fe-9aae-7cf4ac82bc9c,Ubuntu 22.04,Ubuntu Linux 22.04 LTS Jammy Jellyfish Minimal Install (amd64),,vm
-IBM,eu-gb,r018-1d7417c6-893e-49d4-b14d-9643d6b29812,Ubuntu 18.04,,,vm
-IBM,jp-osa,r034-522c639c-52e1-4cab-8dfb-bc0fb9f6f577,Ubuntu 18.04,,,vm
-IBM,au-syd,r026-a8c25ce6-0ca1-43e9-9b41-411c6217b8b8,Ubuntu 18.04,,,vm
-IBM,au-syd,r026-3d2be426-8032-4215-a82b-d61075a49a1c,Debian 10,,,vm
-IBM,jp-tok,r022-61fdadec-6b03-4bd2-bfca-62cd16f5673f,Ubuntu 18.04,,,vm
-NCPVPC,all,SW.VSVR.OS.LNX64.UBNTU.SVR2004.B050,Ubuntu 20.04,,,vm|k8s
 NHNCLOUD,KR1,b7bd50d9-bdc2-460d-8b6a-358436ae3897,Ubuntu 20.04,Ubuntu Server 20.04.6 LTS (2024.05.21),,vm
 NHNCLOUD,KR1,280399f1-af96-41b7-b13b-2fae3752e97f,Ubuntu 22.04,Ubuntu Server 22.04.4 LTS (2024.05.21),,vm
 NHNCLOUD,KR1,62202a6a-5de2-4e13-8461-351f4a93a664,Ubuntu 20.04 Container,Ubuntu Server 20.04.6 LTS - Container (2025.02.25),,k8s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -358,7 +358,6 @@ services:
   #     - MB_LOGGER_LEVEL=OFF
   #     - MB_LOGGING_LEVEL=OFF  
   #     - MB_EMOJI_IN_LOGS=false   
-      
   #   volumes:
   #     - ./container-volume/cb-tumblebug-container/meta_db/metabase-data:/metabase-data
   #   depends_on:

--- a/init/init.py
+++ b/init/init.py
@@ -40,7 +40,7 @@ CRED_PATH = os.path.join(os.path.expanduser('~'), '.cloud-barista')
 ENC_FILE_PATH = os.path.join(CRED_PATH, CRED_FILE_NAME_ENC)
 KEY_FILE = os.path.join(CRED_PATH, ".tmp_enc_key")
 
-expected_completion_time_seconds = 100
+expected_completion_time_seconds = 180
 
 # Check for credential path
 if not os.path.exists(CRED_PATH):
@@ -315,9 +315,9 @@ elif response_json:
                 successful_images += 1
 
     print(Fore.CYAN + f"\nLoading completed (elapsed: {duration}s)")
-    print(Fore.RESET + "Registered Common specs")
-    print(Fore.GREEN + f"- Successful: {successful_specs}" + Fore.RESET + f", Failed: {failed_specs}")
-    print(Fore.RESET + "Registered Common images")
-    print(Fore.GREEN + f"- Successful: {successful_images}" + Fore.RESET + f", Failed: {failed_images}")
+    # print(Fore.RESET + "Registered Common specs")
+    # print(Fore.GREEN + f"- Successful: {successful_specs}" + Fore.RESET + f", Failed: {failed_specs}")
+    # print(Fore.RESET + "Registered Common images")
+    # print(Fore.GREEN + f"- Successful: {successful_images}" + Fore.RESET + f", Failed: {failed_images}")
 else:
     print(Fore.RED + "No data returned from the API.")

--- a/src/api/rest/docs/docs.go
+++ b/src/api/rest/docs/docs.go
@@ -9346,6 +9346,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/ns/{nsId}/resources/updateImagesFromAsset": {
+            "post": {
+                "description": "Update image information based on the cloudimage.csv asset file",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra Resource] Image Management"
+                ],
+                "summary": "Update images from cloudimage.csv asset file",
+                "operationId": "UpdateImagesFromAsset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "system",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/resource.FetchImagesAsyncResult"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/ns/{nsId}/resources/vNet": {
             "get": {
                 "description": "List all VNets or VNets' ID",

--- a/src/api/rest/docs/swagger.json
+++ b/src/api/rest/docs/swagger.json
@@ -9339,6 +9339,52 @@
                 }
             }
         },
+        "/ns/{nsId}/resources/updateImagesFromAsset": {
+            "post": {
+                "description": "Update image information based on the cloudimage.csv asset file",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra Resource] Image Management"
+                ],
+                "summary": "Update images from cloudimage.csv asset file",
+                "operationId": "UpdateImagesFromAsset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "system",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/resource.FetchImagesAsyncResult"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/ns/{nsId}/resources/vNet": {
             "get": {
                 "description": "List all VNets or VNets' ID",

--- a/src/api/rest/docs/swagger.yaml
+++ b/src/api/rest/docs/swagger.yaml
@@ -7145,6 +7145,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/updateImagesFromAsset:
+    post:
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Update images from cloudimage.csv asset file
+      description: Update image information based on the cloudimage.csv asset file
+      operationId: UpdateImagesFromAsset
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: system
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource.FetchImagesAsyncResult'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/vNet:
     get:
       tags:

--- a/src/api/rest/server/resource/image.go
+++ b/src/api/rest/server/resource/image.go
@@ -255,6 +255,29 @@ func RestGetFetchImagesAsyncResult(c echo.Context) error {
 	return clientManager.EndRequestWithLog(c, nil, result)
 }
 
+// RestUpdateImagesFromAsset godoc
+// @ID UpdateImagesFromAsset
+// @Summary Update images from cloudimage.csv asset file
+// @Description Update image information based on the cloudimage.csv asset file
+// @Tags [Infra Resource] Image Management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(system)
+// @Success 202 {object} resource.FetchImagesAsyncResult
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Router /ns/{nsId}/resources/updateImagesFromAsset [post]
+func RestUpdateImagesFromAsset(c echo.Context) error {
+	nsId := c.Param("nsId")
+
+	result, err := resource.UpdateImagesFromAsset(nsId)
+	if err != nil {
+		return clientManager.EndRequestWithLog(c, err, nil)
+	}
+
+	return clientManager.EndRequestWithLog(c, nil, result)
+}
+
 // RestGetImage godoc
 // @ID GetImage
 // @Summary Get image

--- a/src/api/rest/server/server.go
+++ b/src/api/rest/server/server.go
@@ -482,6 +482,7 @@ func RunServer() {
 	g.POST("/:nsId/resources/fetchImages", rest_resource.RestFetchImages)
 	g.POST("/:nsId/resources/fetchImagesAsync", rest_resource.RestFetchImagesAsync)
 	g.GET("/:nsId/resources/fetchImagesResult", rest_resource.RestGetFetchImagesAsyncResult)
+	g.POST("/:nsId/resources/updateImagesFromAsset", rest_resource.RestUpdateImagesFromAsset)
 	g.POST("/:nsId/resources/searchImage", rest_resource.RestSearchImage)
 	g.GET("/:nsId/resources/searchImageOptions", rest_resource.RestSearchImageOptions)
 

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -1596,8 +1596,8 @@ func ExtractOSInfo(combinedInfo string) string {
 					numericParts := regexp.MustCompile(`\d+`).FindAllString(version, -1)
 					if len(numericParts) > 0 {
 						// Join the numeric parts with a regex pattern to match any non-numeric characters
-						// Exclude 'T' between numbers (used in time formats like 22T04)
-						versionPattern := strings.Join(numericParts, "[^0-9T]*")
+						// This excludes date formats like 22T04
+						versionPattern := strings.Join(numericParts, "[.\\s-_]?")
 						// Add a regex pattern to avoid matching the version in the middle of numeric strings
 						boundedVersionPattern := fmt.Sprintf("(?:^|[^0-9])%s(?:$|[^0-9])", versionPattern)
 

--- a/src/core/infra/recommendation.go
+++ b/src/core/infra/recommendation.go
@@ -139,7 +139,6 @@ func RecommendVm(nsId string, plan model.DeploymentPlan) ([]model.TbSpecInfo, er
 	// })
 
 	// Prioritizing
-	log.Debug().Msg("[Prioritizing specs]")
 	prioritySpecs := []model.TbSpecInfo{}
 
 	startTime = time.Now()

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -491,7 +491,6 @@ func FilterSpecsByRange(nsId string, filter model.FilterSpecsByRangeRequest) ([]
 	query := model.ORM.Where("namespace = ?", nsId)
 
 	specColumnMapping := getColumnMapping(&model.TbSpecInfo{})
-
 	// Change field names to start with lowercase (GORM convention)
 	val := reflect.ValueOf(filter)
 	typ := val.Type()
@@ -531,6 +530,9 @@ func FilterSpecsByRange(nsId string, filter model.FilterSpecsByRangeRequest) ([]
 	startTime := time.Now()
 
 	var specs []model.TbSpecInfo
+
+	// Check the query before executing
+	query = query.Debug()
 	result := query.Find(&specs)
 	if result.Error != nil {
 		log.Error().Err(result.Error).Msg("Failed to execute query")


### PR DESCRIPTION
This PR proposes combining fetch images and update images from the asset file.

After this PR, init.sh will fetch all images from the registered CSPs except Azure and update fetched images according to the image asset file if necessary. 

Note that Azure images are not fetched and only the images listed in the asset file will be registered.
(fetching Azure images take too much time. I think we need to avoid it.)