### PR TITLE
feat: add basic OS image detection and advanced filtering

### DIFF
--- a/assets/cloudinfo.yaml
+++ b/assets/cloudinfo.yaml
@@ -652,13 +652,6 @@ cloud:
           latitude: -35.3075
           longitude: 149.1244
         zone: []
-      # australiacentral2:
-      #  description: Australia Central 2 - DR region (No VM support)
-      #  location:
-      #    display: Australia Central 2
-      #    latitude: -35.3085
-      #    longitude: 149.1254
-      #  zone: []
       australiaeast:
         description: Australia East
         location:
@@ -763,20 +756,6 @@ cloud:
         - '1'
         - '2'
         - '3'
-      # francesouth:
-      #  description: France South - DR region (No VM support)
-      #  location:
-      #    display: France South
-      #    latitude: 43.8345
-      #    longitude: 2.1972
-      #  zone: []
-      # germanynorth:
-      #  description: Germany North - DR region (No VM support)
-      #  location:
-      #    display: Germany North
-      #    latitude: 53.0736
-      #    longitude: 8.8064
-      #  zone: []
       germanywestcentral:
         description: Germany West Central
         location:
@@ -851,13 +830,6 @@ cloud:
         - '1'
         - '2'
         - '3'
-      # norwaywest:
-      #  description: Norway West - DR region (No VM support)
-      #  location:
-      #    display: Norway West
-      #    latitude: 58.97
-      #    longitude: 5.7331
-      #  zone: []
       southafricanorth:
         description: South Africa North
         location:
@@ -868,13 +840,6 @@ cloud:
         - '1'
         - '2'
         - '3'
-      # southafricawest:
-      #  description: South Africa West - DR region (No VM support)
-      #  location:
-      #    display: South Africa West
-      #    latitude: -34.0757
-      #    longitude: 18.8433
-      #  zone: []
       southcentralus:
         description: South Central US
         location:
@@ -912,20 +877,6 @@ cloud:
         - '1'
         - '2'
         - '3'
-      # switzerlandwest:
-      #  description: Switzerland West - DR region (No VM support)
-      #  location:
-      #    display: Switzerland West
-      #    latitude: 46.2044
-      #    longitude: 6.1432
-      #  zone: []
-      # uaecentral:
-      #  description: UAE Central - DR region (No VM support)
-      #  location:
-      #    display: UAE Central
-      #    latitude: 24.4667
-      #    longitude: 54.3667
-      #  zone: []
       uaenorth:
         description: UAE North
         location:
@@ -1014,23 +965,24 @@ cloud:
         - '1'
         - '2'
         - '3'
-      eastus2euap:
-        description: East US 2 EUAP (Early Updates Access Program)
-        location:
-          display: East US 2 EUAP
-          latitude: 36.6781
-          longitude: -78.3789
-        zone:
-        - '1'
-        - '2'
-        - '3'
-      brazilus:
-        description: brazilus
-        location:
-          display: brazilus
-          latitude: -10.3333333
-          longitude: -53.2
-        zone: []
+      # eastus2euap:
+      #  description: East US 2 EUAP (Early Updates Access Program) - DR region (No
+      #    VM support)
+      #  location:
+      #    display: East US 2 EUAP
+      #    latitude: 36.6781
+      #    longitude: -78.3789
+      #  zone:
+      #  - '1'
+      #  - '2'
+      #  - '3'
+      # brazilus:
+      #  description: brazilus - DR region (No VM support)
+      #  location:
+      #    display: brazilus
+      #    latitude: -10.3333333
+      #    longitude: -53.2
+      #  zone: []
       qatarcentral:
         description: qatar central
         location:
@@ -1041,13 +993,6 @@ cloud:
         - '1'
         - '2'
         - '3'
-      # brazilsoutheast:
-      #  description: brazil southeast - DR region (No VM support)
-      #  location:
-      #    display: brazil southeast
-      #    latitude: -22.4666667
-      #    longitude: -45
-      #  zone: []
       jioindiawest:
         description: Jio India West
         location:
@@ -1055,13 +1000,13 @@ cloud:
           latitude: 19.86858
           longitude: 73.10469
         zone: []
-      jioindiacentral:
-        description: Jio India Central
-        location:
-          display: Jio India Central
-          latitude: 13.00284
-          longitude: 77.59155
-        zone: []
+      # jioindiacentral:
+      #  description: Jio India Central - DR region (No VM support)
+      #  location:
+      #    display: Jio India Central
+      #    latitude: 13.00284
+      #    longitude: 77.59155
+      #  zone: []
       italynorth:
         description: Lombardy Italy
         location:
@@ -1092,20 +1037,21 @@ cloud:
         - '1'
         - '2'
         - '3'
-      eastusstg:
-        description: East US STG
-        location:
-          display: East US STG
-          latitude: 37.3719
-          longitude: -79.8164
-        zone: []
-      centraluseuap:
-        description: Central US 2 EUAP (Early Updates Access Program)
-        location:
-          display: Central US 2 EUAP
-          latitude: 41.5908
-          longitude: -93.6208
-        zone: []
+      # eastusstg:
+      #  description: East US STG - DR region (No VM support)
+      #  location:
+      #    display: East US STG
+      #    latitude: 37.3719
+      #    longitude: -79.8164
+      #  zone: []
+      # centraluseuap:
+      #  description: Central US 2 EUAP (Early Updates Access Program) - DR region
+      #    (No VM support)
+      #  location:
+      #    display: Central US 2 EUAP
+      #    latitude: 41.5908
+      #    longitude: -93.6208
+      #  zone: []
       spaincentral:
         desc: Spain Central
         location:
@@ -1176,6 +1122,70 @@ cloud:
         - '1'
         - '2'
         - '3'
+      # australiacentral2:
+      #  desc: ''
+      #  location:
+      #    display: ''
+      #    latitude: null
+      #    longitude: null
+      #  zone: []
+      #  description: australiacentral2 - DR region (No VM support)
+      # switzerlandwest:
+      #  desc: ''
+      #  location:
+      #    display: ''
+      #    latitude: null
+      #    longitude: null
+      #  zone: []
+      #  description: switzerlandwest - DR region (No VM support)
+      # francesouth:
+      #  desc: ''
+      #  location:
+      #    display: ''
+      #    latitude: null
+      #    longitude: null
+      #  zone: []
+      #  description: francesouth - DR region (No VM support)
+      # uaecentral:
+      #  desc: ''
+      #  location:
+      #    display: ''
+      #    latitude: null
+      #    longitude: null
+      #  zone: []
+      #  description: uaecentral - DR region (No VM support)
+      # southafricawest:
+      #  desc: ''
+      #  location:
+      #    display: ''
+      #    latitude: null
+      #    longitude: null
+      #  zone: []
+      #  description: southafricawest - DR region (No VM support)
+      # germanynorth:
+      #  desc: ''
+      #  location:
+      #    display: ''
+      #    latitude: null
+      #    longitude: null
+      #  zone: []
+      #  description: germanynorth - DR region (No VM support)
+      # brazilsoutheast:
+      #  desc: ''
+      #  location:
+      #    display: ''
+      #    latitude: null
+      #    longitude: null
+      #  zone: []
+      #  description: brazilsoutheast - DR region (No VM support)
+      # norwaywest:
+      #  desc: ''
+      #  location:
+      #    display: ''
+      #    latitude: null
+      #    longitude: null
+      #  zone: []
+      #  description: norwaywest - DR region (No VM support)
   gcp:
     description: Google Cloud Platform
     driver: gcp-driver-v1.0.so

--- a/assets/extractionpatterns.yaml
+++ b/assets/extractionpatterns.yaml
@@ -5,9 +5,10 @@ extractionPatterns:
   osType:
     ubuntu:
       name: "Ubuntu"
-      versions: ["16.04", "18.04", "20.04", "22.04", "22.10", "23.04", "24.04"]
+      versions: ["16.04", "18.04", "20.04", "22.04", "22.10", "23.10", "23.04", "24.04", "24.10", "25.04"]
       defaultVersion: ""
       patterns: ["ubuntu", "canonical"]
+      patternsForBasicImage: ["Ubuntu * 64 bit", "ubuntu/images/*", "0001-com-ubuntu-server*", "Canonical, Ubuntu, * LTS Minimal*", "Ubuntu Linux * LTS*", "ubuntu-*-64bit", "ubuntu-*-base (Hypervisor:KVM)", "Ubuntu Server * LTS (*)", "Ubuntu Server * LTS 64bit"]
     centos:
       name: "CentOS"
       versions: ["7", "8", "9"]

--- a/src/core/model/config.go
+++ b/src/core/model/config.go
@@ -66,10 +66,11 @@ type ExtractPatterns struct {
 
 // OSTypeDetail is structure for OS type detail information
 type OSTypeDetail struct {
-	Name           string   `mapstructure:"name" json:"name"`
-	Versions       []string `mapstructure:"versions" json:"versions"`
-	DefaultVersion string   `mapstructure:"defaultVersion" json:"default_version"`
-	Patterns       []string `mapstructure:"patterns" json:"patterns"`
+	Name                  string   `mapstructure:"name" json:"name"`
+	Versions              []string `mapstructure:"versions" json:"versions"`
+	DefaultVersion        string   `mapstructure:"defaultVersion" json:"default_version"`
+	Patterns              []string `mapstructure:"patterns" json:"patterns"`
+	PatternsForBasicImage []string `mapstructure:"patternsForBasicImage" json:"patternsForBasicImage"`
 }
 
 /*

--- a/src/core/model/image.go
+++ b/src/core/model/image.go
@@ -98,6 +98,7 @@ type TbImageInfo struct {
 
 	IsGPUImage        bool `json:"isGPUImage,omitempty" gorm:"column:is_gpu_image" enum:"true|false" default:"false" description:"Whether the image is GPU-enabled or not."`
 	IsKubernetesImage bool `json:"isKubernetesImage,omitempty" gorm:"column:is_kubernetes_image" enum:"true|false" default:"false" description:"Whether the image is Kubernetes-enabled or not."`
+	IsBasicImage      bool `json:"isBasicImage,omitempty" gorm:"column:is_basic_image" enum:"true|false" default:"false" description:"Whether the image is a basic OS image or not."`
 
 	OSType string `json:"osType,omitempty" gorm:"column:os_type" example:"ubuntu 22.04" description:"Simplified OS name and version string"`
 
@@ -156,6 +157,16 @@ type SearchImageRequest struct {
 	// In usual, deprecated images are not recommended to use, but they can be used if necessary.
 	IncludeDeprecatedImage *bool `json:"includeDeprecatedImage" example:"false" description:"Include deprecated images in the search results."`
 
+	// IncludeBasicImageOnly is to return basic OS distribution only without additional applications.
+	// If true, the search results will include only the basic OS distribution without additional applications.
+	// If false or not specified, the search results will include images with additional applications installed.
+	IncludeBasicImageOnly *bool `json:"includeBasicImageOnly" example:"false" description:"Return basic OS distribution only without additional applications."`
+
+	// MaxResults is the maximum number of images to be returned in the search results.
+	// If not specified, all images will be returned.
+	// If specified, the number of images returned will be limited to the specified value.
+	MaxResults *int `json:"maxResults" example:"100" description:"Maximum number of images to be returned in the search results. If not specified, all images will be returned."`
+
 	// Keywords for searching images in detail.
 	// Space-separated for AND condition (ex: "sql 2022", "ubuntu 22.04", etc.).
 	// Used for if the user wants to search images with specific keywords in their details.
@@ -195,6 +206,11 @@ type SearchImageRequestOptions struct {
 	// If not specified, deprecated images will not be included in the search results.
 	// In usual, deprecated images are not recommended to use, but they can be used if necessary.
 	IncludeDeprecatedImage []bool `json:"includeDeprecatedImage" description:"Include deprecated images in the search results."`
+
+	// MaxResults is the maximum number of images to be returned in the search results.
+	// If not specified, all images will be returned.
+	// If specified, the number of images returned will be limited to the specified value.
+	MaxResults []int `json:"maxResults" example:"100" description:"Maximum number of images to be returned in the search results. If not specified, all images will be returned."`
 
 	// Keywords for searching images in detail.
 	// Space-separated for AND condition (ex: "sql 2022", "ubuntu 22.04", etc.).

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -588,7 +588,7 @@ func fetchSpecsForAllConnConfigsInternal(nsId string, option *model.SpecFetchOpt
 						} else {
 							connResult.Success = true
 							connResult.SpecCount = specCount
-							log.Info().Msgf("[%s][Provider-%s][Conn-%d] Successfully fetched %d specs from %s",
+							log.Info().Msgf("[%s][%s][%d] Successfully fetched %d specs from %s",
 								nsId, provider, index, specCount, connName)
 						}
 					}
@@ -1228,7 +1228,7 @@ func FetchPriceForAllConnConfigs() (connConfigCount uint, priceCount uint, err e
 
 		// Mark as successful and collect prices
 		successCount++
-		log.Debug().Msgf("Successfully processed connection: %s", result.ConnConfig.ConfigName)
+		// log.Debug().Msgf("Successfully processed connection: %s", result.ConnConfig.ConfigName)
 	}
 
 	// Report any errors
@@ -1254,7 +1254,7 @@ func FetchPriceForAllConnConfigs() (connConfigCount uint, priceCount uint, err e
 
 // FetchPriceForConnConfig lookups all Price for region of conn config, processes them in batch
 func FetchPriceForConnConfig(config model.ConnConfig) error {
-	log.Debug().Msg("FetchPriceForConnConfig(" + config.ConfigName + ")")
+	log.Debug().Msg("Init fetching prices for connection: " + config.ConfigName)
 
 	// Reuse existing LookupPriceList function
 	priceInConnection, err := LookupPriceList(config)
@@ -1263,7 +1263,13 @@ func FetchPriceForConnConfig(config model.ConnConfig) error {
 		return err
 	}
 
+	if strings.EqualFold(csp.GCP, config.ProviderName) {
+		log.Info().Msgf("GCP price %v", priceInConnection)
+	}
+
 	if len(priceInConnection.PriceList) == 0 {
+		log.Info().Msgf("No prices found for connection %s",
+			config.ConfigName)
 		return nil
 	}
 


### PR DESCRIPTION
- Add IsBasicImage field to identify pure OS images vs app-bundled images
- Implement CheckBasicOSImage() with pattern matching for OS recognition
- Add intelligent duplicate filtering keeping latest 2 versions per OS group
- Support comprehensive date format parsing for proper version sorting
- Add CSP-specific processing for NHN Cloud and NCP hypervisor detection
- Include basic image patterns in extractionpatterns.yaml for Ubuntu
- Add IncludeBasicImageOnly and MaxResults options to image search API

This enables cb-mapui to distinguish and highlight basic OS images with star icons while filtering out outdated duplicates for better UX.