### PR TITLE
Set a longer API request timeout for the control VM in the NCP VPC

### DIFF
--- a/src/core/infra/control.go
+++ b/src/core/infra/control.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
+	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	"github.com/go-resty/resty/v2"
@@ -436,6 +437,12 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mciId string, vmId string, 
 
 			client := resty.New()
 			client.SetTimeout(10 * time.Minute)
+
+			// Set longer timeout for NCP (VPC)
+			if strings.Contains(strings.ToLower(temp.ConnectionConfig.ProviderName), csp.NCP) {
+				log.Debug().Msgf("Setting longer API request timeout (15m) for %s", csp.NCP)
+				client.SetTimeout(15 * time.Minute)
+			}
 
 			requestBody := model.SpiderConnectionName{}
 			requestBody.ConnectionName = temp.ConnectionName


### PR DESCRIPTION
This PR will set a longer API request timeout.

For NCP VPCs, the API request timeout is set to 45 minutes.
* Note: This time is set to account for the maximum request processing time of Spider/driver.

---

According to [Beetle's NCP test results](https://github.com/cloud-barista/cm-beetle/blob/main/cmd/test-cli/testresult/beetle-test-results-ncp.md), deleting the MCI (option: terminate) in NCP took around 13 minutes.

**Therefore, the current value of 10 minutes needs to be increased. I considered the Spider/driver request processing time and set it to 45 minutes in this PR.**
* Note: It is expected to take around 45 minutes in the worst case.

**Please review the following:**
* Is the time (45 minutes) acceptable?
* Does this need to be set for all CSPs?