### PR TITLE
feat: optimize MCI review performance with parallel processing

### DIFF
--- a/src/core/common/label/label.go
+++ b/src/core/common/label/label.go
@@ -45,25 +45,27 @@ var cspSyncSkipConfig = CSPSyncConfig{
 	CSPGlobalSkip: map[string]bool{
 		// csp.NCP:       true,
 		csp.NHNCloud: true,
+		csp.GCP:      true, // GCP supports tags, but there are some restrictions on naming conventions
 	},
 	CSPSpecificSkipConfig: map[string]map[string]bool{
 		csp.Azure: {
-			model.StrVNet: true,
+			model.StrVNet:   true,
+			model.StrSubnet: true,
 		},
 		csp.Alibaba: {
 			model.StrVNet:       true,
 			model.StrSubnet:     true,
 			model.StrKubernetes: true,
 		},
-		csp.GCP: {
-			model.StrVNet:          true,
-			model.StrSubnet:        true,
-			model.StrSecurityGroup: true,
-			model.StrSSHKey:        true,
-			model.StrCustomImage:   true,
-			model.StrNLB:           true,
-			// and currently there is some restriction on tags for GCP resources because of naming conventions
-		},
+		// csp.GCP: {
+		// 	model.StrVNet:          true,
+		// 	model.StrSubnet:        true,
+		// 	model.StrSecurityGroup: true,
+		// 	model.StrSSHKey:        true,
+		// 	model.StrCustomImage:   true,
+		// 	model.StrNLB:           true,
+		// 	// currently there is some restriction on tags for GCP resources because of naming conventions
+		// },
 		csp.NCP: {
 			model.StrVNet:          true,
 			model.StrSubnet:        true,
@@ -558,7 +560,9 @@ func MergeCSPResourceLabel(labelType, uid string, resourceKey string) error {
 
 	// if kvstore key has LabelConnectionName, try UpdateCSPResourceLabel
 	if connectionName, exists := labelInfo.Labels[model.LabelConnectionName]; exists && connectionName != "" {
-		UpdateCSPResourceLabel(labelType, uid, labelInfo.Labels, connectionName)
+		if isCSPSyncEnabled(labelType, connectionName) {
+			UpdateCSPResourceLabel(labelType, uid, labelInfo.Labels, connectionName)
+		}
 	}
 	return nil
 }

--- a/src/interface/rest/docs/docs.go
+++ b/src/interface/rest/docs/docs.go
@@ -1644,7 +1644,7 @@ const docTemplate = `{
         },
         "/mciDynamicCheckRequest": {
             "post": {
-                "description": "Check available ConnectionConfig list before create MCI Dynamically from common spec and image",
+                "description": "Validate resource availability and discover optimal connection configurations before creating MCI dynamically.\nThis endpoint provides comprehensive resource validation and connection discovery for MCI planning:\n\n**Resource Validation Process:**\n1. **Specification Analysis**: Validates that requested common specs exist and are accessible\n2. **Provider Discovery**: Identifies available cloud providers and regions for each specification\n3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility\n4. **Quota Verification**: Checks available quotas and resource limits where possible\n5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations\n\n**Connection Configuration Discovery:**\n- **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)\n- **Active Regions**: Shows available regions per provider with connectivity status\n- **Specification Mapping**: Maps common specs to provider-specific instance types\n- **Image Compatibility**: Validates image availability across different providers/regions\n- **Network Capabilities**: Identifies supported network features and configurations\n\n**Pre-Deployment Validation:**\n- **Resource Existence**: Confirms all specified resources exist in system namespace\n- **Permission Verification**: Validates CSP credentials and required permissions\n- **API Connectivity**: Tests connection to CSP APIs and service endpoints\n- **Dependency Resolution**: Identifies any missing dependencies or prerequisites\n\n**Optimization Recommendations:**\n- **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources\n- **Performance Optimization**: Recommends regions with better network performance\n- **Availability Zone**: Identifies optimal AZ distribution for high availability\n- **Resource Bundling**: Suggests efficient resource combinations and groupings\n\n**Output Information:**\n- **Connection Candidates**: List of viable connection configurations\n- **Provider Capabilities**: Detailed capabilities matrix per provider\n- **Resource Status**: Real-time availability status for each requested resource\n- **Recommendation Summary**: Actionable recommendations for optimal deployment\n\n**Use Cases:**\n- Pre-validate MCI configuration before expensive deployment operations\n- Discover optimal provider/region combinations for cost or performance\n- Troubleshoot resource availability issues during MCI planning\n- Generate connection configuration templates for standardized deployments\n- Assess infrastructure capacity and planning constraints\n\n**Integration Workflow:**\n1. Use this endpoint to validate and discover connection options\n2. Review recommendations and adjust specifications if needed\n3. Use ` + "`" + `/mciDynamicReview` + "`" + ` for detailed cost estimation and final validation\n4. Proceed with ` + "`" + `/mciDynamic` + "`" + ` using validated configuration",
                 "consumes": [
                     "application/json"
                 ],
@@ -1654,11 +1654,11 @@ const docTemplate = `{
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Check available ConnectionConfig list for creating MCI Dynamically",
+                "summary": "Check Resource Availability for Dynamic MCI Creation",
                 "operationId": "PostMciDynamicCheckRequest",
                 "parameters": [
                     {
-                        "description": "Details for MCI dynamic request information",
+                        "description": "Resource check request containing common specifications to validate",
                         "name": "mciReq",
                         "in": "body",
                         "required": true,
@@ -1669,19 +1669,25 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Resource availability matrix with connection candidates, provider capabilities, and optimization recommendations",
                         "schema": {
                             "$ref": "#/definitions/model.CheckMciDynamicReqInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid request format or malformed specification identifiers",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Specified common specifications not found in system namespace",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "CSP connectivity issues or internal validation service errors",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -3789,7 +3795,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Create MCI",
+                "description": "Create MCI with detailed VM specifications and resource configuration.\nThis endpoint creates a complete multi-cloud infrastructure by:\n1. **VM Provisioning**: Creates VMs across multiple cloud providers using predefined specs and images\n2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration\n3. **Status Tracking**: Monitors VM creation progress and handles failures based on policy settings\n4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands\n\n**Key Features:**\n- Multi-cloud VM deployment with heterogeneous configurations\n- Automatic resource dependency management (VPC → Security Group → VM)\n- Built-in failure handling with configurable policies (continue/rollback/refine)\n- Optional CB-Dragonfly monitoring agent installation\n- Post-deployment command execution support\n- Real-time status updates and progress tracking\n\n**VM Lifecycle:**\n1. Creating → Running (successful deployment)\n2. Creating → Failed (deployment error, handled by failure policy)\n3. Running → Terminated (manual or policy-driven cleanup)\n\n**Failure Policies:**\n- ` + "`" + `continue` + "`" + `: Keep successful VMs, mark failed ones for later refinement\n- ` + "`" + `rollback` + "`" + `: Delete entire MCI if any VM fails (all-or-nothing)\n- ` + "`" + `refine` + "`" + `: Automatically clean up failed VMs, keep successful ones\n\n**Resource Requirements:**\n- Valid VM specifications (must exist in system namespace)\n- Valid images (must be available in target CSP regions)\n- Sufficient CSP quotas and permissions\n- Network connectivity between components",
                 "consumes": [
                     "application/json"
                 ],
@@ -3799,19 +3805,19 @@ const docTemplate = `{
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create MCI",
+                "summary": "Create MCI (Multi-Cloud Infrastructure)",
                 "operationId": "PostMci",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID for resource isolation",
                         "name": "nsId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Details for an MCI object",
+                        "description": "MCI creation request with VM specifications, networking, and deployment options",
                         "name": "mciReq",
                         "in": "body",
                         "required": true,
@@ -3822,19 +3828,31 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Created MCI information with VM details, status, and resource mapping",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid request parameters or missing required fields",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Namespace not found or specified resources unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "MCI name already exists in namespace",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "Internal server error during MCI creation or CSP communication failure",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -5002,7 +5020,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "ScaleOut subGroup in specified MCI",
+                "description": "Horizontally scale an existing VM subgroup by adding more identical instances for increased capacity.\nThis endpoint provides elastic scaling capabilities for running application tiers:\n\n**Scale-Out Process:**\n1. **SubGroup Validation**: Verifies target subgroup exists and is in scalable state\n2. **Template Replication**: Uses existing VM configuration as template for new instances\n3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources\n4. **Parallel Deployment**: Deploys multiple new VMs simultaneously for faster scaling\n5. **Integration**: Seamlessly integrates new VMs into existing subgroup and MCI\n\n**Configuration Inheritance:**\n- **VM Specifications**: New VMs inherit exact specifications from existing subgroup members\n- **Network Settings**: Automatically placed in same VNet, subnet, and security groups\n- **SSH Keys**: Use same SSH key pairs for consistent access management\n- **Monitoring**: Inherit monitoring agent configuration and policies\n- **Labels and Metadata**: Propagate all labels and metadata from parent subgroup\n\n**Scaling Scenarios:**\n- **Traffic Spikes**: Quickly add capacity during high-demand periods\n- **Seasonal Scaling**: Scale out for predictable demand increases\n- **Performance Optimization**: Add instances to reduce per-VM resource utilization\n- **Geographic Expansion**: Scale existing workloads to handle broader user base\n- **Fault Tolerance**: Increase redundancy by adding more instances\n\n**Intelligent Scaling:**\n- **Sequential Naming**: New VMs follow established naming pattern (e.g., web-4, web-5, web-6)\n- **Load Distribution**: New VMs are distributed optimally across availability zones\n- **Resource Efficiency**: Reuses existing network and security infrastructure\n- **Minimal Disruption**: Scaling occurs without affecting existing VM operations\n- **Consistent Configuration**: Ensures all VMs in subgroup remain homogeneous\n\n**Operational Benefits:**\n- **Zero Downtime**: Existing VMs continue running during scale-out operation\n- **Immediate Availability**: New VMs are ready for traffic as soon as deployment completes\n- **Unified Management**: All VMs (old and new) managed through single subgroup\n- **Policy Consistency**: All scaling and management policies apply uniformly\n- **Monitoring Integration**: New VMs automatically included in existing monitoring dashboards\n\n**Scale-Out Considerations:**\n- **CSP Quotas**: Verifies sufficient instance, network, and storage quotas\n- **Region Capacity**: Ensures target region has capacity for requested instance types\n- **Network Limits**: Validates that VNet can accommodate additional VMs\n- **Cost Impact**: Additional VMs incur proportional CSP billing costs\n- **Application Readiness**: Applications should be designed to handle additional instances\n\n**Post-Scale Operations:**\n- New VMs immediately participate in subgroup operations\n- Can be individually managed while maintaining subgroup membership\n- Support for further scaling operations (scale-out or scale-in)\n- Ready for application deployment and load balancer integration\n\n**Best Practices:**\n- Monitor application performance before and after scaling\n- Ensure load balancers are configured to include new instances\n- Verify application clustering and session management handle new instances\n- Consider database connection limits and other resource constraints",
                 "consumes": [
                     "application/json"
                 ],
@@ -5012,13 +5030,13 @@ const docTemplate = `{
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "ScaleOut subGroup in specified MCI",
+                "summary": "Scale Out Existing SubGroup in MCI",
                 "operationId": "PostMciSubGroupScaleOut",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID containing the target MCI and subgroup",
                         "name": "nsId",
                         "in": "path",
                         "required": true
@@ -5026,7 +5044,7 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "default": "mci01",
-                        "description": "MCI ID",
+                        "description": "MCI ID containing the subgroup to scale",
                         "name": "mciId",
                         "in": "path",
                         "required": true
@@ -5034,13 +5052,13 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "default": "g1",
-                        "description": "subGroup ID",
+                        "description": "SubGroup ID to scale out (must exist and contain at least one VM)",
                         "name": "subgroupId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "subGroup scaleOut request",
+                        "description": "Scale-out request specifying the number of additional VMs to create",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
@@ -5051,19 +5069,31 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Updated MCI information with scaled subgroup showing all VMs including newly added instances",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid scale-out request, insufficient quotas, or invalid VM count",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Target MCI or subgroup not found, or namespace inaccessible",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "SubGroup in incompatible state for scaling or resource conflicts detected",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "VM provisioning failed, network configuration error, or CSP capacity limitations",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -5073,7 +5103,7 @@ const docTemplate = `{
         },
         "/ns/{nsId}/mci/{mciId}/vm": {
             "post": {
-                "description": "Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize for multiple VMs)",
+                "description": "Create and add a group of identical virtual machines (subgroup) to an existing MCI using detailed specifications.\nThis endpoint provides precise control over VM configuration and placement within existing infrastructure:\n\n**SubGroup Creation Process:**\n1. **MCI Integration**: Validates target MCI exists and can accommodate new VMs\n2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible\n3. **Homogeneous Deployment**: Creates multiple identical VMs with consistent configuration\n4. **Network Integration**: Integrates new VMs with existing MCI networking and security policies\n5. **Group Management**: Establishes subgroup for collective management and operations\n\n**Detailed Configuration Control:**\n- **Specific Resource References**: Uses exact resource IDs rather than common specifications\n- **Network Placement**: Precise control over VNet, subnet, and security group assignment\n- **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers\n- **Instance Customization**: Full control over VM specifications, images, and metadata\n- **Security Settings**: Explicit security group and SSH key configuration\n\n**SubGroup Benefits:**\n- **Collective Operations**: Perform operations on entire subgroup simultaneously\n- **Homogeneous Scaling**: All VMs in subgroup share identical configuration\n- **Simplified Management**: Single configuration template for multiple VMs\n- **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)\n- **Group Policies**: Apply scaling, monitoring, and lifecycle policies at subgroup level\n\n**Use Cases:**\n- **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases\n- **Load Distribution**: Create multiple identical VMs for load balancing scenarios\n- **High Availability**: Deploy redundant instances across availability zones\n- **Batch Processing**: Create worker nodes for distributed computing workloads\n- **Development Environments**: Provision identical development or testing instances\n\n**Configuration Requirements:**\n- **Resource IDs**: Must specify exact resource identifiers (not common specs)\n- **Network Configuration**: VNet, subnet, and security group must exist and be compatible\n- **SSH Keys**: Must specify valid SSH key pairs for access management\n- **Image Compatibility**: Specified image must be available in target region\n- **Quota Validation**: Sufficient CSP quotas must be available for all requested VMs\n\n**SubGroup Size Considerations:**\n- **Small Groups (1-5 VMs)**: Fast deployment, minimal resource contention\n- **Medium Groups (6-20 VMs)**: Optimized parallel deployment with resource batching\n- **Large Groups (21+ VMs)**: Advanced deployment strategies to avoid CSP rate limits\n- **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits\n\n**Post-Deployment Integration:**\n- SubGroup becomes integral part of parent MCI\n- All VMs inherit MCI-level monitoring and management policies\n- Can be scaled out further or individual VMs can be managed separately\n- Supports all standard CB-Tumblebug VM lifecycle operations",
                 "consumes": [
                     "application/json"
                 ],
@@ -5083,13 +5113,13 @@ const docTemplate = `{
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize for multiple VMs)",
+                "summary": "Add Homogeneous VM SubGroup to Existing MCI",
                 "operationId": "PostMciVm",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID containing the target MCI",
                         "name": "nsId",
                         "in": "path",
                         "required": true
@@ -5097,13 +5127,13 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "default": "mci01",
-                        "description": "MCI ID",
+                        "description": "MCI ID to which the VM subgroup will be added",
                         "name": "mciId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Details for VMs(subGroup)",
+                        "description": "Detailed VM subgroup specification including exact resource IDs, networking, and scaling parameters",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
@@ -5114,19 +5144,31 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Updated MCI information including newly created VM subgroup with individual VM details and status",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid VM request, missing required resources, or configuration conflicts",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Target MCI not found, specified resources unavailable, or namespace inaccessible",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "SubGroup name conflicts, resource allocation conflicts, or MCI state incompatible with expansion",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "VM provisioning failed, network configuration error, or CSP API communication failure",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -5732,7 +5774,7 @@ const docTemplate = `{
         },
         "/ns/{nsId}/mci/{mciId}/vmDynamic": {
             "post": {
-                "description": "Create VM Dynamically and add it to MCI",
+                "description": "Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management.\nThis endpoint provides elastic scaling capabilities for running MCIs:\n\n**Dynamic VM Addition Process:**\n1. **MCI Validation**: Verifies target MCI exists and is in a valid state for expansion\n2. **Resource Discovery**: Resolves common spec and image to provider-specific resources\n3. **Network Integration**: Automatically configures new VMs to use existing MCI network resources\n4. **Subgroup Management**: Creates new subgroups or expands existing ones based on configuration\n5. **Status Synchronization**: Updates MCI status and metadata to reflect new VM additions\n\n**Integration with Existing Infrastructure:**\n- **Network Reuse**: New VMs automatically join existing VNets and security groups\n- **SSH Key Sharing**: Uses existing SSH keys for consistent access management\n- **Monitoring Integration**: New VMs inherit monitoring configuration from parent MCI\n- **Label Propagation**: Applies MCI-level labels and policies to new VMs\n- **Resource Consistency**: Maintains naming conventions and resource organization\n\n**Scaling Scenarios:**\n- **Horizontal Scaling**: Add more instances to handle increased workload\n- **Multi-Region Expansion**: Deploy VMs in new regions while maintaining MCI cohesion\n- **Provider Diversification**: Add VMs from different cloud providers for redundancy\n- **Workload Specialization**: Deploy VMs with different specifications for specific tasks\n\n**Configuration Requirements:**\n- ` + "`" + `commonSpec` + "`" + `: Must specify valid VM specification from system namespace\n- ` + "`" + `commonImage` + "`" + `: Must specify valid image compatible with target provider/region\n- ` + "`" + `name` + "`" + `: Becomes subgroup name; VMs will be named with sequential suffixes\n- ` + "`" + `subGroupSize` + "`" + `: Number of identical VMs to create (default: 1)\n\n**Network and Security:**\n- New VMs automatically inherit security group rules from existing MCI\n- Network connectivity to existing VMs is established automatically\n- Firewall rules and access policies are applied consistently\n- SSH access is configured using existing key pairs\n\n**Example Use Cases:**\n- Scale out web tier during traffic spikes\n- Add GPU instances for machine learning workloads\n- Deploy edge nodes in additional geographic regions\n- Add specialized storage or database nodes to existing application stack\n\n**Post-Addition Operations:**\n- New VMs are immediately available for standard MCI operations\n- Can be individually managed or grouped with existing subgroups\n- Monitoring and logging are automatically configured\n- Application deployment and configuration management can proceed immediately",
                 "consumes": [
                     "application/json"
                 ],
@@ -5742,13 +5784,13 @@ const docTemplate = `{
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create VM Dynamically and add it to MCI",
+                "summary": "Add VM Dynamically to Existing MCI",
                 "operationId": "PostMciVmDynamic",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID containing the target MCI",
                         "name": "nsId",
                         "in": "path",
                         "required": true
@@ -5756,13 +5798,13 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "default": "mci01",
-                        "description": "MCI ID",
+                        "description": "MCI ID to which new VMs will be added",
                         "name": "mciId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Details for Vm dynamic request",
+                        "description": "VM dynamic request specifying commonSpec, commonImage, and scaling parameters",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
@@ -5773,19 +5815,31 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Updated MCI information including newly added VMs and current status",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid VM request or incompatible configuration parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Target MCI not found or specified resources unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "Subgroup name conflicts or MCI in incompatible state",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "VM creation failed or network integration error",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -6151,7 +6205,7 @@ const docTemplate = `{
         },
         "/ns/{nsId}/mciDynamic": {
             "post": {
-                "description": "Create MCI Dynamically from common spec and image",
+                "description": "Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.\nThis is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:\n\n**Dynamic Resource Creation:**\n1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace\n2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider\n3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously\n4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically\n5. **Failure Recovery**: Implements configurable failure policies for robust deployment\n\n**Key Advantages Over Static MCI:**\n- **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources\n- **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys\n- **Multi-Cloud Optimization**: Intelligent placement and configuration across providers\n- **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically\n- **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization\n\n**Configuration Process:**\n1. **Resource Discovery**: Use ` + "`" + `/mciRecommendVm` + "`" + ` to find suitable VM specifications\n2. **Image Selection**: Use system namespace to discover compatible images\n3. **Request Validation**: Use ` + "`" + `/mciDynamicCheckRequest` + "`" + ` to validate configuration before deployment\n4. **Optional Preview**: Use ` + "`" + `/mciDynamicReview` + "`" + ` to estimate costs and review configuration\n5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options\n\n**Failure Policies (PolicyOnPartialFailure):**\n- **` + "`" + `continue` + "`" + `** (default): Create MCI with successful VMs, failed VMs remain for manual refinement\n- **` + "`" + `rollback` + "`" + `**: Delete entire MCI if any VM fails (all-or-nothing deployment)\n- **` + "`" + `refine` + "`" + `**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)\n\n**Deployment Options:**\n- **` + "`" + `hold` + "`" + `**: Create MCI object but hold VM provisioning for manual approval\n- **Normal**: Proceed with immediate VM provisioning after resource creation\n\n**Multi-Cloud Example Configuration:**\n` + "`" + `` + "`" + `` + "`" + `json\n{\n\"name\": \"multi-cloud-web-tier\",\n\"description\": \"Web application across AWS, Azure, and GCP\",\n\"policyOnPartialFailure\": \"refine\",\n\"vm\": [\n{\n\"name\": \"aws-web-servers\",\n\"subGroupSize\": \"3\",\n\"commonSpec\": \"aws+us-east-1+t3.medium\",\n\"commonImage\": \"ami-0abcdef1234567890\",\n\"rootDiskSize\": \"100\",\n\"label\": {\"tier\": \"web\", \"provider\": \"aws\"}\n},\n{\n\"name\": \"azure-api-servers\",\n\"subGroupSize\": \"2\",\n\"commonSpec\": \"azure+eastus+Standard_B2s\",\n\"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts\",\n\"label\": {\"tier\": \"api\", \"provider\": \"azure\"}\n}\n]\n}\n` + "`" + `` + "`" + `` + "`" + `\n\n**Performance Considerations:**\n- VM provisioning occurs in parallel across providers\n- Network resources are created concurrently where possible\n- Large deployments (\u003e10 VMs) automatically use optimized batching\n- Built-in rate limiting prevents CSP API throttling\n\n**Monitoring and Post-Deployment:**\n- Optional CB-Dragonfly monitoring agent installation\n- Custom post-deployment command execution\n- Real-time status tracking and progress updates\n- Automatic resource labeling and metadata management",
                 "consumes": [
                     "application/json"
                 ],
@@ -6161,19 +6215,19 @@ const docTemplate = `{
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create MCI Dynamically",
+                "summary": "Create MCI Dynamically with Intelligent Resource Selection",
                 "operationId": "PostMciDynamic",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID for resource organization and isolation",
                         "name": "nsId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Request body to provision MCI dynamically. Must include commonSpec and commonImage info of each VM request. Example multi-cloud setup: {\\",
+                        "description": "Dynamic MCI request with common specifications. Must include commonSpec and commonImage for each VM group. See description for detailed example.",
                         "name": "mciReq",
                         "in": "body",
                         "required": true,
@@ -6186,32 +6240,44 @@ const docTemplate = `{
                             "hold"
                         ],
                         "type": "string",
-                        "description": "Option for MCI creation",
+                        "description": "Deployment option: 'hold' to create MCI without immediate VM provisioning",
                         "name": "option",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Custom request ID",
+                        "description": "Custom request ID for tracking and correlation across API calls",
                         "name": "x-request-id",
                         "in": "header"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Successfully created MCI with VM deployment status, resource mappings, and configuration details",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid request format, missing required fields, or unsupported configuration",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Namespace not found, specified specs/images unavailable, or CSP resources inaccessible",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "MCI name already exists or resource naming conflicts detected",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "Internal deployment error, CSP API failures, or resource creation timeouts",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -6845,7 +6911,7 @@ const docTemplate = `{
         },
         "/ns/{nsId}/registerCspVm": {
             "post": {
-                "description": "Register existing VM in a CSP to Cloud-Barista MCI",
+                "description": "Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.\nThis endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:\n\n**Registration Process:**\n1. **Discovery**: Validates that the specified VM exists in the target CSP\n2. **Metadata Import**: Retrieves VM configuration, network settings, and current status\n3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources\n4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP VM state\n5. **Management Integration**: Enables CB-Tumblebug operations on the registered VMs\n\n**Supported VM States:**\n- Running VMs (most common use case)\n- Stopped VMs (will be registered with current state)\n- VMs with attached storage and network interfaces\n\n**Resource Compatibility:**\n- VM must exist in a supported CSP (AWS, Azure, GCP, etc.)\n- Network resources (VPC, subnets, security groups) will be discovered and mapped\n- Storage volumes and attached disks will be registered automatically\n- SSH keys and security configurations will be imported\n\n**Post-Registration Capabilities:**\n- Standard CB-Tumblebug VM lifecycle operations (start, stop, terminate)\n- Monitoring agent installation (if CB-Dragonfly is configured)\n- Command execution and automation\n- Integration with other CB-Tumblebug MCIs\n\n**Important Notes:**\n- Registration does not modify the existing VM configuration\n- Original CSP billing and resource management still applies\n- CB-Tumblebug provides additional management layer and automation\n- Ensure proper CSP credentials and permissions are configured",
                 "consumes": [
                     "application/json"
                 ],
@@ -6855,19 +6921,19 @@ const docTemplate = `{
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Register existing VM in a CSP to Cloud-Barista MCI",
+                "summary": "Register Existing CSP VMs into Cloud-Barista MCI",
                 "operationId": "PostRegisterCSPNativeVM",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID for organizing registered resources",
                         "name": "nsId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Details for an MCI object with existing CSP VM ID",
+                        "description": "MCI registration request containing existing CSP VM IDs and connection details",
                         "name": "mciReq",
                         "in": "body",
                         "required": true,
@@ -6878,19 +6944,31 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Registered MCI information with imported VM details and current status",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid request format or missing required CSP VM identifiers",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Specified VMs not found in target CSP or namespace doesn't exist",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "VM already registered or MCI name conflicts",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "CSP communication error or registration process failure",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -11222,7 +11300,7 @@ const docTemplate = `{
         },
         "/systemMci": {
             "post": {
-                "description": "Create System MCI Dynamically for Special Purpose",
+                "description": "Create specialized MCI instances for CB-Tumblebug system operations and infrastructure probing.\nThis endpoint provisions system-level infrastructure that supports CB-Tumblebug's internal functions:\n\n**System MCI Types:**\n- ` + "`" + `probe` + "`" + `: Creates lightweight VMs for network connectivity testing and CSP capability discovery\n- ` + "`" + `monitor` + "`" + `: Deploys monitoring infrastructure for system health and performance tracking\n- ` + "`" + `test` + "`" + `: Provisions test environments for validating CSP integrations and features\n\n**Probe MCI Features:**\n- **Connectivity Testing**: Validates network paths between different CSP regions\n- **Latency Measurement**: Measures inter-region and inter-provider network performance\n- **Feature Discovery**: Tests CSP-specific capabilities and service availability\n- **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources\n\n**System Namespace:**\n- All system MCIs are created in the special ` + "`" + `system` + "`" + ` namespace\n- Isolated from user workloads and regular MCI operations\n- Managed automatically by CB-Tumblebug internal processes\n- May be used for background maintenance and monitoring tasks\n\n**Automatic Configuration:**\n- Uses optimized VM specifications for system tasks (typically minimal resources)\n- Automatically selects appropriate regions and providers based on probe requirements\n- Configures necessary network access and security policies\n- Deploys with minimal attack surface and security hardening\n\n**Lifecycle Management:**\n- System MCIs may be automatically created, updated, or destroyed by CB-Tumblebug\n- Typically short-lived for specific system tasks\n- Resource cleanup is handled automatically\n- Status and results are logged for system administrators\n\n**Use Cases:**\n- Infrastructure health checks and validation\n- Performance benchmarking across cloud providers\n- Automated testing of new CSP integrations\n- Network topology discovery and optimization",
                 "consumes": [
                     "application/json"
                 ],
@@ -11232,34 +11310,50 @@ const docTemplate = `{
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create System MCI Dynamically for Special Purpose in NS:system",
+                "summary": "Create System MCI for CB-Tumblebug Internal Operations",
                 "operationId": "PostSystemMci",
                 "parameters": [
                     {
                         "enum": [
-                            "probe"
+                            "probe",
+                            "monitor",
+                            "test"
                         ],
                         "type": "string",
-                        "description": "Option for the purpose of system MCI",
+                        "description": "System MCI type: 'probe' for connectivity testing, 'monitor' for system monitoring",
                         "name": "option",
                         "in": "query"
+                    },
+                    {
+                        "description": "Optional MCI configuration. If not provided, system defaults will be used",
+                        "name": "mciReq",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.TbMciDynamicReq"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Created system MCI with specialized configuration and status",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
-                    "404": {
-                        "description": "Not Found",
+                    "400": {
+                        "description": "Invalid system option or malformed request",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient permissions for system MCI creation",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "System MCI creation failed or CSP integration error",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -12947,6 +13041,41 @@ const docTemplate = `{
                 }
             }
         },
+        "model.MciCreationErrors": {
+            "type": "object",
+            "properties": {
+                "failedVmCount": {
+                    "description": "FailedVmCount is the number of VMs that failed to be created",
+                    "type": "integer"
+                },
+                "failureHandlingStrategy": {
+                    "description": "FailureHandlingStrategy indicates how failures were handled",
+                    "type": "string"
+                },
+                "successfulVmCount": {
+                    "description": "SuccessfulVmCount is the number of VMs that were successfully created",
+                    "type": "integer"
+                },
+                "totalVmCount": {
+                    "description": "TotalVmCount is the total number of VMs that were supposed to be created",
+                    "type": "integer"
+                },
+                "vmCreationErrors": {
+                    "description": "VmCreationErrors contains errors from actual VM creation phase",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.VmCreationError"
+                    }
+                },
+                "vmObjectCreationErrors": {
+                    "description": "VmObjectCreationErrors contains errors from VM object creation phase",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.VmCreationError"
+                    }
+                }
+            }
+        },
         "model.MciPolicyInfo": {
             "type": "object",
             "properties": {
@@ -13929,6 +14058,19 @@ const docTemplate = `{
                     "description": "Overall assessment of the MCI request",
                     "type": "string",
                     "example": "Ready/Warning/Error"
+                },
+                "policyDescription": {
+                    "type": "string",
+                    "example": "If some VMs fail during creation, MCI will be created with successfully provisioned VMs only"
+                },
+                "policyOnPartialFailure": {
+                    "description": "Failure policy analysis",
+                    "type": "string",
+                    "example": "continue"
+                },
+                "policyRecommendation": {
+                    "type": "string",
+                    "example": "Consider 'refine' policy for automatic cleanup of failed VMs"
                 },
                 "recommendations": {
                     "description": "Recommendations for improvement",
@@ -16230,6 +16372,17 @@ const docTemplate = `{
                     "type": "string",
                     "example": "mci01"
                 },
+                "policyOnPartialFailure": {
+                    "description": "PolicyOnPartialFailure determines how to handle VM creation failures\n- \"continue\": Continue with partial MCI creation (default)\n- \"rollback\": Cleanup entire MCI when any VM fails\n- \"refine\": Mark failed VMs for refinement",
+                    "type": "string",
+                    "default": "continue",
+                    "enum": [
+                        "continue",
+                        "rollback",
+                        "refine"
+                    ],
+                    "example": "continue"
+                },
                 "postCommand": {
                     "description": "PostCommand is for the command to bootstrap the VMs",
                     "allOf": [
@@ -16264,6 +16417,14 @@ const docTemplate = `{
                         "no"
                     ],
                     "example": "yes"
+                },
+                "creationErrors": {
+                    "description": "CreationErrors contains information about VM creation failures (if any)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.MciCreationErrors"
+                        }
+                    ]
                 },
                 "description": {
                     "type": "string"
@@ -16394,6 +16555,17 @@ const docTemplate = `{
                 },
                 "placementAlgo": {
                     "type": "string"
+                },
+                "policyOnPartialFailure": {
+                    "description": "PolicyOnPartialFailure determines how to handle VM creation failures\n- \"continue\": Continue with partial MCI creation (default)\n- \"rollback\": Cleanup entire MCI when any VM fails\n- \"refine\": Mark failed VMs for refinement",
+                    "type": "string",
+                    "default": "continue",
+                    "enum": [
+                        "continue",
+                        "rollback",
+                        "refine"
+                    ],
+                    "example": "continue"
                 },
                 "postCommand": {
                     "description": "PostCommand is for the command to bootstrap the VMs",
@@ -17874,6 +18046,27 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "useFirstNZones": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.VmCreationError": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "description": "Error is the error message",
+                    "type": "string"
+                },
+                "phase": {
+                    "description": "Phase indicates when the error occurred",
+                    "type": "string"
+                },
+                "timestamp": {
+                    "description": "Timestamp when the error occurred",
+                    "type": "string"
+                },
+                "vmName": {
+                    "description": "VmName is the name of the VM that failed",
                     "type": "string"
                 }
             }

--- a/src/interface/rest/docs/swagger.json
+++ b/src/interface/rest/docs/swagger.json
@@ -1637,7 +1637,7 @@
         },
         "/mciDynamicCheckRequest": {
             "post": {
-                "description": "Check available ConnectionConfig list before create MCI Dynamically from common spec and image",
+                "description": "Validate resource availability and discover optimal connection configurations before creating MCI dynamically.\nThis endpoint provides comprehensive resource validation and connection discovery for MCI planning:\n\n**Resource Validation Process:**\n1. **Specification Analysis**: Validates that requested common specs exist and are accessible\n2. **Provider Discovery**: Identifies available cloud providers and regions for each specification\n3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility\n4. **Quota Verification**: Checks available quotas and resource limits where possible\n5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations\n\n**Connection Configuration Discovery:**\n- **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)\n- **Active Regions**: Shows available regions per provider with connectivity status\n- **Specification Mapping**: Maps common specs to provider-specific instance types\n- **Image Compatibility**: Validates image availability across different providers/regions\n- **Network Capabilities**: Identifies supported network features and configurations\n\n**Pre-Deployment Validation:**\n- **Resource Existence**: Confirms all specified resources exist in system namespace\n- **Permission Verification**: Validates CSP credentials and required permissions\n- **API Connectivity**: Tests connection to CSP APIs and service endpoints\n- **Dependency Resolution**: Identifies any missing dependencies or prerequisites\n\n**Optimization Recommendations:**\n- **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources\n- **Performance Optimization**: Recommends regions with better network performance\n- **Availability Zone**: Identifies optimal AZ distribution for high availability\n- **Resource Bundling**: Suggests efficient resource combinations and groupings\n\n**Output Information:**\n- **Connection Candidates**: List of viable connection configurations\n- **Provider Capabilities**: Detailed capabilities matrix per provider\n- **Resource Status**: Real-time availability status for each requested resource\n- **Recommendation Summary**: Actionable recommendations for optimal deployment\n\n**Use Cases:**\n- Pre-validate MCI configuration before expensive deployment operations\n- Discover optimal provider/region combinations for cost or performance\n- Troubleshoot resource availability issues during MCI planning\n- Generate connection configuration templates for standardized deployments\n- Assess infrastructure capacity and planning constraints\n\n**Integration Workflow:**\n1. Use this endpoint to validate and discover connection options\n2. Review recommendations and adjust specifications if needed\n3. Use `/mciDynamicReview` for detailed cost estimation and final validation\n4. Proceed with `/mciDynamic` using validated configuration",
                 "consumes": [
                     "application/json"
                 ],
@@ -1647,11 +1647,11 @@
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Check available ConnectionConfig list for creating MCI Dynamically",
+                "summary": "Check Resource Availability for Dynamic MCI Creation",
                 "operationId": "PostMciDynamicCheckRequest",
                 "parameters": [
                     {
-                        "description": "Details for MCI dynamic request information",
+                        "description": "Resource check request containing common specifications to validate",
                         "name": "mciReq",
                         "in": "body",
                         "required": true,
@@ -1662,19 +1662,25 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Resource availability matrix with connection candidates, provider capabilities, and optimization recommendations",
                         "schema": {
                             "$ref": "#/definitions/model.CheckMciDynamicReqInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid request format or malformed specification identifiers",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Specified common specifications not found in system namespace",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "CSP connectivity issues or internal validation service errors",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -3782,7 +3788,7 @@
                 }
             },
             "post": {
-                "description": "Create MCI",
+                "description": "Create MCI with detailed VM specifications and resource configuration.\nThis endpoint creates a complete multi-cloud infrastructure by:\n1. **VM Provisioning**: Creates VMs across multiple cloud providers using predefined specs and images\n2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration\n3. **Status Tracking**: Monitors VM creation progress and handles failures based on policy settings\n4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands\n\n**Key Features:**\n- Multi-cloud VM deployment with heterogeneous configurations\n- Automatic resource dependency management (VPC → Security Group → VM)\n- Built-in failure handling with configurable policies (continue/rollback/refine)\n- Optional CB-Dragonfly monitoring agent installation\n- Post-deployment command execution support\n- Real-time status updates and progress tracking\n\n**VM Lifecycle:**\n1. Creating → Running (successful deployment)\n2. Creating → Failed (deployment error, handled by failure policy)\n3. Running → Terminated (manual or policy-driven cleanup)\n\n**Failure Policies:**\n- `continue`: Keep successful VMs, mark failed ones for later refinement\n- `rollback`: Delete entire MCI if any VM fails (all-or-nothing)\n- `refine`: Automatically clean up failed VMs, keep successful ones\n\n**Resource Requirements:**\n- Valid VM specifications (must exist in system namespace)\n- Valid images (must be available in target CSP regions)\n- Sufficient CSP quotas and permissions\n- Network connectivity between components",
                 "consumes": [
                     "application/json"
                 ],
@@ -3792,19 +3798,19 @@
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create MCI",
+                "summary": "Create MCI (Multi-Cloud Infrastructure)",
                 "operationId": "PostMci",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID for resource isolation",
                         "name": "nsId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Details for an MCI object",
+                        "description": "MCI creation request with VM specifications, networking, and deployment options",
                         "name": "mciReq",
                         "in": "body",
                         "required": true,
@@ -3815,19 +3821,31 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Created MCI information with VM details, status, and resource mapping",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid request parameters or missing required fields",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Namespace not found or specified resources unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "MCI name already exists in namespace",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "Internal server error during MCI creation or CSP communication failure",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -4995,7 +5013,7 @@
                 }
             },
             "post": {
-                "description": "ScaleOut subGroup in specified MCI",
+                "description": "Horizontally scale an existing VM subgroup by adding more identical instances for increased capacity.\nThis endpoint provides elastic scaling capabilities for running application tiers:\n\n**Scale-Out Process:**\n1. **SubGroup Validation**: Verifies target subgroup exists and is in scalable state\n2. **Template Replication**: Uses existing VM configuration as template for new instances\n3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources\n4. **Parallel Deployment**: Deploys multiple new VMs simultaneously for faster scaling\n5. **Integration**: Seamlessly integrates new VMs into existing subgroup and MCI\n\n**Configuration Inheritance:**\n- **VM Specifications**: New VMs inherit exact specifications from existing subgroup members\n- **Network Settings**: Automatically placed in same VNet, subnet, and security groups\n- **SSH Keys**: Use same SSH key pairs for consistent access management\n- **Monitoring**: Inherit monitoring agent configuration and policies\n- **Labels and Metadata**: Propagate all labels and metadata from parent subgroup\n\n**Scaling Scenarios:**\n- **Traffic Spikes**: Quickly add capacity during high-demand periods\n- **Seasonal Scaling**: Scale out for predictable demand increases\n- **Performance Optimization**: Add instances to reduce per-VM resource utilization\n- **Geographic Expansion**: Scale existing workloads to handle broader user base\n- **Fault Tolerance**: Increase redundancy by adding more instances\n\n**Intelligent Scaling:**\n- **Sequential Naming**: New VMs follow established naming pattern (e.g., web-4, web-5, web-6)\n- **Load Distribution**: New VMs are distributed optimally across availability zones\n- **Resource Efficiency**: Reuses existing network and security infrastructure\n- **Minimal Disruption**: Scaling occurs without affecting existing VM operations\n- **Consistent Configuration**: Ensures all VMs in subgroup remain homogeneous\n\n**Operational Benefits:**\n- **Zero Downtime**: Existing VMs continue running during scale-out operation\n- **Immediate Availability**: New VMs are ready for traffic as soon as deployment completes\n- **Unified Management**: All VMs (old and new) managed through single subgroup\n- **Policy Consistency**: All scaling and management policies apply uniformly\n- **Monitoring Integration**: New VMs automatically included in existing monitoring dashboards\n\n**Scale-Out Considerations:**\n- **CSP Quotas**: Verifies sufficient instance, network, and storage quotas\n- **Region Capacity**: Ensures target region has capacity for requested instance types\n- **Network Limits**: Validates that VNet can accommodate additional VMs\n- **Cost Impact**: Additional VMs incur proportional CSP billing costs\n- **Application Readiness**: Applications should be designed to handle additional instances\n\n**Post-Scale Operations:**\n- New VMs immediately participate in subgroup operations\n- Can be individually managed while maintaining subgroup membership\n- Support for further scaling operations (scale-out or scale-in)\n- Ready for application deployment and load balancer integration\n\n**Best Practices:**\n- Monitor application performance before and after scaling\n- Ensure load balancers are configured to include new instances\n- Verify application clustering and session management handle new instances\n- Consider database connection limits and other resource constraints",
                 "consumes": [
                     "application/json"
                 ],
@@ -5005,13 +5023,13 @@
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "ScaleOut subGroup in specified MCI",
+                "summary": "Scale Out Existing SubGroup in MCI",
                 "operationId": "PostMciSubGroupScaleOut",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID containing the target MCI and subgroup",
                         "name": "nsId",
                         "in": "path",
                         "required": true
@@ -5019,7 +5037,7 @@
                     {
                         "type": "string",
                         "default": "mci01",
-                        "description": "MCI ID",
+                        "description": "MCI ID containing the subgroup to scale",
                         "name": "mciId",
                         "in": "path",
                         "required": true
@@ -5027,13 +5045,13 @@
                     {
                         "type": "string",
                         "default": "g1",
-                        "description": "subGroup ID",
+                        "description": "SubGroup ID to scale out (must exist and contain at least one VM)",
                         "name": "subgroupId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "subGroup scaleOut request",
+                        "description": "Scale-out request specifying the number of additional VMs to create",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
@@ -5044,19 +5062,31 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Updated MCI information with scaled subgroup showing all VMs including newly added instances",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid scale-out request, insufficient quotas, or invalid VM count",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Target MCI or subgroup not found, or namespace inaccessible",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "SubGroup in incompatible state for scaling or resource conflicts detected",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "VM provisioning failed, network configuration error, or CSP capacity limitations",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -5066,7 +5096,7 @@
         },
         "/ns/{nsId}/mci/{mciId}/vm": {
             "post": {
-                "description": "Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize for multiple VMs)",
+                "description": "Create and add a group of identical virtual machines (subgroup) to an existing MCI using detailed specifications.\nThis endpoint provides precise control over VM configuration and placement within existing infrastructure:\n\n**SubGroup Creation Process:**\n1. **MCI Integration**: Validates target MCI exists and can accommodate new VMs\n2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible\n3. **Homogeneous Deployment**: Creates multiple identical VMs with consistent configuration\n4. **Network Integration**: Integrates new VMs with existing MCI networking and security policies\n5. **Group Management**: Establishes subgroup for collective management and operations\n\n**Detailed Configuration Control:**\n- **Specific Resource References**: Uses exact resource IDs rather than common specifications\n- **Network Placement**: Precise control over VNet, subnet, and security group assignment\n- **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers\n- **Instance Customization**: Full control over VM specifications, images, and metadata\n- **Security Settings**: Explicit security group and SSH key configuration\n\n**SubGroup Benefits:**\n- **Collective Operations**: Perform operations on entire subgroup simultaneously\n- **Homogeneous Scaling**: All VMs in subgroup share identical configuration\n- **Simplified Management**: Single configuration template for multiple VMs\n- **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)\n- **Group Policies**: Apply scaling, monitoring, and lifecycle policies at subgroup level\n\n**Use Cases:**\n- **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases\n- **Load Distribution**: Create multiple identical VMs for load balancing scenarios\n- **High Availability**: Deploy redundant instances across availability zones\n- **Batch Processing**: Create worker nodes for distributed computing workloads\n- **Development Environments**: Provision identical development or testing instances\n\n**Configuration Requirements:**\n- **Resource IDs**: Must specify exact resource identifiers (not common specs)\n- **Network Configuration**: VNet, subnet, and security group must exist and be compatible\n- **SSH Keys**: Must specify valid SSH key pairs for access management\n- **Image Compatibility**: Specified image must be available in target region\n- **Quota Validation**: Sufficient CSP quotas must be available for all requested VMs\n\n**SubGroup Size Considerations:**\n- **Small Groups (1-5 VMs)**: Fast deployment, minimal resource contention\n- **Medium Groups (6-20 VMs)**: Optimized parallel deployment with resource batching\n- **Large Groups (21+ VMs)**: Advanced deployment strategies to avoid CSP rate limits\n- **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits\n\n**Post-Deployment Integration:**\n- SubGroup becomes integral part of parent MCI\n- All VMs inherit MCI-level monitoring and management policies\n- Can be scaled out further or individual VMs can be managed separately\n- Supports all standard CB-Tumblebug VM lifecycle operations",
                 "consumes": [
                     "application/json"
                 ],
@@ -5076,13 +5106,13 @@
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize for multiple VMs)",
+                "summary": "Add Homogeneous VM SubGroup to Existing MCI",
                 "operationId": "PostMciVm",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID containing the target MCI",
                         "name": "nsId",
                         "in": "path",
                         "required": true
@@ -5090,13 +5120,13 @@
                     {
                         "type": "string",
                         "default": "mci01",
-                        "description": "MCI ID",
+                        "description": "MCI ID to which the VM subgroup will be added",
                         "name": "mciId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Details for VMs(subGroup)",
+                        "description": "Detailed VM subgroup specification including exact resource IDs, networking, and scaling parameters",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
@@ -5107,19 +5137,31 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Updated MCI information including newly created VM subgroup with individual VM details and status",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid VM request, missing required resources, or configuration conflicts",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Target MCI not found, specified resources unavailable, or namespace inaccessible",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "SubGroup name conflicts, resource allocation conflicts, or MCI state incompatible with expansion",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "VM provisioning failed, network configuration error, or CSP API communication failure",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -5725,7 +5767,7 @@
         },
         "/ns/{nsId}/mci/{mciId}/vmDynamic": {
             "post": {
-                "description": "Create VM Dynamically and add it to MCI",
+                "description": "Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management.\nThis endpoint provides elastic scaling capabilities for running MCIs:\n\n**Dynamic VM Addition Process:**\n1. **MCI Validation**: Verifies target MCI exists and is in a valid state for expansion\n2. **Resource Discovery**: Resolves common spec and image to provider-specific resources\n3. **Network Integration**: Automatically configures new VMs to use existing MCI network resources\n4. **Subgroup Management**: Creates new subgroups or expands existing ones based on configuration\n5. **Status Synchronization**: Updates MCI status and metadata to reflect new VM additions\n\n**Integration with Existing Infrastructure:**\n- **Network Reuse**: New VMs automatically join existing VNets and security groups\n- **SSH Key Sharing**: Uses existing SSH keys for consistent access management\n- **Monitoring Integration**: New VMs inherit monitoring configuration from parent MCI\n- **Label Propagation**: Applies MCI-level labels and policies to new VMs\n- **Resource Consistency**: Maintains naming conventions and resource organization\n\n**Scaling Scenarios:**\n- **Horizontal Scaling**: Add more instances to handle increased workload\n- **Multi-Region Expansion**: Deploy VMs in new regions while maintaining MCI cohesion\n- **Provider Diversification**: Add VMs from different cloud providers for redundancy\n- **Workload Specialization**: Deploy VMs with different specifications for specific tasks\n\n**Configuration Requirements:**\n- `commonSpec`: Must specify valid VM specification from system namespace\n- `commonImage`: Must specify valid image compatible with target provider/region\n- `name`: Becomes subgroup name; VMs will be named with sequential suffixes\n- `subGroupSize`: Number of identical VMs to create (default: 1)\n\n**Network and Security:**\n- New VMs automatically inherit security group rules from existing MCI\n- Network connectivity to existing VMs is established automatically\n- Firewall rules and access policies are applied consistently\n- SSH access is configured using existing key pairs\n\n**Example Use Cases:**\n- Scale out web tier during traffic spikes\n- Add GPU instances for machine learning workloads\n- Deploy edge nodes in additional geographic regions\n- Add specialized storage or database nodes to existing application stack\n\n**Post-Addition Operations:**\n- New VMs are immediately available for standard MCI operations\n- Can be individually managed or grouped with existing subgroups\n- Monitoring and logging are automatically configured\n- Application deployment and configuration management can proceed immediately",
                 "consumes": [
                     "application/json"
                 ],
@@ -5735,13 +5777,13 @@
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create VM Dynamically and add it to MCI",
+                "summary": "Add VM Dynamically to Existing MCI",
                 "operationId": "PostMciVmDynamic",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID containing the target MCI",
                         "name": "nsId",
                         "in": "path",
                         "required": true
@@ -5749,13 +5791,13 @@
                     {
                         "type": "string",
                         "default": "mci01",
-                        "description": "MCI ID",
+                        "description": "MCI ID to which new VMs will be added",
                         "name": "mciId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Details for Vm dynamic request",
+                        "description": "VM dynamic request specifying commonSpec, commonImage, and scaling parameters",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
@@ -5766,19 +5808,31 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Updated MCI information including newly added VMs and current status",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid VM request or incompatible configuration parameters",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Target MCI not found or specified resources unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "Subgroup name conflicts or MCI in incompatible state",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "VM creation failed or network integration error",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -6144,7 +6198,7 @@
         },
         "/ns/{nsId}/mciDynamic": {
             "post": {
-                "description": "Create MCI Dynamically from common spec and image",
+                "description": "Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.\nThis is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:\n\n**Dynamic Resource Creation:**\n1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace\n2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider\n3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously\n4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically\n5. **Failure Recovery**: Implements configurable failure policies for robust deployment\n\n**Key Advantages Over Static MCI:**\n- **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources\n- **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys\n- **Multi-Cloud Optimization**: Intelligent placement and configuration across providers\n- **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically\n- **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization\n\n**Configuration Process:**\n1. **Resource Discovery**: Use `/mciRecommendVm` to find suitable VM specifications\n2. **Image Selection**: Use system namespace to discover compatible images\n3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment\n4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration\n5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options\n\n**Failure Policies (PolicyOnPartialFailure):**\n- **`continue`** (default): Create MCI with successful VMs, failed VMs remain for manual refinement\n- **`rollback`**: Delete entire MCI if any VM fails (all-or-nothing deployment)\n- **`refine`**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)\n\n**Deployment Options:**\n- **`hold`**: Create MCI object but hold VM provisioning for manual approval\n- **Normal**: Proceed with immediate VM provisioning after resource creation\n\n**Multi-Cloud Example Configuration:**\n```json\n{\n\"name\": \"multi-cloud-web-tier\",\n\"description\": \"Web application across AWS, Azure, and GCP\",\n\"policyOnPartialFailure\": \"refine\",\n\"vm\": [\n{\n\"name\": \"aws-web-servers\",\n\"subGroupSize\": \"3\",\n\"commonSpec\": \"aws+us-east-1+t3.medium\",\n\"commonImage\": \"ami-0abcdef1234567890\",\n\"rootDiskSize\": \"100\",\n\"label\": {\"tier\": \"web\", \"provider\": \"aws\"}\n},\n{\n\"name\": \"azure-api-servers\",\n\"subGroupSize\": \"2\",\n\"commonSpec\": \"azure+eastus+Standard_B2s\",\n\"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts\",\n\"label\": {\"tier\": \"api\", \"provider\": \"azure\"}\n}\n]\n}\n```\n\n**Performance Considerations:**\n- VM provisioning occurs in parallel across providers\n- Network resources are created concurrently where possible\n- Large deployments (\u003e10 VMs) automatically use optimized batching\n- Built-in rate limiting prevents CSP API throttling\n\n**Monitoring and Post-Deployment:**\n- Optional CB-Dragonfly monitoring agent installation\n- Custom post-deployment command execution\n- Real-time status tracking and progress updates\n- Automatic resource labeling and metadata management",
                 "consumes": [
                     "application/json"
                 ],
@@ -6154,19 +6208,19 @@
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create MCI Dynamically",
+                "summary": "Create MCI Dynamically with Intelligent Resource Selection",
                 "operationId": "PostMciDynamic",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID for resource organization and isolation",
                         "name": "nsId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Request body to provision MCI dynamically. Must include commonSpec and commonImage info of each VM request. Example multi-cloud setup: {\\",
+                        "description": "Dynamic MCI request with common specifications. Must include commonSpec and commonImage for each VM group. See description for detailed example.",
                         "name": "mciReq",
                         "in": "body",
                         "required": true,
@@ -6179,32 +6233,44 @@
                             "hold"
                         ],
                         "type": "string",
-                        "description": "Option for MCI creation",
+                        "description": "Deployment option: 'hold' to create MCI without immediate VM provisioning",
                         "name": "option",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "Custom request ID",
+                        "description": "Custom request ID for tracking and correlation across API calls",
                         "name": "x-request-id",
                         "in": "header"
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Successfully created MCI with VM deployment status, resource mappings, and configuration details",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid request format, missing required fields, or unsupported configuration",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Namespace not found, specified specs/images unavailable, or CSP resources inaccessible",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "MCI name already exists or resource naming conflicts detected",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "Internal deployment error, CSP API failures, or resource creation timeouts",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -6838,7 +6904,7 @@
         },
         "/ns/{nsId}/registerCspVm": {
             "post": {
-                "description": "Register existing VM in a CSP to Cloud-Barista MCI",
+                "description": "Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.\nThis endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:\n\n**Registration Process:**\n1. **Discovery**: Validates that the specified VM exists in the target CSP\n2. **Metadata Import**: Retrieves VM configuration, network settings, and current status\n3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources\n4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP VM state\n5. **Management Integration**: Enables CB-Tumblebug operations on the registered VMs\n\n**Supported VM States:**\n- Running VMs (most common use case)\n- Stopped VMs (will be registered with current state)\n- VMs with attached storage and network interfaces\n\n**Resource Compatibility:**\n- VM must exist in a supported CSP (AWS, Azure, GCP, etc.)\n- Network resources (VPC, subnets, security groups) will be discovered and mapped\n- Storage volumes and attached disks will be registered automatically\n- SSH keys and security configurations will be imported\n\n**Post-Registration Capabilities:**\n- Standard CB-Tumblebug VM lifecycle operations (start, stop, terminate)\n- Monitoring agent installation (if CB-Dragonfly is configured)\n- Command execution and automation\n- Integration with other CB-Tumblebug MCIs\n\n**Important Notes:**\n- Registration does not modify the existing VM configuration\n- Original CSP billing and resource management still applies\n- CB-Tumblebug provides additional management layer and automation\n- Ensure proper CSP credentials and permissions are configured",
                 "consumes": [
                     "application/json"
                 ],
@@ -6848,19 +6914,19 @@
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Register existing VM in a CSP to Cloud-Barista MCI",
+                "summary": "Register Existing CSP VMs into Cloud-Barista MCI",
                 "operationId": "PostRegisterCSPNativeVM",
                 "parameters": [
                     {
                         "type": "string",
                         "default": "default",
-                        "description": "Namespace ID",
+                        "description": "Namespace ID for organizing registered resources",
                         "name": "nsId",
                         "in": "path",
                         "required": true
                     },
                     {
-                        "description": "Details for an MCI object with existing CSP VM ID",
+                        "description": "MCI registration request containing existing CSP VM IDs and connection details",
                         "name": "mciReq",
                         "in": "body",
                         "required": true,
@@ -6871,19 +6937,31 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Registered MCI information with imported VM details and current status",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
+                    "400": {
+                        "description": "Invalid request format or missing required CSP VM identifiers",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
                     "404": {
-                        "description": "Not Found",
+                        "description": "Specified VMs not found in target CSP or namespace doesn't exist",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "409": {
+                        "description": "VM already registered or MCI name conflicts",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "CSP communication error or registration process failure",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -11215,7 +11293,7 @@
         },
         "/systemMci": {
             "post": {
-                "description": "Create System MCI Dynamically for Special Purpose",
+                "description": "Create specialized MCI instances for CB-Tumblebug system operations and infrastructure probing.\nThis endpoint provisions system-level infrastructure that supports CB-Tumblebug's internal functions:\n\n**System MCI Types:**\n- `probe`: Creates lightweight VMs for network connectivity testing and CSP capability discovery\n- `monitor`: Deploys monitoring infrastructure for system health and performance tracking\n- `test`: Provisions test environments for validating CSP integrations and features\n\n**Probe MCI Features:**\n- **Connectivity Testing**: Validates network paths between different CSP regions\n- **Latency Measurement**: Measures inter-region and inter-provider network performance\n- **Feature Discovery**: Tests CSP-specific capabilities and service availability\n- **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources\n\n**System Namespace:**\n- All system MCIs are created in the special `system` namespace\n- Isolated from user workloads and regular MCI operations\n- Managed automatically by CB-Tumblebug internal processes\n- May be used for background maintenance and monitoring tasks\n\n**Automatic Configuration:**\n- Uses optimized VM specifications for system tasks (typically minimal resources)\n- Automatically selects appropriate regions and providers based on probe requirements\n- Configures necessary network access and security policies\n- Deploys with minimal attack surface and security hardening\n\n**Lifecycle Management:**\n- System MCIs may be automatically created, updated, or destroyed by CB-Tumblebug\n- Typically short-lived for specific system tasks\n- Resource cleanup is handled automatically\n- Status and results are logged for system administrators\n\n**Use Cases:**\n- Infrastructure health checks and validation\n- Performance benchmarking across cloud providers\n- Automated testing of new CSP integrations\n- Network topology discovery and optimization",
                 "consumes": [
                     "application/json"
                 ],
@@ -11225,34 +11303,50 @@
                 "tags": [
                     "[MC-Infra] MCI Provisioning and Management"
                 ],
-                "summary": "Create System MCI Dynamically for Special Purpose in NS:system",
+                "summary": "Create System MCI for CB-Tumblebug Internal Operations",
                 "operationId": "PostSystemMci",
                 "parameters": [
                     {
                         "enum": [
-                            "probe"
+                            "probe",
+                            "monitor",
+                            "test"
                         ],
                         "type": "string",
-                        "description": "Option for the purpose of system MCI",
+                        "description": "System MCI type: 'probe' for connectivity testing, 'monitor' for system monitoring",
                         "name": "option",
                         "in": "query"
+                    },
+                    {
+                        "description": "Optional MCI configuration. If not provided, system defaults will be used",
+                        "name": "mciReq",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.TbMciDynamicReq"
+                        }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Created system MCI with specialized configuration and status",
                         "schema": {
                             "$ref": "#/definitions/model.TbMciInfo"
                         }
                     },
-                    "404": {
-                        "description": "Not Found",
+                    "400": {
+                        "description": "Invalid system option or malformed request",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient permissions for system MCI creation",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "System MCI creation failed or CSP integration error",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -12940,6 +13034,41 @@
                 }
             }
         },
+        "model.MciCreationErrors": {
+            "type": "object",
+            "properties": {
+                "failedVmCount": {
+                    "description": "FailedVmCount is the number of VMs that failed to be created",
+                    "type": "integer"
+                },
+                "failureHandlingStrategy": {
+                    "description": "FailureHandlingStrategy indicates how failures were handled",
+                    "type": "string"
+                },
+                "successfulVmCount": {
+                    "description": "SuccessfulVmCount is the number of VMs that were successfully created",
+                    "type": "integer"
+                },
+                "totalVmCount": {
+                    "description": "TotalVmCount is the total number of VMs that were supposed to be created",
+                    "type": "integer"
+                },
+                "vmCreationErrors": {
+                    "description": "VmCreationErrors contains errors from actual VM creation phase",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.VmCreationError"
+                    }
+                },
+                "vmObjectCreationErrors": {
+                    "description": "VmObjectCreationErrors contains errors from VM object creation phase",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.VmCreationError"
+                    }
+                }
+            }
+        },
         "model.MciPolicyInfo": {
             "type": "object",
             "properties": {
@@ -13922,6 +14051,19 @@
                     "description": "Overall assessment of the MCI request",
                     "type": "string",
                     "example": "Ready/Warning/Error"
+                },
+                "policyDescription": {
+                    "type": "string",
+                    "example": "If some VMs fail during creation, MCI will be created with successfully provisioned VMs only"
+                },
+                "policyOnPartialFailure": {
+                    "description": "Failure policy analysis",
+                    "type": "string",
+                    "example": "continue"
+                },
+                "policyRecommendation": {
+                    "type": "string",
+                    "example": "Consider 'refine' policy for automatic cleanup of failed VMs"
                 },
                 "recommendations": {
                     "description": "Recommendations for improvement",
@@ -16223,6 +16365,17 @@
                     "type": "string",
                     "example": "mci01"
                 },
+                "policyOnPartialFailure": {
+                    "description": "PolicyOnPartialFailure determines how to handle VM creation failures\n- \"continue\": Continue with partial MCI creation (default)\n- \"rollback\": Cleanup entire MCI when any VM fails\n- \"refine\": Mark failed VMs for refinement",
+                    "type": "string",
+                    "default": "continue",
+                    "enum": [
+                        "continue",
+                        "rollback",
+                        "refine"
+                    ],
+                    "example": "continue"
+                },
                 "postCommand": {
                     "description": "PostCommand is for the command to bootstrap the VMs",
                     "allOf": [
@@ -16257,6 +16410,14 @@
                         "no"
                     ],
                     "example": "yes"
+                },
+                "creationErrors": {
+                    "description": "CreationErrors contains information about VM creation failures (if any)",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/model.MciCreationErrors"
+                        }
+                    ]
                 },
                 "description": {
                     "type": "string"
@@ -16387,6 +16548,17 @@
                 },
                 "placementAlgo": {
                     "type": "string"
+                },
+                "policyOnPartialFailure": {
+                    "description": "PolicyOnPartialFailure determines how to handle VM creation failures\n- \"continue\": Continue with partial MCI creation (default)\n- \"rollback\": Cleanup entire MCI when any VM fails\n- \"refine\": Mark failed VMs for refinement",
+                    "type": "string",
+                    "default": "continue",
+                    "enum": [
+                        "continue",
+                        "rollback",
+                        "refine"
+                    ],
+                    "example": "continue"
                 },
                 "postCommand": {
                     "description": "PostCommand is for the command to bootstrap the VMs",
@@ -17867,6 +18039,27 @@
                     "type": "string"
                 },
                 "useFirstNZones": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.VmCreationError": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "description": "Error is the error message",
+                    "type": "string"
+                },
+                "phase": {
+                    "description": "Phase indicates when the error occurred",
+                    "type": "string"
+                },
+                "timestamp": {
+                    "description": "Timestamp when the error occurred",
+                    "type": "string"
+                },
+                "vmName": {
+                    "description": "VmName is the name of the VM that failed",
                     "type": "string"
                 }
             }

--- a/src/interface/rest/docs/swagger.yaml
+++ b/src/interface/rest/docs/swagger.yaml
@@ -1226,12 +1226,58 @@ paths:
     post:
       tags:
       - "[MC-Infra] MCI Provisioning and Management"
-      summary: Check available ConnectionConfig list for creating MCI Dynamically
-      description: Check available ConnectionConfig list before create MCI Dynamically
-        from common spec and image
+      summary: Check Resource Availability for Dynamic MCI Creation
+      description: |-
+        Validate resource availability and discover optimal connection configurations before creating MCI dynamically.
+        This endpoint provides comprehensive resource validation and connection discovery for MCI planning:
+
+        **Resource Validation Process:**
+        1. **Specification Analysis**: Validates that requested common specs exist and are accessible
+        2. **Provider Discovery**: Identifies available cloud providers and regions for each specification
+        3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility
+        4. **Quota Verification**: Checks available quotas and resource limits where possible
+        5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations
+
+        **Connection Configuration Discovery:**
+        - **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)
+        - **Active Regions**: Shows available regions per provider with connectivity status
+        - **Specification Mapping**: Maps common specs to provider-specific instance types
+        - **Image Compatibility**: Validates image availability across different providers/regions
+        - **Network Capabilities**: Identifies supported network features and configurations
+
+        **Pre-Deployment Validation:**
+        - **Resource Existence**: Confirms all specified resources exist in system namespace
+        - **Permission Verification**: Validates CSP credentials and required permissions
+        - **API Connectivity**: Tests connection to CSP APIs and service endpoints
+        - **Dependency Resolution**: Identifies any missing dependencies or prerequisites
+
+        **Optimization Recommendations:**
+        - **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources
+        - **Performance Optimization**: Recommends regions with better network performance
+        - **Availability Zone**: Identifies optimal AZ distribution for high availability
+        - **Resource Bundling**: Suggests efficient resource combinations and groupings
+
+        **Output Information:**
+        - **Connection Candidates**: List of viable connection configurations
+        - **Provider Capabilities**: Detailed capabilities matrix per provider
+        - **Resource Status**: Real-time availability status for each requested resource
+        - **Recommendation Summary**: Actionable recommendations for optimal deployment
+
+        **Use Cases:**
+        - Pre-validate MCI configuration before expensive deployment operations
+        - Discover optimal provider/region combinations for cost or performance
+        - Troubleshoot resource availability issues during MCI planning
+        - Generate connection configuration templates for standardized deployments
+        - Assess infrastructure capacity and planning constraints
+
+        **Integration Workflow:**
+        1. Use this endpoint to validate and discover connection options
+        2. Review recommendations and adjust specifications if needed
+        3. Use `/mciDynamicReview` for detailed cost estimation and final validation
+        4. Proceed with `/mciDynamic` using validated configuration
       operationId: PostMciDynamicCheckRequest
       requestBody:
-        description: Details for MCI dynamic request information
+        description: Resource check request containing common specifications to validate
         content:
           application/json:
             schema:
@@ -1239,19 +1285,26 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: "Resource availability matrix with connection candidates, provider\
+            \ capabilities, and optimization recommendations"
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.CheckMciDynamicReqInfo'
+        "400":
+          description: Invalid request format or malformed specification identifiers
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
-          description: Not Found
+          description: Specified common specifications not found in system namespace
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
-          description: Internal Server Error
+          description: CSP connectivity issues or internal validation service errors
           content:
             application/json:
               schema:
@@ -2873,19 +2926,50 @@ paths:
     post:
       tags:
       - "[MC-Infra] MCI Provisioning and Management"
-      summary: Create MCI
-      description: Create MCI
+      summary: Create MCI (Multi-Cloud Infrastructure)
+      description: |-
+        Create MCI with detailed VM specifications and resource configuration.
+        This endpoint creates a complete multi-cloud infrastructure by:
+        1. **VM Provisioning**: Creates VMs across multiple cloud providers using predefined specs and images
+        2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration
+        3. **Status Tracking**: Monitors VM creation progress and handles failures based on policy settings
+        4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands
+
+        **Key Features:**
+        - Multi-cloud VM deployment with heterogeneous configurations
+        - Automatic resource dependency management (VPC → Security Group → VM)
+        - Built-in failure handling with configurable policies (continue/rollback/refine)
+        - Optional CB-Dragonfly monitoring agent installation
+        - Post-deployment command execution support
+        - Real-time status updates and progress tracking
+
+        **VM Lifecycle:**
+        1. Creating → Running (successful deployment)
+        2. Creating → Failed (deployment error, handled by failure policy)
+        3. Running → Terminated (manual or policy-driven cleanup)
+
+        **Failure Policies:**
+        - `continue`: Keep successful VMs, mark failed ones for later refinement
+        - `rollback`: Delete entire MCI if any VM fails (all-or-nothing)
+        - `refine`: Automatically clean up failed VMs, keep successful ones
+
+        **Resource Requirements:**
+        - Valid VM specifications (must exist in system namespace)
+        - Valid images (must be available in target CSP regions)
+        - Sufficient CSP quotas and permissions
+        - Network connectivity between components
       operationId: PostMci
       parameters:
       - name: nsId
         in: path
-        description: Namespace ID
+        description: Namespace ID for resource isolation
         required: true
         schema:
           type: string
           default: default
       requestBody:
-        description: Details for an MCI object
+        description: "MCI creation request with VM specifications, networking, and\
+          \ deployment options"
         content:
           application/json:
             schema:
@@ -2893,19 +2977,33 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: "Created MCI information with VM details, status, and resource\
+            \ mapping"
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.TbMciInfo'
+        "400":
+          description: Invalid request parameters or missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
-          description: Not Found
+          description: Namespace not found or specified resources unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "409":
+          description: MCI name already exists in namespace
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
-          description: Internal Server Error
+          description: Internal server error during MCI creation or CSP communication
+            failure
           content:
             application/json:
               schema:
@@ -3826,33 +3924,91 @@ paths:
     post:
       tags:
       - "[MC-Infra] MCI Provisioning and Management"
-      summary: ScaleOut subGroup in specified MCI
-      description: ScaleOut subGroup in specified MCI
+      summary: Scale Out Existing SubGroup in MCI
+      description: |-
+        Horizontally scale an existing VM subgroup by adding more identical instances for increased capacity.
+        This endpoint provides elastic scaling capabilities for running application tiers:
+
+        **Scale-Out Process:**
+        1. **SubGroup Validation**: Verifies target subgroup exists and is in scalable state
+        2. **Template Replication**: Uses existing VM configuration as template for new instances
+        3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources
+        4. **Parallel Deployment**: Deploys multiple new VMs simultaneously for faster scaling
+        5. **Integration**: Seamlessly integrates new VMs into existing subgroup and MCI
+
+        **Configuration Inheritance:**
+        - **VM Specifications**: New VMs inherit exact specifications from existing subgroup members
+        - **Network Settings**: Automatically placed in same VNet, subnet, and security groups
+        - **SSH Keys**: Use same SSH key pairs for consistent access management
+        - **Monitoring**: Inherit monitoring agent configuration and policies
+        - **Labels and Metadata**: Propagate all labels and metadata from parent subgroup
+
+        **Scaling Scenarios:**
+        - **Traffic Spikes**: Quickly add capacity during high-demand periods
+        - **Seasonal Scaling**: Scale out for predictable demand increases
+        - **Performance Optimization**: Add instances to reduce per-VM resource utilization
+        - **Geographic Expansion**: Scale existing workloads to handle broader user base
+        - **Fault Tolerance**: Increase redundancy by adding more instances
+
+        **Intelligent Scaling:**
+        - **Sequential Naming**: New VMs follow established naming pattern (e.g., web-4, web-5, web-6)
+        - **Load Distribution**: New VMs are distributed optimally across availability zones
+        - **Resource Efficiency**: Reuses existing network and security infrastructure
+        - **Minimal Disruption**: Scaling occurs without affecting existing VM operations
+        - **Consistent Configuration**: Ensures all VMs in subgroup remain homogeneous
+
+        **Operational Benefits:**
+        - **Zero Downtime**: Existing VMs continue running during scale-out operation
+        - **Immediate Availability**: New VMs are ready for traffic as soon as deployment completes
+        - **Unified Management**: All VMs (old and new) managed through single subgroup
+        - **Policy Consistency**: All scaling and management policies apply uniformly
+        - **Monitoring Integration**: New VMs automatically included in existing monitoring dashboards
+
+        **Scale-Out Considerations:**
+        - **CSP Quotas**: Verifies sufficient instance, network, and storage quotas
+        - **Region Capacity**: Ensures target region has capacity for requested instance types
+        - **Network Limits**: Validates that VNet can accommodate additional VMs
+        - **Cost Impact**: Additional VMs incur proportional CSP billing costs
+        - **Application Readiness**: Applications should be designed to handle additional instances
+
+        **Post-Scale Operations:**
+        - New VMs immediately participate in subgroup operations
+        - Can be individually managed while maintaining subgroup membership
+        - Support for further scaling operations (scale-out or scale-in)
+        - Ready for application deployment and load balancer integration
+
+        **Best Practices:**
+        - Monitor application performance before and after scaling
+        - Ensure load balancers are configured to include new instances
+        - Verify application clustering and session management handle new instances
+        - Consider database connection limits and other resource constraints
       operationId: PostMciSubGroupScaleOut
       parameters:
       - name: nsId
         in: path
-        description: Namespace ID
+        description: Namespace ID containing the target MCI and subgroup
         required: true
         schema:
           type: string
           default: default
       - name: mciId
         in: path
-        description: MCI ID
+        description: MCI ID containing the subgroup to scale
         required: true
         schema:
           type: string
           default: mci01
       - name: subgroupId
         in: path
-        description: subGroup ID
+        description: SubGroup ID to scale out (must exist and contain at least one
+          VM)
         required: true
         schema:
           type: string
           default: g1
       requestBody:
-        description: subGroup scaleOut request
+        description: Scale-out request specifying the number of additional VMs to
+          create
         content:
           application/json:
             schema:
@@ -3860,19 +4016,35 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: Updated MCI information with scaled subgroup showing all VMs
+            including newly added instances
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.TbMciInfo'
+        "400":
+          description: "Invalid scale-out request, insufficient quotas, or invalid\
+            \ VM count"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
-          description: Not Found
+          description: "Target MCI or subgroup not found, or namespace inaccessible"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "409":
+          description: SubGroup in incompatible state for scaling or resource conflicts
+            detected
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
-          description: Internal Server Error
+          description: "VM provisioning failed, network configuration error, or CSP\
+            \ capacity limitations"
           content:
             application/json:
               schema:
@@ -3882,28 +4054,76 @@ paths:
     post:
       tags:
       - "[MC-Infra] MCI Provisioning and Management"
-      summary: Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize
-        for multiple VMs)
-      description: Create and add homogeneous VMs(subGroup) to a specified MCI (Set
-        subGroupSize for multiple VMs)
+      summary: Add Homogeneous VM SubGroup to Existing MCI
+      description: |-
+        Create and add a group of identical virtual machines (subgroup) to an existing MCI using detailed specifications.
+        This endpoint provides precise control over VM configuration and placement within existing infrastructure:
+
+        **SubGroup Creation Process:**
+        1. **MCI Integration**: Validates target MCI exists and can accommodate new VMs
+        2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible
+        3. **Homogeneous Deployment**: Creates multiple identical VMs with consistent configuration
+        4. **Network Integration**: Integrates new VMs with existing MCI networking and security policies
+        5. **Group Management**: Establishes subgroup for collective management and operations
+
+        **Detailed Configuration Control:**
+        - **Specific Resource References**: Uses exact resource IDs rather than common specifications
+        - **Network Placement**: Precise control over VNet, subnet, and security group assignment
+        - **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers
+        - **Instance Customization**: Full control over VM specifications, images, and metadata
+        - **Security Settings**: Explicit security group and SSH key configuration
+
+        **SubGroup Benefits:**
+        - **Collective Operations**: Perform operations on entire subgroup simultaneously
+        - **Homogeneous Scaling**: All VMs in subgroup share identical configuration
+        - **Simplified Management**: Single configuration template for multiple VMs
+        - **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)
+        - **Group Policies**: Apply scaling, monitoring, and lifecycle policies at subgroup level
+
+        **Use Cases:**
+        - **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases
+        - **Load Distribution**: Create multiple identical VMs for load balancing scenarios
+        - **High Availability**: Deploy redundant instances across availability zones
+        - **Batch Processing**: Create worker nodes for distributed computing workloads
+        - **Development Environments**: Provision identical development or testing instances
+
+        **Configuration Requirements:**
+        - **Resource IDs**: Must specify exact resource identifiers (not common specs)
+        - **Network Configuration**: VNet, subnet, and security group must exist and be compatible
+        - **SSH Keys**: Must specify valid SSH key pairs for access management
+        - **Image Compatibility**: Specified image must be available in target region
+        - **Quota Validation**: Sufficient CSP quotas must be available for all requested VMs
+
+        **SubGroup Size Considerations:**
+        - **Small Groups (1-5 VMs)**: Fast deployment, minimal resource contention
+        - **Medium Groups (6-20 VMs)**: Optimized parallel deployment with resource batching
+        - **Large Groups (21+ VMs)**: Advanced deployment strategies to avoid CSP rate limits
+        - **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits
+
+        **Post-Deployment Integration:**
+        - SubGroup becomes integral part of parent MCI
+        - All VMs inherit MCI-level monitoring and management policies
+        - Can be scaled out further or individual VMs can be managed separately
+        - Supports all standard CB-Tumblebug VM lifecycle operations
       operationId: PostMciVm
       parameters:
       - name: nsId
         in: path
-        description: Namespace ID
+        description: Namespace ID containing the target MCI
         required: true
         schema:
           type: string
           default: default
       - name: mciId
         in: path
-        description: MCI ID
+        description: MCI ID to which the VM subgroup will be added
         required: true
         schema:
           type: string
           default: mci01
       requestBody:
-        description: Details for VMs(subGroup)
+        description: "Detailed VM subgroup specification including exact resource\
+          \ IDs, networking, and scaling parameters"
         content:
           application/json:
             schema:
@@ -3911,19 +4131,36 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: Updated MCI information including newly created VM subgroup
+            with individual VM details and status
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.TbMciInfo'
+        "400":
+          description: "Invalid VM request, missing required resources, or configuration\
+            \ conflicts"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
-          description: Not Found
+          description: "Target MCI not found, specified resources unavailable, or\
+            \ namespace inaccessible"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "409":
+          description: "SubGroup name conflicts, resource allocation conflicts, or\
+            \ MCI state incompatible with expansion"
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
-          description: Internal Server Error
+          description: "VM provisioning failed, network configuration error, or CSP\
+            \ API communication failure"
           content:
             application/json:
               schema:
@@ -4390,26 +4627,73 @@ paths:
     post:
       tags:
       - "[MC-Infra] MCI Provisioning and Management"
-      summary: Create VM Dynamically and add it to MCI
-      description: Create VM Dynamically and add it to MCI
+      summary: Add VM Dynamically to Existing MCI
+      description: |-
+        Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management.
+        This endpoint provides elastic scaling capabilities for running MCIs:
+
+        **Dynamic VM Addition Process:**
+        1. **MCI Validation**: Verifies target MCI exists and is in a valid state for expansion
+        2. **Resource Discovery**: Resolves common spec and image to provider-specific resources
+        3. **Network Integration**: Automatically configures new VMs to use existing MCI network resources
+        4. **Subgroup Management**: Creates new subgroups or expands existing ones based on configuration
+        5. **Status Synchronization**: Updates MCI status and metadata to reflect new VM additions
+
+        **Integration with Existing Infrastructure:**
+        - **Network Reuse**: New VMs automatically join existing VNets and security groups
+        - **SSH Key Sharing**: Uses existing SSH keys for consistent access management
+        - **Monitoring Integration**: New VMs inherit monitoring configuration from parent MCI
+        - **Label Propagation**: Applies MCI-level labels and policies to new VMs
+        - **Resource Consistency**: Maintains naming conventions and resource organization
+
+        **Scaling Scenarios:**
+        - **Horizontal Scaling**: Add more instances to handle increased workload
+        - **Multi-Region Expansion**: Deploy VMs in new regions while maintaining MCI cohesion
+        - **Provider Diversification**: Add VMs from different cloud providers for redundancy
+        - **Workload Specialization**: Deploy VMs with different specifications for specific tasks
+
+        **Configuration Requirements:**
+        - `commonSpec`: Must specify valid VM specification from system namespace
+        - `commonImage`: Must specify valid image compatible with target provider/region
+        - `name`: Becomes subgroup name; VMs will be named with sequential suffixes
+        - `subGroupSize`: Number of identical VMs to create (default: 1)
+
+        **Network and Security:**
+        - New VMs automatically inherit security group rules from existing MCI
+        - Network connectivity to existing VMs is established automatically
+        - Firewall rules and access policies are applied consistently
+        - SSH access is configured using existing key pairs
+
+        **Example Use Cases:**
+        - Scale out web tier during traffic spikes
+        - Add GPU instances for machine learning workloads
+        - Deploy edge nodes in additional geographic regions
+        - Add specialized storage or database nodes to existing application stack
+
+        **Post-Addition Operations:**
+        - New VMs are immediately available for standard MCI operations
+        - Can be individually managed or grouped with existing subgroups
+        - Monitoring and logging are automatically configured
+        - Application deployment and configuration management can proceed immediately
       operationId: PostMciVmDynamic
       parameters:
       - name: nsId
         in: path
-        description: Namespace ID
+        description: Namespace ID containing the target MCI
         required: true
         schema:
           type: string
           default: default
       - name: mciId
         in: path
-        description: MCI ID
+        description: MCI ID to which new VMs will be added
         required: true
         schema:
           type: string
           default: mci01
       requestBody:
-        description: Details for Vm dynamic request
+        description: "VM dynamic request specifying commonSpec, commonImage, and scaling\
+          \ parameters"
         content:
           application/json:
             schema:
@@ -4417,19 +4701,32 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: Updated MCI information including newly added VMs and current
+            status
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.TbMciInfo'
+        "400":
+          description: Invalid VM request or incompatible configuration parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
-          description: Not Found
+          description: Target MCI not found or specified resources unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "409":
+          description: Subgroup name conflicts or MCI in incompatible state
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
-          description: Internal Server Error
+          description: VM creation failed or network integration error
           content:
             application/json:
               schema:
@@ -4730,32 +5027,104 @@ paths:
     post:
       tags:
       - "[MC-Infra] MCI Provisioning and Management"
-      summary: Create MCI Dynamically
-      description: Create MCI Dynamically from common spec and image
+      summary: Create MCI Dynamically with Intelligent Resource Selection
+      description: |-
+        Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.
+        This is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:
+
+        **Dynamic Resource Creation:**
+        1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace
+        2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider
+        3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously
+        4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically
+        5. **Failure Recovery**: Implements configurable failure policies for robust deployment
+
+        **Key Advantages Over Static MCI:**
+        - **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources
+        - **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys
+        - **Multi-Cloud Optimization**: Intelligent placement and configuration across providers
+        - **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically
+        - **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization
+
+        **Configuration Process:**
+        1. **Resource Discovery**: Use `/mciRecommendVm` to find suitable VM specifications
+        2. **Image Selection**: Use system namespace to discover compatible images
+        3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment
+        4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration
+        5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options
+
+        **Failure Policies (PolicyOnPartialFailure):**
+        - **`continue`** (default): Create MCI with successful VMs, failed VMs remain for manual refinement
+        - **`rollback`**: Delete entire MCI if any VM fails (all-or-nothing deployment)
+        - **`refine`**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)
+
+        **Deployment Options:**
+        - **`hold`**: Create MCI object but hold VM provisioning for manual approval
+        - **Normal**: Proceed with immediate VM provisioning after resource creation
+
+        **Multi-Cloud Example Configuration:**
+        ```json
+        {
+        "name": "multi-cloud-web-tier",
+        "description": "Web application across AWS, Azure, and GCP",
+        "policyOnPartialFailure": "refine",
+        "vm": [
+        {
+        "name": "aws-web-servers",
+        "subGroupSize": "3",
+        "commonSpec": "aws+us-east-1+t3.medium",
+        "commonImage": "ami-0abcdef1234567890",
+        "rootDiskSize": "100",
+        "label": {"tier": "web", "provider": "aws"}
+        },
+        {
+        "name": "azure-api-servers",
+        "subGroupSize": "2",
+        "commonSpec": "azure+eastus+Standard_B2s",
+        "commonImage": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts",
+        "label": {"tier": "api", "provider": "azure"}
+        }
+        ]
+        }
+        ```
+
+        **Performance Considerations:**
+        - VM provisioning occurs in parallel across providers
+        - Network resources are created concurrently where possible
+        - Large deployments (>10 VMs) automatically use optimized batching
+        - Built-in rate limiting prevents CSP API throttling
+
+        **Monitoring and Post-Deployment:**
+        - Optional CB-Dragonfly monitoring agent installation
+        - Custom post-deployment command execution
+        - Real-time status tracking and progress updates
+        - Automatic resource labeling and metadata management
       operationId: PostMciDynamic
       parameters:
       - name: nsId
         in: path
-        description: Namespace ID
+        description: Namespace ID for resource organization and isolation
         required: true
         schema:
           type: string
           default: default
       - name: option
         in: query
-        description: Option for MCI creation
+        description: "Deployment option: 'hold' to create MCI without immediate VM\
+          \ provisioning"
         schema:
           type: string
           enum:
           - hold
       - name: x-request-id
         in: header
-        description: Custom request ID
+        description: Custom request ID for tracking and correlation across API calls
         schema:
           type: string
       requestBody:
-        description: "Request body to provision MCI dynamically. Must include commonSpec\
-          \ and commonImage info of each VM request. Example multi-cloud setup: {\\"
+        description: Dynamic MCI request with common specifications. Must include
+          commonSpec and commonImage for each VM group. See description for detailed
+          example.
         content:
           application/json:
             schema:
@@ -4763,19 +5132,35 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: "Successfully created MCI with VM deployment status, resource\
+            \ mappings, and configuration details"
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.TbMciInfo'
+        "400":
+          description: "Invalid request format, missing required fields, or unsupported\
+            \ configuration"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
-          description: Not Found
+          description: "Namespace not found, specified specs/images unavailable, or\
+            \ CSP resources inaccessible"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "409":
+          description: MCI name already exists or resource naming conflicts detected
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
-          description: Internal Server Error
+          description: "Internal deployment error, CSP API failures, or resource creation\
+            \ timeouts"
           content:
             application/json:
               schema:
@@ -5293,19 +5678,52 @@ paths:
     post:
       tags:
       - "[MC-Infra] MCI Provisioning and Management"
-      summary: Register existing VM in a CSP to Cloud-Barista MCI
-      description: Register existing VM in a CSP to Cloud-Barista MCI
+      summary: Register Existing CSP VMs into Cloud-Barista MCI
+      description: |-
+        Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.
+        This endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:
+
+        **Registration Process:**
+        1. **Discovery**: Validates that the specified VM exists in the target CSP
+        2. **Metadata Import**: Retrieves VM configuration, network settings, and current status
+        3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources
+        4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP VM state
+        5. **Management Integration**: Enables CB-Tumblebug operations on the registered VMs
+
+        **Supported VM States:**
+        - Running VMs (most common use case)
+        - Stopped VMs (will be registered with current state)
+        - VMs with attached storage and network interfaces
+
+        **Resource Compatibility:**
+        - VM must exist in a supported CSP (AWS, Azure, GCP, etc.)
+        - Network resources (VPC, subnets, security groups) will be discovered and mapped
+        - Storage volumes and attached disks will be registered automatically
+        - SSH keys and security configurations will be imported
+
+        **Post-Registration Capabilities:**
+        - Standard CB-Tumblebug VM lifecycle operations (start, stop, terminate)
+        - Monitoring agent installation (if CB-Dragonfly is configured)
+        - Command execution and automation
+        - Integration with other CB-Tumblebug MCIs
+
+        **Important Notes:**
+        - Registration does not modify the existing VM configuration
+        - Original CSP billing and resource management still applies
+        - CB-Tumblebug provides additional management layer and automation
+        - Ensure proper CSP credentials and permissions are configured
       operationId: PostRegisterCSPNativeVM
       parameters:
       - name: nsId
         in: path
-        description: Namespace ID
+        description: Namespace ID for organizing registered resources
         required: true
         schema:
           type: string
           default: default
       requestBody:
-        description: Details for an MCI object with existing CSP VM ID
+        description: MCI registration request containing existing CSP VM IDs and connection
+          details
         content:
           application/json:
             schema:
@@ -5313,19 +5731,33 @@ paths:
         required: true
       responses:
         "200":
-          description: OK
+          description: Registered MCI information with imported VM details and current
+            status
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.TbMciInfo'
+        "400":
+          description: Invalid request format or missing required CSP VM identifiers
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
         "404":
-          description: Not Found
+          description: Specified VMs not found in target CSP or namespace doesn't
+            exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "409":
+          description: VM already registered or MCI name conflicts
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
-          description: Internal Server Error
+          description: CSP communication error or registration process failure
           content:
             application/json:
               schema:
@@ -8683,36 +9115,91 @@ paths:
     post:
       tags:
       - "[MC-Infra] MCI Provisioning and Management"
-      summary: Create System MCI Dynamically for Special Purpose in NS:system
-      description: Create System MCI Dynamically for Special Purpose
+      summary: Create System MCI for CB-Tumblebug Internal Operations
+      description: |-
+        Create specialized MCI instances for CB-Tumblebug system operations and infrastructure probing.
+        This endpoint provisions system-level infrastructure that supports CB-Tumblebug's internal functions:
+
+        **System MCI Types:**
+        - `probe`: Creates lightweight VMs for network connectivity testing and CSP capability discovery
+        - `monitor`: Deploys monitoring infrastructure for system health and performance tracking
+        - `test`: Provisions test environments for validating CSP integrations and features
+
+        **Probe MCI Features:**
+        - **Connectivity Testing**: Validates network paths between different CSP regions
+        - **Latency Measurement**: Measures inter-region and inter-provider network performance
+        - **Feature Discovery**: Tests CSP-specific capabilities and service availability
+        - **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources
+
+        **System Namespace:**
+        - All system MCIs are created in the special `system` namespace
+        - Isolated from user workloads and regular MCI operations
+        - Managed automatically by CB-Tumblebug internal processes
+        - May be used for background maintenance and monitoring tasks
+
+        **Automatic Configuration:**
+        - Uses optimized VM specifications for system tasks (typically minimal resources)
+        - Automatically selects appropriate regions and providers based on probe requirements
+        - Configures necessary network access and security policies
+        - Deploys with minimal attack surface and security hardening
+
+        **Lifecycle Management:**
+        - System MCIs may be automatically created, updated, or destroyed by CB-Tumblebug
+        - Typically short-lived for specific system tasks
+        - Resource cleanup is handled automatically
+        - Status and results are logged for system administrators
+
+        **Use Cases:**
+        - Infrastructure health checks and validation
+        - Performance benchmarking across cloud providers
+        - Automated testing of new CSP integrations
+        - Network topology discovery and optimization
       operationId: PostSystemMci
       parameters:
       - name: option
         in: query
-        description: Option for the purpose of system MCI
+        description: "System MCI type: 'probe' for connectivity testing, 'monitor'\
+          \ for system monitoring"
         schema:
           type: string
           enum:
           - probe
+          - monitor
+          - test
+      requestBody:
+        description: "Optional MCI configuration. If not provided, system defaults\
+          \ will be used"
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.TbMciDynamicReq'
+        required: false
       responses:
         "200":
-          description: OK
+          description: Created system MCI with specialized configuration and status
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.TbMciInfo'
-        "404":
-          description: Not Found
+        "400":
+          description: Invalid system option or malformed request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "403":
+          description: Insufficient permissions for system MCI creation
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
         "500":
-          description: Internal Server Error
+          description: System MCI creation failed or CSP integration error
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: mciReq
   /testStreamResponse:
     post:
       tags:
@@ -9874,6 +10361,34 @@ components:
           - gcp+us-west1+g1-small
           items:
             type: string
+    model.MciCreationErrors:
+      type: object
+      properties:
+        failedVmCount:
+          type: integer
+          description: FailedVmCount is the number of VMs that failed to be created
+        failureHandlingStrategy:
+          type: string
+          description: FailureHandlingStrategy indicates how failures were handled
+        successfulVmCount:
+          type: integer
+          description: SuccessfulVmCount is the number of VMs that were successfully
+            created
+        totalVmCount:
+          type: integer
+          description: TotalVmCount is the total number of VMs that were supposed
+            to be created
+        vmCreationErrors:
+          type: array
+          description: VmCreationErrors contains errors from actual VM creation phase
+          items:
+            $ref: '#/components/schemas/model.VmCreationError'
+        vmObjectCreationErrors:
+          type: array
+          description: VmObjectCreationErrors contains errors from VM object creation
+            phase
+          items:
+            $ref: '#/components/schemas/model.VmCreationError'
     model.MciPolicyInfo:
       type: object
       properties:
@@ -10568,6 +11083,17 @@ components:
           type: string
           description: Overall assessment of the MCI request
           example: Ready/Warning/Error
+        policyDescription:
+          type: string
+          example: "If some VMs fail during creation, MCI will be created with successfully\
+            \ provisioned VMs only"
+        policyOnPartialFailure:
+          type: string
+          description: Failure policy analysis
+          example: continue
+        policyRecommendation:
+          type: string
+          example: Consider 'refine' policy for automatic cleanup of failed VMs
         recommendations:
           type: array
           description: Recommendations for improvement
@@ -12318,6 +12844,19 @@ components:
         name:
           type: string
           example: mci01
+        policyOnPartialFailure:
+          type: string
+          description: |-
+            PolicyOnPartialFailure determines how to handle VM creation failures
+            - "continue": Continue with partial MCI creation (default)
+            - "rollback": Cleanup entire MCI when any VM fails
+            - "refine": Mark failed VMs for refinement
+          example: continue
+          default: continue
+          enum:
+          - continue
+          - rollback
+          - refine
         postCommand:
           type: object
           description: PostCommand is for the command to bootstrap the VMs
@@ -12373,6 +12912,12 @@ components:
           enum:
           - "yes"
           - "no"
+        creationErrors:
+          type: object
+          description: CreationErrors contains information about VM creation failures
+            (if any)
+          allOf:
+          - $ref: '#/components/schemas/model.MciCreationErrors'
         description:
           type: string
         id:
@@ -12473,6 +13018,19 @@ components:
           example: mci01
         placementAlgo:
           type: string
+        policyOnPartialFailure:
+          type: string
+          description: |-
+            PolicyOnPartialFailure determines how to handle VM creation failures
+            - "continue": Continue with partial MCI creation (default)
+            - "rollback": Cleanup entire MCI when any VM fails
+            - "refine": Mark failed VMs for refinement
+          example: continue
+          default: continue
+          enum:
+          - continue
+          - rollback
+          - refine
         postCommand:
           type: object
           description: PostCommand is for the command to bootstrap the VMs
@@ -13568,6 +14126,21 @@ components:
           type: string
         useFirstNZones:
           type: string
+    model.VmCreationError:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error is the error message
+        phase:
+          type: string
+          description: Phase indicates when the error occurred
+        timestamp:
+          type: string
+          description: Timestamp when the error occurred
+        vmName:
+          type: string
+          description: VmName is the name of the VM that failed
     model.VpnIdList:
       type: object
       properties:

--- a/src/interface/rest/server/infra/provisioning.go
+++ b/src/interface/rest/server/infra/provisioning.go
@@ -26,16 +26,47 @@ import (
 
 // RestPostMci godoc
 // @ID PostMci
-// @Summary Create MCI
-// @Description Create MCI
+// @Summary Create MCI (Multi-Cloud Infrastructure)
+// @Description Create MCI with detailed VM specifications and resource configuration.
+// @Description This endpoint creates a complete multi-cloud infrastructure by:
+// @Description 1. **VM Provisioning**: Creates VMs across multiple cloud providers using predefined specs and images
+// @Description 2. **Resource Management**: Automatically handles VPC/VNet, security groups, SSH keys, and network configuration
+// @Description 3. **Status Tracking**: Monitors VM creation progress and handles failures based on policy settings
+// @Description 4. **Post-Deployment**: Optionally installs monitoring agents and executes custom commands
+// @Description
+// @Description **Key Features:**
+// @Description - Multi-cloud VM deployment with heterogeneous configurations
+// @Description - Automatic resource dependency management (VPC → Security Group → VM)
+// @Description - Built-in failure handling with configurable policies (continue/rollback/refine)
+// @Description - Optional CB-Dragonfly monitoring agent installation
+// @Description - Post-deployment command execution support
+// @Description - Real-time status updates and progress tracking
+// @Description
+// @Description **VM Lifecycle:**
+// @Description 1. Creating → Running (successful deployment)
+// @Description 2. Creating → Failed (deployment error, handled by failure policy)
+// @Description 3. Running → Terminated (manual or policy-driven cleanup)
+// @Description
+// @Description **Failure Policies:**
+// @Description - `continue`: Keep successful VMs, mark failed ones for later refinement
+// @Description - `rollback`: Delete entire MCI if any VM fails (all-or-nothing)
+// @Description - `refine`: Automatically clean up failed VMs, keep successful ones
+// @Description
+// @Description **Resource Requirements:**
+// @Description - Valid VM specifications (must exist in system namespace)
+// @Description - Valid images (must be available in target CSP regions)
+// @Description - Sufficient CSP quotas and permissions
+// @Description - Network connectivity between components
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param mciReq body model.TbMciReq true "Details for an MCI object"
-// @Success 200 {object} model.TbMciInfo
-// @Failure 404 {object} model.SimpleMsg
-// @Failure 500 {object} model.SimpleMsg
+// @Param nsId path string true "Namespace ID for resource isolation" default(default)
+// @Param mciReq body model.TbMciReq true "MCI creation request with VM specifications, networking, and deployment options"
+// @Success 200 {object} model.TbMciInfo "Created MCI information with VM details, status, and resource mapping"
+// @Failure 400 {object} model.SimpleMsg "Invalid request parameters or missing required fields"
+// @Failure 404 {object} model.SimpleMsg "Namespace not found or specified resources unavailable"
+// @Failure 409 {object} model.SimpleMsg "MCI name already exists in namespace"
+// @Failure 500 {object} model.SimpleMsg "Internal server error during MCI creation or CSP communication failure"
 // @Router /ns/{nsId}/mci [post]
 func RestPostMci(c echo.Context) error {
 
@@ -53,16 +84,49 @@ func RestPostMci(c echo.Context) error {
 
 // RestPostRegisterCSPNativeVM godoc
 // @ID PostRegisterCSPNativeVM
-// @Summary Register existing VM in a CSP to Cloud-Barista MCI
-// @Description Register existing VM in a CSP to Cloud-Barista MCI
+// @Summary Register Existing CSP VMs into Cloud-Barista MCI
+// @Description Import and register pre-existing virtual machines from cloud service providers into CB-Tumblebug management.
+// @Description This endpoint allows you to bring existing CSP resources under CB-Tumblebug control without recreating them:
+// @Description
+// @Description **Registration Process:**
+// @Description 1. **Discovery**: Validates that the specified VM exists in the target CSP
+// @Description 2. **Metadata Import**: Retrieves VM configuration, network settings, and current status
+// @Description 3. **Resource Mapping**: Creates CB-Tumblebug resource objects that reference the existing CSP resources
+// @Description 4. **Status Synchronization**: Aligns CB-Tumblebug status with actual CSP VM state
+// @Description 5. **Management Integration**: Enables CB-Tumblebug operations on the registered VMs
+// @Description
+// @Description **Supported VM States:**
+// @Description - Running VMs (most common use case)
+// @Description - Stopped VMs (will be registered with current state)
+// @Description - VMs with attached storage and network interfaces
+// @Description
+// @Description **Resource Compatibility:**
+// @Description - VM must exist in a supported CSP (AWS, Azure, GCP, etc.)
+// @Description - Network resources (VPC, subnets, security groups) will be discovered and mapped
+// @Description - Storage volumes and attached disks will be registered automatically
+// @Description - SSH keys and security configurations will be imported
+// @Description
+// @Description **Post-Registration Capabilities:**
+// @Description - Standard CB-Tumblebug VM lifecycle operations (start, stop, terminate)
+// @Description - Monitoring agent installation (if CB-Dragonfly is configured)
+// @Description - Command execution and automation
+// @Description - Integration with other CB-Tumblebug MCIs
+// @Description
+// @Description **Important Notes:**
+// @Description - Registration does not modify the existing VM configuration
+// @Description - Original CSP billing and resource management still applies
+// @Description - CB-Tumblebug provides additional management layer and automation
+// @Description - Ensure proper CSP credentials and permissions are configured
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param mciReq body model.TbMciReq true "Details for an MCI object with existing CSP VM ID"
-// @Success 200 {object} model.TbMciInfo
-// @Failure 404 {object} model.SimpleMsg
-// @Failure 500 {object} model.SimpleMsg
+// @Param nsId path string true "Namespace ID for organizing registered resources" default(default)
+// @Param mciReq body model.TbMciReq true "MCI registration request containing existing CSP VM IDs and connection details"
+// @Success 200 {object} model.TbMciInfo "Registered MCI information with imported VM details and current status"
+// @Failure 400 {object} model.SimpleMsg "Invalid request format or missing required CSP VM identifiers"
+// @Failure 404 {object} model.SimpleMsg "Specified VMs not found in target CSP or namespace doesn't exist"
+// @Failure 409 {object} model.SimpleMsg "VM already registered or MCI name conflicts"
+// @Failure 500 {object} model.SimpleMsg "CSP communication error or registration process failure"
 // @Router /ns/{nsId}/registerCspVm [post]
 func RestPostRegisterCSPNativeVM(c echo.Context) error {
 
@@ -80,15 +144,53 @@ func RestPostRegisterCSPNativeVM(c echo.Context) error {
 
 // RestPostSystemMci godoc
 // @ID PostSystemMci
-// @Summary Create System MCI Dynamically for Special Purpose in NS:system
-// @Description Create System MCI Dynamically for Special Purpose
+// @Summary Create System MCI for CB-Tumblebug Internal Operations
+// @Description Create specialized MCI instances for CB-Tumblebug system operations and infrastructure probing.
+// @Description This endpoint provisions system-level infrastructure that supports CB-Tumblebug's internal functions:
+// @Description
+// @Description **System MCI Types:**
+// @Description - `probe`: Creates lightweight VMs for network connectivity testing and CSP capability discovery
+// @Description - `monitor`: Deploys monitoring infrastructure for system health and performance tracking
+// @Description - `test`: Provisions test environments for validating CSP integrations and features
+// @Description
+// @Description **Probe MCI Features:**
+// @Description - **Connectivity Testing**: Validates network paths between different CSP regions
+// @Description - **Latency Measurement**: Measures inter-region and inter-provider network performance
+// @Description - **Feature Discovery**: Tests CSP-specific capabilities and service availability
+// @Description - **Resource Validation**: Verifies that CB-Tumblebug can successfully provision resources
+// @Description
+// @Description **System Namespace:**
+// @Description - All system MCIs are created in the special `system` namespace
+// @Description - Isolated from user workloads and regular MCI operations
+// @Description - Managed automatically by CB-Tumblebug internal processes
+// @Description - May be used for background maintenance and monitoring tasks
+// @Description
+// @Description **Automatic Configuration:**
+// @Description - Uses optimized VM specifications for system tasks (typically minimal resources)
+// @Description - Automatically selects appropriate regions and providers based on probe requirements
+// @Description - Configures necessary network access and security policies
+// @Description - Deploys with minimal attack surface and security hardening
+// @Description
+// @Description **Lifecycle Management:**
+// @Description - System MCIs may be automatically created, updated, or destroyed by CB-Tumblebug
+// @Description - Typically short-lived for specific system tasks
+// @Description - Resource cleanup is handled automatically
+// @Description - Status and results are logged for system administrators
+// @Description
+// @Description **Use Cases:**
+// @Description - Infrastructure health checks and validation
+// @Description - Performance benchmarking across cloud providers
+// @Description - Automated testing of new CSP integrations
+// @Description - Network topology discovery and optimization
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param option query string false "Option for the purpose of system MCI" Enums(probe)
-// @Success 200 {object} model.TbMciInfo
-// @Failure 404 {object} model.SimpleMsg
-// @Failure 500 {object} model.SimpleMsg
+// @Param option query string false "System MCI type: 'probe' for connectivity testing, 'monitor' for system monitoring" Enums(probe,monitor,test)
+// @Param mciReq body model.TbMciDynamicReq false "Optional MCI configuration. If not provided, system defaults will be used"
+// @Success 200 {object} model.TbMciInfo "Created system MCI with specialized configuration and status"
+// @Failure 400 {object} model.SimpleMsg "Invalid system option or malformed request"
+// @Failure 403 {object} model.SimpleMsg "Insufficient permissions for system MCI creation"
+// @Failure 500 {object} model.SimpleMsg "System MCI creation failed or CSP integration error"
 // @Router /systemMci [post]
 func RestPostSystemMci(c echo.Context) error {
 
@@ -105,18 +207,89 @@ func RestPostSystemMci(c echo.Context) error {
 
 // RestPostMciDynamic godoc
 // @ID PostMciDynamic
-// @Summary Create MCI Dynamically
-// @Description Create MCI Dynamically from common spec and image
+// @Summary Create MCI Dynamically with Intelligent Resource Selection
+// @Description Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.
+// @Description This is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:
+// @Description
+// @Description **Dynamic Resource Creation:**
+// @Description 1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace
+// @Description 2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider
+// @Description 3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously
+// @Description 4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically
+// @Description 5. **Failure Recovery**: Implements configurable failure policies for robust deployment
+// @Description
+// @Description **Key Advantages Over Static MCI:**
+// @Description - **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources
+// @Description - **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys
+// @Description - **Multi-Cloud Optimization**: Intelligent placement and configuration across providers
+// @Description - **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically
+// @Description - **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization
+// @Description
+// @Description **Configuration Process:**
+// @Description 1. **Resource Discovery**: Use `/mciRecommendVm` to find suitable VM specifications
+// @Description 2. **Image Selection**: Use system namespace to discover compatible images
+// @Description 3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment
+// @Description 4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration
+// @Description 5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options
+// @Description
+// @Description **Failure Policies (PolicyOnPartialFailure):**
+// @Description - **`continue`** (default): Create MCI with successful VMs, failed VMs remain for manual refinement
+// @Description - **`rollback`**: Delete entire MCI if any VM fails (all-or-nothing deployment)
+// @Description - **`refine`**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)
+// @Description
+// @Description **Deployment Options:**
+// @Description - **`hold`**: Create MCI object but hold VM provisioning for manual approval
+// @Description - **Normal**: Proceed with immediate VM provisioning after resource creation
+// @Description
+// @Description **Multi-Cloud Example Configuration:**
+// @Description ```json
+// @Description {
+// @Description   "name": "multi-cloud-web-tier",
+// @Description   "description": "Web application across AWS, Azure, and GCP",
+// @Description   "policyOnPartialFailure": "refine",
+// @Description   "vm": [
+// @Description     {
+// @Description       "name": "aws-web-servers",
+// @Description       "subGroupSize": "3",
+// @Description       "commonSpec": "aws+us-east-1+t3.medium",
+// @Description       "commonImage": "ami-0abcdef1234567890",
+// @Description       "rootDiskSize": "100",
+// @Description       "label": {"tier": "web", "provider": "aws"}
+// @Description     },
+// @Description     {
+// @Description       "name": "azure-api-servers",
+// @Description       "subGroupSize": "2",
+// @Description       "commonSpec": "azure+eastus+Standard_B2s",
+// @Description       "commonImage": "Canonical:0001-com-ubuntu-server-jammy:22_04-lts",
+// @Description       "label": {"tier": "api", "provider": "azure"}
+// @Description     }
+// @Description   ]
+// @Description }
+// @Description ```
+// @Description
+// @Description **Performance Considerations:**
+// @Description - VM provisioning occurs in parallel across providers
+// @Description - Network resources are created concurrently where possible
+// @Description - Large deployments (>10 VMs) automatically use optimized batching
+// @Description - Built-in rate limiting prevents CSP API throttling
+// @Description
+// @Description **Monitoring and Post-Deployment:**
+// @Description - Optional CB-Dragonfly monitoring agent installation
+// @Description - Custom post-deployment command execution
+// @Description - Real-time status tracking and progress updates
+// @Description - Automatic resource labeling and metadata management
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param mciReq body model.TbMciDynamicReq true "Request body to provision MCI dynamically. Must include commonSpec and commonImage info of each VM request. Example multi-cloud setup: {\"name\":\"mc-infra\",\"description\":\"Multi-cloud infrastructure\",\"vm\":[{\"name\":\"aws-workers\",\"subGroupSize\":\"3\",\"commonSpec\":\"aws+ap-northeast-2+t3.nano\",\"commonImage\":\"ami-01f71f215b23ba262\",\"rootDiskSize\":\"50\",\"label\":{\"role\":\"worker\",\"csp\":\"aws\"}},{\"name\":\"azure-head\",\"subGroupSize\":\"2\",\"commonSpec\":\"azure+koreasouth+standard_b1s\",\"commonImage\":\"Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210\",\"rootDiskSize\":\"50\",\"label\":{\"role\":\"head\",\"csp\":\"azure\"}},{\"name\":\"gcp-test\",\"subGroupSize\":\"1\",\"commonSpec\":\"gcp+asia-northeast3+g1-small\",\"commonImage\":\"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250712\",\"rootDiskSize\":\"50\",\"label\":{\"role\":\"test\",\"csp\":\"gcp\"}}}]. Use /mciRecommendVm and /mciDynamicCheckRequest for resource discovery. Guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1570"
-// @Param option query string false "Option for MCI creation" Enums(hold)
-// @Param x-request-id header string false "Custom request ID"
-// @Success 200 {object} model.TbMciInfo
-// @Failure 404 {object} model.SimpleMsg
-// @Failure 500 {object} model.SimpleMsg
+// @Param nsId path string true "Namespace ID for resource organization and isolation" default(default)
+// @Param mciReq body model.TbMciDynamicReq true "Dynamic MCI request with common specifications. Must include commonSpec and commonImage for each VM group. See description for detailed example."
+// @Param option query string false "Deployment option: 'hold' to create MCI without immediate VM provisioning" Enums(hold)
+// @Param x-request-id header string false "Custom request ID for tracking and correlation across API calls"
+// @Success 200 {object} model.TbMciInfo "Successfully created MCI with VM deployment status, resource mappings, and configuration details"
+// @Failure 400 {object} model.SimpleMsg "Invalid request format, missing required fields, or unsupported configuration"
+// @Failure 404 {object} model.SimpleMsg "Namespace not found, specified specs/images unavailable, or CSP resources inaccessible"
+// @Failure 409 {object} model.SimpleMsg "MCI name already exists or resource naming conflicts detected"
+// @Failure 500 {object} model.SimpleMsg "Internal deployment error, CSP API failures, or resource creation timeouts"
 // @Router /ns/{nsId}/mciDynamic [post]
 func RestPostMciDynamic(c echo.Context) error {
 	reqID := c.Request().Header.Get(echo.HeaderXRequestID)
@@ -197,17 +370,64 @@ func RestPostMciDynamicReview(c echo.Context) error {
 
 // RestPostMciVmDynamic godoc
 // @ID PostMciVmDynamic
-// @Summary Create VM Dynamically and add it to MCI
-// @Description Create VM Dynamically and add it to MCI
+// @Summary Add VM Dynamically to Existing MCI
+// @Description Dynamically add new virtual machines to an existing MCI using common specifications and automated resource management.
+// @Description This endpoint provides elastic scaling capabilities for running MCIs:
+// @Description
+// @Description **Dynamic VM Addition Process:**
+// @Description 1. **MCI Validation**: Verifies target MCI exists and is in a valid state for expansion
+// @Description 2. **Resource Discovery**: Resolves common spec and image to provider-specific resources
+// @Description 3. **Network Integration**: Automatically configures new VMs to use existing MCI network resources
+// @Description 4. **Subgroup Management**: Creates new subgroups or expands existing ones based on configuration
+// @Description 5. **Status Synchronization**: Updates MCI status and metadata to reflect new VM additions
+// @Description
+// @Description **Integration with Existing Infrastructure:**
+// @Description - **Network Reuse**: New VMs automatically join existing VNets and security groups
+// @Description - **SSH Key Sharing**: Uses existing SSH keys for consistent access management
+// @Description - **Monitoring Integration**: New VMs inherit monitoring configuration from parent MCI
+// @Description - **Label Propagation**: Applies MCI-level labels and policies to new VMs
+// @Description - **Resource Consistency**: Maintains naming conventions and resource organization
+// @Description
+// @Description **Scaling Scenarios:**
+// @Description - **Horizontal Scaling**: Add more instances to handle increased workload
+// @Description - **Multi-Region Expansion**: Deploy VMs in new regions while maintaining MCI cohesion
+// @Description - **Provider Diversification**: Add VMs from different cloud providers for redundancy
+// @Description - **Workload Specialization**: Deploy VMs with different specifications for specific tasks
+// @Description
+// @Description **Configuration Requirements:**
+// @Description - `commonSpec`: Must specify valid VM specification from system namespace
+// @Description - `commonImage`: Must specify valid image compatible with target provider/region
+// @Description - `name`: Becomes subgroup name; VMs will be named with sequential suffixes
+// @Description - `subGroupSize`: Number of identical VMs to create (default: 1)
+// @Description
+// @Description **Network and Security:**
+// @Description - New VMs automatically inherit security group rules from existing MCI
+// @Description - Network connectivity to existing VMs is established automatically
+// @Description - Firewall rules and access policies are applied consistently
+// @Description - SSH access is configured using existing key pairs
+// @Description
+// @Description **Example Use Cases:**
+// @Description - Scale out web tier during traffic spikes
+// @Description - Add GPU instances for machine learning workloads
+// @Description - Deploy edge nodes in additional geographic regions
+// @Description - Add specialized storage or database nodes to existing application stack
+// @Description
+// @Description **Post-Addition Operations:**
+// @Description - New VMs are immediately available for standard MCI operations
+// @Description - Can be individually managed or grouped with existing subgroups
+// @Description - Monitoring and logging are automatically configured
+// @Description - Application deployment and configuration management can proceed immediately
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param mciId path string true "MCI ID" default(mci01)
-// @Param vmReq body model.TbVmDynamicReq true "Details for Vm dynamic request"
-// @Success 200 {object} model.TbMciInfo
-// @Failure 404 {object} model.SimpleMsg
-// @Failure 500 {object} model.SimpleMsg
+// @Param nsId path string true "Namespace ID containing the target MCI" default(default)
+// @Param mciId path string true "MCI ID to which new VMs will be added" default(mci01)
+// @Param vmReq body model.TbVmDynamicReq true "VM dynamic request specifying commonSpec, commonImage, and scaling parameters"
+// @Success 200 {object} model.TbMciInfo "Updated MCI information including newly added VMs and current status"
+// @Failure 400 {object} model.SimpleMsg "Invalid VM request or incompatible configuration parameters"
+// @Failure 404 {object} model.SimpleMsg "Target MCI not found or specified resources unavailable"
+// @Failure 409 {object} model.SimpleMsg "Subgroup name conflicts or MCI in incompatible state"
+// @Failure 500 {object} model.SimpleMsg "VM creation failed or network integration error"
 // @Router /ns/{nsId}/mci/{mciId}/vmDynamic [post]
 func RestPostMciVmDynamic(c echo.Context) error {
 
@@ -225,15 +445,62 @@ func RestPostMciVmDynamic(c echo.Context) error {
 
 // RestPostMciDynamicCheckRequest godoc
 // @ID PostMciDynamicCheckRequest
-// @Summary Check available ConnectionConfig list for creating MCI Dynamically
-// @Description Check available ConnectionConfig list before create MCI Dynamically from common spec and image
+// @Summary Check Resource Availability for Dynamic MCI Creation
+// @Description Validate resource availability and discover optimal connection configurations before creating MCI dynamically.
+// @Description This endpoint provides comprehensive resource validation and connection discovery for MCI planning:
+// @Description
+// @Description **Resource Validation Process:**
+// @Description 1. **Specification Analysis**: Validates that requested common specs exist and are accessible
+// @Description 2. **Provider Discovery**: Identifies available cloud providers and regions for each specification
+// @Description 3. **Connectivity Assessment**: Tests connection configurations and CSP API accessibility
+// @Description 4. **Quota Verification**: Checks available quotas and resource limits where possible
+// @Description 5. **Compatibility Matrix**: Generates matrix of viable spec-provider-region combinations
+// @Description
+// @Description **Connection Configuration Discovery:**
+// @Description - **Available Providers**: Lists all configured cloud providers (AWS, Azure, GCP, etc.)
+// @Description - **Active Regions**: Shows available regions per provider with connectivity status
+// @Description - **Specification Mapping**: Maps common specs to provider-specific instance types
+// @Description - **Image Compatibility**: Validates image availability across different providers/regions
+// @Description - **Network Capabilities**: Identifies supported network features and configurations
+// @Description
+// @Description **Pre-Deployment Validation:**
+// @Description - **Resource Existence**: Confirms all specified resources exist in system namespace
+// @Description - **Permission Verification**: Validates CSP credentials and required permissions
+// @Description - **API Connectivity**: Tests connection to CSP APIs and service endpoints
+// @Description - **Dependency Resolution**: Identifies any missing dependencies or prerequisites
+// @Description
+// @Description **Optimization Recommendations:**
+// @Description - **Cost-Effective Regions**: Suggests regions with lower pricing for specified resources
+// @Description - **Performance Optimization**: Recommends regions with better network performance
+// @Description - **Availability Zone**: Identifies optimal AZ distribution for high availability
+// @Description - **Resource Bundling**: Suggests efficient resource combinations and groupings
+// @Description
+// @Description **Output Information:**
+// @Description - **Connection Candidates**: List of viable connection configurations
+// @Description - **Provider Capabilities**: Detailed capabilities matrix per provider
+// @Description - **Resource Status**: Real-time availability status for each requested resource
+// @Description - **Recommendation Summary**: Actionable recommendations for optimal deployment
+// @Description
+// @Description **Use Cases:**
+// @Description - Pre-validate MCI configuration before expensive deployment operations
+// @Description - Discover optimal provider/region combinations for cost or performance
+// @Description - Troubleshoot resource availability issues during MCI planning
+// @Description - Generate connection configuration templates for standardized deployments
+// @Description - Assess infrastructure capacity and planning constraints
+// @Description
+// @Description **Integration Workflow:**
+// @Description 1. Use this endpoint to validate and discover connection options
+// @Description 2. Review recommendations and adjust specifications if needed
+// @Description 3. Use `/mciDynamicReview` for detailed cost estimation and final validation
+// @Description 4. Proceed with `/mciDynamic` using validated configuration
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param mciReq body model.MciConnectionConfigCandidatesReq true "Details for MCI dynamic request information"
-// @Success 200 {object} model.CheckMciDynamicReqInfo
-// @Failure 404 {object} model.SimpleMsg
-// @Failure 500 {object} model.SimpleMsg
+// @Param mciReq body model.MciConnectionConfigCandidatesReq true "Resource check request containing common specifications to validate"
+// @Success 200 {object} model.CheckMciDynamicReqInfo "Resource availability matrix with connection candidates, provider capabilities, and optimization recommendations"
+// @Failure 400 {object} model.SimpleMsg "Invalid request format or malformed specification identifiers"
+// @Failure 404 {object} model.SimpleMsg "Specified common specifications not found in system namespace"
+// @Failure 500 {object} model.SimpleMsg "CSP connectivity issues or internal validation service errors"
 // @Router /mciDynamicCheckRequest [post]
 func RestPostMciDynamicCheckRequest(c echo.Context) error {
 
@@ -248,17 +515,67 @@ func RestPostMciDynamicCheckRequest(c echo.Context) error {
 
 // RestPostMciVm godoc
 // @ID PostMciVm
-// @Summary Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize for multiple VMs)
-// @Description Create and add homogeneous VMs(subGroup) to a specified MCI (Set subGroupSize for multiple VMs)
+// @Summary Add Homogeneous VM SubGroup to Existing MCI
+// @Description Create and add a group of identical virtual machines (subgroup) to an existing MCI using detailed specifications.
+// @Description This endpoint provides precise control over VM configuration and placement within existing infrastructure:
+// @Description
+// @Description **SubGroup Creation Process:**
+// @Description 1. **MCI Integration**: Validates target MCI exists and can accommodate new VMs
+// @Description 2. **Resource Validation**: Verifies all specified resources (specs, images, networks) exist and are accessible
+// @Description 3. **Homogeneous Deployment**: Creates multiple identical VMs with consistent configuration
+// @Description 4. **Network Integration**: Integrates new VMs with existing MCI networking and security policies
+// @Description 5. **Group Management**: Establishes subgroup for collective management and operations
+// @Description
+// @Description **Detailed Configuration Control:**
+// @Description - **Specific Resource References**: Uses exact resource IDs rather than common specifications
+// @Description - **Network Placement**: Precise control over VNet, subnet, and security group assignment
+// @Description - **Storage Configuration**: Detailed disk configuration including type, size, and performance tiers
+// @Description - **Instance Customization**: Full control over VM specifications, images, and metadata
+// @Description - **Security Settings**: Explicit security group and SSH key configuration
+// @Description
+// @Description **SubGroup Benefits:**
+// @Description - **Collective Operations**: Perform operations on entire subgroup simultaneously
+// @Description - **Homogeneous Scaling**: All VMs in subgroup share identical configuration
+// @Description - **Simplified Management**: Single configuration template for multiple VMs
+// @Description - **Consistent Naming**: Automatic sequential naming (e.g., web-1, web-2, web-3)
+// @Description - **Group Policies**: Apply scaling, monitoring, and lifecycle policies at subgroup level
+// @Description
+// @Description **Use Cases:**
+// @Description - **Application Tiers**: Deploy multiple instances of web servers, application servers, or databases
+// @Description - **Load Distribution**: Create multiple identical VMs for load balancing scenarios
+// @Description - **High Availability**: Deploy redundant instances across availability zones
+// @Description - **Batch Processing**: Create worker nodes for distributed computing workloads
+// @Description - **Development Environments**: Provision identical development or testing instances
+// @Description
+// @Description **Configuration Requirements:**
+// @Description - **Resource IDs**: Must specify exact resource identifiers (not common specs)
+// @Description - **Network Configuration**: VNet, subnet, and security group must exist and be compatible
+// @Description - **SSH Keys**: Must specify valid SSH key pairs for access management
+// @Description - **Image Compatibility**: Specified image must be available in target region
+// @Description - **Quota Validation**: Sufficient CSP quotas must be available for all requested VMs
+// @Description
+// @Description **SubGroup Size Considerations:**
+// @Description - **Small Groups (1-5 VMs)**: Fast deployment, minimal resource contention
+// @Description - **Medium Groups (6-20 VMs)**: Optimized parallel deployment with resource batching
+// @Description - **Large Groups (21+ VMs)**: Advanced deployment strategies to avoid CSP rate limits
+// @Description - **Resource Limits**: Respects CSP quotas and CB-Tumblebug configuration limits
+// @Description
+// @Description **Post-Deployment Integration:**
+// @Description - SubGroup becomes integral part of parent MCI
+// @Description - All VMs inherit MCI-level monitoring and management policies
+// @Description - Can be scaled out further or individual VMs can be managed separately
+// @Description - Supports all standard CB-Tumblebug VM lifecycle operations
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param mciId path string true "MCI ID" default(mci01)
-// @Param vmReq body model.TbVmReq true "Details for VMs(subGroup)"
-// @Success 200 {object} model.TbMciInfo
-// @Failure 404 {object} model.SimpleMsg
-// @Failure 500 {object} model.SimpleMsg
+// @Param nsId path string true "Namespace ID containing the target MCI" default(default)
+// @Param mciId path string true "MCI ID to which the VM subgroup will be added" default(mci01)
+// @Param vmReq body model.TbVmReq true "Detailed VM subgroup specification including exact resource IDs, networking, and scaling parameters"
+// @Success 200 {object} model.TbMciInfo "Updated MCI information including newly created VM subgroup with individual VM details and status"
+// @Failure 400 {object} model.SimpleMsg "Invalid VM request, missing required resources, or configuration conflicts"
+// @Failure 404 {object} model.SimpleMsg "Target MCI not found, specified resources unavailable, or namespace inaccessible"
+// @Failure 409 {object} model.SimpleMsg "SubGroup name conflicts, resource allocation conflicts, or MCI state incompatible with expansion"
+// @Failure 500 {object} model.SimpleMsg "VM provisioning failed, network configuration error, or CSP API communication failure"
 // @Router /ns/{nsId}/mci/{mciId}/vm [post]
 func RestPostMciVm(c echo.Context) error {
 
@@ -275,18 +592,75 @@ func RestPostMciVm(c echo.Context) error {
 
 // RestPostMciSubGroupScaleOut godoc
 // @ID PostMciSubGroupScaleOut
-// @Summary ScaleOut subGroup in specified MCI
-// @Description ScaleOut subGroup in specified MCI
+// @Summary Scale Out Existing SubGroup in MCI
+// @Description Horizontally scale an existing VM subgroup by adding more identical instances for increased capacity.
+// @Description This endpoint provides elastic scaling capabilities for running application tiers:
+// @Description
+// @Description **Scale-Out Process:**
+// @Description 1. **SubGroup Validation**: Verifies target subgroup exists and is in scalable state
+// @Description 2. **Template Replication**: Uses existing VM configuration as template for new instances
+// @Description 3. **Resource Allocation**: Ensures sufficient CSP quotas and network resources
+// @Description 4. **Parallel Deployment**: Deploys multiple new VMs simultaneously for faster scaling
+// @Description 5. **Integration**: Seamlessly integrates new VMs into existing subgroup and MCI
+// @Description
+// @Description **Configuration Inheritance:**
+// @Description - **VM Specifications**: New VMs inherit exact specifications from existing subgroup members
+// @Description - **Network Settings**: Automatically placed in same VNet, subnet, and security groups
+// @Description - **SSH Keys**: Use same SSH key pairs for consistent access management
+// @Description - **Monitoring**: Inherit monitoring agent configuration and policies
+// @Description - **Labels and Metadata**: Propagate all labels and metadata from parent subgroup
+// @Description
+// @Description **Scaling Scenarios:**
+// @Description - **Traffic Spikes**: Quickly add capacity during high-demand periods
+// @Description - **Seasonal Scaling**: Scale out for predictable demand increases
+// @Description - **Performance Optimization**: Add instances to reduce per-VM resource utilization
+// @Description - **Geographic Expansion**: Scale existing workloads to handle broader user base
+// @Description - **Fault Tolerance**: Increase redundancy by adding more instances
+// @Description
+// @Description **Intelligent Scaling:**
+// @Description - **Sequential Naming**: New VMs follow established naming pattern (e.g., web-4, web-5, web-6)
+// @Description - **Load Distribution**: New VMs are distributed optimally across availability zones
+// @Description - **Resource Efficiency**: Reuses existing network and security infrastructure
+// @Description - **Minimal Disruption**: Scaling occurs without affecting existing VM operations
+// @Description - **Consistent Configuration**: Ensures all VMs in subgroup remain homogeneous
+// @Description
+// @Description **Operational Benefits:**
+// @Description - **Zero Downtime**: Existing VMs continue running during scale-out operation
+// @Description - **Immediate Availability**: New VMs are ready for traffic as soon as deployment completes
+// @Description - **Unified Management**: All VMs (old and new) managed through single subgroup
+// @Description - **Policy Consistency**: All scaling and management policies apply uniformly
+// @Description - **Monitoring Integration**: New VMs automatically included in existing monitoring dashboards
+// @Description
+// @Description **Scale-Out Considerations:**
+// @Description - **CSP Quotas**: Verifies sufficient instance, network, and storage quotas
+// @Description - **Region Capacity**: Ensures target region has capacity for requested instance types
+// @Description - **Network Limits**: Validates that VNet can accommodate additional VMs
+// @Description - **Cost Impact**: Additional VMs incur proportional CSP billing costs
+// @Description - **Application Readiness**: Applications should be designed to handle additional instances
+// @Description
+// @Description **Post-Scale Operations:**
+// @Description - New VMs immediately participate in subgroup operations
+// @Description - Can be individually managed while maintaining subgroup membership
+// @Description - Support for further scaling operations (scale-out or scale-in)
+// @Description - Ready for application deployment and load balancer integration
+// @Description
+// @Description **Best Practices:**
+// @Description - Monitor application performance before and after scaling
+// @Description - Ensure load balancers are configured to include new instances
+// @Description - Verify application clustering and session management handle new instances
+// @Description - Consider database connection limits and other resource constraints
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param nsId path string true "Namespace ID" default(default)
-// @Param mciId path string true "MCI ID" default(mci01)
-// @Param subgroupId path string true "subGroup ID" default(g1)
-// @Param vmReq body model.TbScaleOutSubGroupReq true "subGroup scaleOut request"
-// @Success 200 {object} model.TbMciInfo
-// @Failure 404 {object} model.SimpleMsg
-// @Failure 500 {object} model.SimpleMsg
+// @Param nsId path string true "Namespace ID containing the target MCI and subgroup" default(default)
+// @Param mciId path string true "MCI ID containing the subgroup to scale" default(mci01)
+// @Param subgroupId path string true "SubGroup ID to scale out (must exist and contain at least one VM)" default(g1)
+// @Param vmReq body model.TbScaleOutSubGroupReq true "Scale-out request specifying the number of additional VMs to create"
+// @Success 200 {object} model.TbMciInfo "Updated MCI information with scaled subgroup showing all VMs including newly added instances"
+// @Failure 400 {object} model.SimpleMsg "Invalid scale-out request, insufficient quotas, or invalid VM count"
+// @Failure 404 {object} model.SimpleMsg "Target MCI or subgroup not found, or namespace inaccessible"
+// @Failure 409 {object} model.SimpleMsg "SubGroup in incompatible state for scaling or resource conflicts detected"
+// @Failure 500 {object} model.SimpleMsg "VM provisioning failed, network configuration error, or CSP capacity limitations"
 // @Router /ns/{nsId}/mci/{mciId}/subgroup/{subgroupId} [post]
 func RestPostMciSubGroupScaleOut(c echo.Context) error {
 


### PR DESCRIPTION

🚀 Performance Improvements:
- Implement parallel VM validation in ReviewMciDynamicReq using goroutines with semaphore control (maxConcurrency: 10)
- Add concurrent resource rollback with enhanced error handling and progress tracking
- Reduce MCI review response time significantly for multi-VM configurations

📚 API Documentation Enhancement:
- Add comprehensive Swagger documentation for 8 REST API handlers in provisioning.go
- Include detailed descriptions, parameter explanations, and response examples
- Document failure policies, resource requirements, and VM lifecycle management

🔧 Core Functionality Improvements:
- Add PolicyOnPartialFailure support (continue/rollback/refine) for better failure handling
- Enhance error messages with detailed context and troubleshooting information
- Implement structured VM creation error tracking with MciCreationErrors model
- Refactor CreateMci function for better modularity and error handling

🎨 Code Quality & Structure:
- Extract helper functions for better code organization and reusability
- Add thread-safe resource summary tracking with concurrent updates
- Improve logging with detailed progress information and error context
- Enhance validation logic with early error detection and detailed reporting

📊 Model & Schema Updates:
- Add new failure policy constants and validation structures
- Extend TbMciReq and TbMciInfo models with enhanced error tracking
- Update Swagger schemas with comprehensive field documentation

🧪 Stability & Reliability:
- Add proper synchronization using sync.WaitGroup and channels
- Implement graceful error handling in parallel processing scenarios
- Add resource cleanup safeguards with detailed rollback logging
- Ensure order preservation in parallel VM validation results

This update significantly improves MCI provisioning performance while maintaining comprehensive error handling and providing better user feedback through enhanced API documentation.