### PR TITLE
Refactor mciReq model and api path for mciRecommendVm

### DIFF
--- a/src/core/infra/orchestration.go
+++ b/src/core/infra/orchestration.go
@@ -255,10 +255,10 @@ func OrchestrationController() {
 							autoAction.VmDynamicReq.CommonImage = "ubuntu18.04"                // temporal default value. will be changed
 							autoAction.VmDynamicReq.CommonSpec = "aws-ap-northeast-2-t2-small" // temporal default value. will be changed
 
-							deploymentPlan := model.DeploymentPlan{}
+							recommendSpecReq := model.RecommendSpecReq{}
 
-							deploymentPlan.Priority.Policy = append(deploymentPlan.Priority.Policy, model.PriorityCondition{Metric: "random"})
-							specList, err := RecommendVm(model.SystemCommonNs, deploymentPlan)
+							recommendSpecReq.Priority.Policy = append(recommendSpecReq.Priority.Policy, model.PriorityCondition{Metric: "random"})
+							specList, err := RecommendSpec(model.SystemCommonNs, recommendSpecReq)
 							if err != nil {
 								mciPolicyTmp.Policy[policyIndex].Status = model.AutoStatusError
 								UpdateMciPolicyInfo(nsId, mciPolicyTmp)

--- a/src/core/infra/recommendation.go
+++ b/src/core/infra/recommendation.go
@@ -43,7 +43,7 @@ func toUpperFirst(s string) string {
 }
 
 // applyFilterPolicies dynamically sets filters on the request based on the policies.
-func applyFilterPolicies(request *model.FilterSpecsByRangeRequest, plan *model.DeploymentPlan) error {
+func applyFilterPolicies(request *model.FilterSpecsByRangeRequest, plan *model.RecommendSpecReq) error {
 	val := reflect.ValueOf(request).Elem()
 
 	for _, policy := range plan.Filter.Policy {
@@ -94,8 +94,8 @@ func applyRange(field reflect.Value, operator string, operand float32) error {
 	return nil
 }
 
-// RecommendVm is func to recommend a VM
-func RecommendVm(nsId string, plan model.DeploymentPlan) ([]model.TbSpecInfo, error) {
+// RecommendSpec is func to recommend a VM
+func RecommendSpec(nsId string, plan model.RecommendSpecReq) ([]model.TbSpecInfo, error) {
 	// Filtering first
 
 	u := &model.FilterSpecsByRangeRequest{}
@@ -658,13 +658,13 @@ func RecommendVmPerformance(nsId string, specList *[]model.TbSpecInfo) ([]model.
 }
 
 // RecommendK8sNode is func to recommend a node for K8sCluster
-func RecommendK8sNode(nsId string, plan model.DeploymentPlan) ([]model.TbSpecInfo, error) {
+func RecommendK8sNode(nsId string, plan model.RecommendSpecReq) ([]model.TbSpecInfo, error) {
 	emptyObjList := []model.TbSpecInfo{}
 
 	limitOrig := plan.Limit
 	plan.Limit = strconv.Itoa(math.MaxInt)
 
-	tbSpecInfoListForVm, err := RecommendVm(nsId, plan)
+	tbSpecInfoListForVm, err := RecommendSpec(nsId, plan)
 	if err != nil {
 		return emptyObjList, err
 	}

--- a/src/core/infra/utility.go
+++ b/src/core/infra/utility.go
@@ -55,7 +55,7 @@ func init() {
 	// internally dereferences during it's type checks.
 
 	validate.RegisterStructValidation(TbMciReqStructLevelValidation, model.TbMciReq{})
-	validate.RegisterStructValidation(TbVmReqStructLevelValidation, model.TbVmReq{})
+	validate.RegisterStructValidation(TbCreateSubGroupReqStructLevelValidation, model.TbCreateSubGroupReq{})
 	validate.RegisterStructValidation(TbMciCmdReqStructLevelValidation, model.MciCmdReq{})
 	// validate.RegisterStructValidation(TbMciRecommendReqStructLevelValidation, MciRecommendReq{})
 	// validate.RegisterStructValidation(TbVmRecommendReqStructLevelValidation, TbVmRecommendReq{})
@@ -950,29 +950,29 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciId string, op
 			req.Name = mciId
 			req.Name = common.ChangeIdString(req.Name)
 
-			vm := model.TbVmReq{}
-			vm.ConnectionName = connConfig
-			vm.CspResourceId = r.CspResourceId
-			vm.Description = "Ref name: " + r.RefNameOrId + ". CSP managed VM (registered to CB-TB)"
-			vm.Name = vm.ConnectionName + "-" + r.RefNameOrId + "-" + vm.CspResourceId
-			vm.Name = common.ChangeIdString(vm.Name)
+			subGroupReq := model.TbCreateSubGroupReq{}
+			subGroupReq.ConnectionName = connConfig
+			subGroupReq.CspResourceId = r.CspResourceId
+			subGroupReq.Description = "Ref name: " + r.RefNameOrId + ". CSP managed VM (registered to CB-TB)"
+			subGroupReq.Name = subGroupReq.ConnectionName + "-" + r.RefNameOrId + "-" + subGroupReq.CspResourceId
+			subGroupReq.Name = common.ChangeIdString(subGroupReq.Name)
 			if mciFlag == "n" {
 				// (if mciFlag == "n") create a mci for each vm
-				req.Name = vm.Name
+				req.Name = subGroupReq.Name
 			}
 			labels := map[string]string{
 				model.LabelRegistered: "true",
 			}
-			vm.Label = labels
+			subGroupReq.Label = labels
 
-			vm.ImageId = "cannot retrieve"
-			vm.SpecId = "cannot retrieve"
-			vm.SshKeyId = "cannot retrieve"
-			vm.SubnetId = "cannot retrieve"
-			vm.VNetId = "cannot retrieve"
-			vm.SecurityGroupIds = append(vm.SecurityGroupIds, "cannot retrieve")
+			subGroupReq.ImageId = "cannot retrieve"
+			subGroupReq.SpecId = "cannot retrieve"
+			subGroupReq.SshKeyId = "cannot retrieve"
+			subGroupReq.SubnetId = "cannot retrieve"
+			subGroupReq.VNetId = "cannot retrieve"
+			subGroupReq.SecurityGroupIds = append(subGroupReq.SecurityGroupIds, "cannot retrieve")
 
-			req.Vm = append(req.Vm, vm)
+			req.SubGroups = append(req.SubGroups, subGroupReq)
 
 			_, err = CreateMci(nsId, &req, optionFlag)
 
@@ -983,7 +983,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciId string, op
 				result.RegisterationOverview.Vm--
 				result.RegisterationOverview.Failed++
 			}
-			result.RegisterationOutputs.IdList = append(result.RegisterationOutputs.IdList, model.StrVM+": "+vm.Name+registeredStatus)
+			result.RegisterationOutputs.IdList = append(result.RegisterationOutputs.IdList, model.StrVM+": "+subGroupReq.Name+registeredStatus)
 			result.RegisterationOverview.Vm++
 		}
 	}

--- a/src/core/model/mci.go
+++ b/src/core/model/mci.go
@@ -114,7 +114,7 @@ type TbMciReq struct {
 	PlacementAlgo string `json:"placementAlgo,omitempty"`
 	Description   string `json:"description" example:"Made in CB-TB"`
 
-	Vm []TbVmReq `json:"vm" validate:"required"`
+	SubGroups []TbCreateSubGroupReq `json:"subGroups" validate:"required"`
 
 	// PostCommand is for the command to bootstrap the VMs
 	PostCommand MciCmdReq `json:"postCommand" validate:"omitempty"`
@@ -219,9 +219,9 @@ type VmCreationError struct {
 	Timestamp string `json:"timestamp"`
 }
 
-// TbVmReq is struct to get requirements to create a new server instance
-type TbVmReq struct {
-	// VM name or subGroup name if is (not empty) && (> 0). If it is a group, actual VM name will be generated with -N postfix.
+// TbCreateSubGroupReq is struct to get requirements to create a new server instance
+type TbCreateSubGroupReq struct {
+	// SubGroup name of VMs. Actual VM name will be generated with -N postfix.
 	Name string `json:"name" validate:"required" example:"g1-1"`
 
 	// CspResourceId is resource identifier managed by CSP (required for option=register)
@@ -250,7 +250,7 @@ type TbVmReq struct {
 	DataDiskIds      []string `json:"dataDiskIds"`
 }
 
-// TbVmReq is struct to get requirements to create a new server instance
+// TbCreateSubGroupReq is struct to get requirements to create a new server instance
 type TbScaleOutSubGroupReq struct {
 	// Define addtional VMs to scaleOut
 	NumVMsToAdd string `json:"numVMsToAdd" validate:"required" example:"2"`
@@ -271,7 +271,7 @@ type TbMciDynamicReq struct {
 	// InstallMonAgent Option for CB-Dragonfly agent installation ([yes/no] default:no)
 	InstallMonAgent string `json:"installMonAgent" example:"no" default:"no" enums:"yes,no"` // yes or no
 
-	// Vm is array of VM requests for multi-cloud infrastructure
+	// SubGroups is array of VM requests for multi-cloud infrastructure
 	// Example: Multiple VM groups across different CSPs
 	// [
 	//   {
@@ -299,7 +299,7 @@ type TbMciDynamicReq struct {
 	//     "label": {"role": "test", "csp": "gcp"}
 	//   }
 	// ]
-	Vm []TbVmDynamicReq `json:"vm" validate:"required"`
+	SubGroups []TbCreateSubGroupDynamicReq `json:"subGroups" validate:"required"`
 
 	// PostCommand is for the command to bootstrap the VMs
 	PostCommand MciCmdReq `json:"postCommand"`
@@ -313,9 +313,9 @@ type TbMciDynamicReq struct {
 	Label map[string]string `json:"label"`
 }
 
-// TbVmDynamicReq is struct to get requirements to create a new server instance dynamically (with default resource option)
-type TbVmDynamicReq struct {
-	// VM name or subGroup name if is (not empty) && (> 0). If it is a group, actual VM name will be generated with -N postfix.
+// TbCreateSubGroupDynamicReq is struct to get requirements to create a new server instance dynamically (with default resource option)
+type TbCreateSubGroupDynamicReq struct {
+	// SubGroup name, actual VM name will be generated with -N postfix.
 	Name string `json:"name" example:"g1"`
 
 	// if subGroupSize is (not empty) && (> 0), subGroup will be generated. VMs will be created accordingly.
@@ -864,8 +864,8 @@ type AutoCondition struct {
 
 // AutoAction is struct for MCI auto-control action.
 type AutoAction struct {
-	ActionType   string         `json:"actionType" example:"ScaleOut" enums:"ScaleOut,ScaleIn"`
-	VmDynamicReq TbVmDynamicReq `json:"vmDynamicReq"`
+	ActionType   string                     `json:"actionType" example:"ScaleOut" enums:"ScaleOut,ScaleIn"`
+	VmDynamicReq TbCreateSubGroupDynamicReq `json:"vmDynamicReq"`
 
 	// PostCommand is field for providing command to VMs after its creation. example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
 	PostCommand   MciCmdReq `json:"postCommand"`
@@ -932,8 +932,8 @@ type BastionInfo struct {
 	VmId []string `json:"vmId"`
 }
 
-// DeploymentPlan is struct for .
-type DeploymentPlan struct {
+// RecommendSpecReq is struct for .
+type RecommendSpecReq struct {
 	Filter   FilterInfo   `json:"filter"`
 	Priority PriorityInfo `json:"priority"`
 	Limit    string       `json:"limit" example:"5" enums:"1,2,30"`

--- a/src/interface/mcp/architecture.md
+++ b/src/interface/mcp/architecture.md
@@ -249,7 +249,7 @@ mindmap
       search_images
       recommend_vm_spec
       API_resources_searchImage
-      API_mciRecommendVm
+      API_recommendSpec
     
     MCI Management
       create_mci_dynamic

--- a/src/interface/mcp/tb-mcp.py
+++ b/src/interface/mcp/tb-mcp.py
@@ -1733,7 +1733,7 @@ def recommend_vm_spec(
         
         priority_policies.append(priority_config)
     
-    # Build the request data according to model.DeploymentPlan
+    # Build the request data according to model.RecommendSpecReq
     data = {
         "filter": {
             "policy": policies
@@ -1745,7 +1745,7 @@ def recommend_vm_spec(
     }
     
     # Make API request
-    raw_response = api_request("POST", "/mciRecommendVm", json_data=data)
+    raw_response = api_request("POST", "/recommendSpec", json_data=data)
     
     # Summarize response to reduce token usage
     return _summarize_vm_specs(raw_response, include_details=include_full_details)
@@ -1766,7 +1766,7 @@ def _internal_review_mci_dynamic(
     data = {
         "name": name,
         "description": description,
-        "vm": vm_configurations
+        "subGroups": vm_configurations
     }
     
     # Add optional parameters
@@ -2036,7 +2036,7 @@ def review_mci_dynamic_request(
 #     data = {
 #         "name": name,
 #         "description": description,
-#         "vm": vm_config
+#         "subGroups": vm_config
 #     }
     
 #     if post_command:
@@ -2240,7 +2240,7 @@ for i, spec in enumerate(specs["recommended_specs"][:2]):
         When force_create=True or skip_confirmation=True:
         - Created MCI information including:
           • id: MCI ID for future operations
-          • vm: List of created VMs with their details
+          • vm: List of created VMs with their details (in response)
           • status: Current MCI status
           • deployment summary
         
@@ -2503,7 +2503,7 @@ for i, spec in enumerate(specs["recommended_specs"][:2]):
     # Build request data according to model.TbMciDynamicReq spec
     data = {
         "name": name,
-        "vm": processed_vm_configs  # Use processed configs with auto-mapped images
+        "subGroups": processed_vm_configs  # Use processed configs with auto-mapped images
     }
     
     # Add optional fields

--- a/src/interface/rest/docs/docs.go
+++ b/src/interface/rest/docs/docs.go
@@ -1147,10 +1147,10 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "description": "Recommend K8sCluster's Node plan (filter and priority)",
-                        "name": "deploymentPlan",
+                        "name": "recommendSpecReq",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/model.DeploymentPlan"
+                            "$ref": "#/definitions/model.RecommendSpecReq"
                         }
                     }
                 ],
@@ -1688,55 +1688,6 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "CSP connectivity issues or internal validation service errors",
-                        "schema": {
-                            "$ref": "#/definitions/model.SimpleMsg"
-                        }
-                    }
-                }
-            }
-        },
-        "/mciRecommendVm": {
-            "post": {
-                "description": "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[MC-Infra] MCI Provisioning and Management"
-                ],
-                "summary": "Recommend MCI plan (filter and priority)",
-                "operationId": "RecommendVm",
-                "parameters": [
-                    {
-                        "description": "Recommend MCI plan (filter and priority)",
-                        "name": "deploymentPlan",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/model.DeploymentPlan"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.TbSpecInfo"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/model.SimpleMsg"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -5138,7 +5089,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model.TbVmReq"
+                            "$ref": "#/definitions/model.TbCreateSubGroupReq"
                         }
                     }
                 ],
@@ -5804,12 +5755,12 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "VM dynamic request specifying commonSpec, commonImage, and scaling parameters",
+                        "description": "SubGroup dynamic request specifying commonSpec, commonImage, and scaling parameters",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model.TbVmDynamicReq"
+                            "$ref": "#/definitions/model.TbCreateSubGroupDynamicReq"
                         }
                     }
                 ],
@@ -6205,7 +6156,7 @@ const docTemplate = `{
         },
         "/ns/{nsId}/mciDynamic": {
             "post": {
-                "description": "Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.\nThis is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:\n\n**Dynamic Resource Creation:**\n1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace\n2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider\n3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously\n4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically\n5. **Failure Recovery**: Implements configurable failure policies for robust deployment\n\n**Key Advantages Over Static MCI:**\n- **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources\n- **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys\n- **Multi-Cloud Optimization**: Intelligent placement and configuration across providers\n- **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically\n- **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization\n\n**Configuration Process:**\n1. **Resource Discovery**: Use ` + "`" + `/mciRecommendVm` + "`" + ` to find suitable VM specifications\n2. **Image Selection**: Use system namespace to discover compatible images\n3. **Request Validation**: Use ` + "`" + `/mciDynamicCheckRequest` + "`" + ` to validate configuration before deployment\n4. **Optional Preview**: Use ` + "`" + `/mciDynamicReview` + "`" + ` to estimate costs and review configuration\n5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options\n\n**Failure Policies (PolicyOnPartialFailure):**\n- **` + "`" + `continue` + "`" + `** (default): Create MCI with successful VMs, failed VMs remain for manual refinement\n- **` + "`" + `rollback` + "`" + `**: Delete entire MCI if any VM fails (all-or-nothing deployment)\n- **` + "`" + `refine` + "`" + `**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)\n\n**Deployment Options:**\n- **` + "`" + `hold` + "`" + `**: Create MCI object but hold VM provisioning for manual approval\n- **Normal**: Proceed with immediate VM provisioning after resource creation\n\n**Multi-Cloud Example Configuration:**\n` + "`" + `` + "`" + `` + "`" + `json\n{\n\"name\": \"multi-cloud-web-tier\",\n\"description\": \"Web application across AWS, Azure, and GCP\",\n\"policyOnPartialFailure\": \"refine\",\n\"vm\": [\n{\n\"name\": \"aws-web-servers\",\n\"subGroupSize\": \"3\",\n\"commonSpec\": \"aws+us-east-1+t3.medium\",\n\"commonImage\": \"ami-0abcdef1234567890\",\n\"rootDiskSize\": \"100\",\n\"label\": {\"tier\": \"web\", \"provider\": \"aws\"}\n},\n{\n\"name\": \"azure-api-servers\",\n\"subGroupSize\": \"2\",\n\"commonSpec\": \"azure+eastus+Standard_B2s\",\n\"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts\",\n\"label\": {\"tier\": \"api\", \"provider\": \"azure\"}\n}\n]\n}\n` + "`" + `` + "`" + `` + "`" + `\n\n**Performance Considerations:**\n- VM provisioning occurs in parallel across providers\n- Network resources are created concurrently where possible\n- Large deployments (\u003e10 VMs) automatically use optimized batching\n- Built-in rate limiting prevents CSP API throttling\n\n**Monitoring and Post-Deployment:**\n- Optional CB-Dragonfly monitoring agent installation\n- Custom post-deployment command execution\n- Real-time status tracking and progress updates\n- Automatic resource labeling and metadata management",
+                "description": "Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.\nThis is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:\n\n**Dynamic Resource Creation:**\n1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace\n2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider\n3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously\n4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically\n5. **Failure Recovery**: Implements configurable failure policies for robust deployment\n\n**Key Advantages Over Static MCI:**\n- **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources\n- **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys\n- **Multi-Cloud Optimization**: Intelligent placement and configuration across providers\n- **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically\n- **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization\n\n**Configuration Process:**\n1. **Resource Discovery**: Use ` + "`" + `/recommendSpec` + "`" + ` to find suitable VM specifications\n2. **Image Selection**: Use system namespace to discover compatible images\n3. **Request Validation**: Use ` + "`" + `/mciDynamicCheckRequest` + "`" + ` to validate configuration before deployment\n4. **Optional Preview**: Use ` + "`" + `/mciDynamicReview` + "`" + ` to estimate costs and review configuration\n5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options\n\n**Failure Policies (PolicyOnPartialFailure):**\n- **` + "`" + `continue` + "`" + `** (default): Create MCI with successful VMs, failed VMs remain for manual refinement\n- **` + "`" + `rollback` + "`" + `**: Delete entire MCI if any VM fails (all-or-nothing deployment)\n- **` + "`" + `refine` + "`" + `**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)\n\n**Deployment Options:**\n- **` + "`" + `hold` + "`" + `**: Create MCI object but hold VM provisioning for manual approval\n- **Normal**: Proceed with immediate VM provisioning after resource creation\n\n**Multi-Cloud Example Configuration:**\n` + "`" + `` + "`" + `` + "`" + `json\n{\n\"name\": \"multi-cloud-web-tier\",\n\"description\": \"Web application across AWS, Azure, and GCP\",\n\"policyOnPartialFailure\": \"refine\",\n\"vm\": [\n{\n\"name\": \"aws-web-servers\",\n\"subGroupSize\": \"3\",\n\"commonSpec\": \"aws+us-east-1+t3.medium\",\n\"commonImage\": \"ami-0abcdef1234567890\",\n\"rootDiskSize\": \"100\",\n\"label\": {\"tier\": \"web\", \"provider\": \"aws\"}\n},\n{\n\"name\": \"azure-api-servers\",\n\"subGroupSize\": \"2\",\n\"commonSpec\": \"azure+eastus+Standard_B2s\",\n\"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts\",\n\"label\": {\"tier\": \"api\", \"provider\": \"azure\"}\n}\n]\n}\n` + "`" + `` + "`" + `` + "`" + `\n\n**Performance Considerations:**\n- VM provisioning occurs in parallel across providers\n- Network resources are created concurrently where possible\n- Large deployments (\u003e10 VMs) automatically use optimized batching\n- Built-in rate limiting prevents CSP API throttling\n\n**Monitoring and Post-Deployment:**\n- Optional CB-Dragonfly monitoring agent installation\n- Custom post-deployment command execution\n- Real-time status tracking and progress updates\n- Automatic resource labeling and metadata management",
                 "consumes": [
                     "application/json"
                 ],
@@ -8294,7 +8245,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Infra Resource] Image Management"
+                    "[MC-Infra] MCI Provisioning and Management"
                 ],
                 "summary": "Search image",
                 "operationId": "SearchImage",
@@ -8349,7 +8300,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "[Infra Resource] Image Management"
+                    "[MC-Infra] MCI Provisioning and Management"
                 ],
                 "operationId": "SearchImageOptions",
                 "parameters": [
@@ -11040,6 +10991,55 @@ const docTemplate = `{
                 }
             }
         },
+        "/recommendSpec": {
+            "post": {
+                "description": "Recommend specs for configuring an infrastructure (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[MC-Infra] MCI Provisioning and Management"
+                ],
+                "summary": "Recommend specs for configuring an infrastructure (filter and priority)",
+                "operationId": "RecommendSpec",
+                "parameters": [
+                    {
+                        "description": "Conditions for recommending specs (filter and priority)",
+                        "name": "recommendSpecReq",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.RecommendSpecReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.TbSpecInfo"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/regionFromCsp": {
             "get": {
                 "description": "RetrieveR all region lists from CSPs",
@@ -12135,7 +12135,7 @@ const docTemplate = `{
                     ]
                 },
                 "vmDynamicReq": {
-                    "$ref": "#/definitions/model.TbVmDynamicReq"
+                    "$ref": "#/definitions/model.TbCreateSubGroupDynamicReq"
                 }
             }
         },
@@ -12532,26 +12532,6 @@ const docTemplate = `{
                 "MyImageAvailable",
                 "MyImageUnavailable"
             ]
-        },
-        "model.DeploymentPlan": {
-            "type": "object",
-            "properties": {
-                "filter": {
-                    "$ref": "#/definitions/model.FilterInfo"
-                },
-                "limit": {
-                    "type": "string",
-                    "enum": [
-                        "1",
-                        "2",
-                        "30"
-                    ],
-                    "example": "5"
-                },
-                "priority": {
-                    "$ref": "#/definitions/model.PriorityInfo"
-                }
-            }
         },
         "model.DiskStatus": {
             "type": "string",
@@ -13943,6 +13923,26 @@ const docTemplate = `{
                 },
                 "min": {
                     "type": "number"
+                }
+            }
+        },
+        "model.RecommendSpecReq": {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "$ref": "#/definitions/model.FilterInfo"
+                },
+                "limit": {
+                    "type": "string",
+                    "enum": [
+                        "1",
+                        "2",
+                        "30"
+                    ],
+                    "example": "5"
+                },
+                "priority": {
+                    "$ref": "#/definitions/model.PriorityInfo"
                 }
             }
         },
@@ -15673,6 +15673,161 @@ const docTemplate = `{
                 }
             }
         },
+        "model.TbCreateSubGroupDynamicReq": {
+            "type": "object",
+            "required": [
+                "commonImage",
+                "commonSpec"
+            ],
+            "properties": {
+                "commonImage": {
+                    "description": "CommonImage is field for id of a image in common namespace",
+                    "type": "string",
+                    "example": "ami-01f71f215b23ba262"
+                },
+                "commonSpec": {
+                    "description": "CommonSpec is field for id of a spec in common namespace",
+                    "type": "string",
+                    "example": "aws+ap-northeast-2+t3.nano"
+                },
+                "connectionName": {
+                    "description": "if ConnectionName is given, the VM tries to use associtated credential.\nif not, it will use predefined ConnectionName in Spec objects",
+                    "type": "string",
+                    "example": "aws-ap-northeast-2"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Created via CB-Tumblebug"
+                },
+                "label": {
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "example": {
+                        "\"env\"": "\"test\"}",
+                        "{\"role\"": "\"worker\""
+                    }
+                },
+                "name": {
+                    "description": "SubGroup name, actual VM name will be generated with -N postfix.",
+                    "type": "string",
+                    "example": "g1"
+                },
+                "rootDiskSize": {
+                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
+                    "type": "string",
+                    "default": "default",
+                    "example": "50"
+                },
+                "rootDiskType": {
+                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
+                    "type": "string",
+                    "default": "default",
+                    "example": "gp3"
+                },
+                "subGroupSize": {
+                    "description": "if subGroupSize is (not empty) \u0026\u0026 (\u003e 0), subGroup will be generated. VMs will be created accordingly.",
+                    "type": "string",
+                    "default": "1",
+                    "example": "3"
+                },
+                "vmUserPassword": {
+                    "type": "string",
+                    "example": ""
+                }
+            }
+        },
+        "model.TbCreateSubGroupReq": {
+            "type": "object",
+            "required": [
+                "connectionName",
+                "imageId",
+                "name",
+                "securityGroupIds",
+                "specId",
+                "sshKeyId",
+                "subnetId",
+                "vNetId"
+            ],
+            "properties": {
+                "connectionName": {
+                    "type": "string",
+                    "example": "testcloud01-seoul"
+                },
+                "cspResourceId": {
+                    "description": "CspResourceId is resource identifier managed by CSP (required for option=register)",
+                    "type": "string",
+                    "example": "i-014fa6ede6ada0b2c"
+                },
+                "dataDiskIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Description"
+                },
+                "imageId": {
+                    "description": "ImageType        string   ` + "`" + `json:\"imageType\"` + "`" + `",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "description": "SubGroup name of VMs. Actual VM name will be generated with -N postfix.",
+                    "type": "string",
+                    "example": "g1-1"
+                },
+                "rootDiskSize": {
+                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
+                    "type": "string",
+                    "example": "default, 30, 42, ..."
+                },
+                "rootDiskType": {
+                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
+                    "type": "string",
+                    "example": "default, TYPE1, ..."
+                },
+                "securityGroupIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "specId": {
+                    "type": "string"
+                },
+                "sshKeyId": {
+                    "type": "string"
+                },
+                "subGroupSize": {
+                    "description": "if subGroupSize is (not empty) \u0026\u0026 (\u003e 0), subGroup will be generated. VMs will be created accordingly.",
+                    "type": "string",
+                    "example": "3"
+                },
+                "subnetId": {
+                    "type": "string"
+                },
+                "vNetId": {
+                    "type": "string"
+                },
+                "vmUserName": {
+                    "type": "string"
+                },
+                "vmUserPassword": {
+                    "type": "string"
+                }
+            }
+        },
         "model.TbCustomImageInfo": {
             "type": "object",
             "properties": {
@@ -16820,7 +16975,7 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "name",
-                "vm"
+                "subGroups"
             ],
             "properties": {
                 "description": {
@@ -16867,17 +17022,17 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "subGroups": {
+                    "description": "SubGroups is array of VM requests for multi-cloud infrastructure\nExample: Multiple VM groups across different CSPs\n[\n  {\n    \"name\": \"aws-group\",\n    \"subGroupSize\": \"3\",\n    \"commonSpec\": \"aws+ap-northeast-2+t3.nano\",\n    \"commonImage\": \"ami-01f71f215b23ba262\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"worker\", \"csp\": \"aws\"}\n  },\n  {\n    \"name\": \"azure-group\",\n    \"subGroupSize\": \"2\",\n    \"commonSpec\": \"azure+koreasouth+standard_b1s\",\n    \"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"head\", \"csp\": \"azure\"}\n  },\n  {\n    \"name\": \"gcp-group\",\n    \"subGroupSize\": \"1\",\n    \"commonSpec\": \"gcp+asia-northeast3+g1-small\",\n    \"commonImage\": \"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250712\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"test\", \"csp\": \"gcp\"}\n  }\n]",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.TbCreateSubGroupDynamicReq"
+                    }
+                },
                 "systemLabel": {
                     "description": "SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose",
                     "type": "string",
                     "example": ""
-                },
-                "vm": {
-                    "description": "Vm is array of VM requests for multi-cloud infrastructure\nExample: Multiple VM groups across different CSPs\n[\n  {\n    \"name\": \"aws-group\",\n    \"subGroupSize\": \"3\",\n    \"commonSpec\": \"aws+ap-northeast-2+t3.nano\",\n    \"commonImage\": \"ami-01f71f215b23ba262\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"worker\", \"csp\": \"aws\"}\n  },\n  {\n    \"name\": \"azure-group\",\n    \"subGroupSize\": \"2\",\n    \"commonSpec\": \"azure+koreasouth+standard_b1s\",\n    \"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"head\", \"csp\": \"azure\"}\n  },\n  {\n    \"name\": \"gcp-group\",\n    \"subGroupSize\": \"1\",\n    \"commonSpec\": \"gcp+asia-northeast3+g1-small\",\n    \"commonImage\": \"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250712\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"test\", \"csp\": \"gcp\"}\n  }\n]",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/model.TbVmDynamicReq"
-                    }
                 }
             }
         },
@@ -17001,7 +17156,7 @@ const docTemplate = `{
             "type": "object",
             "required": [
                 "name",
-                "vm"
+                "subGroups"
             ],
             "properties": {
                 "description": {
@@ -17051,16 +17206,16 @@ const docTemplate = `{
                         }
                     ]
                 },
+                "subGroups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.TbCreateSubGroupReq"
+                    }
+                },
                 "systemLabel": {
                     "description": "SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose",
                     "type": "string",
                     "example": ""
-                },
-                "vm": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/model.TbVmReq"
-                    }
                 }
             }
         },
@@ -18104,72 +18259,6 @@ const docTemplate = `{
                 }
             }
         },
-        "model.TbVmDynamicReq": {
-            "type": "object",
-            "required": [
-                "commonImage",
-                "commonSpec"
-            ],
-            "properties": {
-                "commonImage": {
-                    "description": "CommonImage is field for id of a image in common namespace",
-                    "type": "string",
-                    "example": "ami-01f71f215b23ba262"
-                },
-                "commonSpec": {
-                    "description": "CommonSpec is field for id of a spec in common namespace",
-                    "type": "string",
-                    "example": "aws+ap-northeast-2+t3.nano"
-                },
-                "connectionName": {
-                    "description": "if ConnectionName is given, the VM tries to use associtated credential.\nif not, it will use predefined ConnectionName in Spec objects",
-                    "type": "string",
-                    "example": "aws-ap-northeast-2"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Created via CB-Tumblebug"
-                },
-                "label": {
-                    "description": "Label is for describing the object by keywords",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "example": {
-                        "\"env\"": "\"test\"}",
-                        "{\"role\"": "\"worker\""
-                    }
-                },
-                "name": {
-                    "description": "VM name or subGroup name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",
-                    "type": "string",
-                    "example": "g1"
-                },
-                "rootDiskSize": {
-                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
-                    "type": "string",
-                    "default": "default",
-                    "example": "50"
-                },
-                "rootDiskType": {
-                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
-                    "type": "string",
-                    "default": "default",
-                    "example": "gp3"
-                },
-                "subGroupSize": {
-                    "description": "if subGroupSize is (not empty) \u0026\u0026 (\u003e 0), subGroup will be generated. VMs will be created accordingly.",
-                    "type": "string",
-                    "default": "1",
-                    "example": "3"
-                },
-                "vmUserPassword": {
-                    "type": "string",
-                    "example": ""
-                }
-            }
-        },
         "model.TbVmInfo": {
             "type": "object",
             "properties": {
@@ -18333,95 +18422,6 @@ const docTemplate = `{
                     "description": "Uid is universally unique identifier for the object, used for labelSelector",
                     "type": "string",
                     "example": "wef12awefadf1221edcf"
-                },
-                "vNetId": {
-                    "type": "string"
-                },
-                "vmUserName": {
-                    "type": "string"
-                },
-                "vmUserPassword": {
-                    "type": "string"
-                }
-            }
-        },
-        "model.TbVmReq": {
-            "type": "object",
-            "required": [
-                "connectionName",
-                "imageId",
-                "name",
-                "securityGroupIds",
-                "specId",
-                "sshKeyId",
-                "subnetId",
-                "vNetId"
-            ],
-            "properties": {
-                "connectionName": {
-                    "type": "string",
-                    "example": "testcloud01-seoul"
-                },
-                "cspResourceId": {
-                    "description": "CspResourceId is resource identifier managed by CSP (required for option=register)",
-                    "type": "string",
-                    "example": "i-014fa6ede6ada0b2c"
-                },
-                "dataDiskIds": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Description"
-                },
-                "imageId": {
-                    "description": "ImageType        string   ` + "`" + `json:\"imageType\"` + "`" + `",
-                    "type": "string"
-                },
-                "label": {
-                    "description": "Label is for describing the object by keywords",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "description": "VM name or subGroup name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",
-                    "type": "string",
-                    "example": "g1-1"
-                },
-                "rootDiskSize": {
-                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
-                    "type": "string",
-                    "example": "default, 30, 42, ..."
-                },
-                "rootDiskType": {
-                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
-                    "type": "string",
-                    "example": "default, TYPE1, ..."
-                },
-                "securityGroupIds": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "specId": {
-                    "type": "string"
-                },
-                "sshKeyId": {
-                    "type": "string"
-                },
-                "subGroupSize": {
-                    "description": "if subGroupSize is (not empty) \u0026\u0026 (\u003e 0), subGroup will be generated. VMs will be created accordingly.",
-                    "type": "string",
-                    "example": "3"
-                },
-                "subnetId": {
-                    "type": "string"
                 },
                 "vNetId": {
                     "type": "string"

--- a/src/interface/rest/docs/swagger.json
+++ b/src/interface/rest/docs/swagger.json
@@ -1140,10 +1140,10 @@
                 "parameters": [
                     {
                         "description": "Recommend K8sCluster's Node plan (filter and priority)",
-                        "name": "deploymentPlan",
+                        "name": "recommendSpecReq",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/model.DeploymentPlan"
+                            "$ref": "#/definitions/model.RecommendSpecReq"
                         }
                     }
                 ],
@@ -1681,55 +1681,6 @@
                     },
                     "500": {
                         "description": "CSP connectivity issues or internal validation service errors",
-                        "schema": {
-                            "$ref": "#/definitions/model.SimpleMsg"
-                        }
-                    }
-                }
-            }
-        },
-        "/mciRecommendVm": {
-            "post": {
-                "description": "Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "[MC-Infra] MCI Provisioning and Management"
-                ],
-                "summary": "Recommend MCI plan (filter and priority)",
-                "operationId": "RecommendVm",
-                "parameters": [
-                    {
-                        "description": "Recommend MCI plan (filter and priority)",
-                        "name": "deploymentPlan",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/model.DeploymentPlan"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.TbSpecInfo"
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/model.SimpleMsg"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "schema": {
                             "$ref": "#/definitions/model.SimpleMsg"
                         }
@@ -5131,7 +5082,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model.TbVmReq"
+                            "$ref": "#/definitions/model.TbCreateSubGroupReq"
                         }
                     }
                 ],
@@ -5797,12 +5748,12 @@
                         "required": true
                     },
                     {
-                        "description": "VM dynamic request specifying commonSpec, commonImage, and scaling parameters",
+                        "description": "SubGroup dynamic request specifying commonSpec, commonImage, and scaling parameters",
                         "name": "vmReq",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/model.TbVmDynamicReq"
+                            "$ref": "#/definitions/model.TbCreateSubGroupDynamicReq"
                         }
                     }
                 ],
@@ -6198,7 +6149,7 @@
         },
         "/ns/{nsId}/mciDynamic": {
             "post": {
-                "description": "Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.\nThis is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:\n\n**Dynamic Resource Creation:**\n1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace\n2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider\n3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously\n4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically\n5. **Failure Recovery**: Implements configurable failure policies for robust deployment\n\n**Key Advantages Over Static MCI:**\n- **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources\n- **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys\n- **Multi-Cloud Optimization**: Intelligent placement and configuration across providers\n- **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically\n- **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization\n\n**Configuration Process:**\n1. **Resource Discovery**: Use `/mciRecommendVm` to find suitable VM specifications\n2. **Image Selection**: Use system namespace to discover compatible images\n3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment\n4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration\n5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options\n\n**Failure Policies (PolicyOnPartialFailure):**\n- **`continue`** (default): Create MCI with successful VMs, failed VMs remain for manual refinement\n- **`rollback`**: Delete entire MCI if any VM fails (all-or-nothing deployment)\n- **`refine`**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)\n\n**Deployment Options:**\n- **`hold`**: Create MCI object but hold VM provisioning for manual approval\n- **Normal**: Proceed with immediate VM provisioning after resource creation\n\n**Multi-Cloud Example Configuration:**\n```json\n{\n\"name\": \"multi-cloud-web-tier\",\n\"description\": \"Web application across AWS, Azure, and GCP\",\n\"policyOnPartialFailure\": \"refine\",\n\"vm\": [\n{\n\"name\": \"aws-web-servers\",\n\"subGroupSize\": \"3\",\n\"commonSpec\": \"aws+us-east-1+t3.medium\",\n\"commonImage\": \"ami-0abcdef1234567890\",\n\"rootDiskSize\": \"100\",\n\"label\": {\"tier\": \"web\", \"provider\": \"aws\"}\n},\n{\n\"name\": \"azure-api-servers\",\n\"subGroupSize\": \"2\",\n\"commonSpec\": \"azure+eastus+Standard_B2s\",\n\"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts\",\n\"label\": {\"tier\": \"api\", \"provider\": \"azure\"}\n}\n]\n}\n```\n\n**Performance Considerations:**\n- VM provisioning occurs in parallel across providers\n- Network resources are created concurrently where possible\n- Large deployments (\u003e10 VMs) automatically use optimized batching\n- Built-in rate limiting prevents CSP API throttling\n\n**Monitoring and Post-Deployment:**\n- Optional CB-Dragonfly monitoring agent installation\n- Custom post-deployment command execution\n- Real-time status tracking and progress updates\n- Automatic resource labeling and metadata management",
+                "description": "Create multi-cloud infrastructure dynamically using common specifications and images with automatic resource discovery and optimization.\nThis is the **recommended approach** for MCI creation, providing simplified configuration with powerful automation:\n\n**Dynamic Resource Creation:**\n1. **Automatic Resource Discovery**: Validates and selects optimal VM specifications and images from common namespace\n2. **Intelligent Network Setup**: Creates VNets, subnets, security groups, and SSH keys automatically per provider\n3. **Cross-Cloud Orchestration**: Coordinates VM provisioning across multiple cloud providers simultaneously\n4. **Dependency Management**: Handles resource creation order and inter-dependencies automatically\n5. **Failure Recovery**: Implements configurable failure policies for robust deployment\n\n**Key Advantages Over Static MCI:**\n- **Simplified Configuration**: Use common spec/image IDs instead of provider-specific resources\n- **Automatic Resource Management**: No need to pre-create VNets, security groups, or SSH keys\n- **Multi-Cloud Optimization**: Intelligent placement and configuration across providers\n- **Built-in Best Practices**: Security groups, network isolation, and access controls applied automatically\n- **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization\n\n**Configuration Process:**\n1. **Resource Discovery**: Use `/recommendSpec` to find suitable VM specifications\n2. **Image Selection**: Use system namespace to discover compatible images\n3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment\n4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration\n5. **Deployment**: Submit MCI dynamic request with failure policy and deployment options\n\n**Failure Policies (PolicyOnPartialFailure):**\n- **`continue`** (default): Create MCI with successful VMs, failed VMs remain for manual refinement\n- **`rollback`**: Delete entire MCI if any VM fails (all-or-nothing deployment)\n- **`refine`**: Automatically clean up failed VMs, keep successful ones (recommended for large deployments)\n\n**Deployment Options:**\n- **`hold`**: Create MCI object but hold VM provisioning for manual approval\n- **Normal**: Proceed with immediate VM provisioning after resource creation\n\n**Multi-Cloud Example Configuration:**\n```json\n{\n\"name\": \"multi-cloud-web-tier\",\n\"description\": \"Web application across AWS, Azure, and GCP\",\n\"policyOnPartialFailure\": \"refine\",\n\"vm\": [\n{\n\"name\": \"aws-web-servers\",\n\"subGroupSize\": \"3\",\n\"commonSpec\": \"aws+us-east-1+t3.medium\",\n\"commonImage\": \"ami-0abcdef1234567890\",\n\"rootDiskSize\": \"100\",\n\"label\": {\"tier\": \"web\", \"provider\": \"aws\"}\n},\n{\n\"name\": \"azure-api-servers\",\n\"subGroupSize\": \"2\",\n\"commonSpec\": \"azure+eastus+Standard_B2s\",\n\"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts\",\n\"label\": {\"tier\": \"api\", \"provider\": \"azure\"}\n}\n]\n}\n```\n\n**Performance Considerations:**\n- VM provisioning occurs in parallel across providers\n- Network resources are created concurrently where possible\n- Large deployments (\u003e10 VMs) automatically use optimized batching\n- Built-in rate limiting prevents CSP API throttling\n\n**Monitoring and Post-Deployment:**\n- Optional CB-Dragonfly monitoring agent installation\n- Custom post-deployment command execution\n- Real-time status tracking and progress updates\n- Automatic resource labeling and metadata management",
                 "consumes": [
                     "application/json"
                 ],
@@ -8287,7 +8238,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Infra Resource] Image Management"
+                    "[MC-Infra] MCI Provisioning and Management"
                 ],
                 "summary": "Search image",
                 "operationId": "SearchImage",
@@ -8342,7 +8293,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "[Infra Resource] Image Management"
+                    "[MC-Infra] MCI Provisioning and Management"
                 ],
                 "operationId": "SearchImageOptions",
                 "parameters": [
@@ -11033,6 +10984,55 @@
                 }
             }
         },
+        "/recommendSpec": {
+            "post": {
+                "description": "Recommend specs for configuring an infrastructure (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "[MC-Infra] MCI Provisioning and Management"
+                ],
+                "summary": "Recommend specs for configuring an infrastructure (filter and priority)",
+                "operationId": "RecommendSpec",
+                "parameters": [
+                    {
+                        "description": "Conditions for recommending specs (filter and priority)",
+                        "name": "recommendSpecReq",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/model.RecommendSpecReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.TbSpecInfo"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/model.SimpleMsg"
+                        }
+                    }
+                }
+            }
+        },
         "/regionFromCsp": {
             "get": {
                 "description": "RetrieveR all region lists from CSPs",
@@ -12128,7 +12128,7 @@
                     ]
                 },
                 "vmDynamicReq": {
-                    "$ref": "#/definitions/model.TbVmDynamicReq"
+                    "$ref": "#/definitions/model.TbCreateSubGroupDynamicReq"
                 }
             }
         },
@@ -12525,26 +12525,6 @@
                 "MyImageAvailable",
                 "MyImageUnavailable"
             ]
-        },
-        "model.DeploymentPlan": {
-            "type": "object",
-            "properties": {
-                "filter": {
-                    "$ref": "#/definitions/model.FilterInfo"
-                },
-                "limit": {
-                    "type": "string",
-                    "enum": [
-                        "1",
-                        "2",
-                        "30"
-                    ],
-                    "example": "5"
-                },
-                "priority": {
-                    "$ref": "#/definitions/model.PriorityInfo"
-                }
-            }
         },
         "model.DiskStatus": {
             "type": "string",
@@ -13936,6 +13916,26 @@
                 },
                 "min": {
                     "type": "number"
+                }
+            }
+        },
+        "model.RecommendSpecReq": {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "$ref": "#/definitions/model.FilterInfo"
+                },
+                "limit": {
+                    "type": "string",
+                    "enum": [
+                        "1",
+                        "2",
+                        "30"
+                    ],
+                    "example": "5"
+                },
+                "priority": {
+                    "$ref": "#/definitions/model.PriorityInfo"
                 }
             }
         },
@@ -15666,6 +15666,161 @@
                 }
             }
         },
+        "model.TbCreateSubGroupDynamicReq": {
+            "type": "object",
+            "required": [
+                "commonImage",
+                "commonSpec"
+            ],
+            "properties": {
+                "commonImage": {
+                    "description": "CommonImage is field for id of a image in common namespace",
+                    "type": "string",
+                    "example": "ami-01f71f215b23ba262"
+                },
+                "commonSpec": {
+                    "description": "CommonSpec is field for id of a spec in common namespace",
+                    "type": "string",
+                    "example": "aws+ap-northeast-2+t3.nano"
+                },
+                "connectionName": {
+                    "description": "if ConnectionName is given, the VM tries to use associtated credential.\nif not, it will use predefined ConnectionName in Spec objects",
+                    "type": "string",
+                    "example": "aws-ap-northeast-2"
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Created via CB-Tumblebug"
+                },
+                "label": {
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "example": {
+                        "\"env\"": "\"test\"}",
+                        "{\"role\"": "\"worker\""
+                    }
+                },
+                "name": {
+                    "description": "SubGroup name, actual VM name will be generated with -N postfix.",
+                    "type": "string",
+                    "example": "g1"
+                },
+                "rootDiskSize": {
+                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
+                    "type": "string",
+                    "default": "default",
+                    "example": "50"
+                },
+                "rootDiskType": {
+                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
+                    "type": "string",
+                    "default": "default",
+                    "example": "gp3"
+                },
+                "subGroupSize": {
+                    "description": "if subGroupSize is (not empty) \u0026\u0026 (\u003e 0), subGroup will be generated. VMs will be created accordingly.",
+                    "type": "string",
+                    "default": "1",
+                    "example": "3"
+                },
+                "vmUserPassword": {
+                    "type": "string",
+                    "example": ""
+                }
+            }
+        },
+        "model.TbCreateSubGroupReq": {
+            "type": "object",
+            "required": [
+                "connectionName",
+                "imageId",
+                "name",
+                "securityGroupIds",
+                "specId",
+                "sshKeyId",
+                "subnetId",
+                "vNetId"
+            ],
+            "properties": {
+                "connectionName": {
+                    "type": "string",
+                    "example": "testcloud01-seoul"
+                },
+                "cspResourceId": {
+                    "description": "CspResourceId is resource identifier managed by CSP (required for option=register)",
+                    "type": "string",
+                    "example": "i-014fa6ede6ada0b2c"
+                },
+                "dataDiskIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "description": {
+                    "type": "string",
+                    "example": "Description"
+                },
+                "imageId": {
+                    "description": "ImageType        string   `json:\"imageType\"`",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "Label is for describing the object by keywords",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "description": "SubGroup name of VMs. Actual VM name will be generated with -N postfix.",
+                    "type": "string",
+                    "example": "g1-1"
+                },
+                "rootDiskSize": {
+                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
+                    "type": "string",
+                    "example": "default, 30, 42, ..."
+                },
+                "rootDiskType": {
+                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
+                    "type": "string",
+                    "example": "default, TYPE1, ..."
+                },
+                "securityGroupIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "specId": {
+                    "type": "string"
+                },
+                "sshKeyId": {
+                    "type": "string"
+                },
+                "subGroupSize": {
+                    "description": "if subGroupSize is (not empty) \u0026\u0026 (\u003e 0), subGroup will be generated. VMs will be created accordingly.",
+                    "type": "string",
+                    "example": "3"
+                },
+                "subnetId": {
+                    "type": "string"
+                },
+                "vNetId": {
+                    "type": "string"
+                },
+                "vmUserName": {
+                    "type": "string"
+                },
+                "vmUserPassword": {
+                    "type": "string"
+                }
+            }
+        },
         "model.TbCustomImageInfo": {
             "type": "object",
             "properties": {
@@ -16813,7 +16968,7 @@
             "type": "object",
             "required": [
                 "name",
-                "vm"
+                "subGroups"
             ],
             "properties": {
                 "description": {
@@ -16860,17 +17015,17 @@
                         }
                     ]
                 },
+                "subGroups": {
+                    "description": "SubGroups is array of VM requests for multi-cloud infrastructure\nExample: Multiple VM groups across different CSPs\n[\n  {\n    \"name\": \"aws-group\",\n    \"subGroupSize\": \"3\",\n    \"commonSpec\": \"aws+ap-northeast-2+t3.nano\",\n    \"commonImage\": \"ami-01f71f215b23ba262\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"worker\", \"csp\": \"aws\"}\n  },\n  {\n    \"name\": \"azure-group\",\n    \"subGroupSize\": \"2\",\n    \"commonSpec\": \"azure+koreasouth+standard_b1s\",\n    \"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"head\", \"csp\": \"azure\"}\n  },\n  {\n    \"name\": \"gcp-group\",\n    \"subGroupSize\": \"1\",\n    \"commonSpec\": \"gcp+asia-northeast3+g1-small\",\n    \"commonImage\": \"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250712\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"test\", \"csp\": \"gcp\"}\n  }\n]",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.TbCreateSubGroupDynamicReq"
+                    }
+                },
                 "systemLabel": {
                     "description": "SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose",
                     "type": "string",
                     "example": ""
-                },
-                "vm": {
-                    "description": "Vm is array of VM requests for multi-cloud infrastructure\nExample: Multiple VM groups across different CSPs\n[\n  {\n    \"name\": \"aws-group\",\n    \"subGroupSize\": \"3\",\n    \"commonSpec\": \"aws+ap-northeast-2+t3.nano\",\n    \"commonImage\": \"ami-01f71f215b23ba262\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"worker\", \"csp\": \"aws\"}\n  },\n  {\n    \"name\": \"azure-group\",\n    \"subGroupSize\": \"2\",\n    \"commonSpec\": \"azure+koreasouth+standard_b1s\",\n    \"commonImage\": \"Canonical:0001-com-ubuntu-server-jammy:22_04-lts:22.04.202505210\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"head\", \"csp\": \"azure\"}\n  },\n  {\n    \"name\": \"gcp-group\",\n    \"subGroupSize\": \"1\",\n    \"commonSpec\": \"gcp+asia-northeast3+g1-small\",\n    \"commonImage\": \"https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20250712\",\n    \"rootDiskSize\": \"50\",\n    \"label\": {\"role\": \"test\", \"csp\": \"gcp\"}\n  }\n]",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/model.TbVmDynamicReq"
-                    }
                 }
             }
         },
@@ -16994,7 +17149,7 @@
             "type": "object",
             "required": [
                 "name",
-                "vm"
+                "subGroups"
             ],
             "properties": {
                 "description": {
@@ -17044,16 +17199,16 @@
                         }
                     ]
                 },
+                "subGroups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.TbCreateSubGroupReq"
+                    }
+                },
                 "systemLabel": {
                     "description": "SystemLabel is for describing the mci in a keyword (any string can be used) for special System purpose",
                     "type": "string",
                     "example": ""
-                },
-                "vm": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/model.TbVmReq"
-                    }
                 }
             }
         },
@@ -18097,72 +18252,6 @@
                 }
             }
         },
-        "model.TbVmDynamicReq": {
-            "type": "object",
-            "required": [
-                "commonImage",
-                "commonSpec"
-            ],
-            "properties": {
-                "commonImage": {
-                    "description": "CommonImage is field for id of a image in common namespace",
-                    "type": "string",
-                    "example": "ami-01f71f215b23ba262"
-                },
-                "commonSpec": {
-                    "description": "CommonSpec is field for id of a spec in common namespace",
-                    "type": "string",
-                    "example": "aws+ap-northeast-2+t3.nano"
-                },
-                "connectionName": {
-                    "description": "if ConnectionName is given, the VM tries to use associtated credential.\nif not, it will use predefined ConnectionName in Spec objects",
-                    "type": "string",
-                    "example": "aws-ap-northeast-2"
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Created via CB-Tumblebug"
-                },
-                "label": {
-                    "description": "Label is for describing the object by keywords",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "example": {
-                        "\"env\"": "\"test\"}",
-                        "{\"role\"": "\"worker\""
-                    }
-                },
-                "name": {
-                    "description": "VM name or subGroup name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",
-                    "type": "string",
-                    "example": "g1"
-                },
-                "rootDiskSize": {
-                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
-                    "type": "string",
-                    "default": "default",
-                    "example": "50"
-                },
-                "rootDiskType": {
-                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
-                    "type": "string",
-                    "default": "default",
-                    "example": "gp3"
-                },
-                "subGroupSize": {
-                    "description": "if subGroupSize is (not empty) \u0026\u0026 (\u003e 0), subGroup will be generated. VMs will be created accordingly.",
-                    "type": "string",
-                    "default": "1",
-                    "example": "3"
-                },
-                "vmUserPassword": {
-                    "type": "string",
-                    "example": ""
-                }
-            }
-        },
         "model.TbVmInfo": {
             "type": "object",
             "properties": {
@@ -18326,95 +18415,6 @@
                     "description": "Uid is universally unique identifier for the object, used for labelSelector",
                     "type": "string",
                     "example": "wef12awefadf1221edcf"
-                },
-                "vNetId": {
-                    "type": "string"
-                },
-                "vmUserName": {
-                    "type": "string"
-                },
-                "vmUserPassword": {
-                    "type": "string"
-                }
-            }
-        },
-        "model.TbVmReq": {
-            "type": "object",
-            "required": [
-                "connectionName",
-                "imageId",
-                "name",
-                "securityGroupIds",
-                "specId",
-                "sshKeyId",
-                "subnetId",
-                "vNetId"
-            ],
-            "properties": {
-                "connectionName": {
-                    "type": "string",
-                    "example": "testcloud01-seoul"
-                },
-                "cspResourceId": {
-                    "description": "CspResourceId is resource identifier managed by CSP (required for option=register)",
-                    "type": "string",
-                    "example": "i-014fa6ede6ada0b2c"
-                },
-                "dataDiskIds": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "description": {
-                    "type": "string",
-                    "example": "Description"
-                },
-                "imageId": {
-                    "description": "ImageType        string   `json:\"imageType\"`",
-                    "type": "string"
-                },
-                "label": {
-                    "description": "Label is for describing the object by keywords",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                },
-                "name": {
-                    "description": "VM name or subGroup name if is (not empty) \u0026\u0026 (\u003e 0). If it is a group, actual VM name will be generated with -N postfix.",
-                    "type": "string",
-                    "example": "g1-1"
-                },
-                "rootDiskSize": {
-                    "description": "\"default\", Integer (GB): [\"50\", ..., \"1000\"]",
-                    "type": "string",
-                    "example": "default, 30, 42, ..."
-                },
-                "rootDiskType": {
-                    "description": "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\", \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"], GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"], ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT: [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]",
-                    "type": "string",
-                    "example": "default, TYPE1, ..."
-                },
-                "securityGroupIds": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "specId": {
-                    "type": "string"
-                },
-                "sshKeyId": {
-                    "type": "string"
-                },
-                "subGroupSize": {
-                    "description": "if subGroupSize is (not empty) \u0026\u0026 (\u003e 0), subGroup will be generated. VMs will be created accordingly.",
-                    "type": "string",
-                    "example": "3"
-                },
-                "subnetId": {
-                    "type": "string"
                 },
                 "vNetId": {
                     "type": "string"

--- a/src/interface/rest/docs/swagger.yaml
+++ b/src/interface/rest/docs/swagger.yaml
@@ -850,7 +850,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/model.DeploymentPlan'
+              $ref: '#/components/schemas/model.RecommendSpecReq'
         required: false
       responses:
         "200":
@@ -873,7 +873,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
-      x-codegen-request-body-name: deploymentPlan
+      x-codegen-request-body-name: recommendSpecReq
   /label/{labelType}/{uid}:
     get:
       tags:
@@ -1310,42 +1310,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
       x-codegen-request-body-name: mciReq
-  /mciRecommendVm:
-    post:
-      tags:
-      - "[MC-Infra] MCI Provisioning and Management"
-      summary: Recommend MCI plan (filter and priority)
-      description: Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
-      operationId: RecommendVm
-      requestBody:
-        description: Recommend MCI plan (filter and priority)
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/model.DeploymentPlan'
-        required: false
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/model.TbSpecInfo'
-        "404":
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.SimpleMsg'
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/model.SimpleMsg'
-      x-codegen-request-body-name: deploymentPlan
   /mergeCSPLabel/{labelType}/{uid}:
     put:
       tags:
@@ -4127,7 +4091,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/model.TbVmReq'
+              $ref: '#/components/schemas/model.TbCreateSubGroupReq'
         required: true
       responses:
         "200":
@@ -4692,12 +4656,12 @@ paths:
           type: string
           default: mci01
       requestBody:
-        description: "VM dynamic request specifying commonSpec, commonImage, and scaling\
-          \ parameters"
+        description: "SubGroup dynamic request specifying commonSpec, commonImage,\
+          \ and scaling parameters"
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/model.TbVmDynamicReq'
+              $ref: '#/components/schemas/model.TbCreateSubGroupDynamicReq'
         required: true
       responses:
         "200":
@@ -5047,7 +5011,7 @@ paths:
         - **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization
 
         **Configuration Process:**
-        1. **Resource Discovery**: Use `/mciRecommendVm` to find suitable VM specifications
+        1. **Resource Discovery**: Use `/recommendSpec` to find suitable VM specifications
         2. **Image Selection**: Use system namespace to discover compatible images
         3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment
         4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration
@@ -6758,7 +6722,7 @@ paths:
   /ns/{nsId}/resources/searchImage:
     post:
       tags:
-      - "[Infra Resource] Image Management"
+      - "[MC-Infra] MCI Provisioning and Management"
       summary: Search image
       description: Search image
       operationId: SearchImage
@@ -6800,7 +6764,7 @@ paths:
   /ns/{nsId}/resources/searchImageOptions:
     get:
       tags:
-      - "[Infra Resource] Image Management"
+      - "[MC-Infra] MCI Provisioning and Management"
       description: Get all available options for image search fields
       operationId: SearchImageOptions
       parameters:
@@ -9003,6 +8967,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/model.SimpleMsg'
+  /recommendSpec:
+    post:
+      tags:
+      - "[MC-Infra] MCI Provisioning and Management"
+      summary: Recommend specs for configuring an infrastructure (filter and priority)
+      description: Recommend specs for configuring an infrastructure (filter and priority)
+        Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+      operationId: RecommendSpec
+      requestBody:
+        description: Conditions for recommending specs (filter and priority)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/model.RecommendSpecReq'
+        required: false
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/model.TbSpecInfo'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/model.SimpleMsg'
+      x-codegen-request-body-name: recommendSpecReq
   /regionFromCsp:
     get:
       tags:
@@ -9876,7 +9877,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/model.MciCmdReq'
         vmDynamicReq:
-          $ref: '#/components/schemas/model.TbVmDynamicReq'
+          $ref: '#/components/schemas/model.TbCreateSubGroupDynamicReq'
     model.AutoCondition:
       type: object
       properties:
@@ -10152,20 +10153,6 @@ components:
       x-enum-varnames:
       - MyImageAvailable
       - MyImageUnavailable
-    model.DeploymentPlan:
-      type: object
-      properties:
-        filter:
-          $ref: '#/components/schemas/model.FilterInfo'
-        limit:
-          type: string
-          example: "5"
-          enum:
-          - "1"
-          - "2"
-          - "30"
-        priority:
-          $ref: '#/components/schemas/model.PriorityInfo'
     model.DiskStatus:
       type: string
       enum:
@@ -11148,6 +11135,20 @@ components:
           type: number
         min:
           type: number
+    model.RecommendSpecReq:
+      type: object
+      properties:
+        filter:
+          $ref: '#/components/schemas/model.FilterInfo'
+        limit:
+          type: string
+          example: "5"
+          enum:
+          - "1"
+          - "2"
+          - "30"
+        priority:
+          $ref: '#/components/schemas/model.PriorityInfo'
     model.RegionDetail:
       type: object
       properties:
@@ -12415,6 +12416,137 @@ components:
           example: Active
           allOf:
           - $ref: '#/components/schemas/model.TbK8sNodeGroupStatus'
+    model.TbCreateSubGroupDynamicReq:
+      required:
+      - commonImage
+      - commonSpec
+      type: object
+      properties:
+        commonImage:
+          type: string
+          description: CommonImage is field for id of a image in common namespace
+          example: ami-01f71f215b23ba262
+        commonSpec:
+          type: string
+          description: CommonSpec is field for id of a spec in common namespace
+          example: aws+ap-northeast-2+t3.nano
+        connectionName:
+          type: string
+          description: |-
+            if ConnectionName is given, the VM tries to use associtated credential.
+            if not, it will use predefined ConnectionName in Spec objects
+          example: aws-ap-northeast-2
+        description:
+          type: string
+          example: Created via CB-Tumblebug
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+          example:
+            '"env"': "\"test\"}"
+            '{"role"': '"worker"'
+        name:
+          type: string
+          description: "SubGroup name, actual VM name will be generated with -N postfix."
+          example: g1
+        rootDiskSize:
+          type: string
+          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
+          example: "50"
+          default: default
+        rootDiskType:
+          type: string
+          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
+            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
+            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
+            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT:\
+            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
+          example: gp3
+          default: default
+        subGroupSize:
+          type: string
+          description: "if subGroupSize is (not empty) && (> 0), subGroup will be\
+            \ generated. VMs will be created accordingly."
+          example: "3"
+          default: "1"
+        vmUserPassword:
+          type: string
+          example: ""
+    model.TbCreateSubGroupReq:
+      required:
+      - connectionName
+      - imageId
+      - name
+      - securityGroupIds
+      - specId
+      - sshKeyId
+      - subnetId
+      - vNetId
+      type: object
+      properties:
+        connectionName:
+          type: string
+          example: testcloud01-seoul
+        cspResourceId:
+          type: string
+          description: CspResourceId is resource identifier managed by CSP (required
+            for option=register)
+          example: i-014fa6ede6ada0b2c
+        dataDiskIds:
+          type: array
+          items:
+            type: string
+        description:
+          type: string
+          example: Description
+        imageId:
+          type: string
+          description: ImageType        string   `json:"imageType"`
+        label:
+          type: object
+          additionalProperties:
+            type: string
+          description: Label is for describing the object by keywords
+        name:
+          type: string
+          description: SubGroup name of VMs. Actual VM name will be generated with
+            -N postfix.
+          example: g1-1
+        rootDiskSize:
+          type: string
+          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
+          example: "default, 30, 42, ..."
+        rootDiskType:
+          type: string
+          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
+            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
+            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
+            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT:\
+            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
+          example: "default, TYPE1, ..."
+        securityGroupIds:
+          type: array
+          items:
+            type: string
+        specId:
+          type: string
+        sshKeyId:
+          type: string
+        subGroupSize:
+          type: string
+          description: "if subGroupSize is (not empty) && (> 0), subGroup will be\
+            \ generated. VMs will be created accordingly."
+          example: "3"
+        subnetId:
+          type: string
+        vNetId:
+          type: string
+        vmUserName:
+          type: string
+        vmUserPassword:
+          type: string
     model.TbCustomImageInfo:
       type: object
       properties:
@@ -13295,7 +13427,7 @@ components:
     model.TbMciDynamicReq:
       required:
       - name
-      - vm
+      - subGroups
       type: object
       properties:
         description:
@@ -13336,15 +13468,10 @@ components:
           description: PostCommand is for the command to bootstrap the VMs
           allOf:
           - $ref: '#/components/schemas/model.MciCmdReq'
-        systemLabel:
-          type: string
-          description: SystemLabel is for describing the mci in a keyword (any string
-            can be used) for special System purpose
-          example: ""
-        vm:
+        subGroups:
           type: array
           description: |-
-            Vm is array of VM requests for multi-cloud infrastructure
+            SubGroups is array of VM requests for multi-cloud infrastructure
             Example: Multiple VM groups across different CSPs
             [
               {
@@ -13373,7 +13500,12 @@ components:
               }
             ]
           items:
-            $ref: '#/components/schemas/model.TbVmDynamicReq'
+            $ref: '#/components/schemas/model.TbCreateSubGroupDynamicReq'
+        systemLabel:
+          type: string
+          description: SystemLabel is for describing the mci in a keyword (any string
+            can be used) for special System purpose
+          example: ""
     model.TbMciInfo:
       type: object
       properties:
@@ -13467,7 +13599,7 @@ components:
     model.TbMciReq:
       required:
       - name
-      - vm
+      - subGroups
       type: object
       properties:
         description:
@@ -13510,15 +13642,15 @@ components:
           description: PostCommand is for the command to bootstrap the VMs
           allOf:
           - $ref: '#/components/schemas/model.MciCmdReq'
+        subGroups:
+          type: array
+          items:
+            $ref: '#/components/schemas/model.TbCreateSubGroupReq'
         systemLabel:
           type: string
           description: SystemLabel is for describing the mci in a keyword (any string
             can be used) for special System purpose
           example: ""
-        vm:
-          type: array
-          items:
-            $ref: '#/components/schemas/model.TbVmReq'
     model.TbNLBAddRemoveVMReq:
       type: object
       properties:
@@ -14275,65 +14407,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/model.TbSubnetReq'
-    model.TbVmDynamicReq:
-      required:
-      - commonImage
-      - commonSpec
-      type: object
-      properties:
-        commonImage:
-          type: string
-          description: CommonImage is field for id of a image in common namespace
-          example: ami-01f71f215b23ba262
-        commonSpec:
-          type: string
-          description: CommonSpec is field for id of a spec in common namespace
-          example: aws+ap-northeast-2+t3.nano
-        connectionName:
-          type: string
-          description: |-
-            if ConnectionName is given, the VM tries to use associtated credential.
-            if not, it will use predefined ConnectionName in Spec objects
-          example: aws-ap-northeast-2
-        description:
-          type: string
-          example: Created via CB-Tumblebug
-        label:
-          type: object
-          additionalProperties:
-            type: string
-          description: Label is for describing the object by keywords
-          example:
-            '"env"': "\"test\"}"
-            '{"role"': '"worker"'
-        name:
-          type: string
-          description: "VM name or subGroup name if is (not empty) && (> 0). If it\
-            \ is a group, actual VM name will be generated with -N postfix."
-          example: g1
-        rootDiskSize:
-          type: string
-          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
-          example: "50"
-          default: default
-        rootDiskType:
-          type: string
-          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
-            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
-            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
-            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_essd\"], TENCENT:\
-            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
-          example: gp3
-          default: default
-        subGroupSize:
-          type: string
-          description: "if subGroupSize is (not empty) && (> 0), subGroup will be\
-            \ generated. VMs will be created accordingly."
-          example: "3"
-          default: "1"
-        vmUserPassword:
-          type: string
-          example: ""
     model.TbVmInfo:
       type: object
       properties:
@@ -14453,79 +14526,6 @@ components:
           description: "Uid is universally unique identifier for the object, used\
             \ for labelSelector"
           example: wef12awefadf1221edcf
-        vNetId:
-          type: string
-        vmUserName:
-          type: string
-        vmUserPassword:
-          type: string
-    model.TbVmReq:
-      required:
-      - connectionName
-      - imageId
-      - name
-      - securityGroupIds
-      - specId
-      - sshKeyId
-      - subnetId
-      - vNetId
-      type: object
-      properties:
-        connectionName:
-          type: string
-          example: testcloud01-seoul
-        cspResourceId:
-          type: string
-          description: CspResourceId is resource identifier managed by CSP (required
-            for option=register)
-          example: i-014fa6ede6ada0b2c
-        dataDiskIds:
-          type: array
-          items:
-            type: string
-        description:
-          type: string
-          example: Description
-        imageId:
-          type: string
-          description: ImageType        string   `json:"imageType"`
-        label:
-          type: object
-          additionalProperties:
-            type: string
-          description: Label is for describing the object by keywords
-        name:
-          type: string
-          description: "VM name or subGroup name if is (not empty) && (> 0). If it\
-            \ is a group, actual VM name will be generated with -N postfix."
-          example: g1-1
-        rootDiskSize:
-          type: string
-          description: "\"default\", Integer (GB): [\"50\", ..., \"1000\"]"
-          example: "default, 30, 42, ..."
-        rootDiskType:
-          type: string
-          description: "\"\", \"default\", \"TYPE1\", AWS: [\"standard\", \"gp2\"\
-            , \"gp3\"], Azure: [\"PremiumSSD\", \"StandardSSD\", \"StandardHDD\"],\
-            \ GCP: [\"pd-standard\", \"pd-balanced\", \"pd-ssd\", \"pd-extreme\"],\
-            \ ALIBABA: [\"cloud_efficiency\", \"cloud\", \"cloud_ssd\"], TENCENT:\
-            \ [\"CLOUD_PREMIUM\", \"CLOUD_SSD\"]"
-          example: "default, TYPE1, ..."
-        securityGroupIds:
-          type: array
-          items:
-            type: string
-        specId:
-          type: string
-        sshKeyId:
-          type: string
-        subGroupSize:
-          type: string
-          description: "if subGroupSize is (not empty) && (> 0), subGroup will be\
-            \ generated. VMs will be created accordingly."
-          example: "3"
-        subnetId:
-          type: string
         vNetId:
           type: string
         vmUserName:

--- a/src/interface/rest/server/infra/provisioning.go
+++ b/src/interface/rest/server/infra/provisioning.go
@@ -228,7 +228,7 @@ func RestPostSystemMci(c echo.Context) error {
 // @Description - **Scalable Architecture**: Supports large-scale deployments with optimized resource utilization
 // @Description
 // @Description **Configuration Process:**
-// @Description 1. **Resource Discovery**: Use `/mciRecommendVm` to find suitable VM specifications
+// @Description 1. **Resource Discovery**: Use `/recommendSpec` to find suitable VM specifications
 // @Description 2. **Image Selection**: Use system namespace to discover compatible images
 // @Description 3. **Request Validation**: Use `/mciDynamicCheckRequest` to validate configuration before deployment
 // @Description 4. **Optional Preview**: Use `/mciDynamicReview` to estimate costs and review configuration
@@ -424,7 +424,7 @@ func RestPostMciDynamicReview(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID containing the target MCI" default(default)
 // @Param mciId path string true "MCI ID to which new VMs will be added" default(mci01)
-// @Param vmReq body model.TbVmDynamicReq true "VM dynamic request specifying commonSpec, commonImage, and scaling parameters"
+// @Param vmReq body model.TbCreateSubGroupDynamicReq true "SubGroup dynamic request specifying commonSpec, commonImage, and scaling parameters"
 // @Success 200 {object} model.TbMciInfo "Updated MCI information including newly added VMs and current status"
 // @Failure 400 {object} model.SimpleMsg "Invalid VM request or incompatible configuration parameters"
 // @Failure 404 {object} model.SimpleMsg "Target MCI not found or specified resources unavailable"
@@ -436,7 +436,7 @@ func RestPostMciVmDynamic(c echo.Context) error {
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
-	req := &model.TbVmDynamicReq{}
+	req := &model.TbCreateSubGroupDynamicReq{}
 	if err := c.Bind(req); err != nil {
 		return clientManager.EndRequestWithLog(c, err, nil)
 	}
@@ -572,7 +572,7 @@ func RestPostMciDynamicCheckRequest(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID containing the target MCI" default(default)
 // @Param mciId path string true "MCI ID to which the VM subgroup will be added" default(mci01)
-// @Param vmReq body model.TbVmReq true "Detailed VM subgroup specification including exact resource IDs, networking, and scaling parameters"
+// @Param vmReq body model.TbCreateSubGroupReq true "Detailed VM subgroup specification including exact resource IDs, networking, and scaling parameters"
 // @Success 200 {object} model.TbMciInfo "Updated MCI information including newly created VM subgroup with individual VM details and status"
 // @Failure 400 {object} model.SimpleMsg "Invalid VM request, missing required resources, or configuration conflicts"
 // @Failure 404 {object} model.SimpleMsg "Target MCI not found, specified resources unavailable, or namespace inaccessible"
@@ -584,7 +584,7 @@ func RestPostMciVm(c echo.Context) error {
 	nsId := c.Param("nsId")
 	mciId := c.Param("mciId")
 
-	vmInfoData := &model.TbVmReq{}
+	vmInfoData := &model.TbCreateSubGroupReq{}
 	if err := c.Bind(vmInfoData); err != nil {
 		return clientManager.EndRequestWithLog(c, err, nil)
 	}

--- a/src/interface/rest/server/infra/recommendation.go
+++ b/src/interface/rest/server/infra/recommendation.go
@@ -21,28 +21,28 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// RestRecommendVm godoc
-// @ID RecommendVm
-// @Summary Recommend MCI plan (filter and priority)
-// @Description Recommend MCI plan (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
+// RestRecommendSpec godoc
+// @ID RecommendSpec
+// @Summary Recommend specs for configuring an infrastructure (filter and priority)
+// @Description Recommend specs for configuring an infrastructure (filter and priority) Find details from https://github.com/cloud-barista/cb-tumblebug/discussions/1234
 // @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
-// @Param deploymentPlan body model.DeploymentPlan false "Recommend MCI plan (filter and priority)"
+// @Param recommendSpecReq body model.RecommendSpecReq false "Conditions for recommending specs (filter and priority)"
 // @Success 200 {object} []model.TbSpecInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
-// @Router /mciRecommendVm [post]
-func RestRecommendVm(c echo.Context) error {
+// @Router /recommendSpec [post]
+func RestRecommendSpec(c echo.Context) error {
 
 	nsId := model.SystemCommonNs
 
-	u := &model.DeploymentPlan{}
+	u := &model.RecommendSpecReq{}
 	if err := c.Bind(u); err != nil {
 		return clientManager.EndRequestWithLog(c, err, nil)
 	}
 
-	content, err := infra.RecommendVm(nsId, *u)
+	content, err := infra.RecommendSpec(nsId, *u)
 	return clientManager.EndRequestWithLog(c, err, content)
 }
 

--- a/src/interface/rest/server/resource/image.go
+++ b/src/interface/rest/server/resource/image.go
@@ -355,7 +355,7 @@ func RestDelAllImage(c echo.Context) error {
 // @ID SearchImage
 // @Summary Search image
 // @Description Search image
-// @Tags [Infra Resource] Image Management
+// @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(system)
@@ -385,7 +385,7 @@ func RestSearchImage(c echo.Context) error {
 // @ID SearchImageOptions
 // @Get available image search request options
 // @Description Get all available options for image search fields
-// @Tags [Infra Resource] Image Management
+// @Tags [MC-Infra] MCI Provisioning and Management
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(system)

--- a/src/interface/rest/server/resource/k8scluster.go
+++ b/src/interface/rest/server/resource/k8scluster.go
@@ -685,7 +685,7 @@ func RestGetControlK8sCluster(c echo.Context) error {
 // @Tags [Kubernetes] Cluster Management
 // @Accept  json
 // @Produce  json
-// @Param deploymentPlan body model.DeploymentPlan false "Recommend K8sCluster's Node plan (filter and priority)"
+// @Param recommendSpecReq body model.RecommendSpecReq false "Recommend K8sCluster's Node plan (filter and priority)"
 // @Success 200 {object} []model.TbSpecInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
@@ -694,7 +694,7 @@ func RestRecommendK8sNode(c echo.Context) error {
 
 	nsId := model.SystemCommonNs
 
-	u := &model.DeploymentPlan{}
+	u := &model.RecommendSpecReq{}
 	if err := c.Bind(u); err != nil {
 		return clientManager.EndRequestWithLog(c, err, nil)
 	}

--- a/src/interface/rest/server/server.go
+++ b/src/interface/rest/server/server.go
@@ -369,7 +369,7 @@ func RunServer() {
 	g.POST("/:nsId/mci", rest_infra.RestPostMci)
 	g.POST("/:nsId/registerCspVm", rest_infra.RestPostRegisterCSPNativeVM)
 
-	e.POST("/tumblebug/mciRecommendVm", rest_infra.RestRecommendVm)
+	e.POST("/tumblebug/recommendSpec", rest_infra.RestRecommendSpec)
 	e.POST("/tumblebug/mciDynamicCheckRequest", rest_infra.RestPostMciDynamicCheckRequest)
 	e.POST("/tumblebug/systemMci", rest_infra.RestPostSystemMci)
 


### PR DESCRIPTION
- explicitly describe subgroups (instead of vm) for mci and mci dynamic provisioning
- change the path for mciRecommendVm to just recommendSpec (to be prepared with k8s node spec selection)