### PR TITLE
Fix IBM error due to VPC zone cidr issue

### DIFF
--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -1451,24 +1451,6 @@ func CreateSharedResource(nsId string, resType string, connectionName string) er
 
 			// set isolated private address space for each cloud region (10.i.0.0/16)
 			reqTmp.CidrBlock = "10." + strconv.Itoa(sliceIndex) + ".0.0/16"
-			if strings.EqualFold(provider, "cloudit") {
-				// CLOUDIT: the list of subnets that can be created is
-				// 10.0.4.0/22,10.0.8.0/22,10.0.12.0/22,10.0.28.0/22,10.0.32.0/22,
-				// 10.0.36.0/22,10.0.40.0/22,10.0.44.0/22,10.0.48.0/22,10.0.52.0/22,
-				// 10.0.56.0/22,10.0.60.0/22,10.0.64.0/22,10.0.68.0/22,10.0.72.0/22,
-				// 10.0.76.0/22,10.0.80.0/22,10.0.84.0/22,10.0.88.0/22,10.0.92.0/22,
-				// 10.0.96.0/22,10.0.100.0/22,10.0.104.0/22,10.0.108.0/22,10.0.112.0/22,
-				// 10.0.116.0/22,10.0.120.0/22,10.0.124.0/22,10.0.132.0/22,10.0.136.0/22,
-				// 10.0.140.0/22,10.0.144.0/22,10.0.148.0/22,10.0.152.0/22,10.0.156.0/22,
-				// 10.0.160.0/22,10.0.164.0/22,10.0.168.0/22,10.0.172.0/22,10.0.176.0/22,
-				// 10.0.180.0/22,10.0.184.0/22,10.0.188.0/22,10.0.192.0/22,10.0.196.0/22,
-				// 10.0.200.0/22,10.0.204.0/22,10.0.208.0/22,10.0.212.0/22,10.0.216.0/22,
-				// 10.0.220.0/22,10.0.224.0/22,10.0.228.0/22,10.0.232.0/22,10.0.236.0/22,
-				// 10.0.240.0/22,10.0.244.0/22,10.0.248.0/22
-
-				// temporally assign 10.0.40.0/22 until new policy.
-				reqTmp.CidrBlock = "10.0.40.0/22"
-			}
 
 			// Consist 2 subnets (10.i.0.0/18, 10.i.64.0/18)
 			// Reserve spaces for tentative 2 subnets (10.i.128.0/18, 10.i.192.0/18)
@@ -1486,6 +1468,12 @@ func CreateSharedResource(nsId string, resType string, connectionName string) er
 			subnet = model.TbSubnetReq{Name: subnetName, IPv4_CIDR: subnetCidr}
 			if length > 1 {
 				subnet.Zone = zones[1]
+				// ref IBM VPC Network structure: https://cloud.ibm.com/docs/vpc?topic=vpc-about-networking-for-vpc&locale=en
+				// IBM VPC Network requires Address Prefix setup for each zone. (but there is limitation in CB-Spider implementation.)
+				// So, we will create 2 subnets in a zone within the limited address space.
+				if provider == csp.IBM {
+					subnet.Zone = zones[0]
+				}
 			}
 			reqTmp.SubnetInfoList = append(reqTmp.SubnetInfoList, subnet)
 


### PR DESCRIPTION
fix #2004

- CB-Spider IBM 클라우드 드라이버 구현 제약상, IBM VPC의 특징인 멀티 존에 걸친 VPC (존별 서브넷)을 지원하지 못하고 있는 것으로 보임. (참고: CB-Spider 구현체 코드를 살펴보면, 첫번째 존에만 존 CIDR을 셋팅하는 것으로 보임. 구현상 개선 필요 사항)
- 기존 CB-TB: MCI Dynamic에서 존2개에 서브넷을 각각 1개씩 생성 ==> IBM 클라우드에서는 VPC 생성 오류가 발생함.
- 수정 CB-TB:  IBM의 경우, 특성 및 현재 구현 한계를 고려해서, 임시적으로 하나의 존에 2개의 서브넷을 추가하도록 수정함.


- ref IBM VPC Network structure: https://cloud.ibm.com/docs/vpc?topic=vpc-about-networking-for-vpc&locale=en
				
// IBM VPC Network requires Address Prefix setup for each zone. (but there is limitation in CB-Spider implementation.)			
// So, we will create 2 subnets in a zone within the limited address space.