### PR TITLE
feat: refactor Security Group firewall rule model and update logic

### DIFF
--- a/src/core/model/securitygroup.go
+++ b/src/core/model/securitygroup.go
@@ -3,7 +3,7 @@ Copyright 2019 The Cloud-Barista Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -71,16 +71,15 @@ type TbSecurityGroupReq struct { // Tumblebug
 	FirewallRules  *[]TbFirewallRuleInfo `json:"firewallRules"` // validate:"required"`
 
 	// CspResourceId is required to register object from CSP (option=register)
-	CspResourceId string `json:"cspResourceId"`
+	CspResourceId string `json:"cspResourceId" example:"required for option=register only. ex: csp-06eb41e14121c550a"`
 }
 
 // TbFirewallRuleInfo is a struct to handle firewall rule info of CB-Tumblebug.
 type TbFirewallRuleInfo struct {
-	FromPort   string `validate:"required"` //`json:"fromPort"`
-	ToPort     string `validate:"required"` //`json:"toPort"`
-	IPProtocol string `validate:"required"` //`json:"ipProtocol"`
-	Direction  string `validate:"required"` //`json:"direction"`
-	CIDR       string
+	Ports     string `json:"Ports" example:"1-65535,22,5555"`
+	Protocol  string `validate:"required" json:"Protocol" example:"TCP" enums:"TCP,UDP,ICMP,ALL"`
+	Direction string `validate:"required" json:"Direction" example:"inbound" enums:"inbound,outbound"`
+	CIDR      string `json:"CIDR" example:"0.0.0.0/0"`
 }
 
 // TbSecurityGroupInfo is a struct that represents TB security group object.
@@ -115,4 +114,9 @@ type TbSecurityGroupInfo struct {
 
 	// Disabled for now
 	//ResourceGroupName  string `json:"resourceGroupName"`
+}
+
+// TbSecurityGroupUpdateReq is a struct to handle 'Update security group' request toward CB-Tumblebug.
+type TbSecurityGroupUpdateReq struct {
+	FirewallRules []TbFirewallRuleInfo `json:"firewallRules"`
 }

--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -1497,14 +1497,14 @@ func CreateSharedResource(nsId string, resType string, connectionName string) er
 			reqTmp.VNetId = resourceName
 
 			// open all firewall for default securityGroup
-			rule := model.TbFirewallRuleInfo{FromPort: "1", ToPort: "65535", IPProtocol: "tcp", Direction: "inbound", CIDR: "0.0.0.0/0"}
+			rule := model.TbFirewallRuleInfo{Ports: "1-65535", Protocol: "tcp", Direction: "inbound", CIDR: "0.0.0.0/0"}
 			var ruleList []model.TbFirewallRuleInfo
 			ruleList = append(ruleList, rule)
-			rule = model.TbFirewallRuleInfo{FromPort: "1", ToPort: "65535", IPProtocol: "udp", Direction: "inbound", CIDR: "0.0.0.0/0"}
+			rule = model.TbFirewallRuleInfo{Ports: "1-65535", Protocol: "udp", Direction: "inbound", CIDR: "0.0.0.0/0"}
 			ruleList = append(ruleList, rule)
 			// CloudIt only offers tcp, udp Protocols
 			if !strings.EqualFold(provider, "cloudit") {
-				rule = model.TbFirewallRuleInfo{FromPort: "-1", ToPort: "-1", IPProtocol: "icmp", Direction: "inbound", CIDR: "0.0.0.0/0"}
+				rule = model.TbFirewallRuleInfo{Protocol: "icmp", Direction: "inbound", CIDR: "0.0.0.0/0"}
 				ruleList = append(ruleList, rule)
 			}
 

--- a/src/interface/rest/docs/docs.go
+++ b/src/interface/rest/docs/docs.go
@@ -8354,6 +8354,66 @@ const docTemplate = `{
                     }
                 }
             },
+            "put": {
+                "description": "Update Security Group: Synchronize the firewall rules of the specified Security Group to match the requested list exactly.\nThis API will add missing rules and delete extra rules so that the Security Group's rules become identical to the requested set.\nOnly firewall rules are updated; other metadata (name, description, etc.) is not changed.\n\nUsage:\nUse this API to update (synchronize) the firewall rules of a Security Group. The rules in the request body will become the only rules in the Security Group after the operation.\n- All existing rules not present in the request will be deleted.\n- All rules in the request that do not exist will be added.\n- If a rule exists but differs in CIDR or port range, it will be replaced.\n- Special protocols (ICMP, ALL, etc.) are handled in the same way.\n\nNotes:\n- \"Ports\" field supports single port (\"22\"), port range (\"80-100\"), and multiple ports/ranges (\"22,80-100,443\").\n- The valid port number range is 0 to 65535 (inclusive).\n- \"Protocol\" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).\n- \"Direction\" must be either \"inbound\" or \"outbound\".\n- \"CIDR\" is the allowed IP range.\n- All existing rules not in the request (including default ICMP, ALL, etc.) will be deleted.\n- Metadata (name, description, etc.) is not changed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra Resource] Security Group Management"
+                ],
+                "summary": "Update Security Group (Synchronize Firewall Rules)",
+                "operationId": "PutSecurityGroup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "default",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Security Group ID",
+                        "name": "securityGroupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Details for an securityGroup object (only firewallRules field is used for update)",
+                        "name": "securityGroupInfo",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.TbSecurityGroupUpdateReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated Security Group info with synchronized firewall rules",
+                        "schema": {
+                            "$ref": "#/definitions/model.TbSecurityGroupInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            },
             "delete": {
                 "description": "Delete Security Group",
                 "consumes": [
@@ -14791,30 +14851,35 @@ const docTemplate = `{
         "model.TbFirewallRuleInfo": {
             "type": "object",
             "required": [
-                "direction",
-                "fromPort",
-                "ipprotocol",
-                "toPort"
+                "Direction",
+                "Protocol"
             ],
             "properties": {
-                "cidr": {
-                    "type": "string"
+                "CIDR": {
+                    "type": "string",
+                    "example": "0.0.0.0/0"
                 },
-                "direction": {
-                    "description": "` + "`" + `json:\"direction\"` + "`" + `",
-                    "type": "string"
+                "Direction": {
+                    "type": "string",
+                    "enum": [
+                        "inbound",
+                        "outbound"
+                    ],
+                    "example": "inbound"
                 },
-                "fromPort": {
-                    "description": "` + "`" + `json:\"fromPort\"` + "`" + `",
-                    "type": "string"
+                "Ports": {
+                    "type": "string",
+                    "example": "1-65535,22,5555"
                 },
-                "ipprotocol": {
-                    "description": "` + "`" + `json:\"ipProtocol\"` + "`" + `",
-                    "type": "string"
-                },
-                "toPort": {
-                    "description": "` + "`" + `json:\"toPort\"` + "`" + `",
-                    "type": "string"
+                "Protocol": {
+                    "type": "string",
+                    "enum": [
+                        "TCP",
+                        "UDP",
+                        "ICMP",
+                        "ALL"
+                    ],
+                    "example": "TCP"
                 }
             }
         },
@@ -16261,7 +16326,8 @@ const docTemplate = `{
                 },
                 "cspResourceId": {
                     "description": "CspResourceId is required to register object from CSP (option=register)",
-                    "type": "string"
+                    "type": "string",
+                    "example": "required for option=register only. ex: csp-06eb41e14121c550a"
                 },
                 "description": {
                     "type": "string"
@@ -16278,6 +16344,17 @@ const docTemplate = `{
                 },
                 "vNetId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.TbSecurityGroupUpdateReq": {
+            "type": "object",
+            "properties": {
+                "firewallRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.TbFirewallRuleInfo"
+                    }
                 }
             }
         },

--- a/src/interface/rest/docs/swagger.json
+++ b/src/interface/rest/docs/swagger.json
@@ -8347,6 +8347,66 @@
                     }
                 }
             },
+            "put": {
+                "description": "Update Security Group: Synchronize the firewall rules of the specified Security Group to match the requested list exactly.\nThis API will add missing rules and delete extra rules so that the Security Group's rules become identical to the requested set.\nOnly firewall rules are updated; other metadata (name, description, etc.) is not changed.\n\nUsage:\nUse this API to update (synchronize) the firewall rules of a Security Group. The rules in the request body will become the only rules in the Security Group after the operation.\n- All existing rules not present in the request will be deleted.\n- All rules in the request that do not exist will be added.\n- If a rule exists but differs in CIDR or port range, it will be replaced.\n- Special protocols (ICMP, ALL, etc.) are handled in the same way.\n\nNotes:\n- \"Ports\" field supports single port (\"22\"), port range (\"80-100\"), and multiple ports/ranges (\"22,80-100,443\").\n- The valid port number range is 0 to 65535 (inclusive).\n- \"Protocol\" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).\n- \"Direction\" must be either \"inbound\" or \"outbound\".\n- \"CIDR\" is the allowed IP range.\n- All existing rules not in the request (including default ICMP, ALL, etc.) will be deleted.\n- Metadata (name, description, etc.) is not changed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[Infra Resource] Security Group Management"
+                ],
+                "summary": "Update Security Group (Synchronize Firewall Rules)",
+                "operationId": "PutSecurityGroup",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "default": "default",
+                        "description": "Namespace ID",
+                        "name": "nsId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Security Group ID",
+                        "name": "securityGroupId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Details for an securityGroup object (only firewallRules field is used for update)",
+                        "name": "securityGroupInfo",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.TbSecurityGroupUpdateReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Updated Security Group info with synchronized firewall rules",
+                        "schema": {
+                            "$ref": "#/definitions/model.TbSecurityGroupInfo"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            },
             "delete": {
                 "description": "Delete Security Group",
                 "consumes": [
@@ -14784,30 +14844,35 @@
         "model.TbFirewallRuleInfo": {
             "type": "object",
             "required": [
-                "direction",
-                "fromPort",
-                "ipprotocol",
-                "toPort"
+                "Direction",
+                "Protocol"
             ],
             "properties": {
-                "cidr": {
-                    "type": "string"
+                "CIDR": {
+                    "type": "string",
+                    "example": "0.0.0.0/0"
                 },
-                "direction": {
-                    "description": "`json:\"direction\"`",
-                    "type": "string"
+                "Direction": {
+                    "type": "string",
+                    "enum": [
+                        "inbound",
+                        "outbound"
+                    ],
+                    "example": "inbound"
                 },
-                "fromPort": {
-                    "description": "`json:\"fromPort\"`",
-                    "type": "string"
+                "Ports": {
+                    "type": "string",
+                    "example": "1-65535,22,5555"
                 },
-                "ipprotocol": {
-                    "description": "`json:\"ipProtocol\"`",
-                    "type": "string"
-                },
-                "toPort": {
-                    "description": "`json:\"toPort\"`",
-                    "type": "string"
+                "Protocol": {
+                    "type": "string",
+                    "enum": [
+                        "TCP",
+                        "UDP",
+                        "ICMP",
+                        "ALL"
+                    ],
+                    "example": "TCP"
                 }
             }
         },
@@ -16254,7 +16319,8 @@
                 },
                 "cspResourceId": {
                     "description": "CspResourceId is required to register object from CSP (option=register)",
-                    "type": "string"
+                    "type": "string",
+                    "example": "required for option=register only. ex: csp-06eb41e14121c550a"
                 },
                 "description": {
                     "type": "string"
@@ -16271,6 +16337,17 @@
                 },
                 "vNetId": {
                     "type": "string"
+                }
+            }
+        },
+        "model.TbSecurityGroupUpdateReq": {
+            "type": "object",
+            "properties": {
+                "firewallRules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.TbFirewallRuleInfo"
+                    }
                 }
             }
         },

--- a/src/interface/rest/docs/swagger.yaml
+++ b/src/interface/rest/docs/swagger.yaml
@@ -1,6258 +1,1750 @@
-basePath: /tumblebug
-definitions:
-  auth.AuthsInfo:
-    properties:
-      authenticated:
-        type: boolean
-      expired-time:
-        type: string
-      name:
-        type: string
-      role:
-        type: string
-      token:
-        type: string
-    type: object
-  client.RequestDetails:
-    properties:
-      endTime:
-        description: The time when the request was fully processed.
-        type: string
-      errorResponse:
-        description: A message describing any error that occurred during request processing.
-        type: string
-      requestInfo:
-        allOf:
-        - $ref: '#/definitions/client.RequestInfo'
-        description: Extracted information about the request.
-      responseData:
-        description: The data sent back in response to the request.
-      startTime:
-        description: The time when the request was received by the server.
-        type: string
-      status:
-        description: The current status of the request (e.g., "Handling", "Error",
-          "Success").
-        type: string
-    type: object
-  client.RequestInfo:
-    properties:
-      body:
-        description: 'Optional: request body'
-      header:
-        additionalProperties:
-          type: string
-        description: Key-value pairs of the request headers.
-        type: object
-      method:
-        description: HTTP method (GET, POST, etc.), indicating the request's action
-          type.
-        type: string
-      url:
-        description: The URL the request is made to.
-        type: string
-    type: object
-  common.JSONResult:
-    type: object
-  common.NumberRequest:
-    properties:
-      number:
-        example: 100
-        type: integer
-    type: object
-  common.RestGetAllConfigResponse:
-    properties:
-      config:
-        description: Name string     `json:"name"`
-        items:
-          $ref: '#/definitions/model.ConfigInfo'
-        type: array
-    type: object
-  common.RestGetAllNsResponse:
-    properties:
-      ns:
-        description: Name string     `json:"name"`
-        items:
-          $ref: '#/definitions/model.NsInfo'
-        type: array
-    type: object
-  common.RestInspectResourcesRequest:
-    properties:
-      connectionName:
-        example: aws-ap-southeast-1
-        type: string
-      resourceType:
-        enum:
-        - vNet
-        - securityGroup
-        - sshKey
-        - vm
-        example: vNet
-        type: string
-    type: object
-  common.RestRegisterCspNativeResourcesRequest:
-    properties:
-      connectionName:
-        example: aws-ap-southeast-1
-        type: string
-      mciName:
-        example: csp
-        type: string
-      nsId:
-        example: default
-        type: string
-    type: object
-  common.RestRegisterCspNativeResourcesRequestAll:
-    properties:
-      mciName:
-        example: csp
-        type: string
-      nsId:
-        example: default
-        type: string
-    type: object
-  common.TbConnectionName:
-    properties:
-      connectionName:
-        type: string
-    type: object
-  infra.JSONResult:
-    type: object
-  infra.RestGetAllBenchmarkRequest:
-    properties:
-      host:
-        type: string
-    type: object
-  infra.RestGetAllMciPolicyResponse:
-    properties:
-      mciPolicy:
-        items:
-          $ref: '#/definitions/model.MciPolicyInfo'
-        type: array
-    type: object
-  infra.RestGetAllMciResponse:
-    properties:
-      mci:
-        items:
-          $ref: '#/definitions/model.TbMciInfo'
-        type: array
-    type: object
-  infra.RestGetAllMciStatusResponse:
-    properties:
-      mci:
-        items:
-          $ref: '#/definitions/model.MciStatusInfo'
-        type: array
-    type: object
-  infra.RestGetAllNLBResponse:
-    properties:
-      nlb:
-        items:
-          $ref: '#/definitions/model.TbNLBInfo'
-        type: array
-    type: object
-  infra.RestGetBenchmarkRequest:
-    properties:
-      host:
-        type: string
-    type: object
-  label.ResourcesResponse:
-    properties:
-      results:
-        items: {}
-        type: array
-    type: object
-  model.AgentInstallContent:
-    properties:
-      mciId:
-        type: string
-      result:
-        type: string
-      vmId:
-        type: string
-      vmIp:
-        type: string
-    type: object
-  model.AgentInstallContentWrapper:
-    properties:
-      resultArray:
-        items:
-          $ref: '#/definitions/model.AgentInstallContent'
-        type: array
-    type: object
-  model.AlibabaSpecificProperty:
-    properties:
-      bgpAsn:
-        default: "65532"
-        example: "65532"
-        type: string
-    type: object
-  model.AutoAction:
-    properties:
-      actionType:
-        enum:
-        - ScaleOut
-        - ScaleIn
-        example: ScaleOut
-        type: string
-      placementAlgo:
-        example: random
-        type: string
-      postCommand:
-        allOf:
-        - $ref: '#/definitions/model.MciCmdReq'
-        description: PostCommand is field for providing command to VMs after its creation.
-          example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh
-          -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
-      vmDynamicReq:
-        $ref: '#/definitions/model.TbVmDynamicReq'
-    type: object
-  model.AutoCondition:
-    properties:
-      evaluationPeriod:
-        example: "10"
-        type: string
-      evaluationValue:
-        items:
-          type: string
-        type: array
-      metric:
-        example: cpu
-        type: string
-      operand:
-        example: "80"
-        type: string
-      operator:
-        enum:
-        - <
-        - <=
-        - '>'
-        - '>='
-        example: '>='
-        type: string
-    type: object
-  model.AwsSpecificProperty:
-    properties:
-      bgpAsn:
-        default: "64512"
-        example: "64512"
-        type: string
-    type: object
-  model.AzureSpecificProperty:
-    properties:
-      bgpAsn:
-        default: "65531"
-        example: "65531"
-        type: string
-      gatewaySubnetCidr:
-        example: xxx.xxx.xxx.xxx/xx
-        type: string
-      vpnSku:
-        default: VpnGw1AZ
-        example: VpnGw1AZ
-        type: string
-    type: object
-  model.BastionNode:
-    properties:
-      mciId:
-        type: string
-      vmId:
-        type: string
-    type: object
-  model.BenchmarkInfo:
-    properties:
-      desc:
-        type: string
-      elapsed:
-        type: string
-      regionName:
-        type: string
-      result:
-        type: string
-      resultarray:
-        description: struct-element cycle ?
-        items:
-          $ref: '#/definitions/model.BenchmarkInfo'
-        type: array
-      specid:
-        type: string
-      unit:
-        type: string
-    type: object
-  model.BenchmarkInfoArray:
-    properties:
-      resultarray:
-        items:
-          $ref: '#/definitions/model.BenchmarkInfo'
-        type: array
-    type: object
-  model.CSPDetail:
-    properties:
-      description:
-        type: string
-      driver:
-        type: string
-      links:
-        items:
-          type: string
-        type: array
-      regions:
-        additionalProperties:
-          $ref: '#/definitions/model.RegionDetail'
-        type: object
-    type: object
-  model.CheckK8sClusterDynamicReqInfo:
-    properties:
-      reqCheck:
-        items:
-          $ref: '#/definitions/model.CheckNodeDynamicReqInfo'
-        type: array
-    required:
-    - reqCheck
-    type: object
-  model.CheckMciDynamicReqInfo:
-    properties:
-      reqCheck:
-        items:
-          $ref: '#/definitions/model.CheckVmDynamicReqInfo'
-        type: array
-    required:
-    - reqCheck
-    type: object
-  model.CheckNodeDynamicReqInfo:
-    properties:
-      connectionConfigCandidates:
-        description: ConnectionConfigCandidates will provide ConnectionConfig options
-        items:
-          type: string
-        type: array
-      image:
-        items:
-          $ref: '#/definitions/model.TbImageInfo'
-        type: array
-      region:
-        $ref: '#/definitions/model.RegionDetail'
-      spec:
-        $ref: '#/definitions/model.TbSpecInfo'
-      systemMessage:
-        description: Latest system message such as error message
-        example: Failed because ...
-        type: string
-    type: object
-  model.CheckVmDynamicReqInfo:
-    properties:
-      connectionConfigCandidates:
-        description: ConnectionConfigCandidates will provide ConnectionConfig options
-        items:
-          type: string
-        type: array
-      image:
-        items:
-          $ref: '#/definitions/model.TbImageInfo'
-        type: array
-      region:
-        $ref: '#/definitions/model.RegionDetail'
-      spec:
-        $ref: '#/definitions/model.TbSpecInfo'
-      systemMessage:
-        description: Latest system message such as error message
-        example: Failed because ...
-        type: string
-    type: object
-  model.CloudInfo:
-    properties:
-      csps:
-        additionalProperties:
-          $ref: '#/definitions/model.CSPDetail'
-        type: object
-    type: object
-  model.ConfigInfo:
-    properties:
-      id:
-        example: TB_SPIDER_REST_URL
-        type: string
-      name:
-        example: TB_SPIDER_REST_URL
-        type: string
-      value:
-        example: http://localhost:1024/spider
-        type: string
-    type: object
-  model.ConfigReq:
-    properties:
-      name:
-        example: TB_SPIDER_REST_URL
-        type: string
-      value:
-        example: http://localhost:1024/spider
-        type: string
-    type: object
-  model.ConnConfig:
-    properties:
-      configName:
-        type: string
-      credentialHolder:
-        type: string
-      credentialName:
-        type: string
-      driverName:
-        type: string
-      providerName:
-        type: string
-      regionDetail:
-        $ref: '#/definitions/model.RegionDetail'
-      regionRepresentative:
-        type: boolean
-      regionZoneInfo:
-        $ref: '#/definitions/model.RegionZoneInfo'
-      regionZoneInfoName:
-        type: string
-      verified:
-        type: boolean
-    type: object
-  model.ConnConfigList:
-    properties:
-      connectionconfig:
-        items:
-          $ref: '#/definitions/model.ConnConfig'
-        type: array
-    type: object
-  model.CredentialInfo:
-    properties:
-      allConnections:
-        $ref: '#/definitions/model.ConnConfigList'
-      credentialHolder:
-        type: string
-      credentialName:
-        type: string
-      keyValueInfoList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      providerName:
-        type: string
-    type: object
-  model.CredentialReq:
-    description: CredentialReq contains the necessary information to register a credential.
-      This includes the AES key encrypted with the RSA public key, which is then used
-      to decrypt the AES key on the server side.
-    properties:
-      credentialHolder:
-        description: CredentialHolder is the entity or user that holds the credential.
-        example: admin
-        type: string
-      credentialKeyValueList:
-        description: CredentialKeyValueList contains key-(encrypted)value pairs that
-          include the sensitive credential data.
-        items:
-          $ref: '#/definitions/model.KeyWithEncryptedValue'
-        type: array
-      encryptedClientAesKeyByPublicKey:
-        description: EncryptedClientAesKeyByPublicKey is the client temporary AES
-          key encrypted with the RSA public key.
-        example: ZzXL27hbAUDT0ohglf2Gwr60sAqdPw3+CnCsn0RJXeiZxXnHfW03mFx5RaSfbwtPYCq1h6wwv7XsiWzfFmr02...
-        type: string
-      providerName:
-        description: ProviderName specifies the cloud provider associated with the
-          credential (e.g., AWS, GCP).
-        example: aws
-        type: string
-      publicKeyTokenId:
-        description: PublicKeyTokenId is the unique token ID used to retrieve the
-          corresponding private key for decryption.
-        example: cr31av30uphc738d7h0g
-        type: string
-    type: object
-  model.CspSpecificProperty:
-    properties:
-      alibaba:
-        $ref: '#/definitions/model.AlibabaSpecificProperty'
-      aws:
-        $ref: '#/definitions/model.AwsSpecificProperty'
-      azure:
-        $ref: '#/definitions/model.AzureSpecificProperty'
-      gcp:
-        $ref: '#/definitions/model.GcpSpecificProperty'
-    type: object
-  model.CustomImageStatus:
-    enum:
-    - Available
-    - Unavailable
-    type: string
-    x-enum-varnames:
-    - MyImageAvailable
-    - MyImageUnavailable
-  model.DeploymentPlan:
-    properties:
-      filter:
-        $ref: '#/definitions/model.FilterInfo'
-      limit:
-        enum:
-        - "1"
-        - "2"
-        - "30"
-        example: "5"
-        type: string
-      priority:
-        $ref: '#/definitions/model.PriorityInfo'
-    type: object
-  model.DiskStatus:
-    enum:
-    - Creating
-    - Available
-    - Attached
-    - Deleting
-    - Error
-    type: string
-    x-enum-varnames:
-    - DiskCreating
-    - DiskAvailable
-    - DiskAttached
-    - DiskDeleting
-    - DiskError
-  model.FilterCondition:
-    properties:
-      condition:
-        items:
-          $ref: '#/definitions/model.Operation'
-        type: array
-      metric:
-        enum:
-        - vCPU
-        - memoryGiB
-        - costPerHour
-        example: vCPU
-        type: string
-    type: object
-  model.FilterInfo:
-    properties:
-      policy:
-        items:
-          $ref: '#/definitions/model.FilterCondition'
-        type: array
-    type: object
-  model.FilterSpecsByRangeRequest:
-    properties:
-      acceleratorCount:
-        $ref: '#/definitions/model.Range'
-      acceleratorMemoryGB:
-        $ref: '#/definitions/model.Range'
-      acceleratorModel:
-        type: string
-      acceleratorType:
-        type: string
-      architecture:
-        type: string
-      connectionName:
-        type: string
-      costPerHour:
-        $ref: '#/definitions/model.Range'
-      cspSpecName:
-        type: string
-      description:
-        type: string
-      diskSizeGB:
-        $ref: '#/definitions/model.Range'
-      evaluationScore01:
-        $ref: '#/definitions/model.Range'
-      evaluationScore02:
-        $ref: '#/definitions/model.Range'
-      evaluationScore03:
-        $ref: '#/definitions/model.Range'
-      evaluationScore04:
-        $ref: '#/definitions/model.Range'
-      evaluationScore05:
-        $ref: '#/definitions/model.Range'
-      evaluationScore06:
-        $ref: '#/definitions/model.Range'
-      evaluationScore07:
-        $ref: '#/definitions/model.Range'
-      evaluationScore08:
-        $ref: '#/definitions/model.Range'
-      evaluationScore09:
-        $ref: '#/definitions/model.Range'
-      evaluationScore10:
-        $ref: '#/definitions/model.Range'
-      evaluationStatus:
-        type: string
-      id:
-        type: string
-      infraType:
-        type: string
-      maxTotalStorageTiB:
-        $ref: '#/definitions/model.Range'
-      memoryGiB:
-        $ref: '#/definitions/model.Range'
-      name:
-        type: string
-      netBwGbps:
-        $ref: '#/definitions/model.Range'
-      osType:
-        type: string
-      providerName:
-        type: string
-      regionName:
-        type: string
-      vCPU:
-        $ref: '#/definitions/model.Range'
-    type: object
-  model.GcpSpecificProperty:
-    properties:
-      bgpAsn:
-        default: "65530"
-        example: "65530"
-        type: string
-    type: object
-  model.IID:
-    properties:
-      NameId:
-        example: user-defined-name
-        type: string
-      SystemId:
-        example: csp-defined-id
-        type: string
-    required:
-    - NameId
-    - SystemId
-    type: object
-  model.IdList:
-    properties:
-      output:
-        items:
-          type: string
-        type: array
-    type: object
-  model.ImageFetchOption:
-    properties:
-      excludedProviders:
-        description: 'providers need to be excluded from the image fetching operation
-          (ex: ["azure"])'
-        example:
-        - azure
-        items:
-          type: string
-        type: array
-      regionAgnosticProviders:
-        description: 'providers that are not region-specific (ex: ["gcp"])'
-        example:
-        - gcp
-        - tencent
-        items:
-          type: string
-        type: array
-    type: object
-  model.ImageStatus:
-    enum:
-    - Available
-    - Unavailable
-    - Deprecated
-    - NA
-    type: string
-    x-enum-varnames:
-    - ImageAvailable
-    - ImageUnavailable
-    - ImageDeprecated
-    - ImageNA
-  model.InspectResource:
-    properties:
-      connectionName:
-        type: string
-      resourceOverview:
-        $ref: '#/definitions/model.ResourceCountOverview'
-      resourceType:
-        type: string
-      resources:
-        $ref: '#/definitions/model.ResourcesByManageType'
-      systemMessage:
-        type: string
-    type: object
-  model.InspectResourceAllResult:
-    properties:
-      availableConnection:
-        type: integer
-      cspOnlyOverview:
-        $ref: '#/definitions/model.inspectOverview'
-      elapsedTime:
-        type: integer
-      inspectResult:
-        items:
-          $ref: '#/definitions/model.InspectResourceResult'
-        type: array
-      registeredConnection:
-        type: integer
-      tumblebugOverview:
-        $ref: '#/definitions/model.inspectOverview'
-    type: object
-  model.InspectResourceResult:
-    properties:
-      connectionName:
-        type: string
-      cspOnlyOverview:
-        $ref: '#/definitions/model.inspectOverview'
-      elapsedTime:
-        type: integer
-      systemMessage:
-        type: string
-      tumblebugOverview:
-        $ref: '#/definitions/model.inspectOverview'
-    type: object
-  model.K8sClusterConnectionConfigCandidatesReq:
-    properties:
-      commonSpec:
-        description: CommonSpec is field for id of a spec in common namespace
-        example:
-        - tencent+ap-seoul+S2.MEDIUM4
-        items:
-          type: string
-        type: array
-    required:
-    - commonSpec
-    type: object
-  model.K8sClusterDetail:
-    properties:
-      node_image_designation:
-        type: boolean
-      node_images:
-        items:
-          $ref: '#/definitions/model.K8sClusterNodeImageDetail'
-        type: array
-      nodegroup_naming_rule:
-        type: string
-      nodegroups_on_creation:
-        type: boolean
-      required_subnet_count:
-        type: integer
-      root_disks:
-        items:
-          $ref: '#/definitions/model.K8sClusterRootDiskDetail'
-        type: array
-      versions:
-        items:
-          $ref: '#/definitions/model.K8sClusterVersionDetail'
-        type: array
-    type: object
-  model.K8sClusterInfo:
-    properties:
-      k8s_cluster:
-        additionalProperties:
-          $ref: '#/definitions/model.K8sClusterDetail'
-        type: object
-    type: object
-  model.K8sClusterNodeGroupsOnCreation:
-    properties:
-      result:
-        example: "true"
-        type: string
-    type: object
-  model.K8sClusterNodeImageDesignation:
-    properties:
-      result:
-        example: "true"
-        type: string
-    type: object
-  model.K8sClusterNodeImageDetail:
-    properties:
-      availables:
-        items:
-          $ref: '#/definitions/model.K8sClusterNodeImageDetailAvailable'
-        type: array
-      region:
-        items:
-          type: string
-        type: array
-    type: object
-  model.K8sClusterNodeImageDetailAvailable:
-    properties:
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  model.K8sClusterRequiredSubnetCount:
-    properties:
-      result:
-        example: "1"
-        type: string
-    type: object
-  model.K8sClusterRootDiskDetail:
-    properties:
-      region:
-        items:
-          type: string
-        type: array
-      size:
-        $ref: '#/definitions/model.K8sClusterRootDiskDetailSize'
-      type:
-        items:
-          $ref: '#/definitions/model.K8sClusterRootDiskDetailType'
-        type: array
-    type: object
-  model.K8sClusterRootDiskDetailSize:
-    properties:
-      max:
-        type: integer
-      min:
-        type: integer
-    type: object
-  model.K8sClusterRootDiskDetailType:
-    properties:
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  model.K8sClusterVersionDetail:
-    properties:
-      availables:
-        items:
-          $ref: '#/definitions/model.K8sClusterVersionDetailAvailable'
-        type: array
-      region:
-        items:
-          type: string
-        type: array
-    type: object
-  model.K8sClusterVersionDetailAvailable:
-    properties:
-      id:
-        example: 1.30.1-aliyun.1
-        type: string
-      name:
-        example: "1.30"
-        type: string
-    type: object
-  model.KeyValue:
-    properties:
-      key:
-        type: string
-      value:
-        type: string
-    type: object
-  model.KeyWithEncryptedValue:
-    properties:
-      key:
-        description: Key for the value
-        type: string
-      value:
-        description: Should be encrypted by the public key issued by GET /credential/publicKey
-        type: string
-    type: object
-  model.Label:
-    properties:
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-    type: object
-  model.LabelInfo:
-    properties:
-      labels:
-        additionalProperties:
-          type: string
-        type: object
-      resourceKey:
-        type: string
-    type: object
-  model.Location:
-    properties:
-      display:
-        type: string
-      latitude:
-        type: number
-      longitude:
-        type: number
-    type: object
-  model.McNetConfigurationDetails:
-    properties:
-      csp:
-        type: string
-      regions:
-        items:
-          $ref: '#/definitions/model.RegionDetails'
-        type: array
-    type: object
-  model.McNlbInfo:
-    properties:
-      deploymentLog:
-        $ref: '#/definitions/model.MciSshCmdResult'
-      mcNlbHostInfo:
-        $ref: '#/definitions/model.TbMciInfo'
-      mciAccessInfo:
-        $ref: '#/definitions/model.MciAccessInfo'
-    type: object
-  model.MciAccessInfo:
-    properties:
-      mciId:
-        type: string
-      mciNlbListener:
-        $ref: '#/definitions/model.MciAccessInfo'
-      mciSubGroupAccessInfo:
-        items:
-          $ref: '#/definitions/model.MciSubGroupAccessInfo'
-        type: array
-    type: object
-  model.MciCmdReq:
-    properties:
-      command:
-        example:
-        - 'client_ip=$(echo $SSH_CLIENT | awk ''{print $1}''); echo SSH client IP
-          is: $client_ip'
-        items:
-          type: string
-        type: array
-      userName:
-        example: cb-user
-        type: string
-    required:
-    - command
-    type: object
-  model.MciConnectionConfigCandidatesReq:
-    properties:
-      commonSpec:
-        description: CommonSpec is field for id of a spec in common namespace
-        example:
-        - aws+ap-northeast-2+t2.small
-        - gcp+us-west1+g1-small
-        items:
-          type: string
-        type: array
-    required:
-    - commonSpec
-    type: object
-  model.MciPolicyInfo:
-    properties:
-      Id:
-        description: MCI Id (generated ID by the Name)
-        type: string
-      Name:
-        description: MCI Name (for request)
-        type: string
-      actionLog:
-        type: string
-      description:
-        example: Description
-        type: string
-      policy:
-        items:
-          $ref: '#/definitions/model.Policy'
-        type: array
-    type: object
-  model.MciPolicyReq:
-    properties:
-      description:
-        example: Description
-        type: string
-      policy:
-        items:
-          $ref: '#/definitions/model.Policy'
-        type: array
-    type: object
-  model.MciSshCmdResult:
-    properties:
-      results:
-        items:
-          $ref: '#/definitions/model.SshCmdResult'
-        type: array
-    type: object
-  model.MciStatusInfo:
-    properties:
-      id:
-        type: string
-      installMonAgent:
-        description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no]
-          default:yes)
-        example: '[yes, no]'
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      masterIp:
-        example: 32.201.134.113
-        type: string
-      masterSSHPort:
-        type: string
-      masterVmId:
-        example: vm-asiaeast1-cb-01
-        type: string
-      name:
-        type: string
-      status:
-        type: string
-      statusCount:
-        $ref: '#/definitions/model.StatusCountInfo'
-      systemLabel:
-        description: SystemLabel is for describing the mci in a keyword (any string
-          can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      targetAction:
-        type: string
-      targetStatus:
-        type: string
-      vm:
-        items:
-          $ref: '#/definitions/model.TbVmStatusInfo'
-        type: array
-    type: object
-  model.MciSubGroupAccessInfo:
-    properties:
-      bastionVmId:
-        type: string
-      mciVmAccessInfo:
-        items:
-          $ref: '#/definitions/model.MciVmAccessInfo'
-        type: array
-      nlbListener:
-        $ref: '#/definitions/model.TbNLBListenerInfo'
-      subGroupId:
-        type: string
-    type: object
-  model.MciVmAccessInfo:
-    properties:
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      privateIP:
-        type: string
-      privateKey:
-        type: string
-      publicIP:
-        type: string
-      sshPort:
-        type: string
-      vmId:
-        type: string
-      vmUserName:
-        type: string
-      vmUserPassword:
-        type: string
-    type: object
-  model.MonResultSimple:
-    properties:
-      err:
-        type: string
-      metric:
-        type: string
-      value:
-        type: string
-      vmId:
-        type: string
-    type: object
-  model.MonResultSimpleResponse:
-    properties:
-      mciId:
-        type: string
-      mciMonitoring:
-        items:
-          $ref: '#/definitions/model.MonResultSimple'
-        type: array
-      nsId:
-        type: string
-    type: object
-  model.NLBListenerReq:
-    properties:
-      port:
-        description: 1-65535
-        example: "80"
-        type: string
-      protocol:
-        description: TCP|UDP
-        example: TCP
-        type: string
-    type: object
-  model.NsInfo:
-    properties:
-      description:
-        example: Description for this namespace
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: default
-        type: string
-      name:
-        description: Name is human-readable string to represent the object
-        example: default
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.NsReq:
-    properties:
-      description:
-        example: Description for this namespace
-        type: string
-      name:
-        example: default
-        type: string
-    type: object
-  model.OSArchitecture:
-    enum:
-    - arm32
-    - arm64
-    - arm64_mac
-    - x86_32
-    - x86_64
-    - x86_32_mac
-    - x86_64_mac
-    - s390x
-    - NA
-    - ""
-    type: string
-    x-enum-varnames:
-    - ARM32
-    - ARM64
-    - ARM64_MAC
-    - X86_32
-    - X86_64
-    - X86_32_MAC
-    - X86_64_MAC
-    - S390X
-    - ArchitectureNA
-    - ArchitectureUnknown
-  model.OSPlatform:
-    enum:
-    - Linux/UNIX
-    - Windows
-    - NA
-    type: string
-    x-enum-varnames:
-    - Linux_UNIX
-    - Windows
-    - PlatformNA
-  model.ObjectStorageInfo:
-    properties:
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        type: string
-      details: {}
-      id:
-        description: Id is unique identifier for the object
-        example: sqldb01
-        type: string
-      name:
-        description: Name is human-readable string to represent the object
-        example: sqldb01
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      status:
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.Operation:
-    properties:
-      operand:
-        description: 10, 70, 80, 98, ...
-        enum:
-        - "4"
-        - "8"
-        - ..
-        example: "4"
-        type: string
-      operator:
-        description: '>=, <=, =='
-        enum:
-        - '>='
-        - <=
-        - ==
-        example: <=
-        type: string
-    type: object
-  model.ParameterKeyVal:
-    properties:
-      key:
-        description: coordinate
-        enum:
-        - coordinateClose
-        - coordinateWithin
-        - coordinateFair
-        example: coordinateClose
-        type: string
-      val:
-        description: '["Latitude,Longitude","12,543",..,"31,433"]'
-        example:
-        - 44.146838/-116.411403
-        items:
-          type: string
-        type: array
-    type: object
-  model.Policy:
-    properties:
-      autoAction:
-        $ref: '#/definitions/model.AutoAction'
-      autoCondition:
-        $ref: '#/definitions/model.AutoCondition'
-      status:
-        type: string
-    type: object
-  model.PriorityCondition:
-    properties:
-      metric:
-        enum:
-        - location
-        - cost
-        - random
-        - performance
-        - latency
-        example: location
-        type: string
-      parameter:
-        items:
-          $ref: '#/definitions/model.ParameterKeyVal'
-        type: array
-      weight:
-        enum:
-        - "0.1"
-        - "0.2"
-        - '...'
-        example: "0.3"
-        type: string
-    type: object
-  model.PriorityInfo:
-    properties:
-      policy:
-        items:
-          $ref: '#/definitions/model.PriorityCondition'
-        type: array
-    type: object
-  model.PublicKeyResponse:
-    properties:
-      publicKey:
-        type: string
-      publicKeyTokenId:
-        type: string
-    type: object
-  model.Range:
-    properties:
-      max:
-        type: number
-      min:
-        type: number
-    type: object
-  model.RegionDetail:
-    properties:
-      description:
-        type: string
-      location:
-        $ref: '#/definitions/model.Location'
-      regionId:
-        type: string
-      regionName:
-        type: string
-      zones:
-        items:
-          type: string
-        type: array
-    type: object
-  model.RegionDetails:
-    properties:
-      name:
-        type: string
-      vNets:
-        items:
-          $ref: '#/definitions/model.VNetDetails'
-        type: array
-    type: object
-  model.RegionInfo:
-    properties:
-      region:
-        type: string
-      zone:
-        type: string
-    type: object
-  model.RegionList:
-    properties:
-      regions:
-        items:
-          $ref: '#/definitions/model.RegionDetail'
-        type: array
-    type: object
-  model.RegionZoneInfo:
-    properties:
-      assignedRegion:
-        type: string
-      assignedZone:
-        type: string
-    type: object
-  model.RegisterResourceAllResult:
-    properties:
-      availableConnection:
-        type: integer
-      elapsedTime:
-        type: integer
-      registerationOverview:
-        $ref: '#/definitions/model.RegisterationOverview'
-      registerationResult:
-        items:
-          $ref: '#/definitions/model.RegisterResourceResult'
-        type: array
-      registeredConnection:
-        type: integer
-    type: object
-  model.RegisterResourceResult:
-    properties:
-      connectionName:
-        type: string
-      elapsedTime:
-        type: integer
-      registerationOutputs:
-        $ref: '#/definitions/model.IdList'
-      registerationOverview:
-        $ref: '#/definitions/model.RegisterationOverview'
-      systemMessage:
-        type: string
-    type: object
-  model.RegisterationOverview:
-    properties:
-      customImage:
-        type: integer
-      dataDisk:
-        type: integer
-      failed:
-        type: integer
-      nlb:
-        type: integer
-      securityGroup:
-        type: integer
-      sshKey:
-        type: integer
-      vNet:
-        type: integer
-      vm:
-        type: integer
-    type: object
-  model.RequiredAWSResourceForSqlDB:
-    properties:
-      subnet1ID:
-        example: subnet-xxxx
-        type: string
-      subnet2ID:
-        example: subnet-xxxx in different AZ
-        type: string
-      vNetID:
-        example: vpc-xxxxx
-        type: string
-    type: object
-  model.RequiredAzureResourceForObjectStorage:
-    properties:
-      resourceGroup:
-        example: koreacentral
-        type: string
-    type: object
-  model.RequiredAzureResourceForSqlDB:
-    properties:
-      resourceGroup:
-        example: koreacentral
-        type: string
-    type: object
-  model.RequiredCSPResourceForObjectStorage:
-    properties:
-      azure:
-        allOf:
-        - $ref: '#/definitions/model.RequiredAzureResourceForObjectStorage'
-        description: AWS   RequiredAWSResourceForObjectStorage   `json:"aws,omitempty"`
-    type: object
-  model.RequiredCSPResourceForSqlDB:
-    properties:
-      aws:
-        $ref: '#/definitions/model.RequiredAWSResourceForSqlDB'
-      azure:
-        $ref: '#/definitions/model.RequiredAzureResourceForSqlDB'
-      ncp:
-        $ref: '#/definitions/model.RequiredNCPResourceForSqlDB'
-    type: object
-  model.RequiredNCPResourceForSqlDB:
-    properties:
-      subnetID:
-        example: "123456"
-        type: string
-    type: object
-  model.ResourceCountOverview:
-    properties:
-      onCspOnly:
-        type: integer
-      onCspTotal:
-        type: integer
-      onSpider:
-        type: integer
-      onTumblebug:
-        type: integer
-    type: object
-  model.ResourceDetail:
-    properties:
-      cspResourceDetail:
-        description: CspResourceDetail is the detailed information of the resource
-          provided from the terrarium.
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      status:
-        type: string
-    type: object
-  model.ResourceOnCsp:
-    properties:
-      count:
-        type: integer
-      info:
-        items:
-          $ref: '#/definitions/model.ResourceOnCspInfo'
-        type: array
-    type: object
-  model.ResourceOnCspInfo:
-    properties:
-      cspResourceId:
-        type: string
-      refNameOrId:
-        type: string
-    type: object
-  model.ResourceOnSpider:
-    properties:
-      count:
-        type: integer
-      info:
-        items:
-          $ref: '#/definitions/model.ResourceOnSpiderInfo'
-        type: array
-    type: object
-  model.ResourceOnSpiderInfo:
-    properties:
-      cspResourceId:
-        type: string
-      idBySp:
-        type: string
-    type: object
-  model.ResourceOnTumblebug:
-    properties:
-      count:
-        type: integer
-      info:
-        items:
-          $ref: '#/definitions/model.ResourceOnTumblebugInfo'
-        type: array
-    type: object
-  model.ResourceOnTumblebugInfo:
-    properties:
-      cspResourceId:
-        type: string
-      idByTb:
-        type: string
-      mciId:
-        type: string
-      nsId:
-        type: string
-      objectKey:
-        type: string
-    type: object
-  model.ResourcesByManageType:
-    properties:
-      onCspOnly:
-        $ref: '#/definitions/model.ResourceOnCsp'
-      onCspTotal:
-        $ref: '#/definitions/model.ResourceOnCsp'
-      onSpider:
-        $ref: '#/definitions/model.ResourceOnSpider'
-      onTumblebug:
-        $ref: '#/definitions/model.ResourceOnTumblebug'
-    type: object
-  model.Response:
-    properties:
-      details:
-        example: Any details
-        type: string
-      list:
-        items: {}
-        type: array
-      message:
-        example: Any message
-        type: string
-      object:
-        additionalProperties: true
-        type: object
-      status:
-        example: 200
-        type: integer
-      success:
-        example: true
-        type: boolean
-    type: object
-  model.RestPostObjectStorageRequest:
-    properties:
-      connectionName:
-        example: aws-ap-northeast-2
-        type: string
-      csp:
-        example: aws
-        type: string
-      name:
-        example: objectstorage01
-        type: string
-      region:
-        example: ap-northeast-2
-        type: string
-      requiredCSPResource:
-        $ref: '#/definitions/model.RequiredCSPResourceForObjectStorage'
-    required:
-    - connectionName
-    - csp
-    - name
-    - region
-    type: object
-  model.RestPostSqlDBRequest:
-    properties:
-      connectionName:
-        example: aws-ap-northeast-2
-        type: string
-      csp:
-        example: aws
-        type: string
-      dbAdminPassword:
-        example: Password1234!
-        type: string
-      dbAdminUsername:
-        example: mydbadmin
-        type: string
-      dbEnginePort:
-        example: 3306
-        type: integer
-      dbEngineVersion:
-        example: 8.0.39
-        type: string
-      dbInstanceSpec:
-        example: db.t3.micro
-        type: string
-      name:
-        example: sqldb01
-        type: string
-      region:
-        example: ap-northeast-2
-        type: string
-      requiredCSPResource:
-        $ref: '#/definitions/model.RequiredCSPResourceForSqlDB'
-    required:
-    - connectionName
-    - csp
-    - dbAdminPassword
-    - dbAdminUsername
-    - dbEnginePort
-    - dbEngineVersion
-    - dbInstanceSpec
-    - name
-    - region
-    type: object
-  model.RestPostVpnRequest:
-    properties:
-      name:
-        example: vpn01
-        type: string
-      site1:
-        $ref: '#/definitions/model.SiteProperty'
-      site2:
-        $ref: '#/definitions/model.SiteProperty'
-    required:
-    - name
-    - site1
-    - site2
-    type: object
-  model.RetrievedRegionList:
-    properties:
-      region:
-        items:
-          $ref: '#/definitions/model.SpiderRegionZoneInfo'
-        type: array
-    type: object
-  model.SearchImageRequest:
-    properties:
-      detailSearchKeys:
-        description: |-
-          Keywords for searching images in detail.
-          Space-separated for AND condition (ex: "sql 2022", "ubuntu 22.04", etc.).
-          Used for if the user wants to search images with specific keywords in their details.
-        example:
-        - tensorflow
-        - "2.17"
-        items:
-          type: string
-        type: array
-      includeBasicImageOnly:
-        description: |-
-          IncludeBasicImageOnly is to return basic OS distribution only without additional applications.
-          If true, the search results will include only the basic OS distribution without additional applications.
-          If false or not specified, the search results will include images with additional applications installed.
-        example: false
-        type: boolean
-      includeDeprecatedImage:
-        description: |-
-          Whether the search results should include deprecated images or not.
-          If not specified, deprecated images will not be included in the search results.
-          In usual, deprecated images are not recommended to use, but they can be used if necessary.
-        example: false
-        type: boolean
-      isGPUImage:
-        description: |-
-          Whether the image is ready for GPU usage or not.
-          In usual, true means the image is ready for GPU usage with GPU drivers and libraries installed.
-          If not specified, both true and false images will be included in the search results.
-          Even if the image is not ready for GPU usage, it can be used with GPU by installing GPU drivers and libraries manually.
-        example: false
-        type: boolean
-      isKubernetesImage:
-        description: |-
-          Whether the image is specialized image only for Kubernetes nodes.
-          If not specified, both true and false images will be included in the search results.
-          Images that are not specialized for Kubernetes also can be used as Kubernetes nodes. It depends on CSPs.
-        example: false
-        type: boolean
-      isRegisteredByAsset:
-        description: Whether the image is registered by CB-Tumblebug asset file or
-          not.
-        example: false
-        type: boolean
-      maxResults:
-        description: |-
-          MaxResults is the maximum number of images to be returned in the search results.
-          If not specified, all images will be returned.
-          If specified, the number of images returned will be limited to the specified value.
-        example: 100
-        type: integer
-      osArchitecture:
-        allOf:
-        - $ref: '#/definitions/model.OSArchitecture'
-        description: 'The architecture of the operating system of the image. (ex:
-          "x86_64", "arm64", etc.)'
-        example: x86_64
-      osType:
-        description: 'Simplified OS name and version string. Space-separated for AND
-          condition (ex: "ubuntu 22.04", "windows 10", etc.).'
-        example: ubuntu 22.04
-        type: string
-      providerName:
-        description: 'Cloud Service Provider (ex: "aws", "azure", "gcp", etc.). Use
-          GET /provider to get the list of available providers.'
-        example: aws
-        type: string
-      regionName:
-        description: 'Cloud Service Provider Region (ex: "us-east-1", "us-west-2",
-          etc.). Use GET /provider/{providerName}/region to get the list of available
-          regions.'
-        example: us-east-1
-        type: string
-    type: object
-  model.SearchImageRequestOptions:
-    properties:
-      detailSearchKeys:
-        description: |-
-          Keywords for searching images in detail.
-          Space-separated for AND condition (ex: "sql 2022", "ubuntu 22.04", etc.).
-          Used for if the user wants to search images with specific keywords in their details.
-        items:
-          items:
-            type: string
-          type: array
-        type: array
-      includeDeprecatedImage:
-        description: |-
-          Whether the search results should include deprecated images or not.
-          If not specified, deprecated images will not be included in the search results.
-          In usual, deprecated images are not recommended to use, but they can be used if necessary.
-        items:
-          type: boolean
-        type: array
-      isGPUImage:
-        description: |-
-          Whether the image is ready for GPU usage or not.
-          In usual, true means the image is ready for GPU usage with GPU drivers and libraries installed.
-          If not specified, both true and false images will be included in the search results.
-          Even if the image is not ready for GPU usage, it can be used with GPU by installing GPU drivers and libraries manually.
-        items:
-          type: boolean
-        type: array
-      isKubernetesImage:
-        description: |-
-          Whether the image is specialized image only for Kubernetes nodes.
-          If not specified, both true and false images will be included in the search results.
-          Images that are not specialized for Kubernetes also can be used as Kubernetes nodes. It depends on CSPs.
-        items:
-          type: boolean
-        type: array
-      isRegisteredByAsset:
-        description: Whether the image is registered by CB-Tumblebug asset file or
-          not.
-        items:
-          type: boolean
-        type: array
-      maxResults:
-        description: |-
-          MaxResults is the maximum number of images to be returned in the search results.
-          If not specified, all images will be returned.
-          If specified, the number of images returned will be limited to the specified value.
-        example:
-        - 100
-        items:
-          type: integer
-        type: array
-      osArchitecture:
-        description: 'The architecture of the operating system of the image. (ex:
-          "x86_64", "arm64", etc.)'
-        items:
-          type: string
-        type: array
-      osType:
-        description: 'Simplified OS name and version string. Space-separated for AND
-          condition (ex: "ubuntu 22.04", "windows 10", etc.).'
-        items:
-          type: string
-        type: array
-      providerName:
-        description: 'Cloud Service Provider (ex: "aws", "azure", "gcp", etc.). Use
-          GET /provider to get the list of available providers.'
-        items:
-          type: string
-        type: array
-      regionName:
-        description: 'Cloud Service Provider Region (ex: "us-east-1", "us-west-2",
-          etc.). Use GET /provider/{providerName}/region to get the list of available
-          regions.'
-        items:
-          type: string
-        type: array
-    type: object
-  model.SearchImageResponse:
-    properties:
-      imageCount:
-        type: integer
-      imageList:
-        items:
-          $ref: '#/definitions/model.TbImageInfo'
-        type: array
-    type: object
-  model.SimpleMsg:
-    properties:
-      message:
-        example: Any message
-        type: string
-    type: object
-  model.SiteDetail:
-    properties:
-      connectionName:
-        example: aws-ap-northeast-2
-        type: string
-      csp:
-        example: aws
-        type: string
-      gatewaySubnetCidr:
-        description: SubnetId          string `json:"subnet,omitempty" example:"subnet-xxxxx"`
-        example: xxx.xxx.xxx.xxx/xx
-        type: string
-      region:
-        example: ap-northeast-2
-        type: string
-      resourceGroup:
-        example: rg-xxxxx
-        type: string
-      vnet:
-        description: Zone              string `json:"zone,omitempty" example:"ap-northeast-2a"`
-        example: vpc-xxxxx
-        type: string
-    type: object
-  model.SiteProperty:
-    properties:
-      cspSpecificProperty:
-        $ref: '#/definitions/model.CspSpecificProperty'
-      vNetId:
-        example: vnet01
-        type: string
-    type: object
-  model.SitesInfo:
-    properties:
-      count:
-        example: 3
-        type: integer
-      mciId:
-        example: mci-01
-        type: string
-      nsId:
-        example: ns-01
-        type: string
-      sites:
-        $ref: '#/definitions/model.sites'
-    type: object
-  model.SpecFetchOption:
-    properties:
-      excludedProviders:
-        description: 'providers need to be excluded from the spec fetching operation
-          (ex: ["azure"])'
-        example:
-        - azure
-        items:
-          type: string
-        type: array
-      regionAgnosticProviders:
-        description: 'providers that are not region-specific (ex: ["gcp"])'
-        example:
-        - gcp
-        - tencent
-        items:
-          type: string
-        type: array
-    type: object
-  model.SpiderAccessInfo:
-    properties:
-      endpoint:
-        description: ex) https://1.2.3.4:6443
-        type: string
-      kubeconfig:
-        type: string
-    type: object
-  model.SpiderAddonsInfo:
-    properties:
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-    type: object
-  model.SpiderClusterInfo:
-    properties:
-      accessInfo:
-        $ref: '#/definitions/model.SpiderAccessInfo'
-      addons:
-        $ref: '#/definitions/model.SpiderAddonsInfo'
-      createdTime:
-        type: string
-      iid:
-        allOf:
-        - $ref: '#/definitions/model.IID'
-        description: '{NameId, SystemId}'
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      network:
-        $ref: '#/definitions/model.SpiderNetworkInfo'
-      nodeGroupList:
-        items:
-          $ref: '#/definitions/model.SpiderNodeGroupInfo'
-        type: array
-      status:
-        $ref: '#/definitions/model.SpiderClusterStatus'
-      version:
-        description: Kubernetes Version, ex) 1.23.3
-        type: string
-    type: object
-  model.SpiderClusterStatus:
-    enum:
-    - Creating
-    - Active
-    - Inactive
-    - Updating
-    - Deleting
-    type: string
-    x-enum-varnames:
-    - SpiderClusterCreating
-    - SpiderClusterActive
-    - SpiderClusterInactive
-    - SpiderClusterUpdating
-    - SpiderClusterDeleting
-  model.SpiderGpuInfo:
-    properties:
-      Count:
-        description: Number of GPUs, "-1" when not applicable
-        example: "2"
-        type: string
-      MemSizeGB:
-        description: Memory size of the GPU in GB, "-1" when not applicable
-        example: "12"
-        type: string
-      Mfr:
-        description: Manufacturer of the GPU, NA when not applicable
-        example: NVIDIA
-        type: string
-      Model:
-        description: Model of the GPU, NA when not applicable
-        example: Tesla K80
-        type: string
-      TotalMemSizeGB:
-        description: Total Memory size of the GPU in GB, "-1" when not applicable
-        example: "24"
-        type: string
-    required:
-    - Count
-    type: object
-  model.SpiderImageInfo:
-    properties:
-      IId:
-        allOf:
-        - $ref: '#/definitions/model.IID'
-        description: '{NameId, SystemId}, {ami-00aa5a103ddf4509f, ami-00aa5a103ddf4509f}'
-      ImageStatus:
-        allOf:
-        - $ref: '#/definitions/model.ImageStatus'
-        description: Available, Unavailable
-        example: Available
-      KeyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      Name:
-        description: ami-00aa5a103ddf4509f
-        example: ami-00aa5a103ddf4509f
-        type: string
-      OSArchitecture:
-        allOf:
-        - $ref: '#/definitions/model.OSArchitecture'
-        description: arm64, x86_64 etc.
-        example: x86_64
-      OSDiskSizeGB:
-        description: 10, 50, 100 etc.
-        example: "50"
-        type: string
-      OSDiskType:
-        description: ebs, HDD, etc.
-        example: HDD
-        type: string
-      OSDistribution:
-        description: Ubuntu 22.04~, CentOS 8 etc.
-        example: Ubuntu 22.04~
-        type: string
-      OSPlatform:
-        allOf:
-        - $ref: '#/definitions/model.OSPlatform'
-        description: Linux/UNIX, Windows, NA
-        example: Linux/UNIX
-    type: object
-  model.SpiderImageList:
-    properties:
-      image:
-        items:
-          $ref: '#/definitions/model.SpiderImageInfo'
-        type: array
-    type: object
-  model.SpiderNetworkInfo:
-    properties:
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      securityGroupIIDs:
-        items:
-          $ref: '#/definitions/model.IID'
-        type: array
-      subnetIIDs:
-        items:
-          $ref: '#/definitions/model.IID'
-        type: array
-      vpcIID:
-        allOf:
-        - $ref: '#/definitions/model.IID'
-        description: '{NameId, SystemId}'
-    type: object
-  model.SpiderNodeGroupInfo:
-    properties:
-      DesiredNodeSize:
-        example: 2
-        type: integer
-      IId:
-        allOf:
-        - $ref: '#/definitions/model.IID'
-        description: '{NameId, SystemId}'
-      ImageIID:
-        allOf:
-        - $ref: '#/definitions/model.IID'
-        description: VM config.
-      KeyPairIID:
-        $ref: '#/definitions/model.IID'
-      KeyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      MaxNodeSize:
-        example: 3
-        type: integer
-      MinNodeSize:
-        example: 1
-        type: integer
-      Nodes:
-        items:
-          $ref: '#/definitions/model.IID'
-        type: array
-      OnAutoScaling:
-        description: Scaling config.
-        example: true
-        type: boolean
-      RootDiskSize:
-        description: '"", "default", "50", "1000" (GB)'
-        example: "50"
-        type: string
-      RootDiskType:
-        description: '"SSD(gp2)", "Premium SSD", ...'
-        type: string
-      Status:
-        allOf:
-        - $ref: '#/definitions/model.SpiderNodeGroupStatus'
-        example: Active
-      VMSpecName:
-        example: t3.medium
-        type: string
-    required:
-    - DesiredNodeSize
-    - IId
-    - ImageIID
-    - KeyPairIID
-    - MaxNodeSize
-    - MinNodeSize
-    - OnAutoScaling
-    - Status
-    - VMSpecName
-    type: object
-  model.SpiderNodeGroupStatus:
-    enum:
-    - Creating
-    - Active
-    - Inactive
-    - Updating
-    - Deleting
-    type: string
-    x-enum-varnames:
-    - SpiderNodeGroupCreating
-    - SpiderNodeGroupActive
-    - SpiderNodeGroupInactive
-    - SpiderNodeGroupUpdating
-    - SpiderNodeGroupDeleting
-  model.SpiderRegionZoneInfo:
-    properties:
-      availableZoneList:
-        items:
-          type: string
-        type: array
-      keyValueInfoList:
-        description: ex) { {region, us-east1}, {zone, us-east1-c} }
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      providerName:
-        description: ex) "GCP"
-        type: string
-      regionName:
-        description: ex) "region01"
-        type: string
-    type: object
-  model.SpiderSpecInfo:
-    properties:
-      DiskSizeGB:
-        description: Disk size in GB, "-1" when not applicable
-        example: "8"
-        type: string
-      Gpu:
-        description: GPU details if available
-        items:
-          $ref: '#/definitions/model.SpiderGpuInfo'
-        type: array
-      KeyValueList:
-        description: Additional key-value pairs for the VM spec
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      MemSizeMib:
-        description: Memory size in MiB
-        example: "1024"
-        type: string
-      Name:
-        description: Name of the VM spec
-        example: t2.micro
-        type: string
-      Region:
-        description: Region where the VM spec is available
-        example: us-east-1
-        type: string
-      VCpu:
-        allOf:
-        - $ref: '#/definitions/model.SpiderVCpuInfo'
-        description: CPU details of the VM spec
-    required:
-    - DiskSizeGB
-    - MemSizeMib
-    - Name
-    - Region
-    - VCpu
-    type: object
-  model.SpiderSpecList:
-    properties:
-      vmspec:
-        items:
-          $ref: '#/definitions/model.SpiderSpecInfo'
-        type: array
-    type: object
-  model.SpiderVCpuInfo:
-    properties:
-      ClockGHz:
-        description: Clock speed in GHz, "-1" when not applicable
-        example: "2.5"
-        type: string
-      Count:
-        description: Number of VCpu, "-1" when not applicable
-        example: "2"
-        type: string
-    required:
-    - Count
-    type: object
-  model.SqlDBInfo:
-    properties:
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        type: string
-      details: {}
-      id:
-        description: Id is unique identifier for the object
-        example: sqldb01
-        type: string
-      name:
-        description: Name is human-readable string to represent the object
-        example: sqldb01
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      status:
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.SshCmdResult:
-    properties:
-      command:
-        additionalProperties:
-          type: string
-        type: object
-      err: {}
-      mciId:
-        type: string
-      stderr:
-        additionalProperties:
-          type: string
-        type: object
-      stdout:
-        additionalProperties:
-          type: string
-        type: object
-      vmId:
-        type: string
-      vmIp:
-        type: string
-    type: object
-  model.StatusCountInfo:
-    properties:
-      countCreating:
-        description: CountCreating is for counting Creating
-        type: integer
-      countFailed:
-        description: CountFailed is for counting Failed
-        type: integer
-      countRebooting:
-        description: CountRebooting is for counting Rebooting
-        type: integer
-      countResuming:
-        description: CountResuming is for counting Resuming
-        type: integer
-      countRunning:
-        description: CountRunning is for counting Running
-        type: integer
-      countSuspended:
-        description: CountSuspended is for counting Suspended
-        type: integer
-      countSuspending:
-        description: CountSuspending is for counting Suspending
-        type: integer
-      countTerminated:
-        description: CountTerminated is for counting Terminated
-        type: integer
-      countTerminating:
-        description: CountTerminating is for counting Terminating
-        type: integer
-      countTotal:
-        description: CountTotal is for Total VMs
-        type: integer
-      countUndefined:
-        description: CountUndefined is for counting Undefined
-        type: integer
-    type: object
-  model.SystemLabelInfo:
-    properties:
-      labelTypes:
-        items:
-          type: string
-        type: array
-      systemLabels:
-        additionalProperties:
-          type: string
-        type: object
-    type: object
-  model.TbAttachDetachDataDiskReq:
-    properties:
-      dataDiskId:
-        type: string
-    required:
-    - dataDiskId
-    type: object
-  model.TbChangeK8sNodeGroupAutoscaleSizeReq:
-    properties:
-      desiredNodeSize:
-        example: "1"
-        type: string
-      maxNodeSize:
-        example: "3"
-        type: string
-      minNodeSize:
-        example: "1"
-        type: string
-    type: object
-  model.TbChangeK8sNodeGroupAutoscaleSizeRes:
-    properties:
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      desiredNodeSize:
-        type: integer
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      imageId:
-        type: string
-      k8sNodes:
-        items:
-          $ref: '#/definitions/model.TbK8sNodeInfo'
-        type: array
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      maxNodeSize:
-        type: integer
-      minNodeSize:
-        type: integer
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      onAutoScaling:
-        type: boolean
-      rootDiskSize:
-        type: string
-      rootDiskType:
-        type: string
-      specId:
-        type: string
-      spiderViewK8sNodeGroupDetail:
-        $ref: '#/definitions/model.SpiderNodeGroupInfo'
-      sshKeyId:
-        type: string
-      status:
-        allOf:
-        - $ref: '#/definitions/model.TbK8sNodeGroupStatus'
-        description: Creating, Active, Inactive, Updating, Deleting
-        example: Active
-    type: object
-  model.TbCustomImageInfo:
-    properties:
-      associatedObjectList:
-        items:
-          type: string
-        type: array
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        example: aws-ap-southeast-1
-        type: string
-      creationDate:
-        example: "2022-10-18T08:12:48Z"
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        type: string
-      guestOS:
-        description: Windows7, Ubuntu etc.
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      isAutoGenerated:
-        type: boolean
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      namespace:
-        description: required to save in RDB
-        example: default
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      sourceVmId:
-        example: aws-ap-southeast-1-1
-        type: string
-      status:
-        allOf:
-        - $ref: '#/definitions/model.CustomImageStatus'
-        example: Available
-      systemLabel:
-        description: SystemLabel is for describing the Resource in a keyword (any
-          string can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.TbCustomImageReq:
-    properties:
-      connectionName:
-        type: string
-      cspResourceId:
-        description: This field is for 'Register existing custom image'
-        type: string
-      description:
-        type: string
-      name:
-        type: string
-      sourceVmId:
-        type: string
-    required:
-    - name
-    type: object
-  model.TbDataDiskInfo:
-    properties:
-      associatedObjectList:
-        example:
-        - /ns/default/mci/mci01/vm/aws-ap-southeast-1-1
-        items:
-          type: string
-        type: array
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        example: aws-ap-southeast-1
-        type: string
-      createdTime:
-        example: "2022-10-12T05:09:51.05Z"
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        example: Available
-        type: string
-      diskSize:
-        example: "77"
-        type: string
-      diskType:
-        example: standard
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      isAutoGenerated:
-        type: boolean
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      status:
-        allOf:
-        - $ref: '#/definitions/model.DiskStatus'
-        description: Available, Unavailable, Attached, ...
-        example: Available
-      systemLabel:
-        description: SystemLabel is for describing the Resource in a keyword (any
-          string can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      systemMessage:
-        description: Latest system message such as error message
-        example: Failed because ...
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.TbDataDiskReq:
-    properties:
-      connectionName:
-        example: aws-ap-southeast-1
-        type: string
-      cspResourceId:
-        description: |-
-          Fields for "Register existing dataDisk" feature
-          CspResourceId is required to register object from CSP (option=register)
-        type: string
-      description:
-        type: string
-      diskSize:
-        default: "100"
-        example: "77"
-        type: string
-      diskType:
-        example: default
-        type: string
-      name:
-        example: aws-ap-southeast-1-datadisk
-        type: string
-    required:
-    - connectionName
-    - diskSize
-    - name
-    type: object
-  model.TbDataDiskUpsizeReq:
-    properties:
-      description:
-        type: string
-      diskSize:
-        type: string
-    required:
-    - diskSize
-    type: object
-  model.TbDataDiskVmReq:
-    properties:
-      description:
-        type: string
-      diskSize:
-        default: "100"
-        example: "77"
-        type: string
-      diskType:
-        example: default
-        type: string
-      name:
-        example: aws-ap-southeast-1-datadisk
-        type: string
-    required:
-    - diskSize
-    - name
-    type: object
-  model.TbFirewallRuleInfo:
-    properties:
-      cidr:
-        type: string
-      direction:
-        description: '`json:"direction"`'
-        type: string
-      fromPort:
-        description: '`json:"fromPort"`'
-        type: string
-      ipprotocol:
-        description: '`json:"ipProtocol"`'
-        type: string
-      toPort:
-        description: '`json:"toPort"`'
-        type: string
-    required:
-    - direction
-    - fromPort
-    - ipprotocol
-    - toPort
-    type: object
-  model.TbIdNameInDetailInfo:
-    properties:
-      idInCsp:
-        type: string
-      idInSp:
-        type: string
-      idInTb:
-        type: string
-      nameInCsp:
-        type: string
-    type: object
-  model.TbImageInfo:
-    properties:
-      connectionName:
-        type: string
-      creationDate:
-        type: string
-      cspImageName:
-        example: csp-06eb41e14121c550a
-        type: string
-      description:
-        type: string
-      details:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      fetchedTime:
-        type: string
-      id:
-        example: aws-ap-southeast-1
-        type: string
-      imageStatus:
-        allOf:
-        - $ref: '#/definitions/model.ImageStatus'
-        description: Available, Deprecated, NA
-        example: Available
-      infraType:
-        description: vm|k8s|kubernetes|container, etc.
-        type: string
-      isBasicImage:
-        default: false
-        type: boolean
-      isGPUImage:
-        default: false
-        type: boolean
-      isKubernetesImage:
-        default: false
-        type: boolean
-      name:
-        example: aws-ap-southeast-1
-        type: string
-      namespace:
-        description: Composite primary key
-        example: default
-        type: string
-      osArchitecture:
-        allOf:
-        - $ref: '#/definitions/model.OSArchitecture'
-        description: arm64, x86_64 etc.
-        example: x86_64
-      osDiskSizeGB:
-        description: 10, 50, 100 etc.
-        example: 50
-        type: number
-      osDiskType:
-        description: ebs, HDD, etc.
-        example: HDD
-        type: string
-      osDistribution:
-        description: Ubuntu 22.04~, CentOS 8 etc.
-        example: Ubuntu 22.04~
-        type: string
-      osPlatform:
-        allOf:
-        - $ref: '#/definitions/model.OSPlatform'
-        description: Linux/UNIX, Windows, NA
-        example: Linux/UNIX
-      osType:
-        example: ubuntu 22.04
-        type: string
-      providerName:
-        type: string
-      regionList:
-        description: Array field for supporting multiple regions
-        items:
-          type: string
-        type: array
-      systemLabel:
-        example: Managed by CB-Tumblebug
-        type: string
-      uid:
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.TbImageReq:
-    properties:
-      connectionName:
-        type: string
-      cspImageName:
-        type: string
-      description:
-        type: string
-      name:
-        type: string
-    required:
-    - connectionName
-    - cspImageName
-    - name
-    type: object
-  model.TbK8sAccessInfo:
-    properties:
-      endpoint:
-        example: http://1.2.3.4:6443
-        type: string
-      kubeconfig:
-        example: |-
-          apiVersion: v1
-          clusters:
-          - cluster:
-           certificate-authority-data: LS0...
-        type: string
-    type: object
-  model.TbK8sAddonsInfo:
-    properties:
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-    type: object
-  model.TbK8sClusterContainerCmdReq:
-    properties:
-      command:
-        example:
-        - echo hello
-        items:
-          type: string
-        type: array
-    required:
-    - command
-    type: object
-  model.TbK8sClusterContainerCmdResult:
-    properties:
-      command:
-        type: string
-      err: {}
-      stderr:
-        type: string
-      stdout:
-        type: string
-    type: object
-  model.TbK8sClusterContainerCmdResults:
-    properties:
-      results:
-        items:
-          $ref: '#/definitions/model.TbK8sClusterContainerCmdResult'
-        type: array
-    type: object
-  model.TbK8sClusterDynamicReq:
-    properties:
-      commonImage:
-        description: CommonImage is field for id of a image in common namespace
-        example: default, tencent+ap-seoul+ubuntu20.04
-        type: string
-      commonSpec:
-        description: CommonSpec is field for id of a spec in common namespace
-        example: tencent+ap-seoul+S2.MEDIUM4
-        type: string
-      connectionName:
-        default: tencent-ap-seoul
-        description: |-
-          if ConnectionName is given, the VM tries to use associtated credential.
-          if not, it will use predefined ConnectionName in Spec objects
-        type: string
-      description:
-        example: Description
-        type: string
-      desiredNodeSize:
-        default: "1"
-        example: "1"
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      maxNodeSize:
-        default: "2"
-        example: "3"
-        type: string
-      minNodeSize:
-        default: "1"
-        example: "1"
-        type: string
-      name:
-        description: K8sCluster name if it is not empty.
-        example: k8scluster01
-        type: string
-      nodeGroupName:
-        description: NodeGroup name if it is not empty
-        example: k8sng01
-        type: string
-      onAutoScaling:
-        default: "true"
-        example: "true"
-        type: string
-      rootDiskSize:
-        default: default
-        description: '"default", Integer (GB): ["50", ..., "1000"]'
-        example: default, 30, 42, ...
-        type: string
-      rootDiskType:
-        default: default
-        description: '"", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure:
-          ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced",
-          "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_essd"],
-          TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]'
-        example: default, TYPE1, ...
-        type: string
-      version:
-        description: K8s Clsuter version
-        example: "1.29"
-        type: string
-    required:
-    - commonImage
-    - commonSpec
-    - name
-    type: object
-  model.TbK8sClusterInfo:
-    properties:
-      accessInfo:
-        $ref: '#/definitions/model.TbK8sAccessInfo'
-      addons:
-        $ref: '#/definitions/model.TbK8sAddonsInfo'
-      connectionConfig:
-        allOf:
-        - $ref: '#/definitions/model.ConnConfig'
-        description: ConnectionConfig shows connection info to cloud service provider
-      connectionName:
-        example: alibaba-ap-northeast-2
-        type: string
-      createdTime:
-        example: "1970-01-01T00:00:00.00Z"
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        example: My K8sCluster
-        type: string
-      id:
-        description: Id is unique identifier for the object, same as Name
-        example: k8scluster01
-        type: string
-      k8sNodeGroupList:
-        description: K8sNodeGroupList is for describing network information about
-          the cluster
-        items:
-          $ref: '#/definitions/model.TbK8sNodeGroupInfo'
-        type: array
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      name:
-        description: Name is human-readable string to represent the object
-        example: k8scluster01
-        type: string
-      network:
-        allOf:
-        - $ref: '#/definitions/model.TbK8sClusterNetworkInfo'
-        description: Network is for describing network information about the cluster
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      spiderViewK8sClusterDetail:
-        $ref: '#/definitions/model.SpiderClusterInfo'
-      status:
-        allOf:
-        - $ref: '#/definitions/model.TbK8sClusterStatus'
-        description: Creating, Active, Inactive, Updating, Deleting
-        example: Active
-      systemLabel:
-        description: SystemLabel is for describing the Resource in a keyword (any
-          string can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      systemMessage:
-        description: Latest system message such as error message
-        example: Failed because ...
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-      version:
-        description: Version is for kubernetes version
-        example: 1.30.1
-        type: string
-    type: object
-  model.TbK8sClusterNetworkInfo:
-    properties:
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      securityGroupIds:
-        example:
-        - sg-01
-        items:
-          type: string
-        type: array
-      subnetIds:
-        example:
-        - subnet-01
-        items:
-          type: string
-        type: array
-      vNetId:
-        example: vpc-01
-        type: string
-    type: object
-  model.TbK8sClusterReq:
-    properties:
-      connectionName:
-        description: Namespace      string `json:"namespace" validate:"required" example:"default"`
-        example: alibaba-ap-northeast-2
-        type: string
-      cspResourceId:
-        description: |-
-          Fields for "Register existing K8sCluster" feature
-          @description CspResourceId is required to register a k8s cluster from CSP (option=register)
-        example: required when option is register
-        type: string
-      description:
-        example: My K8sCluster
-        type: string
-      k8sNodeGroupList:
-        description: (3) NodeGroupInfo List
-        items:
-          $ref: '#/definitions/model.TbK8sNodeGroupReq'
-        type: array
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      name:
-        description: (1) K8sCluster Info
-        example: k8scluster01
-        type: string
-      securityGroupIds:
-        example:
-        - sg-01
-        items:
-          type: string
-        type: array
-      subnetIds:
-        example:
-        - subnet-01
-        items:
-          type: string
-        type: array
-      systemLabel:
-        description: SystemLabel is for describing the k8scluster in a keyword (any
-          string can be used) for special System purpose
-        example: ""
-        type: string
-      vNetId:
-        description: (2) Network Info
-        example: vpc-01
-        type: string
-      version:
-        example: 1.30.1-aliyun.1
-        type: string
-    required:
-    - connectionName
-    - name
-    - securityGroupIds
-    - subnetIds
-    - vNetId
-    type: object
-  model.TbK8sClusterStatus:
-    enum:
-    - Creating
-    - Active
-    - Inactive
-    - Updating
-    - Deleting
-    type: string
-    x-enum-varnames:
-    - TbK8sClusterCreating
-    - TbK8sClusterActive
-    - TbK8sClusterInactive
-    - TbK8sClusterUpdating
-    - TbK8sClusterDeleting
-  model.TbK8sNodeGroupDynamicReq:
-    properties:
-      commonImage:
-        description: CommonImage is field for id of a image in common namespace
-        example: default, tencent+ap-seoul+ubuntu20.04
-        type: string
-      commonSpec:
-        description: CommonSpec is field for id of a spec in common namespace
-        example: tencent+ap-seoul+S2.MEDIUM4
-        type: string
-      description:
-        example: Description
-        type: string
-      desiredNodeSize:
-        default: "1"
-        example: "1"
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      maxNodeSize:
-        default: "2"
-        example: "3"
-        type: string
-      minNodeSize:
-        default: "1"
-        example: "1"
-        type: string
-      name:
-        description: K8sNodeGroup name if it is not empty.
-        example: k8sng01
-        type: string
-      onAutoScaling:
-        default: "true"
-        example: "true"
-        type: string
-      rootDiskSize:
-        default: default
-        description: '"default", Integer (GB): ["50", ..., "1000"]'
-        example: default, 30, 42, ...
-        type: string
-      rootDiskType:
-        default: default
-        description: '"", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure:
-          ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced",
-          "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_essd"],
-          TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]'
-        example: default, TYPE1, ...
-        type: string
-    required:
-    - commonImage
-    - commonSpec
-    - name
-    type: object
-  model.TbK8sNodeGroupInfo:
-    properties:
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      desiredNodeSize:
-        type: integer
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      imageId:
-        type: string
-      k8sNodes:
-        items:
-          $ref: '#/definitions/model.TbK8sNodeInfo'
-        type: array
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      maxNodeSize:
-        type: integer
-      minNodeSize:
-        type: integer
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      onAutoScaling:
-        type: boolean
-      rootDiskSize:
-        type: string
-      rootDiskType:
-        type: string
-      specId:
-        type: string
-      spiderViewK8sNodeGroupDetail:
-        $ref: '#/definitions/model.SpiderNodeGroupInfo'
-      sshKeyId:
-        type: string
-      status:
-        allOf:
-        - $ref: '#/definitions/model.TbK8sNodeGroupStatus'
-        description: Creating, Active, Inactive, Updating, Deleting
-        example: Active
-    type: object
-  model.TbK8sNodeGroupReq:
-    properties:
-      description:
-        example: Description
-        type: string
-      desiredNodeSize:
-        example: "1"
-        type: string
-      imageId:
-        example: image-01
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      maxNodeSize:
-        example: "3"
-        type: string
-      minNodeSize:
-        example: "1"
-        type: string
-      name:
-        example: k8sng01
-        type: string
-      onAutoScaling:
-        description: autoscale config.
-        example: "true"
-        type: string
-      rootDiskSize:
-        description: '"default", Integer (GB): ["50", ..., "1000"]'
-        example: "40"
-        type: string
-      rootDiskType:
-        description: '"", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure:
-          ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced",
-          "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_ssd"],
-          TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]'
-        example: cloud_essd
-        type: string
-      specId:
-        example: spec-01
-        type: string
-      sshKeyId:
-        example: sshkey-01
-        type: string
-    type: object
-  model.TbK8sNodeGroupStatus:
-    enum:
-    - Creating
-    - Active
-    - Inactive
-    - Updating
-    - Deleting
-    type: string
-    x-enum-varnames:
-    - TbK8sNodeGroupCreating
-    - TbK8sNodeGroupActive
-    - TbK8sNodeGroupInactive
-    - TbK8sNodeGroupUpdating
-    - TbK8sNodeGroupDeleting
-  model.TbK8sNodeInfo:
-    properties:
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-    type: object
-  model.TbMciDynamicReq:
-    properties:
-      description:
-        example: Made in CB-TB
-        type: string
-      installMonAgent:
-        default: "no"
-        description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no]
-          default:no)
-        enum:
-        - "yes"
-        - "no"
-        example: "no"
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      name:
-        example: mci01
-        type: string
-      postCommand:
-        allOf:
-        - $ref: '#/definitions/model.MciCmdReq'
-        description: PostCommand is for the command to bootstrap the VMs
-      systemLabel:
-        description: SystemLabel is for describing the mci in a keyword (any string
-          can be used) for special System purpose
-        example: ""
-        type: string
-      vm:
-        items:
-          $ref: '#/definitions/model.TbVmDynamicReq'
-        type: array
-    required:
-    - name
-    - vm
-    type: object
-  model.TbMciInfo:
-    properties:
-      configureCloudAdaptiveNetwork:
-        default: "no"
-        description: ConfigureCloudAdaptiveNetwork is an option to configure Cloud
-          Adaptive Network (CLADNet) ([yes/no] default:yes)
-        enum:
-        - "yes"
-        - "no"
-        example: "yes"
-        type: string
-      description:
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      installMonAgent:
-        default: "no"
-        description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no]
-          default:no)
-        enum:
-        - "yes"
-        - "no"
-        example: "no"
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      newVmList:
-        description: List of IDs for new VMs. Return IDs if the VMs are newly added.
-          This field should be used for return body only.
-        items:
-          type: string
-        type: array
-      placementAlgo:
-        type: string
-      postCommand:
-        allOf:
-        - $ref: '#/definitions/model.MciCmdReq'
-        description: PostCommand is for the command to bootstrap the VMs
-      postCommandResult:
-        allOf:
-        - $ref: '#/definitions/model.MciSshCmdResult'
-        description: PostCommandResult is the result of the command for bootstraping
-          the VMs
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      status:
-        type: string
-      statusCount:
-        $ref: '#/definitions/model.StatusCountInfo'
-      systemLabel:
-        description: SystemLabel is for describing the mci in a keyword (any string
-          can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      systemMessage:
-        description: Latest system message such as error message
-        example: Failed because ...
-        type: string
-      targetAction:
-        type: string
-      targetStatus:
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-      vm:
-        items:
-          $ref: '#/definitions/model.TbVmInfo'
-        type: array
-    type: object
-  model.TbMciReq:
-    properties:
-      description:
-        example: Made in CB-TB
-        type: string
-      installMonAgent:
-        default: "no"
-        description: InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no]
-          default:yes)
-        enum:
-        - "yes"
-        - "no"
-        example: "no"
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      name:
-        example: mci01
-        type: string
-      placementAlgo:
-        type: string
-      postCommand:
-        allOf:
-        - $ref: '#/definitions/model.MciCmdReq'
-        description: PostCommand is for the command to bootstrap the VMs
-      systemLabel:
-        description: SystemLabel is for describing the mci in a keyword (any string
-          can be used) for special System purpose
-        example: ""
-        type: string
-      vm:
-        items:
-          $ref: '#/definitions/model.TbVmReq'
-        type: array
-    required:
-    - name
-    - vm
-    type: object
-  model.TbNLBAddRemoveVMReq:
-    properties:
-      targetGroup:
-        $ref: '#/definitions/model.TbNLBTargetGroupInfo'
-    type: object
-  model.TbNLBHealthCheckerInfo:
-    properties:
-      interval:
-        description: secs, Interval time between health checks.
-        example: 10
-        type: integer
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      port:
-        description: Listener Port or 1-65535
-        example: "22"
-        type: string
-      protocol:
-        description: TCP|HTTP|HTTPS
-        example: TCP
-        type: string
-      threshold:
-        description: num, The number of continuous health checks to change the VM
-          status.
-        example: 3
-        type: integer
-      timeout:
-        description: secs, Waiting time to decide an unhealthy VM when no response.
-        example: 10
-        type: integer
-    type: object
-  model.TbNLBHealthCheckerReq:
-    properties:
-      interval:
-        description: secs, Interval time between health checks.
-        example: default
-        type: string
-      threshold:
-        description: num, The number of continuous health checks to change the VM
-          status.
-        example: default
-        type: string
-      timeout:
-        description: secs, Waiting time to decide an unhealthy VM when no response.
-        example: default
-        type: string
-    type: object
-  model.TbNLBInfo:
-    properties:
-      associatedObjectList:
-        items:
-          type: string
-        type: array
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      createdTime:
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        type: string
-      healthChecker:
-        $ref: '#/definitions/model.TbNLBHealthCheckerInfo'
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      isAutoGenerated:
-        type: boolean
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      listener:
-        $ref: '#/definitions/model.TbNLBListenerInfo'
-      location:
-        $ref: '#/definitions/model.Location'
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      scope:
-        description: REGION(V) | GLOBAL
-        type: string
-      status:
-        type: string
-      systemLabel:
-        description: SystemLabel is for describing the Resource in a keyword (any
-          string can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      targetGroup:
-        $ref: '#/definitions/model.TbNLBTargetGroupInfo'
-      type:
-        description: PUBLIC(V) | INTERNAL
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.TbNLBListenerInfo:
-    properties:
-      dnsName:
-        description: Optional, Auto Generated and attached
-        example: default-group-cd3.elb.ap-northeast-2.amazonaws.com
-        type: string
-      ip:
-        description: Auto Generated and attached
-        example: x.x.x.x
-        type: string
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      port:
-        description: 1-65535
-        example: "80"
-        type: string
-      protocol:
-        description: TCP|UDP
-        example: TCP
-        type: string
-    type: object
-  model.TbNLBReq:
-    properties:
-      cspResourceId:
-        description: Existing NLB (used only for option=register)
-        type: string
-      description:
-        type: string
-      healthChecker:
-        allOf:
-        - $ref: '#/definitions/model.TbNLBHealthCheckerReq'
-        description: HealthChecker
-      listener:
-        allOf:
-        - $ref: '#/definitions/model.NLBListenerReq'
-        description: Frontend
-      scope:
-        description: REGION(V) | GLOBAL
-        enum:
-        - REGION
-        - GLOBAL
-        example: REGION
-        type: string
-      targetGroup:
-        allOf:
-        - $ref: '#/definitions/model.TbNLBTargetGroupReq'
-        description: Backend
-      type:
-        description: PUBLIC(V) | INTERNAL
-        enum:
-        - PUBLIC
-        - INTERNAL
-        example: PUBLIC
-        type: string
-    required:
-    - healthChecker
-    - listener
-    - scope
-    - targetGroup
-    - type
-    type: object
-  model.TbNLBTargetGroupInfo:
-    properties:
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      port:
-        description: Listener Port or 1-65535
-        example: "80"
-        type: string
-      protocol:
-        description: TCP|HTTP|HTTPS
-        example: TCP
-        type: string
-      subGroupId:
-        example: g1
-        type: string
-      vms:
-        items:
-          type: string
-        type: array
-    type: object
-  model.TbNLBTargetGroupReq:
-    properties:
-      port:
-        description: Listener Port or 1-65535
-        example: "80"
-        type: string
-      protocol:
-        description: TCP|HTTP|HTTPS
-        example: TCP
-        type: string
-      subGroupId:
-        example: g1
-        type: string
-    type: object
-  model.TbRegisterSubnetReq:
-    properties:
-      connectionName:
-        type: string
-      cspResourceId:
-        type: string
-      description:
-        type: string
-      name:
-        type: string
-      zone:
-        type: string
-    required:
-    - connectionName
-    - cspResourceId
-    - name
-    type: object
-  model.TbRegisterVNetReq:
-    properties:
-      connectionName:
-        type: string
-      cspResourceId:
-        type: string
-      description:
-        type: string
-      name:
-        type: string
-    required:
-    - connectionName
-    - cspResourceId
-    - name
-    type: object
-  model.TbScaleOutSubGroupReq:
-    properties:
-      numVMsToAdd:
-        description: Define addtional VMs to scaleOut
-        example: "2"
-        type: string
-    required:
-    - numVMsToAdd
-    type: object
-  model.TbSecurityGroupInfo:
-    properties:
-      associatedObjectList:
-        items:
-          type: string
-        type: array
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        type: string
-      firewallRules:
-        items:
-          $ref: '#/definitions/model.TbFirewallRuleInfo'
-        type: array
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      isAutoGenerated:
-        type: boolean
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      systemLabel:
-        description: SystemLabel is for describing the Resource in a keyword (any
-          string can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-      vNetId:
-        type: string
-    type: object
-  model.TbSecurityGroupReq:
-    properties:
-      connectionName:
-        type: string
-      cspResourceId:
-        description: CspResourceId is required to register object from CSP (option=register)
-        type: string
-      description:
-        type: string
-      firewallRules:
-        description: validate:"required"`
-        items:
-          $ref: '#/definitions/model.TbFirewallRuleInfo'
-        type: array
-      name:
-        type: string
-      vNetId:
-        type: string
-    required:
-    - connectionName
-    - name
-    - vNetId
-    type: object
-  model.TbSetK8sNodeGroupAutoscalingReq:
-    properties:
-      onAutoScaling:
-        example: "true"
-        type: string
-    type: object
-  model.TbSetK8sNodeGroupAutoscalingRes:
-    properties:
-      result:
-        example: "true"
-        type: string
-    type: object
-  model.TbSpecInfo:
-    properties:
-      acceleratorCount:
-        type: integer
-      acceleratorMemoryGB:
-        type: number
-      acceleratorModel:
-        type: string
-      acceleratorType:
-        type: string
-      architecture:
-        example: x86_64
-        type: string
-      associatedObjectList:
-        items:
-          type: string
-        type: array
-      connectionName:
-        type: string
-      costPerHour:
-        type: number
-      cspSpecName:
-        description: CspSpecName is name of the spec given by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      description:
-        type: string
-      details:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      diskSizeGB:
-        type: number
-      evaluationScore01:
-        type: number
-      evaluationScore02:
-        type: number
-      evaluationScore03:
-        type: number
-      evaluationScore04:
-        type: number
-      evaluationScore05:
-        type: number
-      evaluationScore06:
-        type: number
-      evaluationScore07:
-        type: number
-      evaluationScore08:
-        type: number
-      evaluationScore09:
-        type: number
-      evaluationScore10:
-        type: number
-      evaluationStatus:
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      infraType:
-        description: InfraType can be one of vm|k8s|kubernetes|container, etc.
-        type: string
-      isAutoGenerated:
-        type: boolean
-      maxTotalStorageTiB:
-        type: integer
-      memoryGiB:
-        type: number
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      namespace:
-        example: default
-        type: string
-      netBwGbps:
-        type: integer
-      orderInFilteredResult:
-        type: integer
-      osType:
-        type: string
-      providerName:
-        type: string
-      regionName:
-        type: string
-      rootDiskSize:
-        type: string
-      rootDiskType:
-        type: string
-      systemLabel:
-        description: SystemLabel is for describing the Resource in a keyword (any
-          string can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-      vCPU:
-        type: integer
-    type: object
-  model.TbSpecReq:
-    properties:
-      connectionName:
-        type: string
-      cspSpecName:
-        description: CspSpecName is name of the spec given by CSP
-        type: string
-      description:
-        type: string
-      name:
-        description: Name is human-readable string to represent the object, used to
-          generate Id
-        type: string
-    required:
-    - connectionName
-    - cspSpecName
-    - name
-    type: object
-  model.TbSshKeyInfo:
-    properties:
-      associatedObjectList:
-        items:
-          type: string
-        type: array
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        type: string
-      fingerprint:
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      isAutoGenerated:
-        type: boolean
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      privateKey:
-        type: string
-      publicKey:
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      systemLabel:
-        description: SystemLabel is for describing the Resource in a keyword (any
-          string can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-      username:
-        type: string
-      verifiedUsername:
-        type: string
-    type: object
-  model.TbSshKeyReq:
-    properties:
-      connectionName:
-        type: string
-      cspResourceId:
-        description: |-
-          Fields for "Register existing SSH keys" feature
-          CspResourceId is required to register object from CSP (option=register)
-        type: string
-      description:
-        type: string
-      fingerprint:
-        type: string
-      name:
-        type: string
-      privateKey:
-        type: string
-      publicKey:
-        type: string
-      username:
-        type: string
-      verifiedUsername:
-        type: string
-    required:
-    - connectionName
-    - name
-    type: object
-  model.TbSubnetInfo:
-    properties:
-      bastionNodes:
-        items:
-          $ref: '#/definitions/model.BastionNode'
-        type: array
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      cspVNetId:
-        description: CspVNetId is vNet resource identifier managed by CSP
-        example: csp-45eb41e14121c550a
-        type: string
-      cspVNetName:
-        description: CspVNetName is identifier to handle CSP vNet resource
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      ipv4_CIDR:
-        type: string
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      status:
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-      zone:
-        type: string
-    type: object
-  model.TbSubnetReq:
-    properties:
-      description:
-        example: subnet00 managed by CB-Tumblebug
-        type: string
-      ipv4_CIDR:
-        example: 10.0.1.0/24
-        type: string
-      name:
-        example: subnet00
-        type: string
-      zone:
-        type: string
-    required:
-    - ipv4_CIDR
-    - name
-    type: object
-  model.TbUpgradeK8sClusterReq:
-    properties:
-      version:
-        example: 1.30.1-alyun.1
-        type: string
-    type: object
-  model.TbVNetInfo:
-    properties:
-      associatedObjectList:
-        items:
-          type: string
-        type: array
-      cidrBlock:
-        type: string
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      description:
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      isAutoGenerated:
-        type: boolean
-      keyValueList:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      status:
-        type: string
-      subnetInfoList:
-        items:
-          $ref: '#/definitions/model.TbSubnetInfo'
-        type: array
-      systemLabel:
-        description: SystemLabel is for describing the Resource in a keyword (any
-          string can be used) for special System purpose
-        example: Managed by CB-Tumblebug
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.TbVNetReq:
-    properties:
-      cidrBlock:
-        example: 10.0.0.0/16
-        type: string
-      connectionName:
-        example: aws-ap-northeast-2
-        type: string
-      description:
-        example: vnet00 managed by CB-Tumblebug
-        type: string
-      name:
-        example: vnet00
-        type: string
-      subnetInfoList:
-        items:
-          $ref: '#/definitions/model.TbSubnetReq'
-        type: array
-    required:
-    - connectionName
-    - name
-    type: object
-  model.TbVmDynamicReq:
-    properties:
-      commonImage:
-        description: CommonImage is field for id of a image in common namespace
-        example: ubuntu18.04
-        type: string
-      commonSpec:
-        description: CommonSpec is field for id of a spec in common namespace
-        example: aws+ap-northeast-2+t2.small
-        type: string
-      connectionName:
-        description: |-
-          if ConnectionName is given, the VM tries to use associtated credential.
-          if not, it will use predefined ConnectionName in Spec objects
-        type: string
-      description:
-        example: Description
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      name:
-        description: VM name or subGroup name if is (not empty) && (> 0). If it is
-          a group, actual VM name will be generated with -N postfix.
-        example: g1-1
-        type: string
-      rootDiskSize:
-        default: default
-        description: '"default", Integer (GB): ["50", ..., "1000"]'
-        example: default, 30, 42, ...
-        type: string
-      rootDiskType:
-        default: default
-        description: '"", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure:
-          ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced",
-          "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_essd"],
-          TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]'
-        example: default, TYPE1, ...
-        type: string
-      subGroupSize:
-        default: "1"
-        description: if subGroupSize is (not empty) && (> 0), subGroup will be generated.
-          VMs will be created accordingly.
-        example: "3"
-        type: string
-      vmUserPassword:
-        type: string
-    required:
-    - commonImage
-    - commonSpec
-    type: object
-  model.TbVmInfo:
-    properties:
-      addtionalDetails:
-        items:
-          $ref: '#/definitions/model.KeyValue'
-        type: array
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      createdTime:
-        description: Created time
-        example: "2022-11-10 23:00:00"
-        type: string
-      cspImageName:
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      cspSpecName:
-        type: string
-      cspSshKeyId:
-        type: string
-      cspSubnetId:
-        type: string
-      cspVNetId:
-        type: string
-      dataDiskIds:
-        items:
-          type: string
-        type: array
-      description:
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      imageId:
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        type: object
-      location:
-        $ref: '#/definitions/model.Location'
-      monAgentStatus:
-        description: Montoring agent status
-        example: '[installed, notInstalled, failed]'
-        type: string
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      networkAgentStatus:
-        description: NetworkAgent status
-        example: '[notInstalled, installing, installed, failed]'
-        type: string
-      networkInterface:
-        type: string
-      privateDNS:
-        type: string
-      privateIP:
-        type: string
-      publicDNS:
-        type: string
-      publicIP:
-        type: string
-      region:
-        allOf:
-        - $ref: '#/definitions/model.RegionInfo'
-        description: AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      rootDiskName:
-        type: string
-      rootDiskSize:
-        type: string
-      rootDiskType:
-        type: string
-      securityGroupIds:
-        items:
-          type: string
-        type: array
-      specId:
-        type: string
-      sshKeyId:
-        type: string
-      sshPort:
-        type: string
-      status:
-        description: Required by CB-Tumblebug
-        type: string
-      subGroupId:
-        description: defined if the VM is in a group
-        type: string
-      subnetId:
-        type: string
-      systemMessage:
-        description: Latest system message such as error message
-        example: Failed because ...
-        type: string
-      targetAction:
-        type: string
-      targetStatus:
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-      vNetId:
-        type: string
-      vmUserName:
-        type: string
-      vmUserPassword:
-        type: string
-    type: object
-  model.TbVmReq:
-    properties:
-      connectionName:
-        example: testcloud01-seoul
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP (required
-          for option=register)
-        example: i-014fa6ede6ada0b2c
-        type: string
-      dataDiskIds:
-        items:
-          type: string
-        type: array
-      description:
-        example: Description
-        type: string
-      imageId:
-        description: ImageType        string   `json:"imageType"`
-        type: string
-      label:
-        additionalProperties:
-          type: string
-        description: Label is for describing the object by keywords
-        type: object
-      name:
-        description: VM name or subGroup name if is (not empty) && (> 0). If it is
-          a group, actual VM name will be generated with -N postfix.
-        example: g1-1
-        type: string
-      rootDiskSize:
-        description: '"default", Integer (GB): ["50", ..., "1000"]'
-        example: default, 30, 42, ...
-        type: string
-      rootDiskType:
-        description: '"", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure:
-          ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced",
-          "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_ssd"],
-          TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]'
-        example: default, TYPE1, ...
-        type: string
-      securityGroupIds:
-        items:
-          type: string
-        type: array
-      specId:
-        type: string
-      sshKeyId:
-        type: string
-      subGroupSize:
-        description: if subGroupSize is (not empty) && (> 0), subGroup will be generated.
-          VMs will be created accordingly.
-        example: "3"
-        type: string
-      subnetId:
-        type: string
-      vNetId:
-        type: string
-      vmUserName:
-        type: string
-      vmUserPassword:
-        type: string
-    required:
-    - connectionName
-    - imageId
-    - name
-    - securityGroupIds
-    - specId
-    - sshKeyId
-    - subnetId
-    - vNetId
-    type: object
-  model.TbVmSnapshotReq:
-    properties:
-      name:
-        example: aws-ap-southeast-1-snapshot
-        type: string
-    type: object
-  model.TbVmStatusInfo:
-    properties:
-      createdTime:
-        description: Created time
-        example: "2022-11-10 23:00:00"
-        type: string
-      cspResourceId:
-        description: CspResourceId is resource identifier managed by CSP
-        example: csp-06eb41e14121c550a
-        type: string
-      cspResourceName:
-        description: CspResourceName is name assigned to the CSP resource. This name
-          is internally used to handle the resource.
-        example: we12fawefadf1221edcf
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: aws-ap-southeast-1
-        type: string
-      location:
-        $ref: '#/definitions/model.Location'
-      monAgentStatus:
-        description: Montoring agent status
-        example: '[installed, notInstalled, failed]'
-        type: string
-      name:
-        description: Name is human-readable string to represent the object
-        example: aws-ap-southeast-1
-        type: string
-      nativeStatus:
-        type: string
-      privateIp:
-        type: string
-      publicIp:
-        type: string
-      sshPort:
-        type: string
-      status:
-        type: string
-      systemMessage:
-        description: Latest system message such as error message
-        example: Failed because ...
-        type: string
-      targetAction:
-        type: string
-      targetStatus:
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-    type: object
-  model.VNetDetails:
-    properties:
-      hostsPerSubnet:
-        type: string
-      subnetCount:
-        type: string
-      useFirstNZones:
-        type: string
-    type: object
-  model.VpnIdList:
-    properties:
-      vpnIdList:
-        items:
-          type: string
-        type: array
-    type: object
-  model.VpnInfo:
-    properties:
-      description:
-        type: string
-      id:
-        description: Id is unique identifier for the object
-        example: vpn01
-        type: string
-      name:
-        description: Name is human-readable string to represent the object
-        example: vpn01
-        type: string
-      resourceType:
-        description: ResourceType is the type of the resource
-        type: string
-      status:
-        type: string
-      uid:
-        description: Uid is universally unique identifier for the object, used for
-          labelSelector
-        example: wef12awefadf1221edcf
-        type: string
-      vpnSites:
-        items:
-          $ref: '#/definitions/model.VpnSiteDetail'
-        type: array
-    type: object
-  model.VpnInfoList:
-    properties:
-      vpnInfoList:
-        items:
-          $ref: '#/definitions/model.VpnInfo'
-        type: array
-    type: object
-  model.VpnSiteDetail:
-    properties:
-      connectionConfig:
-        $ref: '#/definitions/model.ConnConfig'
-      connectionName:
-        type: string
-      resourceDetails:
-        description: ResourceDetails represents a CSP's multiple resources associated
-          with the VPN from a CSP.
-        items:
-          $ref: '#/definitions/model.ResourceDetail'
-        type: array
-    type: object
-  model.inspectOverview:
-    properties:
-      customImage:
-        type: integer
-      dataDisk:
-        type: integer
-      nlb:
-        type: integer
-      securityGroup:
-        type: integer
-      sshKey:
-        type: integer
-      vNet:
-        type: integer
-      vm:
-        type: integer
-    type: object
-  model.sites:
-    properties:
-      alibaba:
-        items:
-          $ref: '#/definitions/model.SiteDetail'
-        type: array
-      aws:
-        items:
-          $ref: '#/definitions/model.SiteDetail'
-        type: array
-      azure:
-        items:
-          $ref: '#/definitions/model.SiteDetail'
-        type: array
-      gcp:
-        items:
-          $ref: '#/definitions/model.SiteDetail'
-        type: array
-      ibm:
-        items:
-          $ref: '#/definitions/model.SiteDetail'
-        type: array
-      tencent:
-        items:
-          $ref: '#/definitions/model.SiteDetail'
-        type: array
-    type: object
-  netutil.Network:
-    properties:
-      cidrBlock:
-        type: string
-      name:
-        type: string
-      subnets:
-        items:
-          $ref: '#/definitions/netutil.Network'
-        type: array
-    type: object
-  netutil.RestPostUtilToDesignNetworkReponse:
-    properties:
-      cidrBlock:
-        type: string
-      name:
-        type: string
-      subnets:
-        items:
-          $ref: '#/definitions/netutil.Network'
-        type: array
-    type: object
-  netutil.RestPostUtilToDesignNetworkRequest:
-    properties:
-      cidrBlock:
-        example: 192.168.0.0/16
-        type: string
-      subnettingRules:
-        items:
-          $ref: '#/definitions/netutil.SubnettingRule'
-        type: array
-    type: object
-  netutil.RestPostUtilToDesignVNetReponse:
-    properties:
-      rootNetworkCIDR:
-        description: in case of supernetting enabled
-        type: string
-      vNetReqList:
-        items:
-          $ref: '#/definitions/model.TbVNetReq'
-        type: array
-    type: object
-  netutil.RestPostUtilToDesignVNetRequest:
-    properties:
-      desiredPrivateNetwork:
-        type: string
-      mcNetConfigurations:
-        items:
-          $ref: '#/definitions/model.McNetConfigurationDetails'
-        type: array
-      supernettingEnabled:
-        type: string
-    type: object
-  netutil.RestPostUtilToValidateNetworkRequest:
-    properties:
-      networkConfiguration:
-        $ref: '#/definitions/netutil.Network'
-    type: object
-  netutil.SubnettingRule:
-    properties:
-      type:
-        allOf:
-        - $ref: '#/definitions/netutil.SubnettingRuleType'
-        example: minSubnets
-      value:
-        example: 2
-        type: integer
-    type: object
-  netutil.SubnettingRuleType:
-    enum:
-    - minSubnets
-    - minHosts
-    type: string
-    x-enum-varnames:
-    - SubnettingRuleTypeMinSubnets
-    - SubnettingRuleTypeMinHosts
-  resource.ConnectionImageResult:
-    properties:
-      connName:
-        type: string
-      elapsedTime:
-        type: string
-      errorMsg:
-        type: string
-      imageCount:
-        type: integer
-      provider:
-        type: string
-      region:
-        type: string
-      startTime:
-        type: string
-      success:
-        type: boolean
-    type: object
-  resource.ConnectionSpecResult:
-    properties:
-      connName:
-        type: string
-      elapsedTime:
-        type: string
-      errorMsg:
-        type: string
-      provider:
-        type: string
-      region:
-        type: string
-      specCount:
-        type: integer
-      startTime:
-        type: string
-      success:
-        type: boolean
-    type: object
-  resource.FetchImagesAsyncResult:
-    properties:
-      elapsedTime:
-        type: string
-      failedRegions:
-        type: integer
-      fetchOption:
-        $ref: '#/definitions/model.ImageFetchOption'
-      inProgress:
-        type: boolean
-      namespaceId:
-        type: string
-      registeredImages:
-        type: integer
-      resultInDetail:
-        items:
-          $ref: '#/definitions/resource.ConnectionImageResult'
-        type: array
-      startTime:
-        type: string
-      succeedRegions:
-        type: integer
-      totalRegions:
-        type: integer
-    type: object
-  resource.FetchSpecsAsyncResult:
-    properties:
-      elapsedTime:
-        type: string
-      failedRegions:
-        type: integer
-      fetchOption:
-        $ref: '#/definitions/model.SpecFetchOption'
-      inProgress:
-        type: boolean
-      namespaceId:
-        type: string
-      registeredSpecs:
-        type: integer
-      resultInDetail:
-        items:
-          $ref: '#/definitions/resource.ConnectionSpecResult'
-        type: array
-      startTime:
-        type: string
-      succeedRegions:
-        type: integer
-      totalRegions:
-        type: integer
-    type: object
-  resource.JSONResult:
-    type: object
-  resource.RestFilterSpecsResponse:
-    properties:
-      spec:
-        items:
-          $ref: '#/definitions/model.TbSpecInfo'
-        type: array
-    type: object
-  resource.RestGetAllCustomImageResponse:
-    properties:
-      customImage:
-        items:
-          $ref: '#/definitions/model.TbCustomImageInfo'
-        type: array
-    type: object
-  resource.RestGetAllDataDiskResponse:
-    properties:
-      dataDisk:
-        items:
-          $ref: '#/definitions/model.TbDataDiskInfo'
-        type: array
-    type: object
-  resource.RestGetAllK8sClusterResponse:
-    properties:
-      cluster:
-        items:
-          $ref: '#/definitions/model.TbK8sClusterInfo'
-        type: array
-    type: object
-  resource.RestGetAllSecurityGroupResponse:
-    properties:
-      securityGroup:
-        items:
-          $ref: '#/definitions/model.TbSecurityGroupInfo'
-        type: array
-    type: object
-  resource.RestGetAllSshKeyResponse:
-    properties:
-      sshKey:
-        items:
-          $ref: '#/definitions/model.TbSshKeyInfo'
-        type: array
-    type: object
-  resource.RestGetAllSubnetResponse:
-    properties:
-      subnetInfoList:
-        items:
-          $ref: '#/definitions/model.TbSubnetInfo'
-        type: array
-    type: object
-  resource.RestGetAllVNetResponse:
-    properties:
-      vNet:
-        items:
-          $ref: '#/definitions/model.TbVNetInfo'
-        type: array
-    type: object
-  resource.RestLookupImageRequest:
-    properties:
-      connectionName:
-        type: string
-      cspImageName:
-        type: string
-    type: object
-  resource.RestLookupSpecRequest:
-    properties:
-      connectionName:
-        type: string
-      cspResourceId:
-        type: string
-    type: object
-  resource.TbFirewallRulesWrapper:
-    properties:
-      firewallRules:
-        description: validate:"required"`
-        items:
-          $ref: '#/definitions/model.TbFirewallRuleInfo'
-        type: array
-    type: object
+openapi: 3.0.1
 info:
+  title: CB-Tumblebug REST API
+  description: CB-Tumblebug is an open source system for managing multi-cloud infrastructure
+    consisting of resources from multiple cloud service providers. (Cloud-Barista)
+  termsOfService: https://github.com/cloud-barista/cb-tumblebug/blob/main/README.md
   contact:
     name: API Support
     url: https://github.com/cloud-barista/cb-tumblebug/issues/new/choose
-  description: CB-Tumblebug is an open source system for managing multi-cloud infrastructure
-    consisting of resources from multiple cloud service providers. (Cloud-Barista)
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  termsOfService: https://github.com/cloud-barista/cb-tumblebug/blob/main/README.md
-  title: CB-Tumblebug REST API
   version: latest
+servers:
+- url: /tumblebug
 paths:
   /auth/test:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] API Request Management"
+      summary: Test JWT authentication
       description: Test JWT authentication
       operationId: TestJWTAuth
-      produces:
-      - application/json
       responses:
         "200":
           description: Information of JWT authentication
-          schema:
-            $ref: '#/definitions/auth.AuthsInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/auth.AuthsInfo'
         "400":
           description: Invalid Request
-          schema:
-            type: object
+          content:
+            application/json:
+              schema:
+                type: object
       security:
       - Bearer: []
-      summary: Test JWT authentication
-      tags:
-      - '[Admin] API Request Management'
   /availableK8sNodeImage:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
       description: (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
       operationId: GetAvailableK8sNodeImage
       parameters:
-      - description: Name of the CSP to retrieve
+      - name: providerName
         in: query
-        name: providerName
+        description: Name of the CSP to retrieve
         required: true
-        type: string
-      - description: Name of region to retrieve
+        schema:
+          type: string
+      - name: regionName
         in: query
-        name: regionName
+        description: Name of region to retrieve
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.K8sClusterNodeImageDetailAvailable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.K8sClusterNodeImageDetailAvailable'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: (UNDER DEVELOPMENT!!!) Get available kubernetes cluster node image
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /availableK8sVersion:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Get available kubernetes cluster version
       description: Get available kubernetes cluster version
       operationId: GetAvailableK8sVersion
       parameters:
-      - description: Name of the CSP to retrieve
+      - name: providerName
         in: query
-        name: providerName
+        description: Name of the CSP to retrieve
         required: true
-        type: string
-      - description: Name of region to retrieve
+        schema:
+          type: string
+      - name: regionName
         in: query
-        name: regionName
+        description: Name of region to retrieve
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.K8sClusterVersionDetailAvailable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.K8sClusterVersionDetailAvailable'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get available kubernetes cluster version
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /checkK8sNodeGroupsOnK8sCreation:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Check whether nodegroups are required during the K8sCluster creation
       description: Check whether nodegroups are required during the K8sCluster creation
       operationId: CheckK8sNodeGroupsOnK8sCreation
       parameters:
-      - description: Name of the CSP to retrieve
+      - name: providerName
         in: query
-        name: providerName
+        description: Name of the CSP to retrieve
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.K8sClusterNodeGroupsOnCreation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.K8sClusterNodeGroupsOnCreation'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Check whether nodegroups are required during the K8sCluster creation
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /checkK8sNodeImageDesignation:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Check whether node image designation is possible to create a K8sCluster
       description: Check whether node image designation is possible to create a K8sCluster
       operationId: CheckK8sNodeImageDesignation
       parameters:
-      - description: Name of the CSP to retrieve
+      - name: providerName
         in: query
-        name: providerName
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.K8sClusterNodeImageDesignation'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Check whether node image designation is possible to create a K8sCluster
-      tags:
-      - '[Kubernetes] Cluster Management'
-  /cloudInfo:
-    get:
-      consumes:
-      - application/json
-      description: Get cloud information
-      operationId: GetCloudInfo
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.CloudInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get cloud information
-      tags:
-      - '[Admin] Multi-Cloud Information'
-  /config:
-    delete:
-      consumes:
-      - application/json
-      description: Init all configs
-      operationId: InitAllConfig
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Init all configs
-      tags:
-      - '[Admin] System Configuration'
-    get:
-      consumes:
-      - application/json
-      description: List all configs
-      operationId: GetAllConfig
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/common.RestGetAllConfigResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all configs
-      tags:
-      - '[Admin] System Configuration'
-    post:
-      consumes:
-      - application/json
-      description: Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL,
-        ...)
-      operationId: PostConfig
-      parameters:
-      - description: Key and Value for configuration
-        in: body
-        name: config
+        description: Name of the CSP to retrieve
         required: true
         schema:
-          $ref: '#/definitions/model.ConfigReq'
-      produces:
-      - application/json
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.ConfigInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.K8sClusterNodeImageDesignation'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create or Update config
-      tags:
-      - '[Admin] System Configuration'
-  /config/{configId}:
-    delete:
-      consumes:
-      - application/json
-      description: Init config
-      operationId: InitConfig
-      parameters:
-      - description: Config ID
-        in: path
-        name: configId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.ConfigInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Init config
-      tags:
-      - '[Admin] System Configuration'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /cloudInfo:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] Multi-Cloud Information"
+      summary: Get cloud information
+      description: Get cloud information
+      operationId: GetCloudInfo
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.CloudInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /config:
+    get:
+      tags:
+      - "[Admin] System Configuration"
+      summary: List all configs
+      description: List all configs
+      operationId: GetAllConfig
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/common.RestGetAllConfigResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    post:
+      tags:
+      - "[Admin] System Configuration"
+      summary: Create or Update config
+      description: "Create or Update config (TB_SPIDER_REST_URL, TB_DRAGONFLY_REST_URL,\
+        \ ...)"
+      operationId: PostConfig
+      requestBody:
+        description: Key and Value for configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.ConfigReq'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.ConfigInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: config
+    delete:
+      tags:
+      - "[Admin] System Configuration"
+      summary: Init all configs
+      description: Init all configs
+      operationId: InitAllConfig
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /config/{configId}:
+    get:
+      tags:
+      - "[Admin] System Configuration"
+      summary: Get config
       description: Get config
       operationId: GetConfig
       parameters:
-      - description: Config ID
+      - name: configId
         in: path
-        name: configId
+        description: Config ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.ConfigInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.ConfigInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
       tags:
-      - '[Admin] System Configuration'
+      - "[Admin] System Configuration"
+      summary: Init config
+      description: Init config
+      operationId: InitConfig
+      parameters:
+      - name: configId
+        in: path
+        description: Config ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.ConfigInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /connConfig:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] Credential Management"
+      summary: List all registered ConnConfig
       description: List all registered ConnConfig
       operationId: GetConnConfigList
       parameters:
-      - default: ""
+      - name: filterCredentialHolder
+        in: query
         description: filter objects by Credential Holder
+        schema:
+          type: string
+      - name: filterVerified
         in: query
-        name: filterCredentialHolder
-        type: string
-      - default: true
         description: filter verified connections only
-        enum:
-        - true
-        - false
+        schema:
+          type: boolean
+          default: true
+          enum:
+          - true
+          - false
+      - name: filterRegionRepresentative
         in: query
-        name: filterVerified
-        type: boolean
-      - default: false
         description: filter connections with the representative region only
-        enum:
-        - true
-        - false
-        in: query
-        name: filterRegionRepresentative
-        type: boolean
-      produces:
-      - application/json
+        schema:
+          type: boolean
+          default: false
+          enum:
+          - true
+          - false
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.ConnConfigList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.ConnConfigList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all registered ConnConfig
-      tags:
-      - '[Admin] Credential Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /connConfig/{connConfigName}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] Credential Management"
+      summary: Get registered ConnConfig info
       description: Get registered ConnConfig info
       operationId: GetConnConfig
       parameters:
-      - description: Name of connection config (cloud config)
+      - name: connConfigName
         in: path
-        name: connConfigName
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.ConnConfig'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get registered ConnConfig info
-      tags:
-      - '[Admin] Credential Management'
-  /credential:
-    post:
-      consumes:
-      - application/json
-      description: This API registers credential information using hybrid encryption.
-        The process involves compressing and encrypting sensitive data with AES-256,
-        encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET
-        /credential/publicKey`), and using OAEP padding with SHA-256. All values,
-        including the AES key, must be base64 encoded before sending, and the public
-        key token ID must be included in the request.
-      operationId: RegisterCredential
-      parameters:
-      - description: Credential request info
-        in: body
-        name: CredentialReq
+        description: Name of connection config (cloud config)
         required: true
         schema:
-          $ref: '#/definitions/model.CredentialReq'
-      produces:
-      - application/json
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.CredentialInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.ConnConfig'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register Credential Information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /credential:
+    post:
       tags:
-      - '[Admin] Credential Management'
+      - "[Admin] Credential Management"
+      summary: Register Credential Information
+      description: "This API registers credential information using hybrid encryption.\
+        \ The process involves compressing and encrypting sensitive data with AES-256,\
+        \ encrypting the AES key with a 4096-bit RSA public key (retrieved via `GET\
+        \ /credential/publicKey`), and using OAEP padding with SHA-256. All values,\
+        \ including the AES key, must be base64 encoded before sending, and the public\
+        \ key token ID must be included in the request."
+      operationId: RegisterCredential
+      requestBody:
+        description: Credential request info
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.CredentialReq'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.CredentialInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: CredentialReq
   /credential/publicKey:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] Credential Management"
+      summary: Get RSA Public Key for Credential Encryption
       description: Generates an RSA key pair using a 4096-bit key size with the RSA
         algorithm. The public key is generated using the RSA algorithm with OAEP padding
         and SHA-256 as the hash function. This key is used to encrypt an AES key that
         will be used for hybrid encryption of credentials.
       operationId: GetPublicKeyForCredentialEncryption
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.PublicKeyResponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.PublicKeyResponse'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get RSA Public Key for Credential Encryption
-      tags:
-      - '[Admin] Credential Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /fetchImages:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Fetch images for regions of each CSP synchronously
       description: Fetch images waiting for completion
       operationId: FetchImages
-      parameters:
-      - description: Fetch option
-        in: body
-        name: fetchOption
+      requestBody:
+        description: Fetch option
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.ImageFetchOption'
         required: true
-        schema:
-          $ref: '#/definitions/model.ImageFetchOption'
-      produces:
-      - application/json
       responses:
         "202":
           description: Accepted
-          schema:
-            $ref: '#/definitions/resource.FetchImagesAsyncResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource.FetchImagesAsyncResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Fetch images for regions of each CSP synchronously
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: fetchOption
   /fetchImagesAsync:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Fetch images asynchronously
       description: Fetch images in the background without waiting for completion
       operationId: FetchImagesAsync
-      parameters:
-      - description: Fetch option
-        in: body
-        name: fetchOption
+      requestBody:
+        description: Fetch option
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.ImageFetchOption'
         required: true
-        schema:
-          $ref: '#/definitions/model.ImageFetchOption'
-      produces:
-      - application/json
       responses:
         "202":
           description: Accepted
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Fetch images asynchronously
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: fetchOption
   /fetchImagesResult:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Get result of asynchronous image fetching
       description: Get detailed results from the last asynchronous image fetch operation
       operationId: GetFetchImagesAsyncResult
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/resource.FetchImagesAsyncResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource.FetchImagesAsyncResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get result of asynchronous image fetching
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /fetchPrice:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Spec Management"
+      summary: Fetch price from all CSP connections and update the price information
+        for associated specs in the system.
       description: Fetch price from all CSP connections and update the price information
         for associated specs in the system.
       operationId: FetchPrice
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Fetch price from all CSP connections and update the price information
-        for associated specs in the system.
-      tags:
-      - '[Infra Resource] Spec Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /fetchSpecs:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Spec Management"
+      summary: Fetch specs from CSPs and register them in the system.
       description: Fetch specs from CSPs and register them in the system.
       operationId: FetchSpecs
-      parameters:
-      - description: Fetch option
-        in: body
-        name: fetchOption
+      requestBody:
+        description: Fetch option
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.SpecFetchOption'
         required: true
-        schema:
-          $ref: '#/definitions/model.SpecFetchOption'
-      produces:
-      - application/json
       responses:
         "202":
           description: Accepted
-          schema:
-            $ref: '#/definitions/resource.FetchSpecsAsyncResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource.FetchSpecsAsyncResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Fetch specs from CSPs and register them in the system.
-      tags:
-      - '[Infra Resource] Spec Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: fetchOption
   /forward/{path}:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] API Request Management"
+      summary: Forward any (GET) request to CB-Spider
       description: Forward any (GET) request to CB-Spider
       operationId: ForwardAnyReqToAny
       parameters:
-      - default: vmspec
-        description: Internal call path to CB-Spider (path without /spider/ prefix)
-          - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc]
-          for more details
+      - name: path
         in: path
-        name: path
+        description: "Internal call path to CB-Spider (path without /spider/ prefix)\
+          \ - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc]\
+          \ for more details"
         required: true
-        type: string
-      - description: Request body (various formats) - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc]
-          for more details
-        in: body
-        name: Request
-        schema: {}
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: vmspec
+      requestBody:
+        description: "Request body (various formats) - see [https://documenter.getpostman.com/view/24786935/2s9Ykq8Lpf#231eec23-b0ab-4966-83ce-a0ef92ead7bc]\
+          \ for more details"
+        content:
+          application/json:
+            schema:
+              type: object
+        required: false
       responses:
         "200":
           description: OK
-          schema:
-            additionalProperties: true
-            type: object
-      summary: Forward any (GET) request to CB-Spider
-      tags:
-      - '[Admin] API Request Management'
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+      x-codegen-request-body-name: Request
   /httpVersion:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] API Request Management"
+      summary: Check HTTP version of incoming request
       description: Checks and logs the HTTP version of the incoming request to the
         server console.
       operationId: CheckHTTPVersion
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Check HTTP version of incoming request
-      tags:
-      - '[Admin] API Request Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /inspectResources:
     post:
-      consumes:
-      - application/json
-      description: Inspect Resources (vNet, securityGroup, sshKey, vm) registered
-        in CB-Tumblebug, CB-Spider, CSP
+      tags:
+      - "[Admin] System Management"
+      summary: "Inspect Resources (vNet, securityGroup, sshKey, vm) registered in\
+        \ CB-Tumblebug, CB-Spider, CSP"
+      description: "Inspect Resources (vNet, securityGroup, sshKey, vm) registered\
+        \ in CB-Tumblebug, CB-Spider, CSP"
       operationId: InspectResources
-      parameters:
-      - description: Specify connectionName and resource type
-        in: body
-        name: connectionName
+      requestBody:
+        description: Specify connectionName and resource type
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/common.RestInspectResourcesRequest'
         required: true
-        schema:
-          $ref: '#/definitions/common.RestInspectResourcesRequest'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.InspectResource'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.InspectResource'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Inspect Resources (vNet, securityGroup, sshKey, vm) registered in CB-Tumblebug,
-        CB-Spider, CSP
-      tags:
-      - '[Admin] System Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: connectionName
   /inspectResourcesOverview:
     get:
-      consumes:
-      - application/json
-      description: Inspect Resources Overview (vNet, securityGroup, sshKey, vm) registered
-        in CB-Tumblebug and CSP for all connections
+      tags:
+      - "[Admin] System Management"
+      summary: "Inspect Resources Overview (vNet, securityGroup, sshKey, vm) registered\
+        \ in CB-Tumblebug and CSP for all connections"
+      description: "Inspect Resources Overview (vNet, securityGroup, sshKey, vm) registered\
+        \ in CB-Tumblebug and CSP for all connections"
       operationId: InspectResourcesOverview
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.InspectResourceAllResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.InspectResourceAllResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Inspect Resources Overview (vNet, securityGroup, sshKey, vm) registered
-        in CB-Tumblebug and CSP for all connections
-      tags:
-      - '[Admin] System Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /k8sClusterDynamicCheckRequest:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Check available ConnectionConfig list for creating K8sCluster Dynamically
       description: Check available ConnectionConfig list before create K8sCluster
         Dynamically from common spec and image
       operationId: PostK8sClusterDynamicCheckRequest
-      parameters:
-      - description: Details for K8sCluster dynamic request information
-        in: body
-        name: k8sClusterConnectionConfigCandidatesReq
+      requestBody:
+        description: Details for K8sCluster dynamic request information
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.K8sClusterConnectionConfigCandidatesReq'
         required: true
-        schema:
-          $ref: '#/definitions/model.K8sClusterConnectionConfigCandidatesReq'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.CheckK8sClusterDynamicReqInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.CheckK8sClusterDynamicReqInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Check available ConnectionConfig list for creating K8sCluster Dynamically
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: k8sClusterConnectionConfigCandidatesReq
   /k8sClusterInfo:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Get kubernetes cluster information
       description: Get kubernetes cluster information
       operationId: GetK8sClusterInfo
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.K8sClusterInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.K8sClusterInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get kubernetes cluster information
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /k8sClusterRecommendNode:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Recommend K8sCluster's Node plan (filter and priority)
       description: Recommend K8sCluster's Node plan (filter and priority) Find details
         from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
       operationId: RecommendK8sNode
-      parameters:
-      - description: Recommend K8sCluster's Node plan (filter and priority)
-        in: body
-        name: deploymentPlan
-        schema:
-          $ref: '#/definitions/model.DeploymentPlan'
-      produces:
-      - application/json
+      requestBody:
+        description: Recommend K8sCluster's Node plan (filter and priority)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.DeploymentPlan'
+        required: false
       responses:
         "200":
           description: OK
-          schema:
-            items:
-              $ref: '#/definitions/model.TbSpecInfo'
-            type: array
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/model.TbSpecInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Recommend K8sCluster's Node plan (filter and priority)
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: deploymentPlan
   /label/{labelType}/{uid}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Get labels for a resource
       description: Get labels for a resource identified by its uid
       operationId: GetLabels
       parameters:
-      - description: Label Type
-        enum:
-        - ns
-        - mci
-        - subGroup
-        - vm
-        - k8s
-        - vNet
-        - subnet
-        - vpn
-        - securityGroup
-        - sshKey
-        - dataDisk
-        - sqlDb
-        - objectStorage
+      - name: labelType
         in: path
-        name: labelType
+        description: Label Type
         required: true
-        type: string
-      - description: Resource uid
+        schema:
+          type: string
+          enum:
+          - ns
+          - mci
+          - subGroup
+          - vm
+          - k8s
+          - vNet
+          - subnet
+          - vpn
+          - securityGroup
+          - sshKey
+          - dataDisk
+          - sqlDb
+          - objectStorage
+      - name: uid
         in: path
-        name: uid
+        description: Resource uid
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: Labels for the resource
-          schema:
-            $ref: '#/definitions/model.LabelInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.LabelInfo'
         "400":
           description: Invalid request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get labels for a resource
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Create or update a label for a resource
       description: Create or update a label for a resource identified by its uid
       operationId: CreateOrUpdateLabel
       parameters:
-      - description: Label Type
-        enum:
-        - ns
-        - mci
-        - subGroup
-        - vm
-        - k8s
-        - vNet
-        - subnet
-        - vpn
-        - securityGroup
-        - sshKey
-        - dataDisk
-        - sqlDb
-        - objectStorage
+      - name: labelType
         in: path
-        name: labelType
-        required: true
-        type: string
-      - description: Resource uid
-        in: path
-        name: uid
-        required: true
-        type: string
-      - description: Labels to create or update
-        in: body
-        name: labels
+        description: Label Type
         required: true
         schema:
-          $ref: '#/definitions/model.Label'
-      produces:
-      - application/json
+          type: string
+          enum:
+          - ns
+          - mci
+          - subGroup
+          - vm
+          - k8s
+          - vNet
+          - subnet
+          - vpn
+          - securityGroup
+          - sshKey
+          - dataDisk
+          - sqlDb
+          - objectStorage
+      - name: uid
+        in: path
+        description: Resource uid
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Labels to create or update
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.Label'
+        required: true
       responses:
         "200":
           description: Label created or updated successfully
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "400":
           description: Invalid request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create or update a label for a resource
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: labels
   /label/{labelType}/{uid}/{key}:
     delete:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Remove a label from a resource
       description: Remove a label from a resource identified by its uid
       operationId: RemoveLabel
       parameters:
-      - description: Label Type
-        enum:
-        - ns
-        - mci
-        - subGroup
-        - vm
-        - k8s
-        - vNet
-        - subnet
-        - vpn
-        - securityGroup
-        - sshKey
-        - dataDisk
-        - sqlDb
-        - objectStorage
+      - name: labelType
         in: path
-        name: labelType
+        description: Label Type
         required: true
-        type: string
-      - description: Resource uid
+        schema:
+          type: string
+          enum:
+          - ns
+          - mci
+          - subGroup
+          - vm
+          - k8s
+          - vNet
+          - subnet
+          - vpn
+          - securityGroup
+          - sshKey
+          - dataDisk
+          - sqlDb
+          - objectStorage
+      - name: uid
         in: path
-        name: uid
+        description: Resource uid
         required: true
-        type: string
-      - description: Label key to remove
+        schema:
+          type: string
+      - name: key
         in: path
-        name: key
+        description: Label key to remove
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: Label removed successfully
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "400":
           description: Invalid request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Remove a label from a resource
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /labelInfo:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Return LabelTypes and system defined label keys with example
       description: Return LabelTypes and system defined label keys with example
       operationId: GetSystemLabelInfo
-      produces:
-      - application/json
       responses:
         "200":
           description: LabelTypes and System labels with example values
-          schema:
-            $ref: '#/definitions/model.SystemLabelInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SystemLabelInfo'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Return LabelTypes and system defined label keys with example
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /loadAssets:
     get:
-      consumes:
-      - application/json
-      description: Load Common Resources from internal asset files (Spec, Image)
+      tags:
+      - "[Admin] System Configuration"
+      summary: Load Common Resources from internal asset files
+      description: "Load Common Resources from internal asset files (Spec, Image)"
       operationId: LoadAssets
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Load Common Resources from internal asset files
-      tags:
-      - '[Admin] System Configuration'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /lookupImage:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Lookup image (for debugging purposes)
       description: Lookup image (for debugging purposes)
       operationId: LookupImage
-      parameters:
-      - description: Specify connectionName, cspImageName
-        in: body
-        name: lookupImageReq
+      requestBody:
+        description: "Specify connectionName, cspImageName"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/resource.RestLookupImageRequest'
         required: true
-        schema:
-          $ref: '#/definitions/resource.RestLookupImageRequest'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SpiderImageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SpiderImageInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Lookup image (for debugging purposes)
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: lookupImageReq
   /lookupImages:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Lookup image list (for debugging purposes)
       description: Lookup image list (for debugging purposes)
       operationId: LookupImageList
-      parameters:
-      - description: Specify connectionName
-        in: body
-        name: lookupImagesReq
+      requestBody:
+        description: Specify connectionName
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/common.TbConnectionName'
         required: true
-        schema:
-          $ref: '#/definitions/common.TbConnectionName'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SpiderImageList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SpiderImageList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Lookup image list (for debugging purposes)
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: lookupImagesReq
   /lookupSpec:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Spec Management"
+      summary: Lookup spec (for debugging purposes)
       description: Lookup spec (for debugging purposes)
       operationId: LookupSpec
-      parameters:
-      - description: Specify connectionName & cspSpecNameS
-        in: body
-        name: lookupSpecReq
+      requestBody:
+        description: Specify connectionName & cspSpecNameS
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/resource.RestLookupSpecRequest'
         required: true
-        schema:
-          $ref: '#/definitions/resource.RestLookupSpecRequest'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SpiderSpecInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SpiderSpecInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Lookup spec (for debugging purposes)
-      tags:
-      - '[Infra Resource] Spec Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: lookupSpecReq
   /lookupSpecs:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Spec Management"
+      summary: Lookup spec list (for debugging purposes)
       description: Lookup spec list (for debugging purposes)
       operationId: LookupSpecList
-      parameters:
-      - description: Specify connectionName
-        in: body
-        name: lookupSpecsReq
+      requestBody:
+        description: Specify connectionName
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/common.TbConnectionName'
         required: true
-        schema:
-          $ref: '#/definitions/common.TbConnectionName'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SpiderSpecList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SpiderSpecList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Lookup spec list (for debugging purposes)
-      tags:
-      - '[Infra Resource] Spec Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: lookupSpecsReq
   /mciDynamicCheckRequest:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Check available ConnectionConfig list for creating MCI Dynamically
       description: Check available ConnectionConfig list before create MCI Dynamically
         from common spec and image
       operationId: PostMciDynamicCheckRequest
-      parameters:
-      - description: Details for MCI dynamic request information
-        in: body
-        name: mciReq
+      requestBody:
+        description: Details for MCI dynamic request information
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.MciConnectionConfigCandidatesReq'
         required: true
-        schema:
-          $ref: '#/definitions/model.MciConnectionConfigCandidatesReq'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.CheckMciDynamicReqInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.CheckMciDynamicReqInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Check available ConnectionConfig list for creating MCI Dynamically
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciReq
   /mciRecommendVm:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Recommend MCI plan (filter and priority)
       description: Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
       operationId: RecommendVm
-      parameters:
-      - description: Recommend MCI plan (filter and priority)
-        in: body
-        name: deploymentPlan
-        schema:
-          $ref: '#/definitions/model.DeploymentPlan'
-      produces:
-      - application/json
+      requestBody:
+        description: Recommend MCI plan (filter and priority)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.DeploymentPlan'
+        required: false
       responses:
         "200":
           description: OK
-          schema:
-            items:
-              $ref: '#/definitions/model.TbSpecInfo'
-            type: array
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/model.TbSpecInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Recommend MCI plan (filter and priority)
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: deploymentPlan
   /mergeCSPLabel/{labelType}/{uid}:
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Fetch the labels in the CSP and merge them with the existing labels
       description: Fetch the labels in the CSP and merge them with the existing labels
       operationId: MergeCSPResourceLabel
       parameters:
-      - description: Label Type
-        enum:
-        - ns
-        - mci
-        - subGroup
-        - vm
-        - k8s
-        - vNet
-        - subnet
-        - vpn
-        - securityGroup
-        - sshKey
-        - dataDisk
-        - sqlDb
-        - objectStorage
+      - name: labelType
         in: path
-        name: labelType
+        description: Label Type
         required: true
-        type: string
-      - description: Resource uid
+        schema:
+          type: string
+          enum:
+          - ns
+          - mci
+          - subGroup
+          - vm
+          - k8s
+          - vNet
+          - subnet
+          - vpn
+          - securityGroup
+          - sshKey
+          - dataDisk
+          - sqlDb
+          - objectStorage
+      - name: uid
         in: path
-        name: uid
+        description: Resource uid
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: Merged CSP labels successfully
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "400":
           description: Invalid request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Fetch the labels in the CSP and merge them with the existing labels
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns:
-    delete:
-      consumes:
-      - application/json
-      description: Delete all namespaces
-      operationId: DelAllNs
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all namespaces
-      tags:
-      - '[Admin] System Configuration'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] System Configuration"
+      summary: List all namespaces or namespaces' ID
       description: List all namespaces or namespaces' ID
       operationId: GetAllNs
       parameters:
-      - description: Option
-        enum:
-        - id
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/common.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/common.RestGetAllNsResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/common.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/common.RestGetAllNsResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all namespaces or namespaces' ID
-      tags:
-      - '[Admin] System Configuration'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] System Configuration"
+      summary: Create namespace
       description: Create namespace
       operationId: PostNs
-      parameters:
-      - description: Details for a new namespace
-        in: body
-        name: nsReq
+      requestBody:
+        description: Details for a new namespace
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.NsReq'
         required: true
-        schema:
-          $ref: '#/definitions/model.NsReq'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.NsInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.NsInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create namespace
-      tags:
-      - '[Admin] System Configuration'
-  /ns/{nsId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: nsReq
     delete:
-      consumes:
-      - application/json
-      description: Delete namespace
-      operationId: DelNs
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      produces:
-      - application/json
+      tags:
+      - "[Admin] System Configuration"
+      summary: Delete all namespaces
+      description: Delete all namespaces
+      operationId: DelAllNs
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete namespace
-      tags:
-      - '[Admin] System Configuration'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] System Configuration"
+      summary: Get namespace
       description: Get namespace
       operationId: GetNs
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.NsInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.NsInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get namespace
-      tags:
-      - '[Admin] System Configuration'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] System Configuration"
+      summary: Update namespace
       description: Update namespace
       operationId: PutNs
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Details to update existing namespace
-        in: body
-        name: namespace
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.NsReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      requestBody:
+        description: Details to update existing namespace
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.NsReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.NsInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.NsInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Update namespace
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: namespace
+    delete:
       tags:
-      - '[Admin] System Configuration'
+      - "[Admin] System Configuration"
+      summary: Delete namespace
+      description: Delete namespace
+      operationId: DelNs
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/benchmark/mci/{mciId}:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Performance Benchmarking (WIP)"
+      summary: Run MCI benchmark for a single performance metric and return results
       description: Run MCI benchmark for a single performance metric and return results
       operationId: GetBenchmark
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Host IP address to benchmark
-        in: body
-        name: hostIP
         required: true
         schema:
-          $ref: '#/definitions/infra.RestGetBenchmarkRequest'
-      - description: Benchmark Action to MCI
-        enum:
-        - install
-        - init
-        - cpus
-        - cpum
-        - memR
-        - memW
-        - fioR
-        - fioW
-        - dbR
-        - dbW
-        - rtt
-        - mrtt
-        - clean
-        in: query
-        name: action
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: mci01
+      - name: action
+        in: query
+        description: Benchmark Action to MCI
+        required: true
+        schema:
+          type: string
+          enum:
+          - install
+          - init
+          - cpus
+          - cpum
+          - memR
+          - memW
+          - fioR
+          - fioW
+          - dbR
+          - dbW
+          - rtt
+          - mrtt
+          - clean
+      requestBody:
+        description: Host IP address to benchmark
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/infra.RestGetBenchmarkRequest'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.BenchmarkInfoArray'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.BenchmarkInfoArray'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Run MCI benchmark for a single performance metric and return results
-      tags:
-      - '[MC-Infra] MCI Performance Benchmarking (WIP)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: hostIP
   /ns/{nsId}/benchmarkAll/mci/{mciId}:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Performance Benchmarking (WIP)"
+      summary: Run MCI benchmark for all performance metrics and return results
       description: Run MCI benchmark for all performance metrics and return results
       operationId: GetAllBenchmark
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Host IP address to benchmark
-        in: body
-        name: hostIP
         required: true
         schema:
-          $ref: '#/definitions/infra.RestGetAllBenchmarkRequest'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      requestBody:
+        description: Host IP address to benchmark
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/infra.RestGetAllBenchmarkRequest'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.BenchmarkInfoArray'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.BenchmarkInfoArray'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Run MCI benchmark for all performance metrics and return results
-      tags:
-      - '[MC-Infra] MCI Performance Benchmarking (WIP)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: hostIP
   /ns/{nsId}/benchmarkLatency/mci/{mciId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Performance Benchmarking (WIP)"
+      summary: Run MCI benchmark for network latency
       description: Run MCI benchmark for network latency
       operationId: GetLatencyBenchmark
       parameters:
-      - default: system
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: probe
+        schema:
+          type: string
+          default: system
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: probe
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.BenchmarkInfoArray'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.BenchmarkInfoArray'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Run MCI benchmark for network latency
-      tags:
-      - '[MC-Infra] MCI Performance Benchmarking (WIP)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/checkResource/{resourceType}/{resourceId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Check resources' existence
       description: Check resources' existence
       operationId: CheckResource
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: Resource Type
+        schema:
+          type: string
+          default: default
+      - name: resourceType
         in: path
-        name: resourceType
+        description: Resource Type
         required: true
-        type: string
-      - description: Resource ID
+        schema:
+          type: string
+      - name: resourceId
         in: path
-        name: resourceId
+        description: Resource ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Check resources' existence
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/cmd/k8sCluster/{k8sClusterId}:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster's Container Remote Command"
+      summary: Send a command to specified Container in K8sCluster
       description: |-
         Send a command to specified Container in K8sCluster
         [note] This feature is not intended for general use
@@ -6260,2351 +1752,2634 @@ paths:
         Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.
       operationId: PostCmdK8sCluster
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: k8scluster01
-        description: K8sCluster ID
-        in: path
-        name: k8sClusterId
-        required: true
-        type: string
-      - default: default
-        description: Namespace in K8sCluster to apply the command
-        in: query
-        name: k8sClusterNamespace
-        required: true
-        type: string
-      - default: mypod
-        description: Pod Name in K8sCluster to apply the command
-        in: query
-        name: k8sClusterPodName
-        required: true
-        type: string
-      - description: Container Name in K8sCluster to apply the command
-        in: query
-        name: k8sClusterContainerName
-        type: string
-      - description: K8sCluster's Container Command Request
-        in: body
-        name: k8sClusterContainerCmdReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbK8sClusterContainerCmdReq'
-      - description: Custom request ID
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
+        description: K8sCluster ID
+        required: true
+        schema:
+          type: string
+          default: k8scluster01
+      - name: k8sClusterNamespace
+        in: query
+        description: Namespace in K8sCluster to apply the command
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: k8sClusterPodName
+        in: query
+        description: Pod Name in K8sCluster to apply the command
+        required: true
+        schema:
+          type: string
+          default: mypod
+      - name: k8sClusterContainerName
+        in: query
+        description: Container Name in K8sCluster to apply the command
+        schema:
+          type: string
+      - name: x-request-id
         in: header
-        name: x-request-id
-        type: string
-      produces:
-      - application/json
+        description: Custom request ID
+        schema:
+          type: string
+      requestBody:
+        description: K8sCluster's Container Command Request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbK8sClusterContainerCmdReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbK8sClusterContainerCmdResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbK8sClusterContainerCmdResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Send a command to specified Container in K8sCluster
-      tags:
-      - '[Kubernetes] Cluster''s Container Remote Command'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: k8sClusterContainerCmdReq
   /ns/{nsId}/cmd/mci/{mciId}:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Remote Command"
+      summary: Send a command to specified MCI
       description: Send a command to specified MCI
       operationId: PostCmdMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: MCI Command Request
-        in: body
-        name: mciCmdReq
         required: true
         schema:
-          $ref: '#/definitions/model.MciCmdReq'
-      - default: g1
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: subGroupId
+        in: query
         description: subGroupId to apply the command only for VMs in subGroup of MCI
+        schema:
+          type: string
+          default: g1
+      - name: vmId
         in: query
-        name: subGroupId
-        type: string
-      - default: g1-1
         description: vmId to apply the command only for a VM in MCI
+        schema:
+          type: string
+          default: g1-1
+      - name: labelSelector
         in: query
-        name: vmId
-        type: string
-      - description: 'Target VM Label selector query. Example: sys.id=g1-1,role=worker'
-        in: query
-        name: labelSelector
-        type: string
-      - description: Custom request ID
+        description: "Target VM Label selector query. Example: sys.id=g1-1,role=worker"
+        schema:
+          type: string
+      - name: x-request-id
         in: header
-        name: x-request-id
-        type: string
-      produces:
-      - application/json
+        description: Custom request ID
+        schema:
+          type: string
+      requestBody:
+        description: MCI Command Request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.MciCmdReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.MciSshCmdResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.MciSshCmdResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Send a command to specified MCI
-      tags:
-      - '[MC-Infra] MCI Remote Command'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciCmdReq
   /ns/{nsId}/control/k8sCluster/{k8sClusterId}:
     get:
-      consumes:
-      - application/json
-      description: Control the creation of K8sCluster (continue, withdraw)
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: "Control the creation of K8sCluster (continue, withdraw)"
+      description: "Control the creation of K8sCluster (continue, withdraw)"
       operationId: GetControlK8sCluster
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: k8scluster01
+        schema:
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
         description: K8sCluster ID
-        in: path
-        name: k8sClusterId
         required: true
-        type: string
-      - description: Action to K8sCluster
-        enum:
-        - continue
-        - withdraw
+        schema:
+          type: string
+          default: k8scluster01
+      - name: action
         in: query
-        name: action
+        description: Action to K8sCluster
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          enum:
+          - continue
+          - withdraw
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Control the creation of K8sCluster (continue, withdraw)
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/control/mci/{mciId}:
     get:
-      consumes:
-      - application/json
-      description: Control the lifecycle of MCI (refine, suspend, resume, reboot,
-        terminate)
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: "Control the lifecycle of MCI (refine, suspend, resume, reboot, terminate)"
+      description: "Control the lifecycle of MCI (refine, suspend, resume, reboot,\
+        \ terminate)"
       operationId: GetControlMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - description: Action to MCI
-        enum:
-        - suspend
-        - resume
-        - reboot
-        - terminate
-        - refine
-        - continue
-        - withdraw
+        schema:
+          type: string
+          default: mci01
+      - name: action
         in: query
-        name: action
+        description: Action to MCI
         required: true
-        type: string
-      - description: Force control to skip checking controllable status
-        enum:
-        - "false"
-        - "true"
+        schema:
+          type: string
+          enum:
+          - suspend
+          - resume
+          - reboot
+          - terminate
+          - refine
+          - continue
+          - withdraw
+      - name: force
         in: query
-        name: force
-        type: string
-      produces:
-      - application/json
+        description: Force control to skip checking controllable status
+        schema:
+          type: string
+          enum:
+          - "false"
+          - "true"
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Control the lifecycle of MCI (refine, suspend, resume, reboot, terminate)
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/control/mci/{mciId}/vm/{vmId}:
     get:
-      consumes:
-      - application/json
-      description: Control the lifecycle of VM (suspend, resume, reboot, terminate)
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: "Control the lifecycle of VM (suspend, resume, reboot, terminate)"
+      description: "Control the lifecycle of VM (suspend, resume, reboot, terminate)"
       operationId: GetControlMciVm
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1-1
+        schema:
+          type: string
+          default: mci01
+      - name: vmId
+        in: path
         description: VM ID
-        in: path
-        name: vmId
         required: true
-        type: string
-      - description: Action to MCI
-        enum:
-        - suspend
-        - resume
-        - reboot
-        - terminate
+        schema:
+          type: string
+          default: g1-1
+      - name: action
         in: query
-        name: action
+        description: Action to MCI
         required: true
-        type: string
-      - description: Force control to skip checking controllable status
-        enum:
-        - "false"
-        - "true"
+        schema:
+          type: string
+          enum:
+          - suspend
+          - resume
+          - reboot
+          - terminate
+      - name: force
         in: query
-        name: force
-        type: string
-      produces:
-      - application/json
+        description: Force control to skip checking controllable status
+        schema:
+          type: string
+          enum:
+          - "false"
+          - "true"
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Control the lifecycle of VM (suspend, resume, reboot, terminate)
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/deregisterCspResource/vNet/{vNetId}:
     delete:
-      consumes:
-      - application/json
-      description: Deregister the VNet, which was created in CSP
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Deregister VNet (created in CSP)
+      description: "Deregister the VNet, which was created in CSP"
       operationId: DeleteDeregisterVNet
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: VNet ID
+        schema:
+          type: string
+          default: default
+      - name: vNetId
         in: path
-        name: vNetId
+        description: VNet ID
         required: true
-        type: string
-      - description: Delete subnets as well
-        enum:
-        - "true"
-        - "false"
+        schema:
+          type: string
+      - name: withSubnets
         in: query
-        name: withSubnets
-        type: string
-      produces:
-      - application/json
+        description: Delete subnets as well
+        schema:
+          type: string
+          enum:
+          - "true"
+          - "false"
       responses:
         "201":
           description: Created
-          schema:
-            $ref: '#/definitions/model.TbVNetInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbVNetInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Deregister VNet (created in CSP)
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/deregisterCspResource/vNet/{vNetId}/subnet/{subnetId}:
     delete:
-      consumes:
-      - application/json
-      description: Deregister Subnet, which was created in CSP
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Deregister Subnet (created in CSP)
+      description: "Deregister Subnet, which was created in CSP"
       operationId: DeleteDeregisterSubnet
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: VNet ID
+        schema:
+          type: string
+          default: default
+      - name: vNetId
         in: path
-        name: vNetId
+        description: VNet ID
         required: true
-        type: string
-      - description: Subnet ID
+        schema:
+          type: string
+      - name: subnetId
         in: path
-        name: subnetId
+        description: Subnet ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Deregister Subnet (created in CSP)
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/installBenchmarkAgent/mci/{mciId}:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Performance Benchmarking (WIP)"
+      summary: Install the benchmark agent to specified MCI
       description: Install the benchmark agent to specified MCI
       operationId: PostInstallBenchmarkAgentToMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: MCI Command Request
-        in: body
-        name: mciCmdReq
         required: true
         schema:
-          $ref: '#/definitions/model.MciCmdReq'
-      - description: Option for checking update
-        enum:
-        - update
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option for checking update
+        schema:
+          type: string
+          enum:
+          - update
+      requestBody:
+        description: MCI Command Request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.MciCmdReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.MciSshCmdResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.MciSshCmdResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Install the benchmark agent to specified MCI
-      tags:
-      - '[MC-Infra] MCI Performance Benchmarking (WIP)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciCmdReq
   /ns/{nsId}/k8sCluster:
-    delete:
-      consumes:
-      - application/json
-      description: Delete all K8sClusters
-      operationId: DeleteAllK8sCluster
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: ""
-        description: Delete resources containing matched ID-substring only
-        in: query
-        name: match
-        type: string
-      - description: Option for K8sCluster deletion
-        enum:
-        - force
-        in: query
-        name: option
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all K8sClusters
-      tags:
-      - '[Kubernetes] Cluster Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: List all K8sClusters or K8sClusters' ID
       description: List all K8sClusters or K8sClusters' ID
       operationId: GetAllK8sCluster
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: 'Field key for filtering (ex: cspResourceName)'
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: 'Field value for filtering (ex: default-alibaba-ap-northeast-2-vpc)'
+        description: "Field key for filtering (ex: cspResourceName)"
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      produces:
-      - application/json
+        description: "Field value for filtering (ex: default-alibaba-ap-northeast-2-vpc)"
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/resource.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/resource.RestGetAllK8sClusterResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/resource.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/resource.RestGetAllK8sClusterResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all K8sClusters or K8sClusters' ID
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Create K8sCluster
       description: Create K8sCluster<br>Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1614
       operationId: PostK8sCluster
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: 'Option: [required params for register] connectionName, name,
-          cspResourceId'
-        enum:
-        - register
-        in: query
-        name: option
-        type: string
-      - description: Details of the K8sCluster object
-        in: body
-        name: k8sClusterReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbK8sClusterReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: option
+        in: query
+        description: "Option: [required params for register] connectionName, name,\
+          \ cspResourceId"
+        schema:
+          type: string
+          enum:
+          - register
+      requestBody:
+        description: Details of the K8sCluster object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbK8sClusterReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbK8sClusterInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbK8sClusterInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create K8sCluster
-      tags:
-      - '[Kubernetes] Cluster Management'
-  /ns/{nsId}/k8sCluster/{k8sClusterId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: k8sClusterReq
     delete:
-      consumes:
-      - application/json
-      description: Delete K8sCluster
-      operationId: DeleteK8sCluster
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Delete all K8sClusters
+      description: Delete all K8sClusters
+      operationId: DeleteAllK8sCluster
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: k8scluster01
-        description: K8sCluster ID
-        in: path
-        name: k8sClusterId
-        required: true
-        type: string
-      - description: Option for K8sCluster deletion
-        enum:
-        - force
+        schema:
+          type: string
+          default: default
+      - name: match
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
+      - name: option
+        in: query
+        description: Option for K8sCluster deletion
+        schema:
+          type: string
+          enum:
+          - force
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete K8sCluster
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/k8sCluster/{k8sClusterId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Get K8sCluster
       description: Get K8sCluster
       operationId: GetK8sCluster
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: k8scluster01
+        schema:
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
         description: K8sCluster ID
-        in: path
-        name: k8sClusterId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: k8scluster01
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbK8sClusterInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbK8sClusterInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get K8sCluster
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
       tags:
-      - '[Kubernetes] Cluster Management'
+      - "[Kubernetes] Cluster Management"
+      summary: Delete K8sCluster
+      description: Delete K8sCluster
+      operationId: DeleteK8sCluster
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
+        description: K8sCluster ID
+        required: true
+        schema:
+          type: string
+          default: k8scluster01
+      - name: option
+        in: query
+        description: Option for K8sCluster deletion
+        schema:
+          type: string
+          enum:
+          - force
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Add a K8sNodeGroup
       description: Add a K8sNodeGroup
       operationId: PostK8sNodeGroup
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: k8scluster01
-        description: K8sCluster ID
-        in: path
-        name: k8sClusterId
-        required: true
-        type: string
-      - description: Details of the K8sNodeGroup object
-        in: body
-        name: k8sNodeGroupReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbK8sNodeGroupReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
+        description: K8sCluster ID
+        required: true
+        schema:
+          type: string
+          default: k8scluster01
+      requestBody:
+        description: Details of the K8sNodeGroup object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbK8sNodeGroupReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbK8sClusterInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbK8sClusterInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Add a K8sNodeGroup
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: k8sNodeGroupReq
   /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}:
     delete:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Remove a K8sNodeGroup
       description: Remove a K8sNodeGroup
       operationId: DeleteK8sNodeGroup
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: k8scluster01
+        schema:
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
         description: K8sCluster ID
-        in: path
-        name: k8sClusterId
         required: true
-        type: string
-      - default: k8sng01
+        schema:
+          type: string
+          default: k8scluster01
+      - name: k8sNodeGroupName
+        in: path
         description: K8sNodeGroup Name
-        in: path
-        name: k8sNodeGroupName
         required: true
-        type: string
-      - description: Option for K8sNodeGroup deletion
-        enum:
-        - force
+        schema:
+          type: string
+          default: k8sng01
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option for K8sNodeGroup deletion
+        schema:
+          type: string
+          enum:
+          - force
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Remove a K8sNodeGroup
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/autoscaleSize:
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Change a K8sNodeGroup's Autoscale Size
       description: Change a K8sNodeGroup's Autoscale Size
       operationId: PutChangeK8sNodeGroupAutoscaleSize
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: k8scluster01
-        description: K8sCluster ID
-        in: path
-        name: k8sClusterId
-        required: true
-        type: string
-      - default: k8sng01
-        description: K8sNodeGroup Name
-        in: path
-        name: k8sNodeGroupName
-        required: true
-        type: string
-      - description: Details of the TbChangeK8sNodeGroupAutoscaleSizeReq object
-        in: body
-        name: changeK8sNodeGroupAutoscaleSizeReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbChangeK8sNodeGroupAutoscaleSizeReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
+        description: K8sCluster ID
+        required: true
+        schema:
+          type: string
+          default: k8scluster01
+      - name: k8sNodeGroupName
+        in: path
+        description: K8sNodeGroup Name
+        required: true
+        schema:
+          type: string
+          default: k8sng01
+      requestBody:
+        description: Details of the TbChangeK8sNodeGroupAutoscaleSizeReq object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbChangeK8sNodeGroupAutoscaleSizeReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbChangeK8sNodeGroupAutoscaleSizeRes'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbChangeK8sNodeGroupAutoscaleSizeRes'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Change a K8sNodeGroup's Autoscale Size
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: changeK8sNodeGroupAutoscaleSizeReq
   /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroup/{k8sNodeGroupName}/onAutoscaling:
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Set a K8sNodeGroup's Autoscaling On/Off
       description: Set a K8sNodeGroup's Autoscaling On/Off
       operationId: PutSetK8sNodeGroupAutoscaling
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: k8scluster01
-        description: K8sCluster ID
-        in: path
-        name: k8sClusterId
-        required: true
-        type: string
-      - default: k8sng01
-        description: K8sNodeGroup Name
-        in: path
-        name: k8sNodeGroupName
-        required: true
-        type: string
-      - description: Details of the TbSetK8sNodeGroupAutoscalingReq object
-        in: body
-        name: setK8sNodeGroupAutoscalingReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbSetK8sNodeGroupAutoscalingReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
+        description: K8sCluster ID
+        required: true
+        schema:
+          type: string
+          default: k8scluster01
+      - name: k8sNodeGroupName
+        in: path
+        description: K8sNodeGroup Name
+        required: true
+        schema:
+          type: string
+          default: k8sng01
+      requestBody:
+        description: Details of the TbSetK8sNodeGroupAutoscalingReq object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbSetK8sNodeGroupAutoscalingReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSetK8sNodeGroupAutoscalingRes'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSetK8sNodeGroupAutoscalingRes'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Set a K8sNodeGroup's Autoscaling On/Off
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: setK8sNodeGroupAutoscalingReq
   /ns/{nsId}/k8sCluster/{k8sClusterId}/k8sNodeGroupDynamic:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Create K8sNodeGroup Dynamically
       description: Create K8sNodeGroup Dynamically from common spec and image
       operationId: PostK8sNodeGroupDynamic
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: k8scluster01
-        description: K8sCluster ID
-        in: path
-        name: k8sClusterId
-        required: true
-        type: string
-      - description: 'Request body to provision K8sNodeGroup dynamically. <br> Must
-          include commonSpec and commonImage info. <br> (ex: {name: k8sng01, commonImage:
-          azure+koreacentral+ubuntu22.04, commonSpec: azure+koreacentral+Standard_B2s}]})
-          <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest
-          to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913'
-        in: body
-        name: k8sNodeGroupDynamicReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbK8sNodeGroupDynamicReq'
-      - description: Custom request ID
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
+        description: K8sCluster ID
+        required: true
+        schema:
+          type: string
+          default: k8scluster01
+      - name: x-request-id
         in: header
-        name: x-request-id
-        type: string
-      produces:
-      - application/json
+        description: Custom request ID
+        schema:
+          type: string
+      requestBody:
+        description: "Request body to provision K8sNodeGroup dynamically. <br> Must\
+          \ include commonSpec and commonImage info. <br> (ex: {name: k8sng01, commonImage:\
+          \ azure+koreacentral+ubuntu22.04, commonSpec: azure+koreacentral+Standard_B2s}]})\
+          \ <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest\
+          \ to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbK8sNodeGroupDynamicReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbK8sNodeGroupInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbK8sNodeGroupInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create K8sNodeGroup Dynamically
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: k8sNodeGroupDynamicReq
   /ns/{nsId}/k8sCluster/{k8sClusterId}/upgrade:
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Upgrade a K8sCluster's version
       description: Upgrade a K8sCluster's version
       operationId: PutUpgradeK8sCluster
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: k8scluster01
-        description: K8sCluster ID
-        in: path
-        name: k8sClusterId
-        required: true
-        type: string
-      - description: Details of the TbUpgradeK8sClusterReq object
-        in: body
-        name: upgradeK8sClusterReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbUpgradeK8sClusterReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
+        description: K8sCluster ID
+        required: true
+        schema:
+          type: string
+          default: k8scluster01
+      requestBody:
+        description: Details of the TbUpgradeK8sClusterReq object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbUpgradeK8sClusterReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Upgrade a K8sCluster's version
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: upgradeK8sClusterReq
   /ns/{nsId}/k8sClusterDynamic:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Create K8sCluster Dynamically
       description: Create K8sCluster Dynamically from common spec and image
       operationId: PostK8sClusterDynamic
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: 'Request body to provision K8sCluster dynamically. <br> Must
-          include commonSpec and commonImage info. <br> (ex: {name: k8scluster01,
-          commonImage: azure+koreacentral+ubuntu22.04, commonSpec: azure+koreacentral+Standard_B2s}]})
-          <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest
-          to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913'
-        in: body
-        name: k8sClusterDyanmicReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbK8sClusterDynamicReq'
-      - description: Option for K8sCluster creation
-        enum:
-        - hold
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: Custom request ID
+        description: Option for K8sCluster creation
+        schema:
+          type: string
+          enum:
+          - hold
+      - name: x-request-id
         in: header
-        name: x-request-id
-        type: string
-      produces:
-      - application/json
+        description: Custom request ID
+        schema:
+          type: string
+      requestBody:
+        description: "Request body to provision K8sCluster dynamically. <br> Must\
+          \ include commonSpec and commonImage info. <br> (ex: {name: k8scluster01,\
+          \ commonImage: azure+koreacentral+ubuntu22.04, commonSpec: azure+koreacentral+Standard_B2s}]})\
+          \ <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest\
+          \ to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbK8sClusterDynamicReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbK8sClusterInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbK8sClusterInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create K8sCluster Dynamically
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: k8sClusterDyanmicReq
   /ns/{nsId}/mci:
-    delete:
-      consumes:
-      - application/json
-      description: Delete all MCIs
-      operationId: DelAllMci
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Option for delete all MCIs (support force object delete, terminate
-          before delete)
-        enum:
-        - force
-        - terminate
-        in: query
-        name: option
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all MCIs
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: List all MCIs or MCIs' ID
       description: List all MCIs or MCIs' ID
       operationId: GetAllMci
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
-        - simple
-        - status
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+          - simple
+          - status
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/infra.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/infra.RestGetAllMciResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-                '[SIMPLE]':
-                  $ref: '#/definitions/infra.RestGetAllMciResponse'
-                '[STATUS]':
-                  $ref: '#/definitions/infra.RestGetAllMciStatusResponse'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/infra.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/infra.RestGetAllMciResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
+                    '[SIMPLE]':
+                      $ref: '#/components/schemas/infra.RestGetAllMciResponse'
+                    '[STATUS]':
+                      $ref: '#/components/schemas/infra.RestGetAllMciStatusResponse'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all MCIs or MCIs' ID
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Create MCI
       description: Create MCI
       operationId: PostMci
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Details for an MCI object
-        in: body
-        name: mciReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbMciReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      requestBody:
+        description: Details for an MCI object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbMciReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbMciInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbMciInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create MCI
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
-  /ns/{nsId}/mci/{mciId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciReq
     delete:
-      consumes:
-      - application/json
-      description: Delete MCI
-      operationId: DelMci
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Delete all MCIs
+      description: Delete all MCIs
+      operationId: DelAllMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Option for delete MCI (support force delete)
-        enum:
-        - terminate
-        - force
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: "Option for delete all MCIs (support force object delete, terminate\
+          \ before delete)"
+        schema:
+          type: string
+          enum:
+          - force
+          - terminate
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete MCI
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/mci/{mciId}:
     get:
-      consumes:
-      - application/json
-      description: 'Get MCI object (option: status, accessInfo, vmId)'
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: "Get MCI object (option: status, accessInfo, vmId)"
+      description: "Get MCI object (option: status, accessInfo, vmId)"
       operationId: GetMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - description: Option
-        enum:
-        - default
-        - id
-        - status
-        - accessinfo
+        schema:
+          type: string
+          default: mci01
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: '(For option=id) Field key for filtering (ex: connectionName)'
+        description: Option
+        schema:
+          type: string
+          enum:
+          - default
+          - id
+          - status
+          - accessinfo
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: '(For option=id) Field value for filtering (ex: aws-ap-northeast-2)'
+        description: "(For option=id) Field key for filtering (ex: connectionName)"
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      - description: (For option=accessinfo) accessInfoOption (showSshKey)
+        description: "(For option=id) Field value for filtering (ex: aws-ap-northeast-2)"
+        schema:
+          type: string
+      - name: accessInfoOption
         in: query
-        name: accessInfoOption
-        type: string
-      produces:
-      - application/json
+        description: (For option=accessinfo) accessInfoOption (showSshKey)
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given action param
-          schema:
-            allOf:
-            - $ref: '#/definitions/infra.JSONResult'
-            - properties:
-                '[AccessInfo]':
-                  $ref: '#/definitions/model.MciAccessInfo'
-                '[DEFAULT]':
-                  $ref: '#/definitions/model.TbMciInfo'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-                '[STATUS]':
-                  $ref: '#/definitions/model.MciStatusInfo'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/infra.JSONResult'
+                - type: object
+                  properties:
+                    '[AccessInfo]':
+                      $ref: '#/components/schemas/model.MciAccessInfo'
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/model.TbMciInfo'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
+                    '[STATUS]':
+                      $ref: '#/components/schemas/model.MciStatusInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: 'Get MCI object (option: status, accessInfo, vmId)'
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
-  /ns/{nsId}/mci/{mciId}/bastion/{bastionVmId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     delete:
-      consumes:
-      - application/json
-      description: Remove a bastion VM from all vNets
-      operationId: RemoveBastionNodes
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Delete MCI
+      description: Delete MCI
+      operationId: DelMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1-1
-        description: Bastion VM ID
-        in: path
-        name: bastionVmId
-        required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: mci01
+      - name: option
+        in: query
+        description: Option for delete MCI (support force delete)
+        schema:
+          type: string
+          enum:
+          - terminate
+          - force
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/mci/{mciId}/bastion/{bastionVmId}:
+    delete:
+      tags:
+      - "[MC-Infra] MCI Remote Command"
+      summary: Remove a bastion VM from all vNets
+      description: Remove a bastion VM from all vNets
+      operationId: RemoveBastionNodes
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: bastionVmId
+        in: path
+        description: Bastion VM ID
+        required: true
+        schema:
+          type: string
+          default: g1-1
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Remove a bastion VM from all vNets
-      tags:
-      - '[MC-Infra] MCI Remote Command'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mci/{mciId}/mcSwNlb:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] NLB Management"
+      summary: Create a special purpose MCI for NLB and depoly and setting SW NLB
       description: Create a special purpose MCI for NLB and depoly and setting SW
         NLB
       operationId: PostMcNLB
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Details of the NLB object
-        in: body
-        name: nlbReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbNLBReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      requestBody:
+        description: Details of the NLB object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbNLBReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.McNlbInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.McNlbInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create a special purpose MCI for NLB and depoly and setting SW NLB
-      tags:
-      - '[Infra Resource] NLB Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: nlbReq
   /ns/{nsId}/mci/{mciId}/nlb:
-    delete:
-      consumes:
-      - application/json
-      description: Delete all NLBs
-      operationId: DelAllNLB
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - default: ""
-        description: Delete resources containing matched ID-substring only
-        in: query
-        name: match
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all NLBs
-      tags:
-      - '[Infra Resource] NLB Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] NLB Management"
+      summary: List all NLBs or NLBs' ID
       description: List all NLBs or NLBs' ID
       operationId: GetAllNLB
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: mci01
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: 'Field key for filtering (ex: cspResourceName)'
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: 'Field value for filtering (ex: default-alibaba-ap-northeast-1-vpc)'
+        description: "Field key for filtering (ex: cspResourceName)"
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      produces:
-      - application/json
+        description: "Field value for filtering (ex: default-alibaba-ap-northeast-1-vpc)"
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/infra.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/infra.RestGetAllNLBResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/infra.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/infra.RestGetAllNLBResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all NLBs or NLBs' ID
-      tags:
-      - '[Infra Resource] NLB Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] NLB Management"
+      summary: Create NLB
       description: Create NLB
       operationId: PostNLB
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: 'Option: [required params for register] connectionName, name,
-          cspResourceId'
-        enum:
-        - register
-        in: query
-        name: option
-        type: string
-      - description: Details of the NLB object
-        in: body
-        name: nlbReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbNLBReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: option
+        in: query
+        description: "Option: [required params for register] connectionName, name,\
+          \ cspResourceId"
+        schema:
+          type: string
+          enum:
+          - register
+      requestBody:
+        description: Details of the NLB object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbNLBReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbNLBInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbNLBInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create NLB
-      tags:
-      - '[Infra Resource] NLB Management'
-  /ns/{nsId}/mci/{mciId}/nlb/{nlbId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: nlbReq
     delete:
-      consumes:
-      - application/json
-      description: Delete NLB
-      operationId: DelNLB
+      tags:
+      - "[Infra Resource] NLB Management"
+      summary: Delete all NLBs
+      description: Delete all NLBs
+      operationId: DelAllNLB
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - description: NLB ID
-        in: path
-        name: nlbId
-        required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: mci01
+      - name: match
+        in: query
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete NLB
-      tags:
-      - '[Infra Resource] NLB Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/mci/{mciId}/nlb/{nlbId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] NLB Management"
+      summary: Get NLB
       description: Get NLB
       operationId: GetNLB
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1
+        schema:
+          type: string
+          default: mci01
+      - name: nlbId
+        in: path
         description: NLB ID
-        in: path
-        name: nlbId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: g1
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbNLBInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbNLBInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get NLB
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
       tags:
-      - '[Infra Resource] NLB Management'
+      - "[Infra Resource] NLB Management"
+      summary: Delete NLB
+      description: Delete NLB
+      operationId: DelNLB
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: nlbId
+        in: path
+        description: NLB ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/healthz:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] NLB Management"
+      summary: Get NLB Health
       description: Get NLB Health
       operationId: GetNLBHealth
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - default: g1
-        description: NLB ID
-        in: path
-        name: nlbId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.TbNLBInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get NLB Health
-      tags:
-      - '[Infra Resource] NLB Management'
-  /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm:
-    delete:
-      consumes:
-      - application/json
-      description: Delete VMs from NLB
-      operationId: RemoveNLBVMs
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - default: g1
-        description: NLB ID
-        in: path
-        name: nlbId
-        required: true
-        type: string
-      - description: Select VMs to remove from NLB
-        in: body
-        name: nlbAddRemoveVMReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbNLBAddRemoveVMReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: nlbId
+        in: path
+        description: NLB ID
+        required: true
+        schema:
+          type: string
+          default: g1
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbNLBInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete VMs from NLB
-      tags:
-      - '[Infra Resource] NLB Management (for developer)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/mci/{mciId}/nlb/{nlbId}/vm:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] NLB Management (for developer)"
+      summary: Add VMs to NLB
       description: Add VMs to NLB
       operationId: AddNLBVMs
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - default: g1
-        description: NLB ID
-        in: path
-        name: nlbId
-        required: true
-        type: string
-      - description: VMs to add to NLB
-        in: body
-        name: nlbAddRemoveVMReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbNLBAddRemoveVMReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: nlbId
+        in: path
+        description: NLB ID
+        required: true
+        schema:
+          type: string
+          default: g1
+      requestBody:
+        description: VMs to add to NLB
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbNLBAddRemoveVMReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbNLBInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbNLBInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Add VMs to NLB
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: nlbAddRemoveVMReq
+    delete:
       tags:
-      - '[Infra Resource] NLB Management (for developer)'
+      - "[Infra Resource] NLB Management (for developer)"
+      summary: Delete VMs from NLB
+      description: Delete VMs from NLB
+      operationId: RemoveNLBVMs
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: nlbId
+        in: path
+        description: NLB ID
+        required: true
+        schema:
+          type: string
+          default: g1
+      requestBody:
+        description: Select VMs to remove from NLB
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbNLBAddRemoveVMReq'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: nlbAddRemoveVMReq
   /ns/{nsId}/mci/{mciId}/site:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Site-to-site VPN Management (under development)"
+      summary: Get sites in MCI
       description: Get sites in MCI
       operationId: GetSitesInMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: mci01
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SitesInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SitesInfo'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get sites in MCI
-      tags:
-      - '[Infra Resource] Site-to-site VPN Management (under development)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mci/{mciId}/subgroup:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: List SubGroup IDs in a specified MCI
       description: List SubGroup IDs in a specified MCI
       operationId: GetMciGroupIds
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: mci01
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List SubGroup IDs in a specified MCI
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: List VMs with a SubGroup label in a specified MCI
       description: List VMs with a SubGroup label in a specified MCI
       operationId: GetMciGroupVms
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1
+        schema:
+          type: string
+          default: mci01
+      - name: subgroupId
+        in: path
         description: subGroup ID
-        in: path
-        name: subgroupId
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: g1
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List VMs with a SubGroup label in a specified MCI
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: ScaleOut subGroup in specified MCI
       description: ScaleOut subGroup in specified MCI
       operationId: PostMciSubGroupScaleOut
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - default: g1
-        description: subGroup ID
-        in: path
-        name: subgroupId
-        required: true
-        type: string
-      - description: subGroup scaleOut request
-        in: body
-        name: vmReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbScaleOutSubGroupReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: subgroupId
+        in: path
+        description: subGroup ID
+        required: true
+        schema:
+          type: string
+          default: g1
+      requestBody:
+        description: subGroup scaleOut request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbScaleOutSubGroupReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbMciInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbMciInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: ScaleOut subGroup in specified MCI
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: vmReq
   /ns/{nsId}/mci/{mciId}/vm:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize
+        for multiple VMs)
       description: Create and add homogeneous VMs(subGroup) to a specified MCI (Set
         subGroupSize for multiple VMs)
       operationId: PostMciVm
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Details for VMs(subGroup)
-        in: body
-        name: vmReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbVmReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      requestBody:
+        description: Details for VMs(subGroup)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbVmReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbMciInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbMciInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize
-        for multiple VMs)
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: vmReq
   /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Remote Command"
+      summary: Get bastion nodes for a VM
       description: Get bastion nodes for a VM
       operationId: GetBastionNodes
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1-1
+        schema:
+          type: string
+          default: mci01
+      - name: targetVmId
+        in: path
         description: Target VM ID
-        in: path
-        name: targetVmId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: g1-1
       responses:
         "200":
           description: OK
-          schema:
-            items:
-              $ref: '#/definitions/model.BastionNode'
-            type: array
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/model.BastionNode'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get bastion nodes for a VM
-      tags:
-      - '[MC-Infra] MCI Remote Command'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mci/{mciId}/vm/{targetVmId}/bastion/{bastionVmId}:
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Remote Command"
+      summary: Set bastion nodes for a VM
       description: Set bastion nodes for a VM
       operationId: SetBastionNodes
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1-1
+        schema:
+          type: string
+          default: mci01
+      - name: targetVmId
+        in: path
         description: Target VM ID
-        in: path
-        name: targetVmId
         required: true
-        type: string
-      - default: g1-1
+        schema:
+          type: string
+          default: g1-1
+      - name: bastionVmId
+        in: path
         description: Bastion VM ID
-        in: path
-        name: bastionVmId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: g1-1
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Set bastion nodes for a VM
-      tags:
-      - '[MC-Infra] MCI Remote Command'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mci/{mciId}/vm/{vmId}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete VM in specified MCI
-      operationId: DelMciVm
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - default: g1-1
-        description: VM ID
-        in: path
-        name: vmId
-        required: true
-        type: string
-      - description: Option for delete VM (support force delete)
-        enum:
-        - force
-        in: query
-        name: option
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete VM in specified MCI
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Get VM in specified MCI
       description: Get VM in specified MCI
       operationId: GetMciVm
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1-1
+        schema:
+          type: string
+          default: mci01
+      - name: vmId
+        in: path
         description: VM ID
-        in: path
-        name: vmId
         required: true
-        type: string
-      - description: Option for MCI
-        enum:
-        - default
-        - status
-        - idsInDetail
-        - accessinfo
+        schema:
+          type: string
+          default: g1-1
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: (For option=accessinfo) accessInfoOption (showSshKey)
+        description: Option for MCI
+        schema:
+          type: string
+          enum:
+          - default
+          - status
+          - idsInDetail
+          - accessinfo
+      - name: accessInfoOption
         in: query
-        name: accessInfoOption
-        type: string
-      produces:
-      - application/json
+        description: (For option=accessinfo) accessInfoOption (showSshKey)
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/infra.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/model.TbVmInfo'
-                '[IDNAME]':
-                  $ref: '#/definitions/model.TbIdNameInDetailInfo'
-                '[STATUS]':
-                  $ref: '#/definitions/model.TbVmStatusInfo'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/infra.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/model.TbVmInfo'
+                    '[IDNAME]':
+                      $ref: '#/components/schemas/model.TbIdNameInDetailInfo'
+                    '[STATUS]':
+                      $ref: '#/components/schemas/model.TbVmStatusInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get VM in specified MCI
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
       tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Delete VM in specified MCI
+      description: Delete VM in specified MCI
+      operationId: DelMciVm
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: vmId
+        in: path
+        description: VM ID
+        required: true
+        schema:
+          type: string
+          default: g1-1
+      - name: option
+        in: query
+        description: Option for delete VM (support force delete)
+        schema:
+          type: string
+          enum:
+          - force
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mci/{mciId}/vm/{vmId}/dataDisk:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Data Disk Management"
+      summary: Get available dataDisks for a VM
       description: Get available dataDisks for a VM
       operationId: GetVmDataDisk
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1-1
+        schema:
+          type: string
+          default: mci01
+      - name: vmId
+        in: path
         description: VM ID
-        in: path
-        name: vmId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: g1-1
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/resource.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/resource.RestGetAllDataDiskResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/resource.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/resource.RestGetAllDataDiskResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get available dataDisks for a VM
-      tags:
-      - '[Infra Resource] Data Disk Management'
-    post:
-      consumes:
-      - application/json
-      description: Provisioning (Create and attach) dataDisk
-      operationId: PostVmDataDisk
-      parameters:
-      - description: Details for an Data Disk object
-        in: body
-        name: dataDiskInfo
-        required: true
-        schema:
-          $ref: '#/definitions/model.TbDataDiskVmReq'
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - default: g1-1
-        description: VM ID
-        in: path
-        name: vmId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.TbVmInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Provisioning (Create and attach) dataDisk
-      tags:
-      - '[Infra Resource] Data Disk Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Data Disk Management"
+      summary: Attach/Detach available dataDisk
       description: Attach/Detach available dataDisk
       operationId: PutVmDataDisk
       parameters:
-      - description: Request body to attach/detach dataDisk
-        in: body
-        name: attachDetachDataDiskReq
-        schema:
-          $ref: '#/definitions/model.TbAttachDetachDataDiskReq'
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1-1
+        schema:
+          type: string
+          default: mci01
+      - name: vmId
+        in: path
         description: VM ID
-        in: path
-        name: vmId
         required: true
-        type: string
-      - description: Option for MCI
-        enum:
-        - attach
-        - detach
+        schema:
+          type: string
+          default: g1-1
+      - name: option
         in: query
-        name: option
+        description: Option for MCI
         required: true
-        type: string
-      - description: Force to attach/detach even if VM info is not matched
-        enum:
-        - "true"
-        - "false"
+        schema:
+          type: string
+          enum:
+          - attach
+          - detach
+      - name: force
         in: query
-        name: force
-        type: string
-      produces:
-      - application/json
+        description: Force to attach/detach even if VM info is not matched
+        schema:
+          type: string
+          enum:
+          - "true"
+          - "false"
+      requestBody:
+        description: Request body to attach/detach dataDisk
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbAttachDetachDataDiskReq'
+        required: false
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbVmInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbVmInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Attach/Detach available dataDisk
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: attachDetachDataDiskReq
+    post:
       tags:
-      - '[Infra Resource] Data Disk Management'
+      - "[Infra Resource] Data Disk Management"
+      summary: Provisioning (Create and attach) dataDisk
+      description: Provisioning (Create and attach) dataDisk
+      operationId: PostVmDataDisk
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: vmId
+        in: path
+        description: VM ID
+        required: true
+        schema:
+          type: string
+          default: g1-1
+      requestBody:
+        description: Details for an Data Disk object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbDataDiskVmReq'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbVmInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: dataDiskInfo
   /ns/{nsId}/mci/{mciId}/vm/{vmId}/snapshot:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Snapshot VM and create a Custom Image Object using the Snapshot
       description: Snapshot VM and create a Custom Image Object using the Snapshot
       operationId: PostMciVmSnapshot
       parameters:
-      - description: Request body to create VM snapshot
-        in: body
-        name: vmSnapshotReq
+      - name: nsId
+        in: path
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbVmSnapshotReq'
-      - default: default
-        description: Namespace ID
+          type: string
+          default: default
+      - name: mciId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1-1
+        schema:
+          type: string
+          default: mci01
+      - name: vmId
+        in: path
         description: VM ID
-        in: path
-        name: vmId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: g1-1
+      requestBody:
+        description: Request body to create VM snapshot
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbVmSnapshotReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbCustomImageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbCustomImageInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Snapshot VM and create a Custom Image Object using the Snapshot
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: vmSnapshotReq
   /ns/{nsId}/mci/{mciId}/vmDynamic:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Create VM Dynamically and add it to MCI
       description: Create VM Dynamically and add it to MCI
       operationId: PostMciVmDynamic
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Details for Vm dynamic request
-        in: body
-        name: vmReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbVmDynamicReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      requestBody:
+        description: Details for Vm dynamic request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbVmDynamicReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbMciInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbMciInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create VM Dynamically and add it to MCI
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: vmReq
   /ns/{nsId}/mci/{mciId}/vpn:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Site-to-site VPN Management (under development)"
+      summary: Get all site-to-site VPNs
       description: Get all site-to-site VPNs
       operationId: GetAllSiteToSiteVpn
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: IdList
-        description: Option
-        enum:
-        - InfoList
-        - IdList
+        schema:
+          type: string
+          default: mci01
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option
+        schema:
+          type: string
+          default: IdList
+          enum:
+          - InfoList
+          - IdList
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.VpnIdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.VpnIdList'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get all site-to-site VPNs
-      tags:
-      - '[Infra Resource] Site-to-site VPN Management (under development)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Site-to-site VPN Management (under development)"
+      summary: Create a site-to-site VPN
       description: |-
         Create a site-to-site VPN
 
@@ -8615,1422 +4390,1585 @@ paths:
         - Note: It will take about `15 ~ 45 minutes`.
       operationId: PostSiteToSiteVpn
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Sites info for VPN configuration
-        in: body
-        name: vpnReq
         required: true
         schema:
-          $ref: '#/definitions/model.RestPostVpnRequest'
-      - description: Action
-        enum:
-        - retry
-        in: query
-        name: action
-        type: string
-      produces:
-      - application/x-json-stream
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "503":
-          description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create a site-to-site VPN
-      tags:
-      - '[Infra Resource] Site-to-site VPN Management (under development)'
-  /ns/{nsId}/mci/{mciId}/vpn/{vpnId}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete a site-to-site VPN
-      operationId: DeleteSiteToSiteVpn
-      parameters:
-      - default: default
-        description: Namespace ID
+          type: string
+          default: default
+      - name: mciId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: vpn01
-        description: VPN ID
-        in: path
-        name: vpnId
+        schema:
+          type: string
+          default: mci01
+      - name: action
+        in: query
+        description: Action
+        schema:
+          type: string
+          enum:
+          - retry
+      requestBody:
+        description: Sites info for VPN configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.RestPostVpnRequest'
         required: true
-        type: string
-      produces:
-      - application/x-json-stream
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/x-json-stream:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/x-json-stream:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/x-json-stream:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete a site-to-site VPN
-      tags:
-      - '[Infra Resource] Site-to-site VPN Management (under development)'
+          content:
+            application/x-json-stream:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: vpnReq
+  /ns/{nsId}/mci/{mciId}/vpn/{vpnId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Site-to-site VPN Management (under development)"
+      summary: Get resource info of a site-to-site VPN
       description: Get resource info of a site-to-site VPN
       operationId: GetSiteToSiteVpn
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: vpn01
+        schema:
+          type: string
+          default: mci01
+      - name: vpnId
+        in: path
         description: VPN ID
-        in: path
-        name: vpnId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: vpn01
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.VpnInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.VpnInfo'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get resource info of a site-to-site VPN
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
       tags:
-      - '[Infra Resource] Site-to-site VPN Management (under development)'
+      - "[Infra Resource] Site-to-site VPN Management (under development)"
+      summary: Delete a site-to-site VPN
+      description: Delete a site-to-site VPN
+      operationId: DeleteSiteToSiteVpn
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      - name: vpnId
+        in: path
+        description: VPN ID
+        required: true
+        schema:
+          type: string
+          default: vpn01
+      responses:
+        "200":
+          description: OK
+          content:
+            application/x-json-stream:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "400":
+          description: Bad Request
+          content:
+            application/x-json-stream:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/x-json-stream:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "503":
+          description: Service Unavailable
+          content:
+            application/x-json-stream:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mci/{mciId}/vpn/{vpnId}/request/{requestId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Site-to-site VPN Management (under development)"
+      summary: Check the status of a specific request by its ID
       description: Check the status of a specific request by its ID
       operationId: GetRequestStatusOfSiteToSiteVpn
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: vpn01
+        schema:
+          type: string
+          default: mci01
+      - name: vpnId
+        in: path
         description: VPN ID
-        in: path
-        name: vpnId
         required: true
-        type: string
-      - description: Request ID
+        schema:
+          type: string
+          default: vpn01
+      - name: requestId
         in: path
-        name: requestId
+        description: Request ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.Response'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.Response'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Check the status of a specific request by its ID
-      tags:
-      - '[Infra Resource] Site-to-site VPN Management (under development)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/mciDynamic:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Create MCI Dynamically
       description: Create MCI Dynamically from common spec and image
       operationId: PostMciDynamic
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: 'Request body to provision MCI dynamically. Must include commonSpec
-          and commonImage info of each VM request.(ex: {name: mci01,vm: [{commonImage:
-          aws+ap-northeast-2+ubuntu22.04,commonSpec: aws+ap-northeast-2+t2.small}]}
-          ) You can use /mciRecommendVm and /mciDynamicCheckRequest to get it) Check
-          the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1570'
-        in: body
-        name: mciReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbMciDynamicReq'
-      - description: Option for MCI creation
-        enum:
-        - hold
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: Custom request ID
+        description: Option for MCI creation
+        schema:
+          type: string
+          enum:
+          - hold
+      - name: x-request-id
         in: header
-        name: x-request-id
-        type: string
-      produces:
-      - application/json
+        description: Custom request ID
+        schema:
+          type: string
+      requestBody:
+        description: "Request body to provision MCI dynamically. Must include commonSpec\
+          \ and commonImage info of each VM request.(ex: {name: mci01,vm: [{commonImage:\
+          \ aws+ap-northeast-2+ubuntu22.04,commonSpec: aws+ap-northeast-2+t2.small}]}\
+          \ ) You can use /mciRecommendVm and /mciDynamicCheckRequest to get it) Check\
+          \ the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1570"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbMciDynamicReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbMciInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbMciInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create MCI Dynamically
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciReq
   /ns/{nsId}/monitoring/install/mci/{mciId}:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Resource Monitor (for developer)"
+      summary: Install monitoring agent (CB-Dragonfly agent) to MCI
       description: Install monitoring agent (CB-Dragonfly agent) to MCI
       operationId: PostInstallMonitorAgentToMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Details for an MCI object
-        in: body
-        name: mciInfo
         required: true
         schema:
-          $ref: '#/definitions/model.MciCmdReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      requestBody:
+        description: Details for an MCI object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.MciCmdReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.AgentInstallContentWrapper'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.AgentInstallContentWrapper'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Install monitoring agent (CB-Dragonfly agent) to MCI
-      tags:
-      - '[MC-Infra] MCI Resource Monitor (for developer)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciInfo
   /ns/{nsId}/monitoring/mci/{mciId}/metric/{metric}:
     get:
-      consumes:
-      - application/json
-      description: Get monitoring data of specified MCI for specified monitoring metric
-        (cpu, memory, disk, network)
+      tags:
+      - "[MC-Infra] MCI Resource Monitor (for developer)"
+      summary: "Get monitoring data of specified MCI for specified monitoring metric\
+        \ (cpu, memory, disk, network)"
+      description: "Get monitoring data of specified MCI for specified monitoring\
+        \ metric (cpu, memory, disk, network)"
       operationId: GetMonitorData
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - description: 'Metric type: cpu, memory, disk, network'
+        schema:
+          type: string
+          default: mci01
+      - name: metric
         in: path
-        name: metric
+        description: "Metric type: cpu, memory, disk, network"
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.MonResultSimpleResponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.MonResultSimpleResponse'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get monitoring data of specified MCI for specified monitoring metric
-        (cpu, memory, disk, network)
-      tags:
-      - '[MC-Infra] MCI Resource Monitor (for developer)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/monitoring/status/mci/{mciId}/vm/{vmId}:
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Resource Monitor (for developer)"
+      summary: Set monitoring agent (CB-Dragonfly agent) installation status installed
+        (for Windows VM only)
       description: Set monitoring agent (CB-Dragonfly agent) installation status installed
         (for Windows VM only)
       operationId: PutMonitorAgentStatusInstalled
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: vm01
+        schema:
+          type: string
+          default: mci01
+      - name: vmId
+        in: path
         description: VM ID
-        in: path
-        name: vmId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: vm01
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbVmInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbVmInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Set monitoring agent (CB-Dragonfly agent) installation status installed
-        (for Windows VM only)
-      tags:
-      - '[MC-Infra] MCI Resource Monitor (for developer)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/policy/mci:
-    delete:
-      consumes:
-      - application/json
-      description: Delete all MCI policies
-      operationId: DelAllMciPolicy
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all MCI policies
-      tags:
-      - '[MC-Infra] MCI Orchestration Management (WIP)'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Orchestration Management (WIP)"
+      summary: List all MCI policies
       description: List all MCI policies
       operationId: GetAllMciPolicy
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/infra.RestGetAllMciPolicyResponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/infra.RestGetAllMciPolicyResponse'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all MCI policies
-      tags:
-      - '[MC-Infra] MCI Orchestration Management (WIP)'
-  /ns/{nsId}/policy/mci/{mciId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     delete:
-      consumes:
-      - application/json
-      description: Delete MCI Policy
-      operationId: DelMciPolicy
+      tags:
+      - "[MC-Infra] MCI Orchestration Management (WIP)"
+      summary: Delete all MCI policies
+      description: Delete all MCI policies
+      operationId: DelAllMciPolicy
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete MCI Policy
-      tags:
-      - '[MC-Infra] MCI Orchestration Management (WIP)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/policy/mci/{mciId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Orchestration Management (WIP)"
+      summary: Get MCI Policy
       description: Get MCI Policy
       operationId: GetMciPolicy
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: mci01
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.MciPolicyInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.MciPolicyInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get MCI Policy
-      tags:
-      - '[MC-Infra] MCI Orchestration Management (WIP)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Orchestration Management (WIP)"
+      summary: Create MCI Automation policy
       description: Create MCI Automation policy
       operationId: PostMciPolicy
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: mci01
-        description: MCI ID
-        in: path
-        name: mciId
-        required: true
-        type: string
-      - description: Details for an MCI automation policy request
-        in: body
-        name: mciPolicyReq
         required: true
         schema:
-          $ref: '#/definitions/model.MciPolicyReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      requestBody:
+        description: Details for an MCI automation policy request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.MciPolicyReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.MciPolicyInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.MciPolicyInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create MCI Automation policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciPolicyReq
+    delete:
       tags:
-      - '[MC-Infra] MCI Orchestration Management (WIP)'
-  /ns/{nsId}/registerCspResource/vNet:
-    post:
-      consumes:
-      - application/json
-      description: Register the VNet, which was created in CSP
-      operationId: PostRegisterVNet
+      - "[MC-Infra] MCI Orchestration Management (WIP)"
+      summary: Delete MCI Policy
+      description: Delete MCI Policy
+      operationId: DelMciPolicy
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Inforamation required to register the VNet created externally
-        in: body
-        name: vNetRegisterReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbRegisterVNetReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: mciId
+        in: path
+        description: MCI ID
+        required: true
+        schema:
+          type: string
+          default: mci01
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/registerCspResource/vNet:
+    post:
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Register VNet (created in CSP)
+      description: "Register the VNet, which was created in CSP"
+      operationId: PostRegisterVNet
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      requestBody:
+        description: Inforamation required to register the VNet created externally
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbRegisterVNetReq'
+        required: true
       responses:
         "201":
           description: Created
-          schema:
-            $ref: '#/definitions/model.TbVNetInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbVNetInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register VNet (created in CSP)
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: vNetRegisterReq
   /ns/{nsId}/registerCspResource/vNet/{vNetId}/subnet:
     post:
-      consumes:
-      - application/json
-      description: Register Subnet, which was created in CSP
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Register Subnet (created in CSP)
+      description: "Register Subnet, which was created in CSP"
       operationId: PostRegisterSubnet
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: VNet ID
-        in: path
-        name: vNetId
-        required: true
-        type: string
-      - description: Details for an Subnet object
-        in: body
-        name: subnetReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbRegisterSubnetReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: vNetId
+        in: path
+        description: VNet ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Details for an Subnet object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbRegisterSubnetReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSubnetInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSubnetInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register Subnet (created in CSP)
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: subnetReq
   /ns/{nsId}/registerCspVm:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Register existing VM in a CSP to Cloud-Barista MCI
       description: Register existing VM in a CSP to Cloud-Barista MCI
       operationId: PostRegisterCSPNativeVM
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Details for an MCI object with existing CSP VM ID
-        in: body
-        name: mciReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbMciReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      requestBody:
+        description: Details for an MCI object with existing CSP VM ID
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbMciReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbMciInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbMciInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register existing VM in a CSP to Cloud-Barista MCI
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciReq
   /ns/{nsId}/resources/customImage:
-    delete:
-      consumes:
-      - application/json
-      description: Delete all customImages
-      operationId: DelAllCustomImage
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: ""
-        description: Delete resources containing matched ID-substring only
-        in: query
-        name: match
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all customImages
-      tags:
-      - '[Infra Resource] Image Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: List all customImages or customImages' ID
       description: List all customImages or customImages' ID
       operationId: GetAllCustomImage
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: Field key for filtering (ex:guestOS)
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: 'Field value for filtering (ex: Ubuntu18.04)'
+        description: Field key for filtering (ex:guestOS)
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      produces:
-      - application/json
+        description: "Field value for filtering (ex: Ubuntu18.04)"
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/resource.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/resource.RestGetAllCustomImageResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/resource.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/resource.RestGetAllCustomImageResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all customImages or customImages' ID
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Register existing Custom Image in a CSP
       description: Register existing Custom Image in a CSP (option=register)
       operationId: PostCustomImage
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: 'Option: '
-        enum:
-        - register
-        in: query
-        name: option
-        required: true
-        type: string
-      - description: Request to Register existing Custom Image in a CSP
-        in: body
-        name: customImageRegisterReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbCustomImageReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: option
+        in: query
+        description: "Option: "
+        required: true
+        schema:
+          type: string
+          enum:
+          - register
+      requestBody:
+        description: Request to Register existing Custom Image in a CSP
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbCustomImageReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbCustomImageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbCustomImageInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register existing Custom Image in a CSP
-      tags:
-      - '[Infra Resource] Image Management'
-  /ns/{nsId}/resources/customImage/{customImageId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: customImageRegisterReq
     delete:
-      consumes:
-      - application/json
-      description: Delete customImage
-      operationId: DelCustomImage
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Delete all customImages
+      description: Delete all customImages
+      operationId: DelAllCustomImage
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: customImage ID
-        in: path
-        name: customImageId
-        required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
+      - name: match
+        in: query
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete customImage
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/customImage/{customImageId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Get customImage
       description: Get customImage
       operationId: GetCustomImage
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: customImage ID
+        schema:
+          type: string
+          default: default
+      - name: customImageId
         in: path
-        name: customImageId
+        description: customImage ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbCustomImageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbCustomImageInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get customImage
-      tags:
-      - '[Infra Resource] Image Management'
-  /ns/{nsId}/resources/dataDisk:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     delete:
-      consumes:
-      - application/json
-      description: Delete all Data Disks
-      operationId: DelAllDataDisk
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Delete customImage
+      description: Delete customImage
+      operationId: DelCustomImage
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - default: ""
-        description: Delete resources containing matched ID-substring only
-        in: query
-        name: match
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
+      - name: customImageId
+        in: path
+        description: customImage ID
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all Data Disks
-      tags:
-      - '[Infra Resource] Data Disk Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/dataDisk:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Data Disk Management"
+      summary: List all Data Disks or Data Disks' ID
       description: List all Data Disks or Data Disks' ID
       operationId: GetAllDataDisk
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: 'Field key for filtering (ex: systemLabel)'
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: 'Field value for filtering (ex: Registered from CSP resource)'
+        description: "Field key for filtering (ex: systemLabel)"
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      produces:
-      - application/json
+        description: "Field value for filtering (ex: Registered from CSP resource)"
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/resource.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/resource.RestGetAllDataDiskResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/resource.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/resource.RestGetAllDataDiskResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all Data Disks or Data Disks' ID
-      tags:
-      - '[Infra Resource] Data Disk Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Data Disk Management"
+      summary: Create Data Disk
       description: Create Data Disk
       operationId: PostDataDisk
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: 'Option: '
-        enum:
-        - register
-        in: query
-        name: option
-        type: string
-      - description: Details for an Data Disk object
-        in: body
-        name: dataDiskInfo
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbDataDiskReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: option
+        in: query
+        description: "Option: "
+        schema:
+          type: string
+          enum:
+          - register
+      requestBody:
+        description: Details for an Data Disk object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbDataDiskReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbDataDiskInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbDataDiskInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create Data Disk
-      tags:
-      - '[Infra Resource] Data Disk Management'
-  /ns/{nsId}/resources/dataDisk/{dataDiskId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: dataDiskInfo
     delete:
-      consumes:
-      - application/json
-      description: Delete Data Disk
-      operationId: DelDataDisk
+      tags:
+      - "[Infra Resource] Data Disk Management"
+      summary: Delete all Data Disks
+      description: Delete all Data Disks
+      operationId: DelAllDataDisk
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: Data Disk ID
-        in: path
-        name: dataDiskId
-        required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
+      - name: match
+        in: query
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete Data Disk
-      tags:
-      - '[Infra Resource] Data Disk Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/dataDisk/{dataDiskId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Data Disk Management"
+      summary: Get Data Disk
       description: Get Data Disk
       operationId: GetDataDisk
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: Data Disk ID
+        schema:
+          type: string
+          default: default
+      - name: dataDiskId
         in: path
-        name: dataDiskId
+        description: Data Disk ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbDataDiskInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbDataDiskInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get Data Disk
-      tags:
-      - '[Infra Resource] Data Disk Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Data Disk Management"
+      summary: Upsize Data Disk
       description: Upsize Data Disk
       operationId: PutDataDisk
       parameters:
-      - description: Request body to upsize the dataDisk
-        in: body
-        name: dataDiskUpsizeReq
+      - name: nsId
+        in: path
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbDataDiskUpsizeReq'
-      - default: default
-        description: Namespace ID
+          type: string
+          default: default
+      - name: dataDiskId
         in: path
-        name: nsId
+        description: DataDisk ID
         required: true
-        type: string
-      - description: DataDisk ID
-        in: path
-        name: dataDiskId
+        schema:
+          type: string
+      requestBody:
+        description: Request body to upsize the dataDisk
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbDataDiskUpsizeReq'
         required: true
-        type: string
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbDataDiskInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbDataDiskInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Upsize Data Disk
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: dataDiskUpsizeReq
+    delete:
       tags:
-      - '[Infra Resource] Data Disk Management'
+      - "[Infra Resource] Data Disk Management"
+      summary: Delete Data Disk
+      description: Delete Data Disk
+      operationId: DelDataDisk
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: dataDiskId
+        in: path
+        description: Data Disk ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/filterSpecsByRange:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Spec Management"
+      summary: Filter specs by range
       description: Filter specs by range
       operationId: FilterSpecsByRange
       parameters:
-      - default: system
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Filter for range-filtering specs
-        in: body
-        name: specRangeFilter
         schema:
-          $ref: '#/definitions/model.FilterSpecsByRangeRequest'
-      produces:
-      - application/json
+          type: string
+          default: system
+      requestBody:
+        description: Filter for range-filtering specs
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.FilterSpecsByRangeRequest'
+        required: false
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/resource.RestFilterSpecsResponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource.RestFilterSpecsResponse'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Filter specs by range
-      tags:
-      - '[Infra Resource] Spec Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: specRangeFilter
   /ns/{nsId}/resources/image:
-    delete:
-      consumes:
-      - application/json
-      description: Delete all images
-      operationId: DelAllImage
-      parameters:
-      - default: system
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: ""
-        description: Delete resources containing matched ID-substring only
-        in: query
-        name: match
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all images
-      tags:
-      - '[Infra Resource] Image Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: List all images or images' ID
       description: List all images or images' ID
       operationId: GetAllImage
       parameters:
-      - default: system
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: system
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: Field key for filtering (ex:guestOS)
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: 'Field value for filtering (ex: Ubuntu18.04)'
+        description: Field key for filtering (ex:guestOS)
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      produces:
-      - application/json
+        description: "Field value for filtering (ex: Ubuntu18.04)"
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/resource.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/model.SearchImageResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/resource.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/model.SearchImageResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all images or images' ID
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Register image
       description: Register image
       operationId: PostImage
       parameters:
-      - description: registeringMethod
-        enum:
-        - registerWithInfo
-        - registerWithId
+      - name: action
         in: query
-        name: action
+        description: registeringMethod
         required: true
-        type: string
-      - default: system
-        description: Namespace ID
+        schema:
+          type: string
+          enum:
+          - registerWithInfo
+          - registerWithId
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Specify details of a image object (cspResourceName, guestOS,
-          description, ...) manually
-        in: body
-        name: imageInfo
         schema:
-          $ref: '#/definitions/model.TbImageInfo'
-      - description: Specify (name, connectionName, cspImageName) to register an image
-          object automatically
-        in: body
-        name: imageReq
-        schema:
-          $ref: '#/definitions/model.TbImageReq'
-      - default: false
-        description: Force update to existing image object
+          type: string
+          default: system
+      - name: update
         in: query
-        name: update
-        type: boolean
-      produces:
-      - application/json
+        description: Force update to existing image object
+        schema:
+          type: boolean
+          default: false
+      requestBody:
+        description: "Specify (name, connectionName, cspImageName) to register an\
+          \ image object automatically"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbImageReq'
+        required: false
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbImageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbImageInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register image
-      tags:
-      - '[Infra Resource] Image Management'
-  /ns/{nsId}/resources/image/{imageId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: imageReq
     delete:
-      consumes:
-      - application/json
-      description: Delete image
-      operationId: DelImage
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Delete all images
+      description: Delete all images
+      operationId: DelAllImage
       parameters:
-      - default: system
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: Image ID ({providerName}+{regionName}+{cspImageName})
-        in: path
-        name: imageId
-        required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: system
+      - name: match
+        in: query
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete image
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/image/{imageId}:
     get:
-      consumes:
-      - application/json
-      description: GetImage returns an image object if there are matched images for
-        the given namespace and imageKey(Id, CspResourceName, GuestOS,...)
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Get image
+      description: "GetImage returns an image object if there are matched images for\
+        \ the given namespace and imageKey(Id, CspResourceName, GuestOS,...)"
       operationId: GetImage
       parameters:
-      - default: system
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: '(Note: imageId param will be refined in next release, enabled
-          for temporal support) This param accepts vaious input types as Image Key:
-          [1. registerd ID: ({providerName}+{regionName}+{GuestOS}). 2. cspImageName.
-          3. GuestOS)]'
+        schema:
+          type: string
+          default: system
+      - name: imageId
         in: path
-        name: imageId
+        description: "(Note: imageId param will be refined in next release, enabled\
+          \ for temporal support) This param accepts vaious input types as Image Key:\
+          \ [1. registerd ID: ({providerName}+{regionName}+{GuestOS}). 2. cspImageName.\
+          \ 3. GuestOS)]"
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbImageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbImageInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get image
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Update image
       description: Update image
       operationId: PutImage
       parameters:
-      - description: Details for an image object
-        in: body
-        name: imageInfo
+      - name: nsId
+        in: path
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbImageInfo'
-      - default: system
-        description: Namespace ID
+          type: string
+          default: system
+      - name: imageId
         in: path
-        name: nsId
+        description: "Image ID ({providerName}+{regionName}+{cspImageName})"
         required: true
-        type: string
-      - description: Image ID ({providerName}+{regionName}+{cspImageName})
-        in: path
-        name: imageId
+        schema:
+          type: string
+      requestBody:
+        description: Details for an image object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbImageInfo'
         required: true
-        type: string
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbImageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbImageInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Update image
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: imageInfo
+    delete:
       tags:
-      - '[Infra Resource] Image Management'
+      - "[Infra Resource] Image Management"
+      summary: Delete image
+      description: Delete image
+      operationId: DelImage
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: system
+      - name: imageId
+        in: path
+        description: "Image ID ({providerName}+{regionName}+{cspImageName})"
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/objectStorage:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Object Storage Management (under development)"
+      summary: Get all Object Storages (TBD)
       description: Get all Object Storages (TBD)
       operationId: GetAllObjectStorage
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - default: IdList
-        description: Option
-        enum:
-        - InfoList
-        - IdList
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option
+        schema:
+          type: string
+          default: IdList
+          enum:
+          - InfoList
+          - IdList
       responses:
         "200":
           description: OK" /////////////
-          schema:
-            $ref: '#/definitions/model.VpnIdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.VpnIdList'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get all Object Storages (TBD)
-      tags:
-      - '[Infra Resource] Object Storage Management (under development)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Object Storage Management (under development)"
+      summary: Create a Object Storages
       description: |
         Create a Object Storages
 
@@ -10042,680 +5980,826 @@ paths:
         - Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/117
       operationId: PostObjectStorage
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Request body to create a Object Storage
-        in: body
-        name: objectStorageReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.RestPostObjectStorageRequest'
-      - description: Action
-        enum:
-        - retry
+          type: string
+          default: default
+      - name: action
         in: query
-        name: action
-        type: string
-      produces:
-      - application/json
+        description: Action
+        schema:
+          type: string
+          enum:
+          - retry
+      requestBody:
+        description: Request body to create a Object Storage
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.RestPostObjectStorageRequest'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.ObjectStorageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.ObjectStorageInfo'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create a Object Storages
-      tags:
-      - '[Infra Resource] Object Storage Management (under development)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: objectStorageReq
   /ns/{nsId}/resources/objectStorage/{objectStorageId}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete a Object Storage
-      operationId: DeleteObjectStorage
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: objectstorage01
-        description: Object Storage ID
-        in: path
-        name: objectStorageId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "503":
-          description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete a Object Storage
-      tags:
-      - '[Infra Resource] Object Storage Management (under development)'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Object Storage Management (under development)"
+      summary: Get resource info of a Object Storage
       description: Get resource info of a Object Storage
       operationId: GetObjectStorage
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: objectstorage01
+        schema:
+          type: string
+          default: default
+      - name: objectStorageId
+        in: path
         description: Object Storage ID
-        in: path
-        name: objectStorageId
         required: true
-        type: string
-      - default: refined
-        description: Resource info by detail (refined, raw)
+        schema:
+          type: string
+          default: objectstorage01
+      - name: detail
         in: query
-        name: detail
-        type: string
-      produces:
-      - application/json
+        description: "Resource info by detail (refined, raw)"
+        schema:
+          type: string
+          default: refined
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.ObjectStorageInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.ObjectStorageInfo'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get resource info of a Object Storage
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
       tags:
-      - '[Infra Resource] Object Storage Management (under development)'
+      - "[Infra Resource] Object Storage Management (under development)"
+      summary: Delete a Object Storage
+      description: Delete a Object Storage
+      operationId: DeleteObjectStorage
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: objectStorageId
+        in: path
+        description: Object Storage ID
+        required: true
+        schema:
+          type: string
+          default: objectstorage01
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/searchImage:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Search image
       description: Search image
       operationId: SearchImage
       parameters:
-      - default: system
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: condition
-        in: body
-        name: condition
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.SearchImageRequest'
-      produces:
-      - application/json
+          type: string
+          default: system
+      requestBody:
+        description: condition
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.SearchImageRequest'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SearchImageResponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SearchImageResponse'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Search image
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: condition
   /ns/{nsId}/resources/searchImageOptions:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
       description: Get all available options for image search fields
       operationId: SearchImageOptions
       parameters:
-      - default: system
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: system
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SearchImageRequestOptions'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SearchImageRequestOptions'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/securityGroup:
-    delete:
-      consumes:
-      - application/json
-      description: Delete all Security Groups
-      operationId: DelAllSecurityGroup
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: ""
-        description: Delete resources containing matched ID-substring only
-        in: query
-        name: match
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all Security Groups
-      tags:
-      - '[Infra Resource] Security Group Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Security Group Management"
+      summary: List all Security Groups or Security Groups' ID
       description: List all Security Groups or Security Groups' ID
       operationId: GetAllSecurityGroup
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: 'Field key for filtering (ex: systemLabel)'
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: 'Field value for filtering (ex: Registered from CSP resource)'
+        description: "Field key for filtering (ex: systemLabel)"
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      produces:
-      - application/json
+        description: "Field value for filtering (ex: Registered from CSP resource)"
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/resource.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/resource.RestGetAllSecurityGroupResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/resource.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/resource.RestGetAllSecurityGroupResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all Security Groups or Security Groups' ID
-      tags:
-      - '[Infra Resource] Security Group Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Security Group Management"
+      summary: Create Security Group
       description: Create Security Group
       operationId: PostSecurityGroup
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: 'Option: [required params for register] connectionName, name,
-          vNetId, cspResourceId'
-        enum:
-        - register
-        in: query
-        name: option
-        type: string
-      - description: Details for an securityGroup object
-        in: body
-        name: securityGroupReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbSecurityGroupReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: option
+        in: query
+        description: "Option: [required params for register] connectionName, name,\
+          \ vNetId, cspResourceId"
+        schema:
+          type: string
+          enum:
+          - register
+      requestBody:
+        description: Details for an securityGroup object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbSecurityGroupReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSecurityGroupInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSecurityGroupInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create Security Group
-      tags:
-      - '[Infra Resource] Security Group Management'
-  /ns/{nsId}/resources/securityGroup/{securityGroupId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: securityGroupReq
     delete:
-      consumes:
-      - application/json
-      description: Delete Security Group
-      operationId: DelSecurityGroup
+      tags:
+      - "[Infra Resource] Security Group Management"
+      summary: Delete all Security Groups
+      description: Delete all Security Groups
+      operationId: DelAllSecurityGroup
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: Security Group ID
-        in: path
-        name: securityGroupId
-        required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
+      - name: match
+        in: query
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete Security Group
-      tags:
-      - '[Infra Resource] Security Group Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/securityGroup/{securityGroupId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Security Group Management"
+      summary: Get Security Group
       description: Get Security Group
       operationId: GetSecurityGroup
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Security Group ID
-        in: path
-        name: securityGroupId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.TbSecurityGroupInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get Security Group
-      tags:
-      - '[Infra Resource] Security Group Management'
-  /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules:
-    delete:
-      consumes:
-      - application/json
-      description: Delete FirewallRules
-      operationId: DelFirewallRules
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Security Group ID
-        in: path
-        name: securityGroupId
-        required: true
-        type: string
-      - description: FirewallRules to delete
-        in: body
-        name: firewallRuleReq
         required: true
         schema:
-          $ref: '#/definitions/resource.TbFirewallRulesWrapper'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: securityGroupId
+        in: path
+        description: Security Group ID
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSecurityGroupInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSecurityGroupInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete FirewallRules
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    put:
       tags:
-      - '[Infra Resource] Security Group Management'
+      - "[Infra Resource] Security Group Management"
+      summary: Update Security Group (Synchronize Firewall Rules)
+      description: |-
+        Update Security Group: Synchronize the firewall rules of the specified Security Group to match the requested list exactly.
+        This API will add missing rules and delete extra rules so that the Security Group's rules become identical to the requested set.
+        Only firewall rules are updated; other metadata (name, description, etc.) is not changed.
+
+        Usage:
+        Use this API to update (synchronize) the firewall rules of a Security Group. The rules in the request body will become the only rules in the Security Group after the operation.
+        - All existing rules not present in the request will be deleted.
+        - All rules in the request that do not exist will be added.
+        - If a rule exists but differs in CIDR or port range, it will be replaced.
+        - Special protocols (ICMP, ALL, etc.) are handled in the same way.
+
+        Notes:
+        - "Ports" field supports single port ("22"), port range ("80-100"), and multiple ports/ranges ("22,80-100,443").
+        - The valid port number range is 0 to 65535 (inclusive).
+        - "Protocol" can be TCP, UDP, ICMP, ALL, etc. (as supported by the cloud provider).
+        - "Direction" must be either "inbound" or "outbound".
+        - "CIDR" is the allowed IP range.
+        - All existing rules not in the request (including default ICMP, ALL, etc.) will be deleted.
+        - Metadata (name, description, etc.) is not changed.
+      operationId: PutSecurityGroup
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: securityGroupId
+        in: path
+        description: Security Group ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Details for an securityGroup object (only firewallRules field
+          is used for update)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbSecurityGroupUpdateReq'
+        required: true
+      responses:
+        "200":
+          description: Updated Security Group info with synchronized firewall rules
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSecurityGroupInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: securityGroupInfo
+    delete:
+      tags:
+      - "[Infra Resource] Security Group Management"
+      summary: Delete Security Group
+      description: Delete Security Group
+      operationId: DelSecurityGroup
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: securityGroupId
+        in: path
+        description: Security Group ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/securityGroup/{securityGroupId}/rules:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Security Group Management"
+      summary: Create FirewallRules
       description: Create FirewallRules
       operationId: PostFirewallRules
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Security Group ID
-        in: path
-        name: securityGroupId
-        required: true
-        type: string
-      - description: FirewallRules to create
-        in: body
-        name: firewallRuleReq
         required: true
         schema:
-          $ref: '#/definitions/resource.TbFirewallRulesWrapper'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: securityGroupId
+        in: path
+        description: Security Group ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: FirewallRules to create
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/resource.TbFirewallRulesWrapper'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSecurityGroupInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSecurityGroupInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create FirewallRules
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: firewallRuleReq
+    delete:
       tags:
-      - '[Infra Resource] Security Group Management'
+      - "[Infra Resource] Security Group Management"
+      summary: Delete FirewallRules
+      description: Delete FirewallRules
+      operationId: DelFirewallRules
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: securityGroupId
+        in: path
+        description: Security Group ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: FirewallRules to delete
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/resource.TbFirewallRulesWrapper'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSecurityGroupInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: firewallRuleReq
   /ns/{nsId}/resources/spec:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Spec Management"
+      summary: Register spec
       description: Register spec
       operationId: PostSpec
       parameters:
-      - description: registeringMethod
-        enum:
-        - registerWithInfo
-        - registerWithCspResourceId
+      - name: action
         in: query
-        name: action
+        description: registeringMethod
         required: true
-        type: string
-      - default: system
-        description: Namespace ID
+        schema:
+          type: string
+          enum:
+          - registerWithInfo
+          - registerWithCspResourceId
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Specify details of a spec object (vCPU, memoryGiB, ...) manually
-        in: body
-        name: specInfo
         schema:
-          $ref: '#/definitions/model.TbSpecInfo'
-      - description: Specify n(ame, connectionName, cspSpecName) to register a spec
-          object automatically
-        in: body
-        name: specReq
-        schema:
-          $ref: '#/definitions/model.TbSpecReq'
-      - default: false
-        description: Force update to existing spec object
+          type: string
+          default: system
+      - name: update
         in: query
-        name: update
-        type: boolean
-      produces:
-      - application/json
+        description: Force update to existing spec object
+        schema:
+          type: boolean
+          default: false
+      requestBody:
+        description: "Specify n(ame, connectionName, cspSpecName) to register a spec\
+          \ object automatically"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbSpecReq'
+        required: false
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSpecInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSpecInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register spec
-      tags:
-      - '[Infra Resource] Spec Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: specReq
   /ns/{nsId}/resources/spec/{specId}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete spec
-      operationId: DelSpec
-      parameters:
-      - default: system
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Spec ID ({providerName}+{regionName}+{cspSpecName})
-        in: path
-        name: specId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete spec
-      tags:
-      - '[Infra Resource] Spec Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Spec Management"
+      summary: Get spec
       description: Get spec
       operationId: GetSpec
       parameters:
-      - default: system
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: Spec ID ({providerName}+{regionName}+{cspSpecName})
+        schema:
+          type: string
+          default: system
+      - name: specId
         in: path
-        name: specId
+        description: "Spec ID ({providerName}+{regionName}+{cspSpecName})"
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSpecInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSpecInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get spec
-      tags:
-      - '[Infra Resource] Spec Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Spec Management"
+      summary: Update spec
       description: Update spec
       operationId: PutSpec
       parameters:
-      - description: Details for an spec object
-        in: body
-        name: specInfo
+      - name: nsId
+        in: path
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbSpecInfo'
-      - default: system
-        description: Namespace ID
+          type: string
+          default: system
+      - name: specId
         in: path
-        name: nsId
+        description: "Spec ID ({providerName}+{regionName}+{cspSpecName})"
         required: true
-        type: string
-      - description: Spec ID ({providerName}+{regionName}+{cspSpecName})
-        in: path
-        name: specId
+        schema:
+          type: string
+      requestBody:
+        description: Details for an spec object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbSpecInfo'
         required: true
-        type: string
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSpecInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSpecInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Update spec
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: specInfo
+    delete:
       tags:
-      - '[Infra Resource] Spec Management'
+      - "[Infra Resource] Spec Management"
+      summary: Delete spec
+      description: Delete spec
+      operationId: DelSpec
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: system
+      - name: specId
+        in: path
+        description: "Spec ID ({providerName}+{regionName}+{cspSpecName})"
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/sqlDb:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] SQL Database Management (under development)"
+      summary: Get all SQL Databases (TBD)
       description: Get all SQL Databases (TBD)
       operationId: GetAllSqlDb
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - default: IdList
-        description: Option
-        enum:
-        - InfoList
-        - IdList
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option
+        schema:
+          type: string
+          default: IdList
+          enum:
+          - InfoList
+          - IdList
       responses:
         "200":
           description: OK" /////////////
-          schema:
-            $ref: '#/definitions/model.VpnIdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.VpnIdList'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get all SQL Databases (TBD)
-      tags:
-      - '[Infra Resource] SQL Database Management (under development)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] SQL Database Management (under development)"
+      summary: Create a SQL Databases
       description: |
         Create a SQL Databases
 
@@ -10727,488 +6811,586 @@ paths:
         - Note - You can find the API usage examples on this link, https://github.com/cloud-barista/mc-terrarium/discussions/110
       operationId: PostSqlDb
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: Request body to create a SQL database
-        in: body
-        name: sqlDbReq
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.RestPostSqlDBRequest'
-      - description: Action
-        enum:
-        - retry
+          type: string
+          default: default
+      - name: action
         in: query
-        name: action
-        type: string
-      produces:
-      - application/json
+        description: Action
+        schema:
+          type: string
+          enum:
+          - retry
+      requestBody:
+        description: Request body to create a SQL database
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.RestPostSqlDBRequest'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SqlDBInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SqlDBInfo'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create a SQL Databases
-      tags:
-      - '[Infra Resource] SQL Database Management (under development)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: sqlDbReq
   /ns/{nsId}/resources/sqlDb/{sqlDbId}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete a SQL datatbase
-      operationId: DeleteSqlDb
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - default: sqldb01
-        description: SQL DB ID
-        in: path
-        name: sqlDbId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "503":
-          description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete a SQL datatbase
-      tags:
-      - '[Infra Resource] SQL Database Management (under development)'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] SQL Database Management (under development)"
+      summary: Get resource info of a SQL datatbase
       description: Get resource info of a SQL datatbase
       operationId: GetSqlDb
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: sqldb01
+        schema:
+          type: string
+          default: default
+      - name: sqlDbId
+        in: path
         description: SQL DB ID
-        in: path
-        name: sqlDbId
         required: true
-        type: string
-      - default: refined
-        description: Resource info by detail (refined, raw)
+        schema:
+          type: string
+          default: sqldb01
+      - name: detail
         in: query
-        name: detail
-        type: string
-      produces:
-      - application/json
+        description: "Resource info by detail (refined, raw)"
+        schema:
+          type: string
+          default: refined
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SqlDBInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SqlDBInfo'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get resource info of a SQL datatbase
-      tags:
-      - '[Infra Resource] SQL Database Management (under development)'
-  /ns/{nsId}/resources/sshKey:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     delete:
-      consumes:
-      - application/json
-      description: Delete all SSH Keys
-      operationId: DelAllSshKey
+      tags:
+      - "[Infra Resource] SQL Database Management (under development)"
+      summary: Delete a SQL datatbase
+      description: Delete a SQL datatbase
+      operationId: DeleteSqlDb
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - default: ""
-        description: Delete resources containing matched ID-substring only
-        in: query
-        name: match
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
+      - name: sqlDbId
+        in: path
+        description: SQL DB ID
+        required: true
+        schema:
+          type: string
+          default: sqldb01
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all SSH Keys
-      tags:
-      - '[Infra Resource] Access Key Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/sshKey:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Access Key Management"
+      summary: List all SSH Keys or SSH Keys' ID
       description: List all SSH Keys or SSH Keys' ID
       operationId: GetAllSshKey
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: 'Field key for filtering (ex: systemLabel)'
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: 'Field value for filtering (ex: Registered from CSP resource)'
+        description: "Field key for filtering (ex: systemLabel)"
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      produces:
-      - application/json
+        description: "Field value for filtering (ex: Registered from CSP resource)"
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/resource.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/resource.RestGetAllSshKeyResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/resource.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/resource.RestGetAllSshKeyResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all SSH Keys or SSH Keys' ID
-      tags:
-      - '[Infra Resource] Access Key Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Access Key Management"
+      summary: Create SSH Key
       description: Create SSH Key
       operationId: PostSshKey
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
-        required: true
-        type: string
-      - description: 'Option: [required params for register] connectionName, name,
-          cspResourceId, fingerprint, username, publicKey, privateKey'
-        enum:
-        - register
-        in: query
-        name: option
-        type: string
-      - description: Details for an SSH Key object
-        in: body
-        name: sshKeyInfo
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbSshKeyReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: option
+        in: query
+        description: "Option: [required params for register] connectionName, name,\
+          \ cspResourceId, fingerprint, username, publicKey, privateKey"
+        schema:
+          type: string
+          enum:
+          - register
+      requestBody:
+        description: Details for an SSH Key object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbSshKeyReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSshKeyInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSshKeyInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create SSH Key
-      tags:
-      - '[Infra Resource] Access Key Management'
-  /ns/{nsId}/resources/sshKey/{sshKeyId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: sshKeyInfo
     delete:
-      consumes:
-      - application/json
-      description: Delete SSH Key
-      operationId: DelSshKey
+      tags:
+      - "[Infra Resource] Access Key Management"
+      summary: Delete all SSH Keys
+      description: Delete all SSH Keys
+      operationId: DelAllSshKey
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: SSH Key ID
-        in: path
-        name: sshKeyId
-        required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
+      - name: match
+        in: query
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete SSH Key
-      tags:
-      - '[Infra Resource] Access Key Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/sshKey/{sshKeyId}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Access Key Management"
+      summary: Get SSH Key
       description: Get SSH Key
       operationId: GetSshKey
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: SSH Key ID
+        schema:
+          type: string
+          default: default
+      - name: sshKeyId
         in: path
-        name: sshKeyId
+        description: SSH Key ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSshKeyInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSshKeyInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get SSH Key
-      tags:
-      - '[Infra Resource] Access Key Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     put:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Access Key Management"
+      summary: Update SSH Key
       description: Update SSH Key
       operationId: PutSshKey
       parameters:
-      - description: Details for an SSH Key object
-        in: body
-        name: sshKeyInfo
+      - name: nsId
+        in: path
+        description: Namespace ID
         required: true
         schema:
-          $ref: '#/definitions/model.TbSshKeyInfo'
-      - default: default
-        description: Namespace ID
+          type: string
+          default: default
+      - name: sshKeyId
         in: path
-        name: nsId
+        description: SshKey ID
         required: true
-        type: string
-      - description: SshKey ID
-        in: path
-        name: sshKeyId
+        schema:
+          type: string
+      requestBody:
+        description: Details for an SSH Key object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbSshKeyInfo'
         required: true
-        type: string
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSshKeyInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSshKeyInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Update SSH Key
-      tags:
-      - '[Infra Resource] Access Key Management'
-  /ns/{nsId}/resources/vNet:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: sshKeyInfo
     delete:
-      consumes:
-      - application/json
-      description: Delete all VNets
-      operationId: DelAllVNet
+      tags:
+      - "[Infra Resource] Access Key Management"
+      summary: Delete SSH Key
+      description: Delete SSH Key
+      operationId: DelSshKey
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - default: ""
-        description: Delete resources containing matched ID-substring only
-        in: query
-        name: match
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
+      - name: sshKeyId
+        in: path
+        description: SSH Key ID
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all VNets
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/vNet:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: List all VNets or VNets' ID
       description: List all VNets or VNets' ID
       operationId: GetAllVNet
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - id
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
-        type: string
-      - description: 'Field key for filtering (ex: cspResourceName)'
+        description: Option
+        schema:
+          type: string
+          enum:
+          - id
+      - name: filterKey
         in: query
-        name: filterKey
-        type: string
-      - description: 'Field value for filtering (ex: default-alibaba-ap-northeast-1-vpc)'
+        description: "Field key for filtering (ex: cspResourceName)"
+        schema:
+          type: string
+      - name: filterVal
         in: query
-        name: filterVal
-        type: string
-      produces:
-      - application/json
+        description: "Field value for filtering (ex: default-alibaba-ap-northeast-1-vpc)"
+        schema:
+          type: string
       responses:
         "200":
           description: Different return structures by the given option param
-          schema:
-            allOf:
-            - $ref: '#/definitions/resource.JSONResult'
-            - properties:
-                '[DEFAULT]':
-                  $ref: '#/definitions/resource.RestGetAllVNetResponse'
-                '[ID]':
-                  $ref: '#/definitions/model.IdList'
-              type: object
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/resource.JSONResult'
+                - type: object
+                  properties:
+                    '[DEFAULT]':
+                      $ref: '#/components/schemas/resource.RestGetAllVNetResponse'
+                    '[ID]':
+                      $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all VNets or VNets' ID
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Create VNet
       description: Create a new VNet
       operationId: PostVNet
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Details for an VNet object
-        in: body
-        name: vNetReq
         schema:
-          $ref: '#/definitions/model.TbVNetReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      requestBody:
+        description: Details for an VNet object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbVNetReq'
+        required: false
       responses:
         "201":
           description: Created
-          schema:
-            $ref: '#/definitions/model.TbVNetInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbVNetInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create VNet
-      tags:
-      - '[Infra Resource] Network Management'
-  /ns/{nsId}/resources/vNet/{vNetId}:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: vNetReq
     delete:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Delete all VNets
+      description: Delete all VNets
+      operationId: DelAllVNet
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: match
+        in: query
+        description: Delete resources containing matched ID-substring only
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /ns/{nsId}/resources/vNet/{vNetId}:
+    get:
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Get VNet
+      description: Get VNet
+      operationId: GetVNet
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: vNetId
+        in: path
+        description: VNet ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbVNetInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: "Delete VNet (supporting actions: withsubnet, refine, force)"
       description: |-
         Delete VNet
         - withsubnets: delete VNet and its subnets
@@ -11216,311 +7398,301 @@ paths:
         - force: delete VNet and its subnets regardless of the status of info/resource in Spider/CSP
       operationId: DelVNet
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: VNet ID
+        schema:
+          type: string
+          default: default
+      - name: vNetId
         in: path
-        name: vNetId
+        description: VNet ID
         required: true
-        type: string
-      - description: Action
-        enum:
-        - withsubnets
-        - refine
-        - force
+        schema:
+          type: string
+      - name: action
         in: query
-        name: action
-        type: string
-      produces:
-      - application/json
+        description: Action
+        schema:
+          type: string
+          enum:
+          - withsubnets
+          - refine
+          - force
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: 'Delete VNet (supporting actions: withsubnet, refine, force)'
-      tags:
-      - '[Infra Resource] Network Management'
-    get:
-      consumes:
-      - application/json
-      description: Get VNet
-      operationId: GetVNet
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: VNet ID
-        in: path
-        name: vNetId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.TbVNetInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get VNet
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/resources/vNet/{vNetId}/subnet:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: List all subnets
       description: List all subnets
       operationId: GetAllSubnet
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: VNet ID
+        schema:
+          type: string
+          default: default
+      - name: vNetId
         in: path
-        name: vNetId
+        description: VNet ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/resource.RestGetAllSubnetResponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource.RestGetAllSubnetResponse'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all subnets
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Create Subnet
       description: Create Subnet
       operationId: PostSubnet
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: VNet ID
-        in: path
-        name: vNetId
-        required: true
-        type: string
-      - description: Details for an Subnet object
-        in: body
-        name: subnetReq
         required: true
         schema:
-          $ref: '#/definitions/model.TbSubnetReq'
-      produces:
-      - application/json
+          type: string
+          default: default
+      - name: vNetId
+        in: path
+        description: VNet ID
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Details for an Subnet object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbSubnetReq'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbSubnetInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSubnetInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create Subnet
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: subnetReq
   /ns/{nsId}/resources/vNet/{vNetId}/subnet/{subnetId}:
+    get:
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Get Subnet
+      description: Get Subnet
+      operationId: GetSubnet
+      parameters:
+      - name: nsId
+        in: path
+        description: Namespace ID
+        required: true
+        schema:
+          type: string
+          default: default
+      - name: vNetId
+        in: path
+        description: VNet ID
+        required: true
+        schema:
+          type: string
+      - name: subnetId
+        in: path
+        description: Subnet ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbSubnetInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     delete:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: "Delete Subnet (supporting actions: refine, force)"
       description: |-
         Delete Subnet
         - refine: delete a subnet `object` if there's no resource on CSP or no inforamation on Spider
         - force: force: delete a subnet `resource` on a CSP regardless of the current resource status (e.g., attempt to delete even if in use)
       operationId: DelSubnet
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - description: VNet ID
+        schema:
+          type: string
+          default: default
+      - name: vNetId
         in: path
-        name: vNetId
+        description: VNet ID
         required: true
-        type: string
-      - description: Subnet ID
+        schema:
+          type: string
+      - name: subnetId
         in: path
-        name: subnetId
+        description: Subnet ID
         required: true
-        type: string
-      - description: Action
-        enum:
-        - refine
-        - force
+        schema:
+          type: string
+      - name: action
         in: query
-        name: action
-        type: string
-      produces:
-      - application/json
+        description: Action
+        schema:
+          type: string
+          enum:
+          - refine
+          - force
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: 'Delete Subnet (supporting actions: refine, force)'
-      tags:
-      - '[Infra Resource] Network Management'
-    get:
-      consumes:
-      - application/json
-      description: Get Subnet
-      operationId: GetSubnet
-      parameters:
-      - default: default
-        description: Namespace ID
-        in: path
-        name: nsId
-        required: true
-        type: string
-      - description: VNet ID
-        in: path
-        name: vNetId
-        required: true
-        type: string
-      - description: Subnet ID
-        in: path
-        name: subnetId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.TbSubnetInfo'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get Subnet
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/sharedResource:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Create shared resources for MC-Infra
       description: Create shared resources for MC-Infra
       operationId: CreateSharedResource
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      - description: Option
-        enum:
-        - all
-        - vnet
-        - sg
-        - sshkey
+        schema:
+          type: string
+          default: default
+      - name: option
         in: query
-        name: option
+        description: Option
         required: true
-        type: string
-      - default: ""
+        schema:
+          type: string
+          enum:
+          - all
+          - vnet
+          - sg
+          - sshkey
+      - name: connectionName
+        in: query
         description: connectionName of cloud for designated resource
-        in: query
-        name: connectionName
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create shared resources for MC-Infra
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/sharedResources:
     delete:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Delete all Default Resource Objects in the given namespace
       description: Delete all Default Resource Objects in the given namespace
       operationId: DelAllSharedResources
       parameters:
-      - default: default
-        description: Namespace ID
+      - name: nsId
         in: path
-        name: nsId
+        description: Namespace ID
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: default
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all Default Resource Objects in the given namespace
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/transferFile/k8sCluster/{k8sClusterId}:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster's Container Remote Command"
+      summary: Transfer a file to specified Container in K8sCluster
       description: |-
         Transfer a file to specified Container in K8sCluster. The tar command is required in the container.
         [note] This feature is not intended for general use
@@ -11528,636 +7700,704 @@ paths:
         Kubernetes resource information required as input for this API is not currently provided, and its availability in the future is uncertain.
       operationId: PostFileToK8sCluster
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: k8scluster01
+        schema:
+          type: string
+          default: default
+      - name: k8sClusterId
+        in: path
         description: K8sCluster ID
-        in: path
-        name: k8sClusterId
         required: true
-        type: string
-      - default: default
+        schema:
+          type: string
+          default: k8scluster01
+      - name: k8sClusterNamespace
+        in: query
         description: Namespace in K8sCluster to apply the command
-        in: query
-        name: k8sClusterNamespace
         required: true
-        type: string
-      - default: mypod
+        schema:
+          type: string
+          default: default
+      - name: k8sClusterPodName
+        in: query
         description: Pod Name in K8sCluster to apply the command
+        required: true
+        schema:
+          type: string
+          default: mypod
+      - name: k8sClusterContainerName
         in: query
-        name: k8sClusterPodName
-        required: true
-        type: string
-      - description: Container Name in K8sCluster to apply the command
-        in: query
-        name: k8sClusterContainerName
-        type: string
-      - default: /tmp
-        description: Target path where the file will be stored
-        in: formData
-        name: path
-        required: true
-        type: string
-      - description: The file to be uploaded (Max 10MB)
-        in: formData
-        name: file
-        required: true
-        type: file
-      - description: Custom request ID
+        description: Container Name in K8sCluster to apply the command
+        schema:
+          type: string
+      - name: x-request-id
         in: header
-        name: x-request-id
-        type: string
-      produces:
-      - application/json
+        description: Custom request ID
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              required:
+              - file
+              - path
+              type: object
+              properties:
+                path:
+                  type: string
+                  description: Target path where the file will be stored
+                  default: /tmp
+                file:
+                  type: string
+                  description: The file to be uploaded (Max 10MB)
+                  format: binary
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbK8sClusterContainerCmdResults'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbK8sClusterContainerCmdResults'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Transfer a file to specified Container in K8sCluster
-      tags:
-      - '[Kubernetes] Cluster''s Container Remote Command'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /ns/{nsId}/transferFile/mci/{mciId}:
     post:
-      consumes:
-      - multipart/form-data
+      tags:
+      - "[MC-Infra] MCI Remote Command"
+      summary: Transfer a file to specified MCI
       description: |-
         Transfer a file to specified MCI to the specified path.
         The file size should be less than 10MB.
         Not for gerneral file transfer but for specific purpose (small configuration files).
       operationId: PostFileToMci
       parameters:
-      - default: default
+      - name: nsId
+        in: path
         description: Namespace ID
-        in: path
-        name: nsId
         required: true
-        type: string
-      - default: mci01
+        schema:
+          type: string
+          default: default
+      - name: mciId
+        in: path
         description: MCI ID
-        in: path
-        name: mciId
         required: true
-        type: string
-      - default: g1
+        schema:
+          type: string
+          default: mci01
+      - name: subGroupId
+        in: query
         description: subGroupId to apply the file transfer only for VMs in subGroup
           of MCI
+        schema:
+          type: string
+          default: g1
+      - name: vmId
         in: query
-        name: subGroupId
-        type: string
-      - default: g1-1
         description: vmId to apply the file transfer only for a VM in MCI
-        in: query
-        name: vmId
-        type: string
-      - default: /home/cb-user/
-        description: Target path where the file will be stored
-        in: formData
-        name: path
-        required: true
-        type: string
-      - description: The file to be uploaded (Max 10MB)
-        in: formData
-        name: file
-        required: true
-        type: file
-      - description: Custom request ID
+        schema:
+          type: string
+          default: g1-1
+      - name: x-request-id
         in: header
-        name: x-request-id
-        type: string
-      produces:
-      - application/json
+        description: Custom request ID
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+              - file
+              - path
+              type: object
+              properties:
+                path:
+                  type: string
+                  description: Target path where the file will be stored
+                  default: /home/cb-user/
+                file:
+                  type: string
+                  description: The file to be uploaded (Max 10MB)
+                  format: binary
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.MciSshCmdResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.MciSshCmdResult'
         "400":
           description: Invalid request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Transfer a file to specified MCI
-      tags:
-      - '[MC-Infra] MCI Remote Command'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /object:
-    delete:
-      consumes:
-      - application/json
-      description: Delete an object
-      operationId: DeleteObject
-      parameters:
-      - description: delete object value by key
-        in: query
-        name: key
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete an object
-      tags:
-      - '[Admin] System Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] System Management"
+      summary: Get value of an object
       description: Get value of an object
       operationId: GetObject
       parameters:
-      - description: get object value by key
+      - name: key
         in: query
-        name: key
+        description: get object value by key
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get value of an object
-      tags:
-      - '[Admin] System Management'
-  /objects:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     delete:
-      consumes:
-      - application/json
-      description: Delete child objects along with the given object
-      operationId: DeleteObjects
+      tags:
+      - "[Admin] System Management"
+      summary: Delete an object
+      description: Delete an object
+      operationId: DeleteObject
       parameters:
-      - description: Delete child objects based on the given key string
+      - name: key
         in: query
-        name: key
+        description: delete object value by key
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete child objects along with the given object
-      tags:
-      - '[Admin] System Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /objects:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] System Management"
+      summary: List all objects for a given key
       description: List all objects for a given key
       operationId: GetObjects
       parameters:
-      - description: retrieve objects by key
+      - name: key
         in: query
-        name: key
+        description: retrieve objects by key
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all objects for a given key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+    delete:
       tags:
-      - '[Admin] System Management'
+      - "[Admin] System Management"
+      summary: Delete child objects along with the given object
+      description: Delete child objects along with the given object
+      operationId: DeleteObjects
+      parameters:
+      - name: key
+        in: query
+        description: Delete child objects based on the given key string
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /provider:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] Multi-Cloud Information"
+      summary: List all registered Providers
       description: List all registered Providers
       operationId: GetProviderList
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.IdList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.IdList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: List all registered Providers
-      tags:
-      - '[Admin] Multi-Cloud Information'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /provider/{providerName}/region:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] Multi-Cloud Information"
+      summary: Get registered region info
       description: Get registered region info
       operationId: GetRegions
       parameters:
-      - description: Name of the CSP to retrieve
+      - name: providerName
         in: path
-        name: providerName
+        description: Name of the CSP to retrieve
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.RegionList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.RegionList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get registered region info
-      tags:
-      - '[Admin] Multi-Cloud Information'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /provider/{providerName}/region/{regionName}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] Multi-Cloud Information"
+      summary: Get registered region info
       description: Get registered region info
       operationId: GetRegion
       parameters:
-      - description: Name of the CSP to retrieve
+      - name: providerName
         in: path
-        name: providerName
+        description: Name of the CSP to retrieve
         required: true
-        type: string
-      - description: Name of region to retrieve
+        schema:
+          type: string
+      - name: regionName
         in: path
-        name: regionName
+        description: Name of region to retrieve
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.RegionDetail'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.RegionDetail'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get registered region info
-      tags:
-      - '[Admin] Multi-Cloud Information'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /readyz:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] System Management"
+      summary: Check Tumblebug is ready
       description: Check Tumblebug is ready
       operationId: GetReadyz
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "503":
           description: Service Unavailable
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Check Tumblebug is ready
-      tags:
-      - '[Admin] System Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /regionFromCsp:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] Multi-Cloud Information"
+      summary: RetrieveR all region lists from CSPs
       description: RetrieveR all region lists from CSPs
       operationId: RetrieveRegionListFromCsp
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.RetrievedRegionList'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.RetrievedRegionList'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: RetrieveR all region lists from CSPs
-      tags:
-      - '[Admin] Multi-Cloud Information'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /registerCspResources:
     post:
-      consumes:
-      - application/json
-      description: Register CSP Native Resources (vNet, securityGroup, sshKey, vm)
-        to CB-Tumblebug
+      tags:
+      - "[Admin] System Management"
+      summary: "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to\
+        \ CB-Tumblebug"
+      description: "Register CSP Native Resources (vNet, securityGroup, sshKey, vm)\
+        \ to CB-Tumblebug"
       operationId: RegisterCspNativeResources
       parameters:
-      - description: Specify connectionName, NS Id, and MCI Name
-        in: body
-        name: Request
-        required: true
+      - name: option
+        in: query
+        description: Option to specify resourceType
         schema:
-          $ref: '#/definitions/common.RestRegisterCspNativeResourcesRequest'
-      - description: Option to specify resourceType
-        enum:
-        - onlyVm
-        - exceptVm
+          type: string
+          enum:
+          - onlyVm
+          - exceptVm
+      - name: mciFlag
         in: query
-        name: option
-        type: string
-      - default: "y"
-        description: Flag to show VMs in a collective MCI form (y,n)
-        enum:
-        - "y"
-        - "n"
-        in: query
-        name: mciFlag
-        type: string
-      produces:
-      - application/json
+        description: "Flag to show VMs in a collective MCI form (y,n)"
+        schema:
+          type: string
+          default: "y"
+          enum:
+          - "y"
+          - "n"
+      requestBody:
+        description: "Specify connectionName, NS Id, and MCI Name"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/common.RestRegisterCspNativeResourcesRequest'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.RegisterResourceResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.RegisterResourceResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register CSP Native Resources (vNet, securityGroup, sshKey, vm) to
-        CB-Tumblebug
-      tags:
-      - '[Admin] System Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: Request
   /registerCspResourcesAll:
     post:
-      consumes:
-      - application/json
-      description: Register CSP Native Resources (vNet, securityGroup, sshKey, vm)
-        from all Clouds to CB-Tumblebug
+      tags:
+      - "[Admin] System Management"
+      summary: "Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from\
+        \ all Clouds to CB-Tumblebug"
+      description: "Register CSP Native Resources (vNet, securityGroup, sshKey, vm)\
+        \ from all Clouds to CB-Tumblebug"
       operationId: RegisterCspNativeResourcesAll
       parameters:
-      - description: Specify NS Id and MCI Name
-        in: body
-        name: Request
-        required: true
+      - name: option
+        in: query
+        description: Option to specify resourceType
         schema:
-          $ref: '#/definitions/common.RestRegisterCspNativeResourcesRequestAll'
-      - description: Option to specify resourceType
-        enum:
-        - onlyVm
-        - exceptVm
+          type: string
+          enum:
+          - onlyVm
+          - exceptVm
+      - name: mciFlag
         in: query
-        name: option
-        type: string
-      - default: "y"
-        description: Flag to show VMs in a collective MCI form (y,n)
-        enum:
-        - "y"
-        - "n"
-        in: query
-        name: mciFlag
-        type: string
-      produces:
-      - application/json
+        description: "Flag to show VMs in a collective MCI form (y,n)"
+        schema:
+          type: string
+          default: "y"
+          enum:
+          - "y"
+          - "n"
+      requestBody:
+        description: Specify NS Id and MCI Name
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/common.RestRegisterCspNativeResourcesRequestAll'
+        required: true
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.RegisterResourceAllResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.RegisterResourceAllResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Register CSP Native Resources (vNet, securityGroup, sshKey, vm) from
-        all Clouds to CB-Tumblebug
-      tags:
-      - '[Admin] System Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: Request
   /request/{reqId}:
-    delete:
-      consumes:
-      - application/json
-      description: Delete details of a specific request
-      operationId: DeleteRequest
-      parameters:
-      - description: Request ID to delete
-        in: path
-        name: reqId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete a specific request's details
-      tags:
-      - '[Admin] API Request Management'
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] API Request Management"
+      summary: Get request details
       description: Get details of a specific request
       operationId: GetRequest
       parameters:
-      - description: Request ID acquired from X-Request-ID header
+      - name: reqId
         in: path
-        name: reqId
+        description: Request ID acquired from X-Request-ID header
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/client.RequestDetails'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/client.RequestDetails'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get request details
-      tags:
-      - '[Admin] API Request Management'
-  /requests:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
     delete:
-      consumes:
-      - application/json
-      description: Delete details of all requests
-      operationId: DeleteAllRequests
-      produces:
-      - application/json
+      tags:
+      - "[Admin] API Request Management"
+      summary: Delete a specific request's details
+      description: Delete details of a specific request
+      operationId: DeleteRequest
+      parameters:
+      - name: reqId
+        in: path
+        description: Request ID to delete
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Delete all requests' details
-      tags:
-      - '[Admin] API Request Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+  /requests:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Admin] API Request Management"
+      summary: Get all requests
       description: Get details of all requests with optional filters.
       operationId: GetAllRequests
       parameters:
-      - default: ""
-        description: Filter by request status (Handling, Error, Success)
-        enum:
-        - Handling
-        - Error
-        - Success
+      - name: status
         in: query
-        name: status
-        type: string
-      - default: ""
-        description: Filter by HTTP method (GET, POST, PUT, DELETE, etc.)
-        enum:
-        - GET
-        - POST
-        - PUT
-        - DELETE
+        description: "Filter by request status (Handling, Error, Success)"
+        schema:
+          type: string
+          enum:
+          - Handling
+          - Error
+          - Success
+      - name: method
         in: query
-        name: method
-        type: string
-      - description: Filter by request URL
+        description: "Filter by HTTP method (GET, POST, PUT, DELETE, etc.)"
+        schema:
+          type: string
+          enum:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+      - name: url
         in: query
-        name: url
-        type: string
-      - description: Filter by time in minutes from now (to get recent requests)
+        description: Filter by request URL
+        schema:
+          type: string
+      - name: time
         in: query
-        name: time
-        type: string
-      - default: "false"
+        description: Filter by time in minutes from now (to get recent requests)
+        schema:
+          type: string
+      - name: savefile
+        in: query
         description: Option to save the results to a file (set 'true' to activate)
-        enum:
-        - "true"
-        - "false"
-        in: query
-        name: savefile
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
+          default: "false"
+          enum:
+          - "true"
+          - "false"
       responses:
         "200":
           description: OK
-          schema:
-            additionalProperties:
-              items:
-                $ref: '#/definitions/client.RequestDetails'
-              type: array
-            type: object
-      summary: Get all requests
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/client.RequestDetails'
+    delete:
       tags:
-      - '[Admin] API Request Management'
+      - "[Admin] API Request Management"
+      summary: Delete all requests' details
+      description: Delete details of all requests
+      operationId: DeleteAllRequests
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /requiredK8sSubnetCount:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Kubernetes] Cluster Management"
+      summary: Get the required subnet count to create a K8sCluster
       description: Get the required subnet count to create a K8sCluster
       operationId: GetRequiredK8sSubnetCount
       parameters:
-      - description: Name of the CSP to retrieve
+      - name: providerName
         in: query
-        name: providerName
+        description: Name of the CSP to retrieve
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.K8sClusterRequiredSubnetCount'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.K8sClusterRequiredSubnetCount'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get the required subnet count to create a K8sCluster
-      tags:
-      - '[Kubernetes] Cluster Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /resources/{labelType}:
     get:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Common Utility"
+      summary: Get resources by label selector
       description: |-
         Get resources based on a label selector. The label selector supports the following operators:
         - `=` : Selects resources where the label key equals the specified value (e.g., `env=production`).
@@ -12168,243 +8408,4986 @@ paths:
         - `!exists` : Selects resources where the label key does not exist (e.g., `env !exists`).
       operationId: GetResourcesByLabelSelector
       parameters:
-      - description: Label Type
-        enum:
-        - ns
-        - mci
-        - subGroup
-        - vm
-        - k8s
-        - vNet
-        - subnet
-        - vpn
-        - securityGroup
-        - sshKey
-        - dataDisk
-        - sqlDb
-        - objectStorage
+      - name: labelType
         in: path
-        name: labelType
+        description: Label Type
         required: true
-        type: string
-      - description: 'Label selector query. Example: env=production,tier=backend'
+        schema:
+          type: string
+          enum:
+          - ns
+          - mci
+          - subGroup
+          - vm
+          - k8s
+          - vNet
+          - subnet
+          - vpn
+          - securityGroup
+          - sshKey
+          - dataDisk
+          - sqlDb
+          - objectStorage
+      - name: labelSelector
         in: query
-        name: labelSelector
+        description: "Label selector query. Example: env=production,tier=backend"
         required: true
-        type: string
-      produces:
-      - application/json
+        schema:
+          type: string
       responses:
         "200":
           description: Matched resources
-          schema:
-            $ref: '#/definitions/label.ResourcesResponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/label.ResourcesResponse'
         "400":
           description: Invalid request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Get resources by label selector
-      tags:
-      - '[Infra Resource] Common Utility'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /systemMci:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Create System MCI Dynamically for Special Purpose in NS:system
       description: Create System MCI Dynamically for Special Purpose
       operationId: PostSystemMci
       parameters:
-      - description: Option for the purpose of system MCI
-        enum:
-        - probe
+      - name: option
         in: query
-        name: option
-        type: string
-      produces:
-      - application/json
+        description: Option for the purpose of system MCI
+        schema:
+          type: string
+          enum:
+          - probe
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.TbMciInfo'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.TbMciInfo'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Create System MCI Dynamically for Special Purpose in NS:system
-      tags:
-      - '[MC-Infra] MCI Provisioning and Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /testStreamResponse:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Test] Stream Response"
+      summary: Stream response of a number decrement
       description: Receives a number and streams the decrementing number every second
         until zero
       operationId: PostTestStreamResponse
-      parameters:
-      - description: Number input
-        in: body
-        name: number
+      requestBody:
+        description: Number input
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/common.NumberRequest'
         required: true
-        schema:
-          $ref: '#/definitions/common.NumberRequest'
-      produces:
-      - application/x-json-stream
       responses:
         "200":
           description: currentNumber
-          schema:
-            additionalProperties:
-              type: integer
-            type: object
+          content:
+            application/x-json-stream:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
         "400":
           description: Invalid input
-          schema:
-            additionalProperties:
-              type: string
-            type: object
+          content:
+            application/x-json-stream:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
         "500":
           description: Stream failed
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      summary: Stream response of a number decrement
-      tags:
-      - '[Test] Stream Response'
+          content:
+            application/x-json-stream:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+      x-codegen-request-body-name: number
   /updateImagesFromAsset:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Image Management"
+      summary: Update images from cloudimage.csv asset file
       description: Update image information based on the cloudimage.csv asset file
       operationId: UpdateImagesFromAsset
-      produces:
-      - application/json
       responses:
         "202":
           description: Accepted
-          schema:
-            $ref: '#/definitions/resource.FetchImagesAsyncResult'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/resource.FetchImagesAsyncResult'
         "404":
           description: Not Found
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Update images from cloudimage.csv asset file
-      tags:
-      - '[Infra Resource] Image Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
   /util/net/design:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Design a multi-cloud network configuration
       description: Design a hierarchical network configuration of a VPC network or
         multi-cloud network consisting of multiple VPC networks
       operationId: PostUtilToDesignNetwork
-      parameters:
-      - description: A root/main network CIDR block and subnetting rules
-        in: body
-        name: subnettingReq
+      requestBody:
+        description: A root/main network CIDR block and subnetting rules
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/netutil.RestPostUtilToDesignNetworkRequest'
         required: true
-        schema:
-          $ref: '#/definitions/netutil.RestPostUtilToDesignNetworkRequest'
-      produces:
-      - application/json
       responses:
         "201":
           description: Created
-          schema:
-            $ref: '#/definitions/netutil.RestPostUtilToDesignNetworkReponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/netutil.RestPostUtilToDesignNetworkReponse'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Design a multi-cloud network configuration
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: subnettingReq
   /util/net/validate:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Validate a multi-cloud network configuration
       description: Validate a hierarchical configuration of a VPC network or multi-cloud
         network consisting of multiple VPC networks
       operationId: PostUtilToValidateNetwork
-      parameters:
-      - description: A hierarchical network configuration
-        in: body
-        name: subnettingReq
+      requestBody:
+        description: A hierarchical network configuration
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/netutil.RestPostUtilToValidateNetworkRequest'
         required: true
-        schema:
-          $ref: '#/definitions/netutil.RestPostUtilToValidateNetworkRequest'
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Validate a multi-cloud network configuration
-      tags:
-      - '[Infra Resource] Network Management'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: subnettingReq
   /util/vNet/design:
     post:
-      consumes:
-      - application/json
+      tags:
+      - "[Infra Resource] Network Management"
+      summary: Design VNet and subnets based on user-friendly properties
       description: Design VNet and subnets based on user-friendly properties
       operationId: PostUtilToDesignVNet
-      parameters:
-      - description: User-friendly properties to design VNet and subnets
-        in: body
-        name: vNetDesignReq
+      requestBody:
+        description: User-friendly properties to design VNet and subnets
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/netutil.RestPostUtilToDesignVNetRequest'
         required: true
-        schema:
-          $ref: '#/definitions/netutil.RestPostUtilToDesignVNetRequest'
-      produces:
-      - application/json
       responses:
         "201":
           description: Created
-          schema:
-            $ref: '#/definitions/netutil.RestPostUtilToDesignVNetReponse'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/netutil.RestPostUtilToDesignVNetReponse'
         "400":
           description: Bad Request
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "500":
           description: Internal Server Error
-          schema:
-            $ref: '#/definitions/model.SimpleMsg'
-      summary: Design VNet and subnets based on user-friendly properties
-      tags:
-      - '[Infra Resource] Network Management'
-securityDefinitions:
-  BasicAuth:
-    type: basic
-  Bearer:
-    description: Type "Bearer" followed by a space and JWT token ([TBD] Get token
-      in http://xxx.xxx.xxx.xxx:xxx/auth)
-    in: header
-    name: Authorization
-    type: apiKey
-swagger: "2.0"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: vNetDesignReq
+components:
+  schemas:
+    auth.AuthsInfo:
+      type: object
+      properties:
+        authenticated:
+          type: boolean
+        expired-time:
+          type: string
+        name:
+          type: string
+        role:
+          type: string
+        token:
+          type: string
+    client.RequestDetails:
+      type: object
+      properties:
+        endTime:
+          type: string
+          description: The time when the request was fully processed.
+        errorResponse:
+          type: string
+          description: A message describing any error that occurred during request
+            processing.
+        requestInfo:
+          type: object
+          description: Extracted information about the request.
+          allOf:
+          - $ref: '#/components/schemas/client.RequestInfo'
+        responseData:
+          type: object
+          description: The data sent back in response to the request.
+        startTime:
+          type: string
+          description: The time when the request was received by the server.
+        status:
+          type: string
+          description: "The current status of the request (e.g., \"Handling\", \"\
+            Error\", \"Success\")."
+    client.RequestInfo:
+      type: object
+      properties:
+        body:
+          type: object
+          description: "Optional: request body"
+        header:
+          type: object
+          additionalProperties:
+            type: string
+          description: Key-value pairs of the request headers.
+        method:
+          type: string
+          description: "HTTP method (GET, POST, etc.), indicating the request's action\
+            \ type."
+        url:
+          type: string
+          description: The URL the request is made to.
+    common.JSONResult:
+      type: object
+    common.NumberRequest:
+      type: object
+      properties:
+        number:
+          type: integer
+          example: 100
+    common.RestGetAllConfigResponse:
+      type: object
+      properties:
+        config:
+          type: array
+          description: Name string     `json:"name"`
+          items:
+            $ref: '#/components/schemas/model.ConfigInfo'
+    common.RestGetAllNsResponse:
+      type: object
+      properties:
+        ns:
+          type: array
+          description: Name string     `json:"name"`
+          items:
+            $ref: '#/components/schemas/model.NsInfo'
+    common.RestInspectResourcesRequest:
+      type: object
+      properties:
+        connectionName:
+          type: string
+          example: aws-ap-southeast-1
+        resourceType:
+          type: string
+          example: vNet
+          enum:
+          - vNet
+          - securityGroup
+          - sshKey
+          - vm
+    common.RestRegisterCspNativeResourcesRequest:
+      type: object
+      properties:
+        connectionName:
+          type: string
+          example: aws-ap-southeast-1
+        mciName:
+          type: string
+          example: csp
+        nsId:
+          type: string
+          example: default
+    common.RestRegisterCspNativeResourcesRequestAll:
+      type: object
+      properties:
+        mciName:
+          type: string
+          example: csp
+        nsId:
+          type: string
+          example: default
+    common.TbConnectionName:
+      type: object
+      properties:
+        connectionName:
+          type: string
+    infra.JSONResult:
+      type: object
+    infra.RestGetAllBenchmarkRequest:
+      type: object
+      properties:
+        host:
+          type: string
+    infra.RestGetAllMciPolicyResponse:
+      type: object
+      properties:
+        mciPolicy:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.MciPolicyInfo'
+    infra.RestGetAllMciResponse:
+      type: object
+      properties:
+        mci:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbMciInfo'
+    infra.RestGetAllMciStatusResponse:
+      type: object
+      properties:
+        mci:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.MciStatusInfo'
+    infra.RestGetAllNLBResponse:
+      type: object
+      properties:
+        nlb:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbNLBInfo'
+    infra.RestGetBenchmarkRequest:
+      type: object
+      properties:
+        host:
+          type: string
+    label.ResourcesResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            type: object
+    model.AgentInstallContent:
+      type: object
+      properties:
+        mciId:
+          type: string
+        result:
+          type: string
+        vmId:
+          type: string
+        vmIp:
+          type: string
+    model.AgentInstallContentWrapper:
+      type: object
+      properties:
+        resultArray:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.AgentInstallContent'
+    model.AlibabaSpecificProperty:
+      type: object
+      properties:
+        bgpAsn:
+          type: string
+          example: "65532"
+          default: "65532"
+    model.AutoAction:
+      type: object
+      properties:
+        actionType:
+          type: string
+          example: ScaleOut
+          enum:
+          - ScaleOut
+          - ScaleIn
+        placementAlgo:
+          type: string
+          example: random
+        postCommand:
+          type: object
+          description: PostCommand is field for providing command to VMs after its
+            creation. example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh
+            -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
+          allOf:
+          - $ref: '#/components/schemas/model.MciCmdReq'
+        vmDynamicReq:
+          $ref: '#/components/schemas/model.TbVmDynamicReq'
+    model.AutoCondition:
+      type: object
+      properties:
+        evaluationPeriod:
+          type: string
+          example: "10"
+        evaluationValue:
+          type: array
+          items:
+            type: string
+        metric:
+          type: string
+          example: cpu
+        operand:
+          type: string
+          example: "80"
+        operator:
+          type: string
+          example: '>='
+          enum:
+          - <
+          - <=
+          - '>'
+          - '>='
+    model.AwsSpecificProperty:
+      type: object
+      properties:
+        bgpAsn:
+          type: string
+          example: "64512"
+          default: "64512"
+    model.AzureSpecificProperty:
+      type: object
+      properties:
+        bgpAsn:
+          type: string
+          example: "65531"
+          default: "65531"
+        gatewaySubnetCidr:
+          type: string
+          example: xxx.xxx.xxx.xxx/xx
+        vpnSku:
+          type: string
+          example: VpnGw1AZ
+          default: VpnGw1AZ
+    model.BastionNode:
+      type: object
+      properties:
+        mciId:
+          type: string
+        vmId:
+          type: string
+    model.BenchmarkInfo:
+      type: object
+      properties:
+        desc:
+          type: string
+        elapsed:
+          type: string
+        regionName:
+          type: string
+        result:
+          type: string
+        resultarray:
+          type: array
+          description: struct-element cycle ?
+          items:
+            $ref: '#/components/schemas/model.BenchmarkInfo'
+        specid:
+          type: string
+        unit:
+          type: string
+    model.BenchmarkInfoArray:
+      type: object
+      properties:
+        resultarray:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.BenchmarkInfo'
+    model.CSPDetail:
+      type: object
+      properties:
+        description:
+          type: string
+        driver:
+          type: string
+        links:
+          type: array
+          items:
+            type: string
+        regions:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/model.RegionDetail'
+    model.CheckK8sClusterDynamicReqInfo:
+      required:
+      - reqCheck
+      type: object
+      properties:
+        reqCheck:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.CheckNodeDynamicReqInfo'
+    model.CheckMciDynamicReqInfo:
+      required:
+      - reqCheck
+      type: object
+      properties:
+        reqCheck:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.CheckVmDynamicReqInfo'
+    model.CheckNodeDynamicReqInfo:
+      type: object
+      properties:
+        connectionConfigCandidates:
+          type: array
+          description: ConnectionConfigCandidates will provide ConnectionConfig options
+          items:
+            type: string
+        image:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbImageInfo'
+        region:
+          $ref: '#/components/schemas/model.RegionDetail'
+        spec:
+          $ref: '#/components/schemas/model.TbSpecInfo'
+        systemMessage:
+          type: string
+          description: Latest system message such as error message
+          example: Failed because ...
+    model.CheckVmDynamicReqInfo:
+      type: object
+      properties:
+        connectionConfigCandidates:
+          type: array
+          description: ConnectionConfigCandidates will provide ConnectionConfig options
+          items:
+            type: string
+        image:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbImageInfo'
+        region:
+          $ref: '#/components/schemas/model.RegionDetail'
+        spec:
+          $ref: '#/components/schemas/model.TbSpecInfo'
+        systemMessage:
+          type: string
+          description: Latest system message such as error message
+          example: Failed because ...
+    model.CloudInfo:
+      type: object
+      properties:
+        csps:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/model.CSPDetail'
+    model.ConfigInfo:
+      type: object
+      properties:
+        id:
+          type: string
+          example: TB_SPIDER_REST_URL
+        name:
+          type: string
+          example: TB_SPIDER_REST_URL
+        value:
+          type: string
+          example: http://localhost:1024/spider
+    model.ConfigReq:
+      type: object
+      properties:
+        name:
+          type: string
+          example: TB_SPIDER_REST_URL
+        value:
+          type: string
+          example: http://localhost:1024/spider
+    model.ConnConfig:
+      type: object
+      properties:
+        configName:
+          type: string
+        credentialHolder:
+          type: string
+        credentialName:
+          type: string
+        driverName:
+          type: string
+        providerName:
+          type: string
+        regionDetail:
+          $ref: '#/components/schemas/model.RegionDetail'
+        regionRepresentative:
+          type: boolean
+        regionZoneInfo:
+          $ref: '#/components/schemas/model.RegionZoneInfo'
+        regionZoneInfoName:
+          type: string
+        verified:
+          type: boolean
+    model.ConnConfigList:
+      type: object
+      properties:
+        connectionconfig:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.ConnConfig'
+    model.CredentialInfo:
+      type: object
+      properties:
+        allConnections:
+          $ref: '#/components/schemas/model.ConnConfigList'
+        credentialHolder:
+          type: string
+        credentialName:
+          type: string
+        keyValueInfoList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        providerName:
+          type: string
+    model.CredentialReq:
+      type: object
+      properties:
+        credentialHolder:
+          type: string
+          description: CredentialHolder is the entity or user that holds the credential.
+          example: admin
+        credentialKeyValueList:
+          type: array
+          description: CredentialKeyValueList contains key-(encrypted)value pairs
+            that include the sensitive credential data.
+          items:
+            $ref: '#/components/schemas/model.KeyWithEncryptedValue'
+        encryptedClientAesKeyByPublicKey:
+          type: string
+          description: EncryptedClientAesKeyByPublicKey is the client temporary AES
+            key encrypted with the RSA public key.
+          example: ZzXL27hbAUDT0ohglf2Gwr60sAqdPw3+CnCsn0RJXeiZxXnHfW03mFx5RaSfbwtPYCq1h6wwv7XsiWzfFmr02...
+        providerName:
+          type: string
+          description: "ProviderName specifies the cloud provider associated with\
+            \ the credential (e.g., AWS, GCP)."
+          example: aws
+        publicKeyTokenId:
+          type: string
+          description: PublicKeyTokenId is the unique token ID used to retrieve the
+            corresponding private key for decryption.
+          example: cr31av30uphc738d7h0g
+      description: "CredentialReq contains the necessary information to register a\
+        \ credential. This includes the AES key encrypted with the RSA public key,\
+        \ which is then used to decrypt the AES key on the server side."
+    model.CspSpecificProperty:
+      type: object
+      properties:
+        alibaba:
+          $ref: '#/components/schemas/model.AlibabaSpecificProperty'
+        aws:
+          $ref: '#/components/schemas/model.AwsSpecificProperty'
+        azure:
+          $ref: '#/components/schemas/model.AzureSpecificProperty'
+        gcp:
+          $ref: '#/components/schemas/model.GcpSpecificProperty'
+    model.CustomImageStatus:
+      type: string
+      enum:
+      - Available
+      - Unavailable
+      x-enum-varnames:
+      - MyImageAvailable
+      - MyImageUnavailable
+    model.DeploymentPlan:
+      type: object
+      properties:
+        filter:
+          $ref: '#/components/schemas/model.FilterInfo'
+        limit:
+          type: string
+          example: "5"
+          enum:
+          - "1"
+          - "2"
+          - "30"
+        priority:
+          $ref: '#/components/schemas/model.PriorityInfo'
+    model.DiskStatus:
+      type: string
+      enum:
+      - Creating
+      - Available
+      - Attached
+      - Deleting
+      - Error
+      x-enum-varnames:
+      - DiskCreating
+      - DiskAvailable
+      - DiskAttached
+      - DiskDeleting
+      - DiskError
+    model.FilterCondition:
+      type: object
+      properties:
+        condition:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.Operation'
+        metric:
+          type: string
+          example: vCPU
+          enum:
+          - vCPU
+          - memoryGiB
+          - costPerHour
+    model.FilterInfo:
+      type: object
+      properties:
+        policy:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.FilterCondition'
+    model.FilterSpecsByRangeRequest:
+      type: object
+      properties:
+        acceleratorCount:
+          $ref: '#/components/schemas/model.Range'
+        acceleratorMemoryGB:
+          $ref: '#/components/schemas/model.Range'
+        acceleratorModel:
+          type: string
+        acceleratorType:
+          type: string
+        architecture:
+          type: string
+        connectionName:
+          type: string
+        costPerHour:
+          $ref: '#/components/schemas/model.Range'
+        cspSpecName:
+          type: string
+        description:
+          type: string
+        diskSizeGB:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore01:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore02:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore03:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore04:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore05:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore06:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore07:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore08:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore09:
+          $ref: '#/components/schemas/model.Range'
+        evaluationScore10:
+          $ref: '#/components/schemas/model.Range'
+        evaluationStatus:
+          type: string
+        id:
+          type: string
+        infraType:
+          type: string
+        maxTotalStorageTiB:
+          $ref: '#/components/schemas/model.Range'
+        memoryGiB:
+          $ref: '#/components/schemas/model.Range'
+        name:
+          type: string
+        netBwGbps:
+          $ref: '#/components/schemas/model.Range'
+        osType:
+          type: string
+        providerName:
+          type: string
+        regionName:
+          type: string
+        vCPU:
+          $ref: '#/components/schemas/model.Range'
+    model.GcpSpecificProperty:
+      type: object
+      properties:
+        bgpAsn:
+          type: string
+          example: "65530"
+          default: "65530"
+    model.IID:
+      required:
+      - NameId
+      - SystemId
+      type: object
+      properties:
+        NameId:
+          type: string
+          example: user-defined-name
+        SystemId:
+          type: string
+          example: csp-defined-id
+    model.IdList:
+      type: object
+      properties:
+        output:
+          type: array
+          items:
+            type: string
+    model.ImageFetchOption:
+      type: object
+      properties:
+        excludedProviders:
+          type: array
+          description: "providers need to be excluded from the image fetching operation\
+            \ (ex: [\"azure\"])"
+          example:
+          - azure
+          items:
+            type: string
+        regionAgnosticProviders:
+          type: array
+          description: "providers that are not region-specific (ex: [\"gcp\"])"
+          example:
+          - gcp
+          - tencent
+          items:
+            type: string
+    model.ImageStatus:
+      type: string
+      enum:
+      - Available
+      - Unavailable
+      - Deprecated
+      - NA
+      x-enum-varnames:
+      - ImageAvailable
+      - ImageUnavailable
+      - ImageDeprecated
+      - ImageNA
+    model.InspectResource:
+      type: object
+      properties:
+        connectionName:
+          type: string
+        resourceOverview:
+          $ref: '#/components/schemas/model.ResourceCountOverview'
+        resourceType:
+          type: string
+        resources:
+          $ref: '#/components/schemas/model.ResourcesByManageType'
+        systemMessage:
+          type: string
+    model.InspectResourceAllResult:
+      type: object
+      properties:
+        availableConnection:
+          type: integer
+        cspOnlyOverview:
+          $ref: '#/components/schemas/model.inspectOverview'
+        elapsedTime:
+          type: integer
+        inspectResult:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.InspectResourceResult'
+        registeredConnection:
+          type: integer
+        tumblebugOverview:
+          $ref: '#/components/schemas/model.inspectOverview'
+    model.InspectResourceResult:
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspOnlyOverview:
+          $ref: '#/components/schemas/model.inspectOverview'
+        elapsedTime:
+          type: integer
+        systemMessage:
+          type: string
+        tumblebugOverview:
+          $ref: '#/components/schemas/model.inspectOverview'
+    model.K8sClusterConnectionConfigCandidatesReq:
+      required:
+      - commonSpec
+      type: object
+      properties:
+        commonSpec:
+          type: array
+          description: CommonSpec is field for id of a spec in common namespace
+          example:
+          - tencent+ap-seoul+S2.MEDIUM4
+          items:
+            type: string
+    model.K8sClusterDetail:
+      type: object
+      properties:
+        node_image_designation:
+          type: boolean
+        node_images:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.K8sClusterNodeImageDetail'
+        nodegroup_naming_rule:
+          type: string
+        nodegroups_on_creation:
+          type: boolean
+        required_subnet_count:
+          type: integer
+        root_disks:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.K8sClusterRootDiskDetail'
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.K8sClusterVersionDetail'
+    model.K8sClusterInfo:
+      type: object
+      properties:
+        k8s_cluster:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/model.K8sClusterDetail'
+    model.K8sClusterNodeGroupsOnCreation:
+      type: object
+      properties:
+        result:
+          type: string
+          example: "true"
+    model.K8sClusterNodeImageDesignation:
+      type: object
+      properties:
+        result:
+          type: string
+          example: "true"
+    model.K8sClusterNodeImageDetail:
+      type: object
+      properties:
+        availables:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.K8sClusterNodeImageDetailAvailable'
+        region:
+          type: array
+          items:
+            type: string
+    model.K8sClusterNodeImageDetailAvailable:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    model.K8sClusterRequiredSubnetCount:
+      type: object
+      properties:
+        result:
+          type: string
+          example: "1"
+    model.K8sClusterRootDiskDetail:
+      type: object
+      properties:
+        region:
+          type: array
+          items:
+            type: string
+        size:
+          $ref: '#/components/schemas/model.K8sClusterRootDiskDetailSize'
+        type:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.K8sClusterRootDiskDetailType'
+    model.K8sClusterRootDiskDetailSize:
+      type: object
+      properties:
+        max:
+          type: integer
+        min:
+          type: integer
+    model.K8sClusterRootDiskDetailType:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    model.K8sClusterVersionDetail:
+      type: object
+      properties:
+        availables:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.K8sClusterVersionDetailAvailable'
+        region:
+          type: array
+          items:
+            type: string
+    model.K8sClusterVersionDetailAvailable:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 1.30.1-aliyun.1
+        name:
+          type: string
+          example: "1.30"
+    model.KeyValue:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+    model.KeyWithEncryptedValue:
+      type: object
+      properties:
+        key:
+          type: string
+          description: Key for the value
+        value:
+          type: string
+          description: Should be encrypted by the public key issued by GET /credential/publicKey
+    model.Label:
+      type: object
+      properties:
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+    model.LabelInfo:
+      type: object
+      properties:
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        resourceKey:
+          type: string
+    model.Location:
+      type: object
+      properties:
+        display:
+          type: string
+        latitude:
+          type: number
+        longitude:
+          type: number
+    model.McNetConfigurationDetails:
+      type: object
+      properties:
+        csp:
+          type: string
+        regions:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.RegionDetails'
+    model.McNlbInfo:
+      type: object
+      properties:
+        deploymentLog:
+          $ref: '#/components/schemas/model.MciSshCmdResult'
+        mcNlbHostInfo:
+          $ref: '#/components/schemas/model.TbMciInfo'
+        mciAccessInfo:
+          $ref: '#/components/schemas/model.MciAccessInfo'
+    model.MciAccessInfo:
+      type: object
+      properties:
+        mciId:
+          type: string
+        mciNlbListener:
+          $ref: '#/components/schemas/model.MciAccessInfo'
+        mciSubGroupAccessInfo:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.MciSubGroupAccessInfo'
+    model.MciCmdReq:
+      required:
+      - command
+      type: object
+      properties:
+        command:
+          type: array
+          example:
+          - "client_ip=$(echo $SSH_CLIENT | awk '{print $1}'); echo SSH client IP\
+            \ is: $client_ip"
+          items:
+            type: string
+        userName:
+          type: string
+          example: cb-user
+    model.MciConnectionConfigCandidatesReq:
+      required:
+      - commonSpec
+      type: object
+      properties:
+        commonSpec:
+          type: array
+          description: CommonSpec is field for id of a spec in common namespace
+          example:
+          - aws+ap-northeast-2+t2.small
+          - gcp+us-west1+g1-small
+          items:
+            type: string
+    model.MciPolicyInfo:
+      type: object
+      properties:
+        Id:
+          type: string
+          description: MCI Id (generated ID by the Name)
+        Name:
+          type: string
+          description: MCI Name (for request)
+        actionLog:
+          type: string
+        description:
+          type: string
+          example: Description
+        policy:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.Policy'
+    model.MciPolicyReq:
+      type: object
+      properties:
+        description:
+          type: string
+          example: Description
+        policy:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.Policy'
+    model.MciSshCmdResult:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SshCmdResult'
+    model.MciStatusInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        installMonAgent:
+          type: string
+          description: "InstallMonAgent Option for CB-Dragonfly agent installation\
+            \ ([yes/no] default:yes)"
+          example: "[yes, no]"
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        masterIp:
+          type: string
+          example: 32.201.134.113
+        masterSSHPort:
+          type: string
+        masterVmId:
+          type: string
+          example: vm-asiaeast1-cb-01
+        name:
+          type: string
+        status:
+          type: string
+        statusCount:
+          $ref: '#/components/schemas/model.StatusCountInfo'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the mci in a keyword (any string
+            can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        targetAction:
+          type: string
+        targetStatus:
+          type: string
+        vm:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbVmStatusInfo'
+    model.MciSubGroupAccessInfo:
+      type: object
+      properties:
+        bastionVmId:
+          type: string
+        mciVmAccessInfo:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.MciVmAccessInfo'
+        nlbListener:
+          $ref: '#/components/schemas/model.TbNLBListenerInfo'
+        subGroupId:
+          type: string
+    model.MciVmAccessInfo:
+      type: object
+      properties:
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        privateIP:
+          type: string
+        privateKey:
+          type: string
+        publicIP:
+          type: string
+        sshPort:
+          type: string
+        vmId:
+          type: string
+        vmUserName:
+          type: string
+        vmUserPassword:
+          type: string
+    model.MonResultSimple:
+      type: object
+      properties:
+        err:
+          type: string
+        metric:
+          type: string
+        value:
+          type: string
+        vmId:
+          type: string
+    model.MonResultSimpleResponse:
+      type: object
+      properties:
+        mciId:
+          type: string
+        mciMonitoring:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.MonResultSimple'
+        nsId:
+          type: string
+    model.NLBListenerReq:
+      type: object
+      properties:
+        port:
+          type: string
+          description: 1-65535
+          example: "80"
+        protocol:
+          type: string
+          description: TCP|UDP
+          example: TCP
+    model.NsInfo:
+      type: object
+      properties:
+        description:
+          type: string
+          example: Description for this namespace
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: default
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: default
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+    model.NsReq:
+      type: object
+      properties:
+        description:
+          type: string
+          example: Description for this namespace
+        name:
+          type: string
+          example: default
+    model.OSArchitecture:
+      type: string
+      enum:
+      - arm32
+      - arm64
+      - arm64_mac
+      - x86_32
+      - x86_64
+      - x86_32_mac
+      - x86_64_mac
+      - s390x
+      - NA
+      - ""
+      x-enum-varnames:
+      - ARM32
+      - ARM64
+      - ARM64_MAC
+      - X86_32
+      - X86_64
+      - X86_32_MAC
+      - X86_64_MAC
+      - S390X
+      - ArchitectureNA
+      - ArchitectureUnknown
+    model.OSPlatform:
+      type: string
+      enum:
+      - Linux/UNIX
+      - Windows
+      - NA
+      x-enum-varnames:
+      - Linux_UNIX
+      - Windows
+      - PlatformNA
+    model.ObjectStorageInfo:
+      type: object
+      properties:
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+        details:
+          type: object
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: sqldb01
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: sqldb01
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        status:
+          type: string
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+    model.Operation:
+      type: object
+      properties:
+        operand:
+          type: string
+          description: "10, 70, 80, 98, ..."
+          example: "4"
+          enum:
+          - "4"
+          - "8"
+          - ..
+        operator:
+          type: string
+          description: ">=, <=, =="
+          example: <=
+          enum:
+          - '>='
+          - <=
+          - ==
+    model.ParameterKeyVal:
+      type: object
+      properties:
+        key:
+          type: string
+          description: coordinate
+          example: coordinateClose
+          enum:
+          - coordinateClose
+          - coordinateWithin
+          - coordinateFair
+        val:
+          type: array
+          description: "[\"Latitude,Longitude\",\"12,543\",..,\"31,433\"]"
+          example:
+          - 44.146838/-116.411403
+          items:
+            type: string
+    model.Policy:
+      type: object
+      properties:
+        autoAction:
+          $ref: '#/components/schemas/model.AutoAction'
+        autoCondition:
+          $ref: '#/components/schemas/model.AutoCondition'
+        status:
+          type: string
+    model.PriorityCondition:
+      type: object
+      properties:
+        metric:
+          type: string
+          example: location
+          enum:
+          - location
+          - cost
+          - random
+          - performance
+          - latency
+        parameter:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.ParameterKeyVal'
+        weight:
+          type: string
+          example: "0.3"
+          enum:
+          - "0.1"
+          - "0.2"
+          - '...'
+    model.PriorityInfo:
+      type: object
+      properties:
+        policy:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.PriorityCondition'
+    model.PublicKeyResponse:
+      type: object
+      properties:
+        publicKey:
+          type: string
+        publicKeyTokenId:
+          type: string
+    model.Range:
+      type: object
+      properties:
+        max:
+          type: number
+        min:
+          type: number
+    model.RegionDetail:
+      type: object
+      properties:
+        description:
+          type: string
+        location:
+          $ref: '#/components/schemas/model.Location'
+        regionId:
+          type: string
+        regionName:
+          type: string
+        zones:
+          type: array
+          items:
+            type: string
+    model.RegionDetails:
+      type: object
+      properties:
+        name:
+          type: string
+        vNets:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.VNetDetails'
+    model.RegionInfo:
+      type: object
+      properties:
+        region:
+          type: string
+        zone:
+          type: string
+    model.RegionList:
+      type: object
+      properties:
+        regions:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.RegionDetail'
+    model.RegionZoneInfo:
+      type: object
+      properties:
+        assignedRegion:
+          type: string
+        assignedZone:
+          type: string
+    model.RegisterResourceAllResult:
+      type: object
+      properties:
+        availableConnection:
+          type: integer
+        elapsedTime:
+          type: integer
+        registerationOverview:
+          $ref: '#/components/schemas/model.RegisterationOverview'
+        registerationResult:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.RegisterResourceResult'
+        registeredConnection:
+          type: integer
+    model.RegisterResourceResult:
+      type: object
+      properties:
+        connectionName:
+          type: string
+        elapsedTime:
+          type: integer
+        registerationOutputs:
+          $ref: '#/components/schemas/model.IdList'
+        registerationOverview:
+          $ref: '#/components/schemas/model.RegisterationOverview'
+        systemMessage:
+          type: string
+    model.RegisterationOverview:
+      type: object
+      properties:
+        customImage:
+          type: integer
+        dataDisk:
+          type: integer
+        failed:
+          type: integer
+        nlb:
+          type: integer
+        securityGroup:
+          type: integer
+        sshKey:
+          type: integer
+        vNet:
+          type: integer
+        vm:
+          type: integer
+    model.RequiredAWSResourceForSqlDB:
+      type: object
+      properties:
+        subnet1ID:
+          type: string
+          example: subnet-xxxx
+        subnet2ID:
+          type: string
+          example: subnet-xxxx in different AZ
+        vNetID:
+          type: string
+          example: vpc-xxxxx
+    model.RequiredAzureResourceForObjectStorage:
+      type: object
+      properties:
+        resourceGroup:
+          type: string
+          example: koreacentral
+    model.RequiredAzureResourceForSqlDB:
+      type: object
+      properties:
+        resourceGroup:
+          type: string
+          example: koreacentral
+    model.RequiredCSPResourceForObjectStorage:
+      type: object
+      properties:
+        azure:
+          type: object
+          description: "AWS   RequiredAWSResourceForObjectStorage   `json:\"aws,omitempty\"\
+            `"
+          allOf:
+          - $ref: '#/components/schemas/model.RequiredAzureResourceForObjectStorage'
+    model.RequiredCSPResourceForSqlDB:
+      type: object
+      properties:
+        aws:
+          $ref: '#/components/schemas/model.RequiredAWSResourceForSqlDB'
+        azure:
+          $ref: '#/components/schemas/model.RequiredAzureResourceForSqlDB'
+        ncp:
+          $ref: '#/components/schemas/model.RequiredNCPResourceForSqlDB'
+    model.RequiredNCPResourceForSqlDB:
+      type: object
+      properties:
+        subnetID:
+          type: string
+          example: "123456"
+    model.ResourceCountOverview:
+      type: object
+      properties:
+        onCspOnly:
+          type: integer
+        onCspTotal:
+          type: integer
+        onSpider:
+          type: integer
+        onTumblebug:
+          type: integer
+    model.ResourceDetail:
+      type: object
+      properties:
+        cspResourceDetail:
+          type: object
+          description: CspResourceDetail is the detailed information of the resource
+            provided from the terrarium.
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        status:
+          type: string
+    model.ResourceOnCsp:
+      type: object
+      properties:
+        count:
+          type: integer
+        info:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.ResourceOnCspInfo'
+    model.ResourceOnCspInfo:
+      type: object
+      properties:
+        cspResourceId:
+          type: string
+        refNameOrId:
+          type: string
+    model.ResourceOnSpider:
+      type: object
+      properties:
+        count:
+          type: integer
+        info:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.ResourceOnSpiderInfo'
+    model.ResourceOnSpiderInfo:
+      type: object
+      properties:
+        cspResourceId:
+          type: string
+        idBySp:
+          type: string
+    model.ResourceOnTumblebug:
+      type: object
+      properties:
+        count:
+          type: integer
+        info:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.ResourceOnTumblebugInfo'
+    model.ResourceOnTumblebugInfo:
+      type: object
+      properties:
+        cspResourceId:
+          type: string
+        idByTb:
+          type: string
+        mciId:
+          type: string
+        nsId:
+          type: string
+        objectKey:
+          type: string
+    model.ResourcesByManageType:
+      type: object
+      properties:
+        onCspOnly:
+          $ref: '#/components/schemas/model.ResourceOnCsp'
+        onCspTotal:
+          $ref: '#/components/schemas/model.ResourceOnCsp'
+        onSpider:
+          $ref: '#/components/schemas/model.ResourceOnSpider'
+        onTumblebug:
+          $ref: '#/components/schemas/model.ResourceOnTumblebug'
+    model.Response:
+      type: object
+      properties:
+        details:
+          type: string
+          example: Any details
+        list:
+          type: array
+          items:
+            type: object
+        message:
+          type: string
+          example: Any message
+        object:
+          type: object
+          additionalProperties: true
+        status:
+          type: integer
+          example: 200
+        success:
+          type: boolean
+          example: true
+    model.RestPostObjectStorageRequest:
+      required:
+      - connectionName
+      - csp
+      - name
+      - region
+      type: object
+      properties:
+        connectionName:
+          type: string
+          example: aws-ap-northeast-2
+        csp:
+          type: string
+          example: aws
+        name:
+          type: string
+          example: objectstorage01
+        region:
+          type: string
+          example: ap-northeast-2
+        requiredCSPResource:
+          $ref: '#/components/schemas/model.RequiredCSPResourceForObjectStorage'
+    model.RestPostSqlDBRequest:
+      required:
+      - connectionName
+      - csp
+      - dbAdminPassword
+      - dbAdminUsername
+      - dbEnginePort
+      - dbEngineVersion
+      - dbInstanceSpec
+      - name
+      - region
+      type: object
+      properties:
+        connectionName:
+          type: string
+          example: aws-ap-northeast-2
+        csp:
+          type: string
+          example: aws
+        dbAdminPassword:
+          type: string
+          example: Password1234!
+        dbAdminUsername:
+          type: string
+          example: mydbadmin
+        dbEnginePort:
+          type: integer
+          example: 3306
+        dbEngineVersion:
+          type: string
+          example: 8.0.39
+        dbInstanceSpec:
+          type: string
+          example: db.t3.micro
+        name:
+          type: string
+          example: sqldb01
+        region:
+          type: string
+          example: ap-northeast-2
+        requiredCSPResource:
+          $ref: '#/components/schemas/model.RequiredCSPResourceForSqlDB'
+    model.RestPostVpnRequest:
+      required:
+      - name
+      - site1
+      - site2
+      type: object
+      properties:
+        name:
+          type: string
+          example: vpn01
+        site1:
+          $ref: '#/components/schemas/model.SiteProperty'
+        site2:
+          $ref: '#/components/schemas/model.SiteProperty'
+    model.RetrievedRegionList:
+      type: object
+      properties:
+        region:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SpiderRegionZoneInfo'
+    model.SearchImageRequest:
+      type: object
+      properties:
+        detailSearchKeys:
+          type: array
+          description: |-
+            Keywords for searching images in detail.
+            Space-separated for AND condition (ex: "sql 2022", "ubuntu 22.04", etc.).
+            Used for if the user wants to search images with specific keywords in their details.
+          example:
+          - tensorflow
+          - "2.17"
+          items:
+            type: string
+        includeBasicImageOnly:
+          type: boolean
+          description: |-
+            IncludeBasicImageOnly is to return basic OS distribution only without additional applications.
+            If true, the search results will include only the basic OS distribution without additional applications.
+            If false or not specified, the search results will include images with additional applications installed.
+          example: false
+        includeDeprecatedImage:
+          type: boolean
+          description: |-
+            Whether the search results should include deprecated images or not.
+            If not specified, deprecated images will not be included in the search results.
+            In usual, deprecated images are not recommended to use, but they can be used if necessary.
+          example: false
+        isGPUImage:
+          type: boolean
+          description: |-
+            Whether the image is ready for GPU usage or not.
+            In usual, true means the image is ready for GPU usage with GPU drivers and libraries installed.
+            If not specified, both true and false images will be included in the search results.
+            Even if the image is not ready for GPU usage, it can be used with GPU by installing GPU drivers and libraries manually.
+          example: false
+        isKubernetesImage:
+          type: boolean
+          description: |-
+            Whether the image is specialized image only for Kubernetes nodes.
+            If not specified, both true and false images will be included in the search results.
+            Images that are not specialized for Kubernetes also can be used as Kubernetes nodes. It depends on CSPs.
+          example: false
+        isRegisteredByAsset:
+          type: boolean
+          description: Whether the image is registered by CB-Tumblebug asset file
+            or not.
+          example: false
+        maxResults:
+          type: integer
+          description: |-
+            MaxResults is the maximum number of images to be returned in the search results.
+            If not specified, all images will be returned.
+            If specified, the number of images returned will be limited to the specified value.
+          example: 100
+        osArchitecture:
+          type: object
+          description: "The architecture of the operating system of the image. (ex:\
+            \ \"x86_64\", \"arm64\", etc.)"
+          example: x86_64
+          allOf:
+          - $ref: '#/components/schemas/model.OSArchitecture'
+        osType:
+          type: string
+          description: "Simplified OS name and version string. Space-separated for\
+            \ AND condition (ex: \"ubuntu 22.04\", \"windows 10\", etc.)."
+          example: ubuntu 22.04
+        providerName:
+          type: string
+          description: "Cloud Service Provider (ex: \"aws\", \"azure\", \"gcp\", etc.).\
+            \ Use GET /provider to get the list of available providers."
+          example: aws
+        regionName:
+          type: string
+          description: "Cloud Service Provider Region (ex: \"us-east-1\", \"us-west-2\"\
+            , etc.). Use GET /provider/{providerName}/region to get the list of available\
+            \ regions."
+          example: us-east-1
+    model.SearchImageRequestOptions:
+      type: object
+      properties:
+        detailSearchKeys:
+          type: array
+          description: |-
+            Keywords for searching images in detail.
+            Space-separated for AND condition (ex: "sql 2022", "ubuntu 22.04", etc.).
+            Used for if the user wants to search images with specific keywords in their details.
+          items:
+            type: array
+            items:
+              type: string
+        includeDeprecatedImage:
+          type: array
+          description: |-
+            Whether the search results should include deprecated images or not.
+            If not specified, deprecated images will not be included in the search results.
+            In usual, deprecated images are not recommended to use, but they can be used if necessary.
+          items:
+            type: boolean
+        isGPUImage:
+          type: array
+          description: |-
+            Whether the image is ready for GPU usage or not.
+            In usual, true means the image is ready for GPU usage with GPU drivers and libraries installed.
+            If not specified, both true and false images will be included in the search results.
+            Even if the image is not ready for GPU usage, it can be used with GPU by installing GPU drivers and libraries manually.
+          items:
+            type: boolean
+        isKubernetesImage:
+          type: array
+          description: |-
+            Whether the image is specialized image only for Kubernetes nodes.
+            If not specified, both true and false images will be included in the search results.
+            Images that are not specialized for Kubernetes also can be used as Kubernetes nodes. It depends on CSPs.
+          items:
+            type: boolean
+        isRegisteredByAsset:
+          type: array
+          description: Whether the image is registered by CB-Tumblebug asset file
+            or not.
+          items:
+            type: boolean
+        maxResults:
+          type: array
+          description: |-
+            MaxResults is the maximum number of images to be returned in the search results.
+            If not specified, all images will be returned.
+            If specified, the number of images returned will be limited to the specified value.
+          example:
+          - 100
+          items:
+            type: integer
+        osArchitecture:
+          type: array
+          description: "The architecture of the operating system of the image. (ex:\
+            \ \"x86_64\", \"arm64\", etc.)"
+          items:
+            type: string
+        osType:
+          type: array
+          description: "Simplified OS name and version string. Space-separated for\
+            \ AND condition (ex: \"ubuntu 22.04\", \"windows 10\", etc.)."
+          items:
+            type: string
+        providerName:
+          type: array
+          description: "Cloud Service Provider (ex: \"aws\", \"azure\", \"gcp\", etc.).\
+            \ Use GET /provider to get the list of available providers."
+          items:
+            type: string
+        regionName:
+          type: array
+          description: "Cloud Service Provider Region (ex: \"us-east-1\", \"us-west-2\"\
+            , etc.). Use GET /provider/{providerName}/region to get the list of available\
+            \ regions."
+          items:
+            type: string
+    model.SearchImageResponse:
+      type: object
+      properties:
+        imageCount:
+          type: integer
+        imageList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbImageInfo'
+    model.SimpleMsg:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Any message
+    model.SiteDetail:
+      type: object
+      properties:
+        connectionName:
+          type: string
+          example: aws-ap-northeast-2
+        csp:
+          type: string
+          example: aws
+        gatewaySubnetCidr:
+          type: string
+          description: "SubnetId          string `json:\"subnet,omitempty\" example:\"\
+            subnet-xxxxx\"`"
+          example: xxx.xxx.xxx.xxx/xx
+        region:
+          type: string
+          example: ap-northeast-2
+        resourceGroup:
+          type: string
+          example: rg-xxxxx
+        vnet:
+          type: string
+          description: "Zone              string `json:\"zone,omitempty\" example:\"\
+            ap-northeast-2a\"`"
+          example: vpc-xxxxx
+    model.SiteProperty:
+      type: object
+      properties:
+        cspSpecificProperty:
+          $ref: '#/components/schemas/model.CspSpecificProperty'
+        vNetId:
+          type: string
+          example: vnet01
+    model.SitesInfo:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 3
+        mciId:
+          type: string
+          example: mci-01
+        nsId:
+          type: string
+          example: ns-01
+        sites:
+          $ref: '#/components/schemas/model.sites'
+    model.SpecFetchOption:
+      type: object
+      properties:
+        excludedProviders:
+          type: array
+          description: "providers need to be excluded from the spec fetching operation\
+            \ (ex: [\"azure\"])"
+          example:
+          - azure
+          items:
+            type: string
+        regionAgnosticProviders:
+          type: array
+          description: "providers that are not region-specific (ex: [\"gcp\"])"
+          example:
+          - gcp
+          - tencent
+          items:
+            type: string
+    model.SpiderAccessInfo:
+      type: object
+      properties:
+        endpoint:
+          type: string
+          description: ex) https://1.2.3.4:6443
+        kubeconfig:
+          type: string
+    model.SpiderAddonsInfo:
+      type: object
+      properties:
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+    model.SpiderClusterInfo:
+      type: object
+      properties:
+        accessInfo:
+          $ref: '#/components/schemas/model.SpiderAccessInfo'
+        addons:
+          $ref: '#/components/schemas/model.SpiderAddonsInfo'
+        createdTime:
+          type: string
+        iid:
+          type: object
+          description: "{NameId, SystemId}"
+          allOf:
+          - $ref: '#/components/schemas/model.IID'
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        network:
+          $ref: '#/components/schemas/model.SpiderNetworkInfo'
+        nodeGroupList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SpiderNodeGroupInfo'
+        status:
+          $ref: '#/components/schemas/model.SpiderClusterStatus'
+        version:
+          type: string
+          description: "Kubernetes Version, ex) 1.23.3"
+    model.SpiderClusterStatus:
+      type: string
+      enum:
+      - Creating
+      - Active
+      - Inactive
+      - Updating
+      - Deleting
+      x-enum-varnames:
+      - SpiderClusterCreating
+      - SpiderClusterActive
+      - SpiderClusterInactive
+      - SpiderClusterUpdating
+      - SpiderClusterDeleting
+    model.SpiderGpuInfo:
+      required:
+      - Count
+      type: object
+      properties:
+        Count:
+          type: string
+          description: "Number of GPUs, \"-1\" when not applicable"
+          example: "2"
+        MemSizeGB:
+          type: string
+          description: "Memory size of the GPU in GB, \"-1\" when not applicable"
+          example: "12"
+        Mfr:
+          type: string
+          description: "Manufacturer of the GPU, NA when not applicable"
+          example: NVIDIA
+        Model:
+          type: string
+          description: "Model of the GPU, NA when not applicable"
+          example: Tesla K80
+        TotalMemSizeGB:
+          type: string
+          description: "Total Memory size of the GPU in GB, \"-1\" when not applicable"
+          example: "24"
+    model.SpiderImageInfo:
+      type: object
+      properties:
+        IId:
+          type: object
+          description: "{NameId, SystemId}, {ami-00aa5a103ddf4509f, ami-00aa5a103ddf4509f}"
+          allOf:
+          - $ref: '#/components/schemas/model.IID'
+        ImageStatus:
+          type: object
+          description: "Available, Unavailable"
+          example: Available
+          allOf:
+          - $ref: '#/components/schemas/model.ImageStatus'
+        KeyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        Name:
+          type: string
+          description: ami-00aa5a103ddf4509f
+          example: ami-00aa5a103ddf4509f
+        OSArchitecture:
+          type: object
+          description: "arm64, x86_64 etc."
+          example: x86_64
+          allOf:
+          - $ref: '#/components/schemas/model.OSArchitecture'
+        OSDiskSizeGB:
+          type: string
+          description: "10, 50, 100 etc."
+          example: "50"
+        OSDiskType:
+          type: string
+          description: "ebs, HDD, etc."
+          example: HDD
+        OSDistribution:
+          type: string
+          description: "Ubuntu 22.04~, CentOS 8 etc."
+          example: Ubuntu 22.04~
+        OSPlatform:
+          type: object
+          description: "Linux/UNIX, Windows, NA"
+          example: Linux/UNIX
+          allOf:
+          - $ref: '#/components/schemas/model.OSPlatform'
+    model.SpiderImageList:
+      type: object
+      properties:
+        image:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SpiderImageInfo'
+    model.SpiderNetworkInfo:
+      type: object
+      properties:
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        securityGroupIIDs:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.IID'
+        subnetIIDs:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.IID'
+        vpcIID:
+          type: object
+          description: "{NameId, SystemId}"
+          allOf:
+          - $ref: '#/components/schemas/model.IID'
+    model.SpiderNodeGroupInfo:
+      required:
+      - DesiredNodeSize
+      - IId
+      - ImageIID
+      - KeyPairIID
+      - MaxNodeSize
+      - MinNodeSize
+      - OnAutoScaling
+      - Status
+      - VMSpecName
+      type: object
+      properties:
+        DesiredNodeSize:
+          type: integer
+          example: 2
+        IId:
+          type: object
+          description: "{NameId, SystemId}"
+          allOf:
+          - $ref: '#/components/schemas/model.IID'
+        ImageIID:
+          type: object
+          description: VM config.
+          allOf:
+          - $ref: '#/components/schemas/model.IID'
+        KeyPairIID:
+          $ref: '#/components/schemas/model.IID'
+        KeyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        MaxNodeSize:
+          type: integer
+          example: 3
+        MinNodeSize:
+          type: integer
+          example: 1
+        Nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.IID'
+        OnAutoScaling:
+          type: boolean
+          description: Scaling config.
+          example: true
+        RootDiskSize:
+          type: string
+          description: "\"\", \"default\", \"50\", \"1000\" (GB)"
+          example: "50"
+        RootDiskType:
+          type: string
+          description: "\"SSD(gp2)\", \"Premium SSD\", ..."
+        Status:
+          type: object
+          example: Active
+          allOf:
+          - $ref: '#/components/schemas/model.SpiderNodeGroupStatus'
+        VMSpecName:
+          type: string
+          example: t3.medium
+    model.SpiderNodeGroupStatus:
+      type: string
+      enum:
+      - Creating
+      - Active
+      - Inactive
+      - Updating
+      - Deleting
+      x-enum-varnames:
+      - SpiderNodeGroupCreating
+      - SpiderNodeGroupActive
+      - SpiderNodeGroupInactive
+      - SpiderNodeGroupUpdating
+      - SpiderNodeGroupDeleting
+    model.SpiderRegionZoneInfo:
+      type: object
+      properties:
+        availableZoneList:
+          type: array
+          items:
+            type: string
+        keyValueInfoList:
+          type: array
+          description: "ex) { {region, us-east1}, {zone, us-east1-c} }"
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        providerName:
+          type: string
+          description: ex) "GCP"
+        regionName:
+          type: string
+          description: ex) "region01"
+    model.SpiderSpecInfo:
+      required:
+      - DiskSizeGB
+      - MemSizeMib
+      - Name
+      - Region
+      - VCpu
+      type: object
+      properties:
+        DiskSizeGB:
+          type: string
+          description: "Disk size in GB, \"-1\" when not applicable"
+          example: "8"
+        Gpu:
+          type: array
+          description: GPU details if available
+          items:
+            $ref: '#/components/schemas/model.SpiderGpuInfo'
+        KeyValueList:
+          type: array
+          description: Additional key-value pairs for the VM spec
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        MemSizeMib:
+          type: string
+          description: Memory size in MiB
+          example: "1024"
+        Name:
+          type: string
+          description: Name of the VM spec
+          example: t2.micro
+        Region:
+          type: string
+          description: Region where the VM spec is available
+          example: us-east-1
+        VCpu:
+          type: object
+          description: CPU details of the VM spec
+          allOf:
+          - $ref: '#/components/schemas/model.SpiderVCpuInfo'
+    model.SpiderSpecList:
+      type: object
+      properties:
+        vmspec:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SpiderSpecInfo'
+    model.SpiderVCpuInfo:
+      required:
+      - Count
+      type: object
+      properties:
+        ClockGHz:
+          type: string
+          description: "Clock speed in GHz, \"-1\" when not applicable"
+          example: "2.5"
+        Count:
+          type: string
+          description: "Number of VCpu, \"-1\" when not applicable"
+          example: "2"
+    model.SqlDBInfo:
+      type: object
+      properties:
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+        details:
+          type: object
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: sqldb01
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: sqldb01
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        status:
+          type: string
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+    model.SshCmdResult:
+      type: object
+      properties:
+        command:
+          type: object
+          additionalProperties:
+            type: string
+        err:
+          type: object
+        mciId:
+          type: string
+        stderr:
+          type: object
+          additionalProperties:
+            type: string
+        stdout:
+          type: object
+          additionalProperties:
+            type: string
+        vmId:
+          type: string
+        vmIp:
+          type: string
+    model.StatusCountInfo:
+      type: object
+      properties:
+        countCreating:
+          type: integer
+          description: CountCreating is for counting Creating
+        countFailed:
+          type: integer
+          description: CountFailed is for counting Failed
+        countRebooting:
+          type: integer
+          description: CountRebooting is for counting Rebooting
+        countResuming:
+          type: integer
+          description: CountResuming is for counting Resuming
+        countRunning:
+          type: integer
+          description: CountRunning is for counting Running
+        countSuspended:
+          type: integer
+          description: CountSuspended is for counting Suspended
+        countSuspending:
+          type: integer
+          description: CountSuspending is for counting Suspending
+        countTerminated:
+          type: integer
+          description: CountTerminated is for counting Terminated
+        countTerminating:
+          type: integer
+          description: CountTerminating is for counting Terminating
+        countTotal:
+          type: integer
+          description: CountTotal is for Total VMs
+        countUndefined:
+          type: integer
+          description: CountUndefined is for counting Undefined
+    model.SystemLabelInfo:
+      type: object
+      properties:
+        labelTypes:
+          type: array
+          items:
+            type: string
+        systemLabels:
+          type: object
+          additionalProperties:
+            type: string
+    model.TbAttachDetachDataDiskReq:
+      required:
+      - dataDiskId
+      type: object
+      properties:
+        dataDiskId:
+          type: string
+    model.TbChangeK8sNodeGroupAutoscaleSizeReq:
+      type: object
+      properties:
+        desiredNodeSize:
+          type: string
+          example: "1"
+        maxNodeSize:
+          type: string
+          example: "3"
+        minNodeSize:
+          type: string
+          example: "1"
+    model.TbChangeK8sNodeGroupAutoscaleSizeRes:
+      type: object
+      properties:
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        desiredNodeSize:
+          type: integer
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        imageId:
+          type: string
+        k8sNodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbK8sNodeInfo'
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        maxNodeSize:
+          type: integer
+        minNodeSize:
+          type: integer
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        onAutoScaling:
+          type: boolean
+        rootDiskSize:
+          type: string
+        rootDiskType:
+          type: string
+        specId:
+          type: string
+        spiderViewK8sNodeGroupDetail:
+          $ref: '#/components/schemas/model.SpiderNodeGroupInfo'
+        sshKeyId:
+          type: string
+        status:
+          type: object
+          description: "Creating, Active, Inactive, Updating, Deleting"
+          example: Active
+          allOf:
+          - $ref: '#/components/schemas/model.TbK8sNodeGroupStatus'
+    model.TbCustomImageInfo:
+      type: object
+      properties:
+        associatedObjectList:
+          type: array
+          items:
+            type: string
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+          example: aws-ap-southeast-1
+        creationDate:
+          type: string
+          example: 2022-10-18T08:12:48Z
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+        guestOS:
+          type: string
+          description: "Windows7, Ubuntu etc."
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        isAutoGenerated:
+          type: boolean
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        namespace:
+          type: string
+          description: required to save in RDB
+          example: default
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        sourceVmId:
+          type: string
+          example: aws-ap-southeast-1-1
+        status:
+          type: object
+          example: Available
+          allOf:
+          - $ref: '#/components/schemas/model.CustomImageStatus'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the Resource in a keyword (any
+            string can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+    model.TbCustomImageReq:
+      required:
+      - name
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: This field is for 'Register existing custom image'
+        description:
+          type: string
+        name:
+          type: string
+        sourceVmId:
+          type: string
+    model.TbDataDiskInfo:
+      type: object
+      properties:
+        associatedObjectList:
+          type: array
+          example:
+          - /ns/default/mci/mci01/vm/aws-ap-southeast-1-1
+          items:
+            type: string
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+          example: aws-ap-southeast-1
+        createdTime:
+          type: string
+          example: 2022-10-12T05:09:51.05Z
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+          example: Available
+        diskSize:
+          type: string
+          example: "77"
+        diskType:
+          type: string
+          example: standard
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        isAutoGenerated:
+          type: boolean
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        status:
+          type: object
+          description: "Available, Unavailable, Attached, ..."
+          example: Available
+          allOf:
+          - $ref: '#/components/schemas/model.DiskStatus'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the Resource in a keyword (any
+            string can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        systemMessage:
+          type: string
+          description: Latest system message such as error message
+          example: Failed because ...
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+    model.TbDataDiskReq:
+      required:
+      - connectionName
+      - diskSize
+      - name
+      type: object
+      properties:
+        connectionName:
+          type: string
+          example: aws-ap-southeast-1
+        cspResourceId:
+          type: string
+          description: |-
+            Fields for "Register existing dataDisk" feature
+            CspResourceId is required to register object from CSP (option=register)
+        description:
+          type: string
+        diskSize:
+          type: string
+          example: "77"
+          default: "100"
+        diskType:
+          type: string
+          example: default
+        name:
+          type: string
+          example: aws-ap-southeast-1-datadisk
+    model.TbDataDiskUpsizeReq:
+      required:
+      - diskSize
+      type: object
+      properties:
+        description:
+          type: string
+        diskSize:
+          type: string
+    model.TbDataDiskVmReq:
+      required:
+      - diskSize
+      - name
+      type: object
+      properties:
+        description:
+          type: string
+        diskSize:
+          type: string
+          example: "77"
+          default: "100"
+        diskType:
+          type: string
+          example: default
+        name:
+          type: string
+          example: aws-ap-southeast-1-datadisk
+    model.TbFirewallRuleInfo:
+      required:
+      - Direction
+      - Protocol
+      type: object
+      properties:
+        CIDR:
+          type: string
+          example: 0.0.0.0/0
+        Direction:
+          type: string
+          example: inbound
+          enum:
+          - inbound
+          - outbound
+        Ports:
+          type: string
+          example: "1-65535,22,5555"
+        Protocol:
+          type: string
+          example: TCP
+          enum:
+          - TCP
+          - UDP
+          - ICMP
+          - ALL
+    model.TbIdNameInDetailInfo:
+      type: object
+      properties:
+        idInCsp:
+          type: string
+        idInSp:
+          type: string
+        idInTb:
+          type: string
+        nameInCsp:
+          type: string
+    model.TbImageInfo:
+      type: object
+      properties:
+        connectionName:
+          type: string
+        creationDate:
+          type: string
+        cspImageName:
+          type: string
+          example: csp-06eb41e14121c550a
+        description:
+          type: string
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        fetchedTime:
+          type: string
+        id:
+          type: string
+          example: aws-ap-southeast-1
+        imageStatus:
+          type: object
+          description: "Available, Deprecated, NA"
+          example: Available
+          allOf:
+          - $ref: '#/components/schemas/model.ImageStatus'
+        infraType:
+          type: string
+          description: "vm|k8s|kubernetes|container, etc."
+        isBasicImage:
+          type: boolean
+          default: false
+        isGPUImage:
+          type: boolean
+          default: false
+        isKubernetesImage:
+          type: boolean
+          default: false
+        name:
+          type: string
+          example: aws-ap-southeast-1
+        namespace:
+          type: string
+          description: Composite primary key
+          example: default
+        osArchitecture:
+          type: object
+          description: "arm64, x86_64 etc."
+          example: x86_64
+          allOf:
+          - $ref: '#/components/schemas/model.OSArchitecture'
+        osDiskSizeGB:
+          type: number
+          description: "10, 50, 100 etc."
+          example: 50.0
+        osDiskType:
+          type: string
+          description: "ebs, HDD, etc."
+          example: HDD
+        osDistribution:
+          type: string
+          description: "Ubuntu 22.04~, CentOS 8 etc."
+          example: Ubuntu 22.04~
+        osPlatform:
+          type: object
+          description: "Linux/UNIX, Windows, NA"
+          example: Linux/UNIX
+          allOf:
+          - $ref: '#/components/schemas/model.OSPlatform'
+        osType:
+          type: string
+          example: ubuntu 22.04
+        providerName:
+          type: string
+        regionList:
+          type: array
+          description: Array field for supporting multiple regions
+          items:
+            type: string
+        systemLabel:
+          type: string
+          example: Managed by CB-Tumblebug
+        uid:
+          type: string
+          example: wef12awefadf1221edcf
+    model.TbImageReq:
+      required:
+      - connectionName
+      - cspImageName
+      - name
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspImageName:
+          type: string
+        description:
+          type: string
+        name:
+          type: string
+    model.TbK8sAccessInfo:
+      type: object
+      properties:
+        endpoint:
+          type: string
+          example: http://1.2.3.4:6443
+        kubeconfig:
+          type: string
+          example: |-
+            apiVersion: v1
+            clusters:
+            - cluster:
+             certificate-authority-data: LS0...
+    model.TbK8sAddonsInfo:
+      type: object
+      properties:
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+    model.TbK8sClusterContainerCmdReq:
+      required:
+      - command
+      type: object
+      properties:
+        command:
+          type: array
+          example:
+          - echo hello
+          items:
+            type: string
+    model.TbK8sClusterContainerCmdResult:
+      type: object
+      properties:
+        command:
+          type: string
+        err:
+          type: object
+        stderr:
+          type: string
+        stdout:
+          type: string
+    model.TbK8sClusterContainerCmdResults:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbK8sClusterContainerCmdResult'
+    model.TbK8sClusterDynamicReq:
+      required:
+      - commonImage
+      - commonSpec
+      - name
+      type: object
+      properties:
+        commonImage:
+          type: string
+          description: CommonImage is field for id of a image in common namespace
+          example: "default, tencent+ap-seoul+ubuntu20.04"
+        commonSpec:
+          type: string
+          description: CommonSpec is field for id of a spec in common namespace
+          example: tencent+ap-seoul+S2.MEDIUM4
+        connectionName:
+          type: string
+          description: |-
+            if ConnectionName is given, the VM tries to use associtated credential.
+            if not, it will use predefined ConnectionName in Spec objects
+          default: tencent-ap-seoul
+        description:
+          type: string
+          example: Description
+        desiredNodeSize:
+          type: string
+          example: "1"
+          default: "1"
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        maxNodeSize:
+          type: string
+          example: "3"
+          default: "2"
+        minNodeSize:
+          type: string
+          example: "1"
+          default: "1"
+        name:
+          type: string
+          description: K8sCluster name if it is not empty.
+          example: k8scluster01
+        nodeGroupName:
+          type: string
+          description: NodeGroup name if it is not empty
+          example: k8sng01
+        onAutoScaling:
+          type: string
+          example: "true"
+          default: "true"
+        rootDiskSize:
+          type: string
+          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
+          example: "default, 30, 42, ..."
+          default: default
+        rootDiskType:
+          type: string
+          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
+            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
+            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
+            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT:\
+            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
+          example: "default, TYPE1, ..."
+          default: default
+        version:
+          type: string
+          description: K8s Clsuter version
+          example: "1.29"
+    model.TbK8sClusterInfo:
+      type: object
+      properties:
+        accessInfo:
+          $ref: '#/components/schemas/model.TbK8sAccessInfo'
+        addons:
+          $ref: '#/components/schemas/model.TbK8sAddonsInfo'
+        connectionConfig:
+          type: object
+          description: ConnectionConfig shows connection info to cloud service provider
+          allOf:
+          - $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+          example: alibaba-ap-northeast-2
+        createdTime:
+          type: string
+          example: 1970-01-01T00:00:00.00Z
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+          example: My K8sCluster
+        id:
+          type: string
+          description: "Id is unique identifier for the object, same as Name"
+          example: k8scluster01
+        k8sNodeGroupList:
+          type: array
+          description: K8sNodeGroupList is for describing network information about
+            the cluster
+          items:
+            $ref: '#/components/schemas/model.TbK8sNodeGroupInfo'
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: k8scluster01
+        network:
+          type: object
+          description: Network is for describing network information about the cluster
+          allOf:
+          - $ref: '#/components/schemas/model.TbK8sClusterNetworkInfo'
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        spiderViewK8sClusterDetail:
+          $ref: '#/components/schemas/model.SpiderClusterInfo'
+        status:
+          type: object
+          description: "Creating, Active, Inactive, Updating, Deleting"
+          example: Active
+          allOf:
+          - $ref: '#/components/schemas/model.TbK8sClusterStatus'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the Resource in a keyword (any
+            string can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        systemMessage:
+          type: string
+          description: Latest system message such as error message
+          example: Failed because ...
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+        version:
+          type: string
+          description: Version is for kubernetes version
+          example: 1.30.1
+    model.TbK8sClusterNetworkInfo:
+      type: object
+      properties:
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        securityGroupIds:
+          type: array
+          example:
+          - sg-01
+          items:
+            type: string
+        subnetIds:
+          type: array
+          example:
+          - subnet-01
+          items:
+            type: string
+        vNetId:
+          type: string
+          example: vpc-01
+    model.TbK8sClusterReq:
+      required:
+      - connectionName
+      - name
+      - securityGroupIds
+      - subnetIds
+      - vNetId
+      type: object
+      properties:
+        connectionName:
+          type: string
+          description: Namespace      string `json:"namespace" validate:"required"
+            example:"default"`
+          example: alibaba-ap-northeast-2
+        cspResourceId:
+          type: string
+          description: |-
+            Fields for "Register existing K8sCluster" feature
+            @description CspResourceId is required to register a k8s cluster from CSP (option=register)
+          example: required when option is register
+        description:
+          type: string
+          example: My K8sCluster
+        k8sNodeGroupList:
+          type: array
+          description: (3) NodeGroupInfo List
+          items:
+            $ref: '#/components/schemas/model.TbK8sNodeGroupReq'
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        name:
+          type: string
+          description: (1) K8sCluster Info
+          example: k8scluster01
+        securityGroupIds:
+          type: array
+          example:
+          - sg-01
+          items:
+            type: string
+        subnetIds:
+          type: array
+          example:
+          - subnet-01
+          items:
+            type: string
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the k8scluster in a keyword (any
+            string can be used) for special System purpose
+          example: ""
+        vNetId:
+          type: string
+          description: (2) Network Info
+          example: vpc-01
+        version:
+          type: string
+          example: 1.30.1-aliyun.1
+    model.TbK8sClusterStatus:
+      type: string
+      enum:
+      - Creating
+      - Active
+      - Inactive
+      - Updating
+      - Deleting
+      x-enum-varnames:
+      - TbK8sClusterCreating
+      - TbK8sClusterActive
+      - TbK8sClusterInactive
+      - TbK8sClusterUpdating
+      - TbK8sClusterDeleting
+    model.TbK8sNodeGroupDynamicReq:
+      required:
+      - commonImage
+      - commonSpec
+      - name
+      type: object
+      properties:
+        commonImage:
+          type: string
+          description: CommonImage is field for id of a image in common namespace
+          example: "default, tencent+ap-seoul+ubuntu20.04"
+        commonSpec:
+          type: string
+          description: CommonSpec is field for id of a spec in common namespace
+          example: tencent+ap-seoul+S2.MEDIUM4
+        description:
+          type: string
+          example: Description
+        desiredNodeSize:
+          type: string
+          example: "1"
+          default: "1"
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        maxNodeSize:
+          type: string
+          example: "3"
+          default: "2"
+        minNodeSize:
+          type: string
+          example: "1"
+          default: "1"
+        name:
+          type: string
+          description: K8sNodeGroup name if it is not empty.
+          example: k8sng01
+        onAutoScaling:
+          type: string
+          example: "true"
+          default: "true"
+        rootDiskSize:
+          type: string
+          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
+          example: "default, 30, 42, ..."
+          default: default
+        rootDiskType:
+          type: string
+          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
+            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
+            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
+            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT:\
+            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
+          example: "default, TYPE1, ..."
+          default: default
+    model.TbK8sNodeGroupInfo:
+      type: object
+      properties:
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        desiredNodeSize:
+          type: integer
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        imageId:
+          type: string
+        k8sNodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbK8sNodeInfo'
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        maxNodeSize:
+          type: integer
+        minNodeSize:
+          type: integer
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        onAutoScaling:
+          type: boolean
+        rootDiskSize:
+          type: string
+        rootDiskType:
+          type: string
+        specId:
+          type: string
+        spiderViewK8sNodeGroupDetail:
+          $ref: '#/components/schemas/model.SpiderNodeGroupInfo'
+        sshKeyId:
+          type: string
+        status:
+          type: object
+          description: "Creating, Active, Inactive, Updating, Deleting"
+          example: Active
+          allOf:
+          - $ref: '#/components/schemas/model.TbK8sNodeGroupStatus'
+    model.TbK8sNodeGroupReq:
+      type: object
+      properties:
+        description:
+          type: string
+          example: Description
+        desiredNodeSize:
+          type: string
+          example: "1"
+        imageId:
+          type: string
+          example: image-01
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        maxNodeSize:
+          type: string
+          example: "3"
+        minNodeSize:
+          type: string
+          example: "1"
+        name:
+          type: string
+          example: k8sng01
+        onAutoScaling:
+          type: string
+          description: autoscale config.
+          example: "true"
+        rootDiskSize:
+          type: string
+          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
+          example: "40"
+        rootDiskType:
+          type: string
+          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
+            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
+            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
+            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT:\
+            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
+          example: cloud_essd
+        specId:
+          type: string
+          example: spec-01
+        sshKeyId:
+          type: string
+          example: sshkey-01
+    model.TbK8sNodeGroupStatus:
+      type: string
+      enum:
+      - Creating
+      - Active
+      - Inactive
+      - Updating
+      - Deleting
+      x-enum-varnames:
+      - TbK8sNodeGroupCreating
+      - TbK8sNodeGroupActive
+      - TbK8sNodeGroupInactive
+      - TbK8sNodeGroupUpdating
+      - TbK8sNodeGroupDeleting
+    model.TbK8sNodeInfo:
+      type: object
+      properties:
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+    model.TbMciDynamicReq:
+      required:
+      - name
+      - vm
+      type: object
+      properties:
+        description:
+          type: string
+          example: Made in CB-TB
+        installMonAgent:
+          type: string
+          description: "InstallMonAgent Option for CB-Dragonfly agent installation\
+            \ ([yes/no] default:no)"
+          example: "no"
+          default: "no"
+          enum:
+          - "yes"
+          - "no"
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        name:
+          type: string
+          example: mci01
+        postCommand:
+          type: object
+          description: PostCommand is for the command to bootstrap the VMs
+          allOf:
+          - $ref: '#/components/schemas/model.MciCmdReq'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the mci in a keyword (any string
+            can be used) for special System purpose
+          example: ""
+        vm:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbVmDynamicReq'
+    model.TbMciInfo:
+      type: object
+      properties:
+        configureCloudAdaptiveNetwork:
+          type: string
+          description: "ConfigureCloudAdaptiveNetwork is an option to configure Cloud\
+            \ Adaptive Network (CLADNet) ([yes/no] default:yes)"
+          example: "yes"
+          default: "no"
+          enum:
+          - "yes"
+          - "no"
+        description:
+          type: string
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        installMonAgent:
+          type: string
+          description: "InstallMonAgent Option for CB-Dragonfly agent installation\
+            \ ([yes/no] default:no)"
+          example: "no"
+          default: "no"
+          enum:
+          - "yes"
+          - "no"
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        newVmList:
+          type: array
+          description: List of IDs for new VMs. Return IDs if the VMs are newly added.
+            This field should be used for return body only.
+          items:
+            type: string
+        placementAlgo:
+          type: string
+        postCommand:
+          type: object
+          description: PostCommand is for the command to bootstrap the VMs
+          allOf:
+          - $ref: '#/components/schemas/model.MciCmdReq'
+        postCommandResult:
+          type: object
+          description: PostCommandResult is the result of the command for bootstraping
+            the VMs
+          allOf:
+          - $ref: '#/components/schemas/model.MciSshCmdResult'
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        status:
+          type: string
+        statusCount:
+          $ref: '#/components/schemas/model.StatusCountInfo'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the mci in a keyword (any string
+            can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        systemMessage:
+          type: string
+          description: Latest system message such as error message
+          example: Failed because ...
+        targetAction:
+          type: string
+        targetStatus:
+          type: string
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+        vm:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbVmInfo'
+    model.TbMciReq:
+      required:
+      - name
+      - vm
+      type: object
+      properties:
+        description:
+          type: string
+          example: Made in CB-TB
+        installMonAgent:
+          type: string
+          description: "InstallMonAgent Option for CB-Dragonfly agent installation\
+            \ ([yes/no] default:yes)"
+          example: "no"
+          default: "no"
+          enum:
+          - "yes"
+          - "no"
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        name:
+          type: string
+          example: mci01
+        placementAlgo:
+          type: string
+        postCommand:
+          type: object
+          description: PostCommand is for the command to bootstrap the VMs
+          allOf:
+          - $ref: '#/components/schemas/model.MciCmdReq'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the mci in a keyword (any string
+            can be used) for special System purpose
+          example: ""
+        vm:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbVmReq'
+    model.TbNLBAddRemoveVMReq:
+      type: object
+      properties:
+        targetGroup:
+          $ref: '#/components/schemas/model.TbNLBTargetGroupInfo'
+    model.TbNLBHealthCheckerInfo:
+      type: object
+      properties:
+        interval:
+          type: integer
+          description: "secs, Interval time between health checks."
+          example: 10
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        port:
+          type: string
+          description: Listener Port or 1-65535
+          example: "22"
+        protocol:
+          type: string
+          description: TCP|HTTP|HTTPS
+          example: TCP
+        threshold:
+          type: integer
+          description: "num, The number of continuous health checks to change the\
+            \ VM status."
+          example: 3
+        timeout:
+          type: integer
+          description: "secs, Waiting time to decide an unhealthy VM when no response."
+          example: 10
+    model.TbNLBHealthCheckerReq:
+      type: object
+      properties:
+        interval:
+          type: string
+          description: "secs, Interval time between health checks."
+          example: default
+        threshold:
+          type: string
+          description: "num, The number of continuous health checks to change the\
+            \ VM status."
+          example: default
+        timeout:
+          type: string
+          description: "secs, Waiting time to decide an unhealthy VM when no response."
+          example: default
+    model.TbNLBInfo:
+      type: object
+      properties:
+        associatedObjectList:
+          type: array
+          items:
+            type: string
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        createdTime:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+        healthChecker:
+          $ref: '#/components/schemas/model.TbNLBHealthCheckerInfo'
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        isAutoGenerated:
+          type: boolean
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        listener:
+          $ref: '#/components/schemas/model.TbNLBListenerInfo'
+        location:
+          $ref: '#/components/schemas/model.Location'
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        scope:
+          type: string
+          description: REGION(V) | GLOBAL
+        status:
+          type: string
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the Resource in a keyword (any
+            string can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        targetGroup:
+          $ref: '#/components/schemas/model.TbNLBTargetGroupInfo'
+        type:
+          type: string
+          description: PUBLIC(V) | INTERNAL
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+    model.TbNLBListenerInfo:
+      type: object
+      properties:
+        dnsName:
+          type: string
+          description: "Optional, Auto Generated and attached"
+          example: default-group-cd3.elb.ap-northeast-2.amazonaws.com
+        ip:
+          type: string
+          description: Auto Generated and attached
+          example: x.x.x.x
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        port:
+          type: string
+          description: 1-65535
+          example: "80"
+        protocol:
+          type: string
+          description: TCP|UDP
+          example: TCP
+    model.TbNLBReq:
+      required:
+      - healthChecker
+      - listener
+      - scope
+      - targetGroup
+      - type
+      type: object
+      properties:
+        cspResourceId:
+          type: string
+          description: Existing NLB (used only for option=register)
+        description:
+          type: string
+        healthChecker:
+          type: object
+          description: HealthChecker
+          allOf:
+          - $ref: '#/components/schemas/model.TbNLBHealthCheckerReq'
+        listener:
+          type: object
+          description: Frontend
+          allOf:
+          - $ref: '#/components/schemas/model.NLBListenerReq'
+        scope:
+          type: string
+          description: REGION(V) | GLOBAL
+          example: REGION
+          enum:
+          - REGION
+          - GLOBAL
+        targetGroup:
+          type: object
+          description: Backend
+          allOf:
+          - $ref: '#/components/schemas/model.TbNLBTargetGroupReq'
+        type:
+          type: string
+          description: PUBLIC(V) | INTERNAL
+          example: PUBLIC
+          enum:
+          - PUBLIC
+          - INTERNAL
+    model.TbNLBTargetGroupInfo:
+      type: object
+      properties:
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        port:
+          type: string
+          description: Listener Port or 1-65535
+          example: "80"
+        protocol:
+          type: string
+          description: TCP|HTTP|HTTPS
+          example: TCP
+        subGroupId:
+          type: string
+          example: g1
+        vms:
+          type: array
+          items:
+            type: string
+    model.TbNLBTargetGroupReq:
+      type: object
+      properties:
+        port:
+          type: string
+          description: Listener Port or 1-65535
+          example: "80"
+        protocol:
+          type: string
+          description: TCP|HTTP|HTTPS
+          example: TCP
+        subGroupId:
+          type: string
+          example: g1
+    model.TbRegisterSubnetReq:
+      required:
+      - connectionName
+      - cspResourceId
+      - name
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+        description:
+          type: string
+        name:
+          type: string
+        zone:
+          type: string
+    model.TbRegisterVNetReq:
+      required:
+      - connectionName
+      - cspResourceId
+      - name
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+        description:
+          type: string
+        name:
+          type: string
+    model.TbScaleOutSubGroupReq:
+      required:
+      - numVMsToAdd
+      type: object
+      properties:
+        numVMsToAdd:
+          type: string
+          description: Define addtional VMs to scaleOut
+          example: "2"
+    model.TbSecurityGroupInfo:
+      type: object
+      properties:
+        associatedObjectList:
+          type: array
+          items:
+            type: string
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+        firewallRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbFirewallRuleInfo'
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        isAutoGenerated:
+          type: boolean
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the Resource in a keyword (any
+            string can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+        vNetId:
+          type: string
+    model.TbSecurityGroupReq:
+      required:
+      - connectionName
+      - name
+      - vNetId
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is required to register object from CSP (option=register)
+          example: "required for option=register only. ex: csp-06eb41e14121c550a"
+        description:
+          type: string
+        firewallRules:
+          type: array
+          description: validate:"required"`
+          items:
+            $ref: '#/components/schemas/model.TbFirewallRuleInfo'
+        name:
+          type: string
+        vNetId:
+          type: string
+    model.TbSecurityGroupUpdateReq:
+      type: object
+      properties:
+        firewallRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbFirewallRuleInfo'
+    model.TbSetK8sNodeGroupAutoscalingReq:
+      type: object
+      properties:
+        onAutoScaling:
+          type: string
+          example: "true"
+    model.TbSetK8sNodeGroupAutoscalingRes:
+      type: object
+      properties:
+        result:
+          type: string
+          example: "true"
+    model.TbSpecInfo:
+      type: object
+      properties:
+        acceleratorCount:
+          type: integer
+        acceleratorMemoryGB:
+          type: number
+        acceleratorModel:
+          type: string
+        acceleratorType:
+          type: string
+        architecture:
+          type: string
+          example: x86_64
+        associatedObjectList:
+          type: array
+          items:
+            type: string
+        connectionName:
+          type: string
+        costPerHour:
+          type: number
+        cspSpecName:
+          type: string
+          description: CspSpecName is name of the spec given by CSP
+          example: csp-06eb41e14121c550a
+        description:
+          type: string
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        diskSizeGB:
+          type: number
+        evaluationScore01:
+          type: number
+        evaluationScore02:
+          type: number
+        evaluationScore03:
+          type: number
+        evaluationScore04:
+          type: number
+        evaluationScore05:
+          type: number
+        evaluationScore06:
+          type: number
+        evaluationScore07:
+          type: number
+        evaluationScore08:
+          type: number
+        evaluationScore09:
+          type: number
+        evaluationScore10:
+          type: number
+        evaluationStatus:
+          type: string
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        infraType:
+          type: string
+          description: "InfraType can be one of vm|k8s|kubernetes|container, etc."
+        isAutoGenerated:
+          type: boolean
+        maxTotalStorageTiB:
+          type: integer
+        memoryGiB:
+          type: number
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        namespace:
+          type: string
+          example: default
+        netBwGbps:
+          type: integer
+        orderInFilteredResult:
+          type: integer
+        osType:
+          type: string
+        providerName:
+          type: string
+        regionName:
+          type: string
+        rootDiskSize:
+          type: string
+        rootDiskType:
+          type: string
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the Resource in a keyword (any
+            string can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+        vCPU:
+          type: integer
+    model.TbSpecReq:
+      required:
+      - connectionName
+      - cspSpecName
+      - name
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspSpecName:
+          type: string
+          description: CspSpecName is name of the spec given by CSP
+        description:
+          type: string
+        name:
+          type: string
+          description: "Name is human-readable string to represent the object, used\
+            \ to generate Id"
+    model.TbSshKeyInfo:
+      type: object
+      properties:
+        associatedObjectList:
+          type: array
+          items:
+            type: string
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+        fingerprint:
+          type: string
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        isAutoGenerated:
+          type: boolean
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        privateKey:
+          type: string
+        publicKey:
+          type: string
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the Resource in a keyword (any
+            string can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+        username:
+          type: string
+        verifiedUsername:
+          type: string
+    model.TbSshKeyReq:
+      required:
+      - connectionName
+      - name
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: |-
+            Fields for "Register existing SSH keys" feature
+            CspResourceId is required to register object from CSP (option=register)
+        description:
+          type: string
+        fingerprint:
+          type: string
+        name:
+          type: string
+        privateKey:
+          type: string
+        publicKey:
+          type: string
+        username:
+          type: string
+        verifiedUsername:
+          type: string
+    model.TbSubnetInfo:
+      type: object
+      properties:
+        bastionNodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.BastionNode'
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        cspVNetId:
+          type: string
+          description: CspVNetId is vNet resource identifier managed by CSP
+          example: csp-45eb41e14121c550a
+        cspVNetName:
+          type: string
+          description: CspVNetName is identifier to handle CSP vNet resource
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        ipv4_CIDR:
+          type: string
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        status:
+          type: string
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+        zone:
+          type: string
+    model.TbSubnetReq:
+      required:
+      - ipv4_CIDR
+      - name
+      type: object
+      properties:
+        description:
+          type: string
+          example: subnet00 managed by CB-Tumblebug
+        ipv4_CIDR:
+          type: string
+          example: 10.0.1.0/24
+        name:
+          type: string
+          example: subnet00
+        zone:
+          type: string
+    model.TbUpgradeK8sClusterReq:
+      type: object
+      properties:
+        version:
+          type: string
+          example: 1.30.1-alyun.1
+    model.TbVNetInfo:
+      type: object
+      properties:
+        associatedObjectList:
+          type: array
+          items:
+            type: string
+        cidrBlock:
+          type: string
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        description:
+          type: string
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        isAutoGenerated:
+          type: boolean
+        keyValueList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        status:
+          type: string
+        subnetInfoList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbSubnetInfo'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the Resource in a keyword (any
+            string can be used) for special System purpose
+          example: Managed by CB-Tumblebug
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+    model.TbVNetReq:
+      required:
+      - connectionName
+      - name
+      type: object
+      properties:
+        cidrBlock:
+          type: string
+          example: 10.0.0.0/16
+        connectionName:
+          type: string
+          example: aws-ap-northeast-2
+        description:
+          type: string
+          example: vnet00 managed by CB-Tumblebug
+        name:
+          type: string
+          example: vnet00
+        subnetInfoList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbSubnetReq'
+    model.TbVmDynamicReq:
+      required:
+      - commonImage
+      - commonSpec
+      type: object
+      properties:
+        commonImage:
+          type: string
+          description: CommonImage is field for id of a image in common namespace
+          example: ubuntu18.04
+        commonSpec:
+          type: string
+          description: CommonSpec is field for id of a spec in common namespace
+          example: aws+ap-northeast-2+t2.small
+        connectionName:
+          type: string
+          description: |-
+            if ConnectionName is given, the VM tries to use associtated credential.
+            if not, it will use predefined ConnectionName in Spec objects
+        description:
+          type: string
+          example: Description
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        name:
+          type: string
+          description: "VM name or subGroup name if is (not empty) && (> 0). If it\
+            \ is a group, actual VM name will be generated with -N postfix."
+          example: g1-1
+        rootDiskSize:
+          type: string
+          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
+          example: "default, 30, 42, ..."
+          default: default
+        rootDiskType:
+          type: string
+          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
+            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
+            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
+            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT:\
+            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
+          example: "default, TYPE1, ..."
+          default: default
+        subGroupSize:
+          type: string
+          description: "if subGroupSize is (not empty) && (> 0), subGroup will be\
+            \ generated. VMs will be created accordingly."
+          example: "3"
+          default: "1"
+        vmUserPassword:
+          type: string
+    model.TbVmInfo:
+      type: object
+      properties:
+        addtionalDetails:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.KeyValue'
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        createdTime:
+          type: string
+          description: Created time
+          example: 2022-11-10 23:00:00
+        cspImageName:
+          type: string
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        cspSpecName:
+          type: string
+        cspSshKeyId:
+          type: string
+        cspSubnetId:
+          type: string
+        cspVNetId:
+          type: string
+        dataDiskIds:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        imageId:
+          type: string
+        label:
+          type: object
+          additionalProperties:
+            type: string
+        location:
+          $ref: '#/components/schemas/model.Location'
+        monAgentStatus:
+          type: string
+          description: Montoring agent status
+          example: "[installed, notInstalled, failed]"
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        networkAgentStatus:
+          type: string
+          description: NetworkAgent status
+          example: "[notInstalled, installing, installed, failed]"
+        networkInterface:
+          type: string
+        privateDNS:
+          type: string
+        privateIP:
+          type: string
+        publicDNS:
+          type: string
+        publicIP:
+          type: string
+        region:
+          type: object
+          description: "AWS, ex) {us-east1, us-east1-c} or {ap-northeast-2}"
+          allOf:
+          - $ref: '#/components/schemas/model.RegionInfo'
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        rootDiskName:
+          type: string
+        rootDiskSize:
+          type: string
+        rootDiskType:
+          type: string
+        securityGroupIds:
+          type: array
+          items:
+            type: string
+        specId:
+          type: string
+        sshKeyId:
+          type: string
+        sshPort:
+          type: string
+        status:
+          type: string
+          description: Required by CB-Tumblebug
+        subGroupId:
+          type: string
+          description: defined if the VM is in a group
+        subnetId:
+          type: string
+        systemMessage:
+          type: string
+          description: Latest system message such as error message
+          example: Failed because ...
+        targetAction:
+          type: string
+        targetStatus:
+          type: string
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+        vNetId:
+          type: string
+        vmUserName:
+          type: string
+        vmUserPassword:
+          type: string
+    model.TbVmReq:
+      required:
+      - connectionName
+      - imageId
+      - name
+      - securityGroupIds
+      - specId
+      - sshKeyId
+      - subnetId
+      - vNetId
+      type: object
+      properties:
+        connectionName:
+          type: string
+          example: testcloud01-seoul
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP (required
+            for option=register)
+          example: i-014fa6ede6ada0b2c
+        dataDiskIds:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+          example: Description
+        imageId:
+          type: string
+          description: ImageType        string   `json:"imageType"`
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        name:
+          type: string
+          description: "VM name or subGroup name if is (not empty) && (> 0). If it\
+            \ is a group, actual VM name will be generated with -N postfix."
+          example: g1-1
+        rootDiskSize:
+          type: string
+          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
+          example: "default, 30, 42, ..."
+        rootDiskType:
+          type: string
+          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
+            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
+            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
+            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT:\
+            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
+          example: "default, TYPE1, ..."
+        securityGroupIds:
+          type: array
+          items:
+            type: string
+        specId:
+          type: string
+        sshKeyId:
+          type: string
+        subGroupSize:
+          type: string
+          description: "if subGroupSize is (not empty) && (> 0), subGroup will be\
+            \ generated. VMs will be created accordingly."
+          example: "3"
+        subnetId:
+          type: string
+        vNetId:
+          type: string
+        vmUserName:
+          type: string
+        vmUserPassword:
+          type: string
+    model.TbVmSnapshotReq:
+      type: object
+      properties:
+        name:
+          type: string
+          example: aws-ap-southeast-1-snapshot
+    model.TbVmStatusInfo:
+      type: object
+      properties:
+        createdTime:
+          type: string
+          description: Created time
+          example: 2022-11-10 23:00:00
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP
+          example: csp-06eb41e14121c550a
+        cspResourceName:
+          type: string
+          description: CspResourceName is name assigned to the CSP resource. This
+            name is internally used to handle the resource.
+          example: we12fawefadf1221edcf
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: aws-ap-southeast-1
+        location:
+          $ref: '#/components/schemas/model.Location'
+        monAgentStatus:
+          type: string
+          description: Montoring agent status
+          example: "[installed, notInstalled, failed]"
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: aws-ap-southeast-1
+        nativeStatus:
+          type: string
+        privateIp:
+          type: string
+        publicIp:
+          type: string
+        sshPort:
+          type: string
+        status:
+          type: string
+        systemMessage:
+          type: string
+          description: Latest system message such as error message
+          example: Failed because ...
+        targetAction:
+          type: string
+        targetStatus:
+          type: string
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+    model.VNetDetails:
+      type: object
+      properties:
+        hostsPerSubnet:
+          type: string
+        subnetCount:
+          type: string
+        useFirstNZones:
+          type: string
+    model.VpnIdList:
+      type: object
+      properties:
+        vpnIdList:
+          type: array
+          items:
+            type: string
+    model.VpnInfo:
+      type: object
+      properties:
+        description:
+          type: string
+        id:
+          type: string
+          description: Id is unique identifier for the object
+          example: vpn01
+        name:
+          type: string
+          description: Name is human-readable string to represent the object
+          example: vpn01
+        resourceType:
+          type: string
+          description: ResourceType is the type of the resource
+        status:
+          type: string
+        uid:
+          type: string
+          description: "Uid is universally unique identifier for the object, used\
+            \ for labelSelector"
+          example: wef12awefadf1221edcf
+        vpnSites:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.VpnSiteDetail'
+    model.VpnInfoList:
+      type: object
+      properties:
+        vpnInfoList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.VpnInfo'
+    model.VpnSiteDetail:
+      type: object
+      properties:
+        connectionConfig:
+          $ref: '#/components/schemas/model.ConnConfig'
+        connectionName:
+          type: string
+        resourceDetails:
+          type: array
+          description: ResourceDetails represents a CSP's multiple resources associated
+            with the VPN from a CSP.
+          items:
+            $ref: '#/components/schemas/model.ResourceDetail'
+    model.inspectOverview:
+      type: object
+      properties:
+        customImage:
+          type: integer
+        dataDisk:
+          type: integer
+        nlb:
+          type: integer
+        securityGroup:
+          type: integer
+        sshKey:
+          type: integer
+        vNet:
+          type: integer
+        vm:
+          type: integer
+    model.sites:
+      type: object
+      properties:
+        alibaba:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SiteDetail'
+        aws:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SiteDetail'
+        azure:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SiteDetail'
+        gcp:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SiteDetail'
+        ibm:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SiteDetail'
+        tencent:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.SiteDetail'
+    netutil.Network:
+      type: object
+      properties:
+        cidrBlock:
+          type: string
+        name:
+          type: string
+        subnets:
+          type: array
+          items:
+            $ref: '#/components/schemas/netutil.Network'
+    netutil.RestPostUtilToDesignNetworkReponse:
+      type: object
+      properties:
+        cidrBlock:
+          type: string
+        name:
+          type: string
+        subnets:
+          type: array
+          items:
+            $ref: '#/components/schemas/netutil.Network'
+    netutil.RestPostUtilToDesignNetworkRequest:
+      type: object
+      properties:
+        cidrBlock:
+          type: string
+          example: 192.168.0.0/16
+        subnettingRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/netutil.SubnettingRule'
+    netutil.RestPostUtilToDesignVNetReponse:
+      type: object
+      properties:
+        rootNetworkCIDR:
+          type: string
+          description: in case of supernetting enabled
+        vNetReqList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbVNetReq'
+    netutil.RestPostUtilToDesignVNetRequest:
+      type: object
+      properties:
+        desiredPrivateNetwork:
+          type: string
+        mcNetConfigurations:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.McNetConfigurationDetails'
+        supernettingEnabled:
+          type: string
+    netutil.RestPostUtilToValidateNetworkRequest:
+      type: object
+      properties:
+        networkConfiguration:
+          $ref: '#/components/schemas/netutil.Network'
+    netutil.SubnettingRule:
+      type: object
+      properties:
+        type:
+          type: object
+          example: minSubnets
+          allOf:
+          - $ref: '#/components/schemas/netutil.SubnettingRuleType'
+        value:
+          type: integer
+          example: 2
+    netutil.SubnettingRuleType:
+      type: string
+      enum:
+      - minSubnets
+      - minHosts
+      x-enum-varnames:
+      - SubnettingRuleTypeMinSubnets
+      - SubnettingRuleTypeMinHosts
+    resource.ConnectionImageResult:
+      type: object
+      properties:
+        connName:
+          type: string
+        elapsedTime:
+          type: string
+        errorMsg:
+          type: string
+        imageCount:
+          type: integer
+        provider:
+          type: string
+        region:
+          type: string
+        startTime:
+          type: string
+        success:
+          type: boolean
+    resource.ConnectionSpecResult:
+      type: object
+      properties:
+        connName:
+          type: string
+        elapsedTime:
+          type: string
+        errorMsg:
+          type: string
+        provider:
+          type: string
+        region:
+          type: string
+        specCount:
+          type: integer
+        startTime:
+          type: string
+        success:
+          type: boolean
+    resource.FetchImagesAsyncResult:
+      type: object
+      properties:
+        elapsedTime:
+          type: string
+        failedRegions:
+          type: integer
+        fetchOption:
+          $ref: '#/components/schemas/model.ImageFetchOption'
+        inProgress:
+          type: boolean
+        namespaceId:
+          type: string
+        registeredImages:
+          type: integer
+        resultInDetail:
+          type: array
+          items:
+            $ref: '#/components/schemas/resource.ConnectionImageResult'
+        startTime:
+          type: string
+        succeedRegions:
+          type: integer
+        totalRegions:
+          type: integer
+    resource.FetchSpecsAsyncResult:
+      type: object
+      properties:
+        elapsedTime:
+          type: string
+        failedRegions:
+          type: integer
+        fetchOption:
+          $ref: '#/components/schemas/model.SpecFetchOption'
+        inProgress:
+          type: boolean
+        namespaceId:
+          type: string
+        registeredSpecs:
+          type: integer
+        resultInDetail:
+          type: array
+          items:
+            $ref: '#/components/schemas/resource.ConnectionSpecResult'
+        startTime:
+          type: string
+        succeedRegions:
+          type: integer
+        totalRegions:
+          type: integer
+    resource.JSONResult:
+      type: object
+    resource.RestFilterSpecsResponse:
+      type: object
+      properties:
+        spec:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbSpecInfo'
+    resource.RestGetAllCustomImageResponse:
+      type: object
+      properties:
+        customImage:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbCustomImageInfo'
+    resource.RestGetAllDataDiskResponse:
+      type: object
+      properties:
+        dataDisk:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbDataDiskInfo'
+    resource.RestGetAllK8sClusterResponse:
+      type: object
+      properties:
+        cluster:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbK8sClusterInfo'
+    resource.RestGetAllSecurityGroupResponse:
+      type: object
+      properties:
+        securityGroup:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbSecurityGroupInfo'
+    resource.RestGetAllSshKeyResponse:
+      type: object
+      properties:
+        sshKey:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbSshKeyInfo'
+    resource.RestGetAllSubnetResponse:
+      type: object
+      properties:
+        subnetInfoList:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbSubnetInfo'
+    resource.RestGetAllVNetResponse:
+      type: object
+      properties:
+        vNet:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbVNetInfo'
+    resource.RestLookupImageRequest:
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspImageName:
+          type: string
+    resource.RestLookupSpecRequest:
+      type: object
+      properties:
+        connectionName:
+          type: string
+        cspResourceId:
+          type: string
+    resource.TbFirewallRulesWrapper:
+      type: object
+      properties:
+        firewallRules:
+          type: array
+          description: validate:"required"`
+          items:
+            $ref: '#/components/schemas/model.TbFirewallRuleInfo'
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    Bearer:
+      type: apiKey
+      description: "Type \"Bearer\" followed by a space and JWT token ([TBD] Get token\
+        \ in http://xxx.xxx.xxx.xxx:xxx/auth)"
+      name: Authorization
+      in: header
+x-original-swagger-version: "2.0"
+
+security:
+  - BasicAuth: []
+  - Bearer: []


### PR DESCRIPTION
- Change firewall rule model to use Ports (string) instead of FromPort/ToPort
- Add protocol-specific handling (ICMP, ALL) and port validation logic
- Implement robust diff logic for AWS-style rule overlap/replace on update
- Add conversion functions between Spider and Tb firewall rule structs
- Implement and document REST API handler for synchronizing firewall rules
- Update Swagger docs and OpenAPI spec with new model, usage, and examples

<img width="280" height="419" alt="image" src="https://github.com/user-attachments/assets/30e95579-4a00-4540-a6a4-1fa6ee57127d" />
