### PR TITLE
Enhance KV existence checks for better reliability and bugfix on creating MCI.

### DIFF
--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -266,7 +266,7 @@ func GetConfig(id string) (model.ConfigInfo, error) {
 
 	key := "/config/" + id
 
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, _, err := kvstore.GetKv(key)
 	if err != nil {
 		err := fmt.Errorf("failed to retrieve config '%s' from key-value store: %v (path: %s)", id, err, key)
 		return res, err
@@ -370,8 +370,8 @@ func CheckConfig(id string) (bool, error) {
 
 	key := "/config/" + id
 
-	keyValue, _ := kvstore.GetKv(key)
-	if keyValue != (kvstore.KeyValue{}) {
+	_, exists, _ := kvstore.GetKv(key)
+	if exists {
 		return true, nil
 	}
 	return false, nil

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -270,12 +270,12 @@ func GetConnConfig(ConnConfigName string) (model.ConnConfig, error) {
 	connConfig := model.ConnConfig{}
 
 	key := GenConnectionKey(ConnConfigName)
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return model.ConnConfig{}, err
 	}
-	if keyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		return model.ConnConfig{}, fmt.Errorf("Cannot find the model.ConnConfig " + key)
 	}
 	err = json.Unmarshal([]byte(keyValue.Value), &connConfig)
@@ -1228,12 +1228,12 @@ func GetObjectList(key string) []string {
 // GetObjectValue is func to return the object value
 func GetObjectValue(key string) (string, error) {
 
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return "", err
 	}
-	if keyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		return "", nil
 	}
 	return keyValue.Value, nil

--- a/src/core/infra/control.go
+++ b/src/core/infra/control.go
@@ -242,7 +242,7 @@ func HandleMciVmAction(nsId string, mciId string, vmId string, action string, fo
 // ControlMciAsync is func to control MCI async
 func ControlMciAsync(nsId string, mciId string, action string, force bool) error {
 
-	mci, err := GetMciObject(nsId, mciId)
+	mci, _, err := GetMciObject(nsId, mciId)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return err
@@ -325,7 +325,7 @@ func ControlMciAsync(nsId string, mciId string, action string, force bool) error
 	}()
 
 	// Update MCI TargetAction to None. Even if there are errors, we want to mark it as complete.
-	mci, err = GetMciObject(nsId, mciId)
+	mci, _, err = GetMciObject(nsId, mciId)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return err
@@ -365,9 +365,9 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mciId string, vmId string, 
 	key := common.GenMciKey(nsId, mciId, vmId)
 	log.Debug().Msg("[ControlVmAsync] " + key)
 
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, exists, err := kvstore.GetKv(key)
 
-	if keyValue == (kvstore.KeyValue{}) || err != nil {
+	if !exists || err != nil {
 		callResult.Error = fmt.Errorf("kvstore.Get() Err in ControlVmAsync. key[" + key + "]")
 		log.Fatal().Err(callResult.Error).Msg("Error in ControlVmAsync")
 

--- a/src/core/infra/loadbalance.go
+++ b/src/core/infra/loadbalance.go
@@ -85,7 +85,7 @@ func CreateMcSwNlb(nsId string, mciId string, req *model.NLBReq, option string) 
 	recommendSpecReq.Priority.Policy = append(recommendSpecReq.Priority.Policy, model.PriorityCondition{Metric: "latency"})
 	recommendSpecReq.Priority.Policy[0].Parameter = append(recommendSpecReq.Priority.Policy[0].Parameter, model.ParameterKeyVal{Key: "latencyMinimal"})
 
-	mci, err := GetMciObject(nsId, mciId)
+	mci, _, err := GetMciObject(nsId, mciId)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyObj, err
@@ -404,7 +404,7 @@ func CreateNLB(nsId string, mciId string, u *model.NLBReq, option string) (model
 		return content, err
 	}
 
-	keyValue, err := kvstore.GetKv(Key)
+	keyValue, _, err := kvstore.GetKv(Key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("In CreateNLB(); kvstore.GetKv() returned an error.")
@@ -459,7 +459,7 @@ func GetNLB(nsId string, mciId string, resourceId string) (model.NLBInfo, error)
 	// key := common.GenResourceKey(nsId, resourceType, resourceId)
 	key := GenNLBKey(nsId, mciId, resourceId)
 
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyObj, err
@@ -467,7 +467,7 @@ func GetNLB(nsId string, mciId string, resourceId string) (model.NLBInfo, error)
 
 	res := model.NLBInfo{}
 
-	if keyValue != (kvstore.KeyValue{}) {
+	if exists {
 		err = json.Unmarshal([]byte(keyValue.Value), &res)
 		if err != nil {
 			log.Error().Err(err).Msg("")
@@ -519,12 +519,12 @@ func CheckNLB(nsId string, mciId string, resourceId string) (bool, error) {
 	// key := common.GenResourceKey(nsId, resourceType, resourceId)
 	key := GenNLBKey(nsId, mciId, resourceId)
 
-	keyValue, err := kvstore.GetKv(key)
+	_, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return false, err
 	}
-	if keyValue != (kvstore.KeyValue{}) {
+	if exists {
 		return true, nil
 	}
 	return false, nil
@@ -696,7 +696,7 @@ func DelNLB(nsId string, mciId string, resourceId string, forceFlag string) erro
 	key := GenNLBKey(nsId, mciId, resourceId)
 	fmt.Println("key: " + key)
 
-	keyValue, _ := kvstore.GetKv(key)
+	keyValue, _, _ := kvstore.GetKv(key)
 	// In CheckResource() above, calling 'kvstore.GetKv()' and checking err parts exist.
 	// So, in here, we don't need to check whether keyValue == nil or err != nil.
 
@@ -1135,7 +1135,7 @@ func AddNLBVMs(nsId string, mciId string, resourceId string, u *model.NLBAddRemo
 		return content, err
 	}
 
-	keyValue, err := kvstore.GetKv(Key)
+	keyValue, _, err := kvstore.GetKv(Key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("In CreateNLB(); kvstore.GetKv() returned an error.")

--- a/src/core/infra/orchestration.go
+++ b/src/core/infra/orchestration.go
@@ -48,7 +48,7 @@ func OrchestrationController() {
 		for _, v := range mciPolicyList {
 
 			key := common.GenMciPolicyKey(nsId, v, "")
-			keyValue, err := kvstore.GetKv(key)
+			keyValue, exists, err := kvstore.GetKv(key)
 			if err != nil {
 				log.Error().Err(err).Msg("")
 				err = fmt.Errorf("In OrchestrationController(); kvstore.GetKv() returned an error.")
@@ -56,7 +56,7 @@ func OrchestrationController() {
 				// return nil, err
 			}
 
-			if keyValue == (kvstore.KeyValue{}) {
+			if !exists {
 				log.Debug().Msg("keyValue is nil")
 			}
 			mciPolicyTmp := model.MciPolicyInfo{}
@@ -414,7 +414,7 @@ func CreateMciPolicy(nsId string, mciId string, u *model.MciPolicyReq) (model.Mc
 		log.Error().Err(err).Msg("")
 		return obj, err
 	}
-	keyValue, err := kvstore.GetKv(Key)
+	keyValue, _, err := kvstore.GetKv(Key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("In CreateMciPolicy(); kvstore.GetKv() returned an error.")
@@ -433,12 +433,12 @@ func GetMciPolicyObject(nsId string, mciId string) (model.MciPolicyInfo, error) 
 
 	key := common.GenMciPolicyKey(nsId, mciId, "")
 	log.Debug().Msgf("Key: %v", key)
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return model.MciPolicyInfo{}, err
 	}
-	if keyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		return model.MciPolicyInfo{}, err
 	}
 
@@ -463,7 +463,7 @@ func GetAllMciPolicyObject(nsId string) ([]model.MciPolicyInfo, error) {
 	for _, v := range mciList {
 
 		key := common.GenMciPolicyKey(nsId, v, "")
-		keyValue, err := kvstore.GetKv(key)
+		keyValue, exists, err := kvstore.GetKv(key)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			err = fmt.Errorf("In GetAllMciPolicyObject(); kvstore.GetKv() returned an error.")
@@ -471,7 +471,7 @@ func GetAllMciPolicyObject(nsId string) ([]model.MciPolicyInfo, error) {
 			// return nil, err
 		}
 
-		if keyValue == (kvstore.KeyValue{}) {
+		if !exists {
 			return nil, fmt.Errorf("Cannot find " + key)
 		}
 		mciTmp := model.MciPolicyInfo{}

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -935,7 +935,12 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 	vmStartIndex := 1
 
 	// Get mci object
+	// Note: return 'an empty MCI object', 'nil' if MCI doesn't exist
 	mciTmp, err := GetMciObject(nsId, mciId)
+	log.Debug().Msgf("Fetched MCI object: %+v, error: %v", mciTmp, err)
+
+	// Note: check the existence
+	exists := (err == nil && mciTmp.Id != "")
 
 	if isReqFromDynamic {
 		// isReqFromDynamic. Do not create MCI object. Reuse the existing one.
@@ -949,7 +954,7 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 		}
 	} else {
 		// fallback for manual mci create. not from isReqFromDynamic.
-		if err != nil {
+		if !exists {
 			log.Debug().Msgf("MCI '%s' does not exist, creating new one", mciId)
 			// Create MCI object first
 			if err := createMciObject(nsId, mciId, req, uid); err != nil {
@@ -958,6 +963,7 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 		} else {
 			// Check MCI existence (skip for register option)
 			if option != "register" {
+				log.Debug().Msgf("MCI '%s' already exists in namespace '%s'", mciId, nsId)
 				return nil, fmt.Errorf("MCI '%s' already exists in namespace '%s'", mciId, nsId)
 			} else {
 				req.SystemLabel = "Registered from CSP"

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -493,7 +493,7 @@ func CreateMciVm(nsId string, mciId string, vmInfoData *model.VmInfo) (*model.Vm
 
 	// Install CB-Dragonfly monitoring agent
 
-	mciTmp, _ := GetMciObject(nsId, mciId)
+	mciTmp, _, _ := GetMciObject(nsId, mciId)
 
 	fmt.Printf("\n[Init monitoring agent] for %+v\n - req.InstallMonAgent: %+v\n\n", mciId, mciTmp.InstallMonAgent)
 
@@ -612,7 +612,7 @@ func CreateMciGroupVm(nsId string, mciId string, vmRequest *model.CreateSubGroup
 		return nil, err
 	}
 
-	mciTmp, err := GetMciObject(nsId, mciId)
+	mciTmp, _, err := GetMciObject(nsId, mciId)
 
 	if err != nil {
 		temp := &model.MciInfo{}
@@ -658,12 +658,12 @@ func CreateMciGroupVm(nsId string, mciId string, vmRequest *model.CreateSubGroup
 		subGroupInfoData.SubGroupSize = vmRequest.SubGroupSize
 
 		key := common.GenMciSubGroupKey(nsId, mciId, vmRequest.Name)
-		keyValue, err := kvstore.GetKv(key)
+		keyValue, exists, err := kvstore.GetKv(key)
 		if err != nil {
 			err = fmt.Errorf("In CreateMciGroupVm(); kvstore.GetKv(): " + err.Error())
 			log.Error().Err(err).Msg("")
 		}
-		if keyValue != (kvstore.KeyValue{}) {
+		if exists {
 			if newSubGroup {
 				json.Unmarshal([]byte(keyValue.Value), &subGroupInfoData)
 				existingVmSize, err := strconv.Atoi(subGroupInfoData.SubGroupSize)
@@ -691,13 +691,12 @@ func CreateMciGroupVm(nsId string, mciId string, vmRequest *model.CreateSubGroup
 			log.Error().Err(err).Msg("")
 		}
 		// check stored subGroup object
-		keyValue, err = kvstore.GetKv(key)
+		_, _, err = kvstore.GetKv(key)
 		if err != nil {
 			err = fmt.Errorf("In CreateMciGroupVm(); kvstore.GetKv(): " + err.Error())
 			log.Error().Err(err).Msg("")
 			// return nil, err
 		}
-
 	}
 
 	for i := vmStartIndex; i <= subGroupSize+vmStartIndex; i++ {
@@ -787,7 +786,7 @@ func CreateMciGroupVm(nsId string, mciId string, vmRequest *model.CreateSubGroup
 
 	//Update MCI status
 
-	mciTmp, err = GetMciObject(nsId, mciId)
+	mciTmp, _, err = GetMciObject(nsId, mciId)
 	if err != nil {
 		temp := &model.MciInfo{}
 		return temp, err
@@ -936,11 +935,8 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 
 	// Get mci object
 	// Note: return 'an empty MCI object', 'nil' if MCI doesn't exist
-	mciTmp, err := GetMciObject(nsId, mciId)
+	mciTmp, exists, err := GetMciObject(nsId, mciId)
 	log.Debug().Msgf("Fetched MCI object: %+v, error: %v", mciTmp, err)
-
-	// Note: check the existence
-	exists := (err == nil && mciTmp.Id != "")
 
 	if isReqFromDynamic {
 		// isReqFromDynamic. Do not create MCI object. Reuse the existing one.
@@ -1154,7 +1150,7 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 	}
 
 	// Update MCI status
-	mciTmp, err = GetMciObject(nsId, mciId)
+	mciTmp, _, err = GetMciObject(nsId, mciId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get MCI object after VM creation: %w", err)
 	}
@@ -1237,7 +1233,7 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 	}
 
 	// Update MCI status
-	mciTmp, err = GetMciObject(nsId, mciId)
+	mciTmp, _, err = GetMciObject(nsId, mciId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get MCI object after VM creation: %w", err)
 	}
@@ -1335,7 +1331,7 @@ func CreateMciDynamic(reqID string, nsId string, req *model.MciDynamicReq, deplo
 		return emptyMci, err
 	}
 	// Get MCI object
-	mciTmp, err := GetMciObject(nsId, mciId)
+	mciTmp, _, err := GetMciObject(nsId, mciId)
 	if err != nil {
 		return emptyMci, err
 	}
@@ -2480,12 +2476,12 @@ func CreateVmObject(wg *sync.WaitGroup, nsId string, mciId string, vmInfoData *m
 	defer wg.Done()
 
 	key := common.GenMciKey(nsId, mciId, "")
-	keyValue, err := kvstore.GetKv(key)
+	_, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Fatal().Err(err).Msg("AddVmToMci kvstore.GetKv() returned an error.")
 		return err
 	}
-	if keyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		return fmt.Errorf("AddVmToMci Cannot find mciId. Key: %s", key)
 	}
 
@@ -3438,16 +3434,15 @@ func GetProvisioningLog(specId string) (*model.ProvisioningLog, error) {
 	log.Debug().Msgf("Getting provisioning log for spec: %s", specId)
 
 	key := generateProvisioningLogKey(specId)
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, exists, err := kvstore.GetKv(key)
 	if err != nil {
-		if err.Error() == "key not found" {
-			log.Debug().Msgf("No provisioning log found for spec: %s", specId)
-			return nil, nil // No log exists yet
-		}
 		log.Error().Err(err).Msgf("Failed to get provisioning log for spec: %s", specId)
 		return nil, fmt.Errorf("failed to get provisioning log: %w", err)
 	}
-
+	if !exists {
+		log.Debug().Msgf("No provisioning log found for spec: %s", specId)
+		return nil, nil // No log exists yet
+	}
 	// Check if the value is empty or invalid
 	if keyValue.Value == "" {
 		log.Debug().Msgf("Empty value found for provisioning log spec: %s, treating as no log exists", specId)
@@ -4007,7 +4002,7 @@ func CleanupCorruptedProvisioningLogs() error {
 
 	cleanupCount := 0
 	for _, key := range keys {
-		keyValue, err := kvstore.GetKv(key.Key)
+		keyValue, _, err := kvstore.GetKv(key.Key)
 		if err != nil {
 			log.Warn().Err(err).Msgf("Failed to get value for key: %s", key.Key)
 			continue
@@ -4045,7 +4040,7 @@ func ValidateProvisioningLogIntegrity(specId string) error {
 	log.Debug().Msgf("Validating provisioning log integrity for spec: %s", specId)
 
 	key := generateProvisioningLogKey(specId)
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, _, err := kvstore.GetKv(key)
 	if err != nil {
 		if err.Error() == "key not found" {
 			log.Debug().Msgf("No provisioning log found for spec: %s", specId)

--- a/src/core/infra/remoteCommand.go
+++ b/src/core/infra/remoteCommand.go
@@ -509,7 +509,7 @@ func GetVmSshKey(nsId string, mciId string, vmId string) (string, string, string
 
 	key := common.GenMciKey(nsId, mciId, vmId)
 
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, _, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("Cannot find the key from DB. key: " + key)
@@ -523,8 +523,8 @@ func GetVmSshKey(nsId string, mciId string, vmId string) (string, string, string
 	}
 
 	sshKey := common.GenResourceKey(nsId, model.StrSSHKey, content.SshKeyId)
-	keyValue, err = kvstore.GetKv(sshKey)
-	if err != nil || keyValue == (kvstore.KeyValue{}) {
+	keyValue, _, err = kvstore.GetKv(sshKey)
+	if err != nil {
 		log.Error().Err(err).Msg("")
 		return "", "", "", err
 	}
@@ -560,7 +560,7 @@ func UpdateVmSshKey(nsId string, mciId string, vmId string, verifiedUserName str
 	}
 
 	key := common.GenMciKey(nsId, mciId, vmId)
-	keyValue, err := kvstore.GetKv(key)
+	keyValue, _, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("In UpdateVmSshKey(); kvstore.GetKv() returned an error.")
@@ -571,7 +571,7 @@ func UpdateVmSshKey(nsId string, mciId string, vmId string, verifiedUserName str
 	json.Unmarshal([]byte(keyValue.Value), &content)
 
 	sshKey := common.GenResourceKey(nsId, model.StrSSHKey, content.SshKeyId)
-	keyValue, _ = kvstore.GetKv(sshKey)
+	keyValue, _, _ = kvstore.GetKv(sshKey)
 
 	tmpSshKeyInfo := model.SshKeyInfo{}
 	json.Unmarshal([]byte(keyValue.Value), &tmpSshKeyInfo)

--- a/src/core/infra/snapshot.go
+++ b/src/core/infra/snapshot.go
@@ -31,9 +31,9 @@ func CreateVmSnapshot(nsId string, mciId string, vmId string, snapshotName strin
 	vmKey := common.GenMciKey(nsId, mciId, vmId)
 
 	// Check existence of the key. If no key, no update.
-	keyValue, err := kvstore.GetKv(vmKey)
-	if keyValue == (kvstore.KeyValue{}) || err != nil {
-		err := fmt.Errorf("Failed to find 'ns/mci/vm': %s/%s/%s \n", nsId, mciId, vmId)
+	keyValue, exists, err := kvstore.GetKv(vmKey)
+	if !exists || err != nil {
+		err := fmt.Errorf("failed to find 'ns/mci/vm': %s/%s/%s \n", nsId, mciId, vmId)
 		log.Error().Err(err).Msg("")
 		return model.CustomImageInfo{}, err
 	}

--- a/src/core/infra/utility.go
+++ b/src/core/infra/utility.go
@@ -92,7 +92,7 @@ func CheckMci(nsId string, mciId string) (bool, error) {
 
 	key := common.GenMciKey(nsId, mciId, "")
 
-	keyValue, err := kvstore.GetKv(key)
+	_, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("In CheckMci(); kvstore.GetKv() returned an error.")
@@ -100,7 +100,7 @@ func CheckMci(nsId string, mciId string) (bool, error) {
 		// return nil, err
 	}
 
-	if keyValue != (kvstore.KeyValue{}) {
+	if exists {
 		return true, nil
 	}
 	return false, nil
@@ -169,7 +169,7 @@ func CheckVm(nsId string, mciId string, vmId string) (bool, error) {
 
 	key := common.GenMciKey(nsId, mciId, vmId)
 
-	keyValue, err := kvstore.GetKv(key)
+	_, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("In CheckVm(); kvstore.GetKv() returned an error.")
@@ -177,7 +177,7 @@ func CheckVm(nsId string, mciId string, vmId string) (bool, error) {
 		// return nil, err
 	}
 
-	if keyValue != (kvstore.KeyValue{}) {
+	if exists {
 		return true, nil
 	}
 	return false, nil
@@ -210,7 +210,7 @@ func CheckMciPolicy(nsId string, mciId string) (bool, error) {
 
 	key := common.GenMciPolicyKey(nsId, mciId, "")
 
-	keyValue, err := kvstore.GetKv(key)
+	_, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("In CheckMciPolicy(); kvstore.GetKv() returned an error.")
@@ -218,7 +218,7 @@ func CheckMciPolicy(nsId string, mciId string) (bool, error) {
 		// return nil, err
 	}
 
-	if keyValue != (kvstore.KeyValue{}) {
+	if exists {
 		return true, nil
 	}
 	return false, nil
@@ -1031,7 +1031,7 @@ func FindTbVmByCspId(nsId string, mciId string, vmCspResourceId string) (model.V
 		return model.VmInfo{}, err
 	}
 
-	mci, err := GetMciObject(nsId, mciId)
+	mci, _, err := GetMciObject(nsId, mciId)
 	if err != nil {
 		err := fmt.Errorf("Failed to get the MCI " + mciId + ".")
 		return model.VmInfo{}, err

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -103,13 +103,13 @@ func createK8sClusterInfo(nsId string, tbK8sCInfo model.K8sClusterInfo) error {
 
 	k8sClusterId := tbK8sCInfo.Id
 	k := common.GenK8sClusterKey(nsId, k8sClusterId)
-	kv, err := kvstore.GetKv(k)
+	_, exists, err := kvstore.GetKv(k)
 	if err != nil {
 		err := fmt.Errorf("failed to create K8sClusterInfo(%s): %v", k8sClusterId, err)
 		return err
 	}
 
-	if kv != (kvstore.KeyValue{}) {
+	if exists {
 		err := fmt.Errorf("failed to create K8sClusterInfo(%s): already exists", k8sClusterId)
 		return err
 	}
@@ -135,14 +135,14 @@ func getK8sClusterInfo(nsId, k8sClusterId string) (*model.K8sClusterInfo, error)
 	emptyObj := &model.K8sClusterInfo{}
 
 	k := common.GenK8sClusterKey(nsId, k8sClusterId)
-	kv, err := kvstore.GetKv(k)
+	kv, exists, err := kvstore.GetKv(k)
 	if err != nil {
 		err := fmt.Errorf("failed to get K8sClusterInfo(%s): %v", k8sClusterId, err)
 		return emptyObj, err
 	}
 
 	tbK8sCInfo := &model.K8sClusterInfo{}
-	if kv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("failed to get K8sClusterInfo(%s): empty keyvalue", k8sClusterId)
 		return emptyObj, err
 	}
@@ -164,8 +164,8 @@ func storeK8sClusterInfo(nsId string, newTbK8sCInfo *model.K8sClusterInfo) {
 	k := common.GenK8sClusterKey(nsId, k8sClusterId)
 
 	// Check existence of the key. If no key, no update.
-	kv, err := kvstore.GetKv(k)
-	if kv == (kvstore.KeyValue{}) || err != nil {
+	kv, exists, err := kvstore.GetKv(k)
+	if !exists || err != nil {
 		return
 	}
 
@@ -1068,12 +1068,12 @@ func CheckK8sCluster(nsId string, k8sClusterId string) (bool, error) {
 
 	key := common.GenK8sClusterKey(nsId, k8sClusterId)
 
-	keyValue, err := kvstore.GetKv(key)
+	_, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Err(err).Msg("Failed to Check K8sCluster")
 		return false, err
 	}
-	if keyValue != (kvstore.KeyValue{}) {
+	if exists {
 		return true, nil
 	}
 	return false, nil
@@ -1123,12 +1123,12 @@ func ListK8sCluster(nsId string, filterKey string, filterVal string) (interface{
 
 	for _, id := range k8sIdList {
 		k := common.GenK8sClusterKey(nsId, id)
-		kv, err := kvstore.GetKv(k)
+		kv, exists, err := kvstore.GetKv(k)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 		}
 
-		if kv == (kvstore.KeyValue{}) {
+		if !exists {
 			err = fmt.Errorf("%s cannot be found", k)
 			log.Err(err).Msg("Failed to List K8sCluster")
 			return nil, err

--- a/src/core/resource/objectStorage.go
+++ b/src/core/resource/objectStorage.go
@@ -167,7 +167,7 @@ func CreateObjectStorage(nsId string, objectStorageReq *model.RestPostObjectStor
 		}
 
 		// Read the stored Object Storage info
-		objectStorageKv, err := kvstore.GetKv(objectStorageKey)
+		objectStorageKv, _, err := kvstore.GetKv(objectStorageKey)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return emptyRet, err
@@ -490,12 +490,12 @@ func CreateObjectStorage(nsId string, objectStorageReq *model.RestPostObjectStor
 	}
 
 	// Check if the Object Storage info is stored
-	objectStorageKv, err := kvstore.GetKv(objectStorageKey)
+	objectStorageKv, exists, err := kvstore.GetKv(objectStorageKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if objectStorageKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, Object Storage: %s", objectStorageInfo.Id)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -577,7 +577,7 @@ func GetObjectStorage(nsId string, objectStorageId string, detail string) (model
 	}
 
 	// Read the stored Object Storage info
-	objectStorageKv, err := kvstore.GetKv(objectStorageKey)
+	objectStorageKv, _, err := kvstore.GetKv(objectStorageKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -677,12 +677,12 @@ func GetObjectStorage(nsId string, objectStorageId string, detail string) (model
 	}
 
 	// Check if the Object Storage info is stored
-	objectStorageKv, err = kvstore.GetKv(objectStorageKey)
+	objectStorageKv, exists, err = kvstore.GetKv(objectStorageKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if objectStorageKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, Object Storage: %s", objectStorageInfo.Id)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -738,7 +738,7 @@ func DeleteObjectStorage(nsId string, objectStorageId string) (model.SimpleMsg, 
 	}
 
 	// Read the stored Object Storage info
-	objectStorageKv, err := kvstore.GetKv(objectStorageKey)
+	objectStorageKv, _, err := kvstore.GetKv(objectStorageKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -936,7 +936,7 @@ func GetRequestStatusOfObjectStorage(nsId string, objectStorageId string, reqId 
 	}
 
 	// Read the stored Object Storage info
-	objectStorageKv, err := kvstore.GetKv(objectStorageKey)
+	objectStorageKv, _, err := kvstore.GetKv(objectStorageKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err

--- a/src/core/resource/securitygroup.go
+++ b/src/core/resource/securitygroup.go
@@ -427,7 +427,7 @@ func CreateFirewallRules(nsId string, securityGroupId string, req []model.Firewa
 	}
 
 	securityGroupKey := common.GenResourceKey(nsId, model.StrSecurityGroup, securityGroupId)
-	securityGroupKeyValue, _ := kvstore.GetKv(securityGroupKey)
+	securityGroupKeyValue, _, _ := kvstore.GetKv(securityGroupKey)
 	oldSecurityGroup := model.SecurityGroupInfo{}
 	err = json.Unmarshal([]byte(securityGroupKeyValue.Value), &oldSecurityGroup)
 	if err != nil {
@@ -572,7 +572,7 @@ func DeleteFirewallRules(nsId string, securityGroupId string, req []model.Firewa
 	}
 
 	securityGroupKey := common.GenResourceKey(nsId, model.StrSecurityGroup, securityGroupId)
-	securityGroupKeyValue, _ := kvstore.GetKv(securityGroupKey)
+	securityGroupKeyValue, _, _ := kvstore.GetKv(securityGroupKey)
 	oldSecurityGroup := model.SecurityGroupInfo{}
 	err = json.Unmarshal([]byte(securityGroupKeyValue.Value), &oldSecurityGroup)
 	if err != nil {

--- a/src/core/resource/sqlDb.go
+++ b/src/core/resource/sqlDb.go
@@ -184,7 +184,7 @@ func CreateSqlDB(nsId string, sqlDbReq *model.RestPostSqlDBRequest, retry string
 		}
 
 		// Read the stored SQL DB info
-		sqlDBKv, err := kvstore.GetKv(sqlDBKey)
+		sqlDBKv, _, err := kvstore.GetKv(sqlDBKey)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return emptyRet, err
@@ -528,12 +528,12 @@ func CreateSqlDB(nsId string, sqlDbReq *model.RestPostSqlDBRequest, retry string
 	}
 
 	// Check if the SQL DB info is stored
-	sqlDBKv, err := kvstore.GetKv(sqlDBKey)
+	sqlDBKv, exists, err := kvstore.GetKv(sqlDBKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if sqlDBKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, SQL DB: %s", sqlDBInfo.Id)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -615,7 +615,7 @@ func GetSqlDB(nsId string, sqlDbId string, detail string) (model.SqlDBInfo, erro
 	}
 
 	// Read the stored SQL DB info
-	sqlDBKv, err := kvstore.GetKv(sqlDBKey)
+	sqlDBKv, _, err := kvstore.GetKv(sqlDBKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -715,12 +715,12 @@ func GetSqlDB(nsId string, sqlDbId string, detail string) (model.SqlDBInfo, erro
 	}
 
 	// Check if the SQL DB info is stored
-	sqlDBKv, err = kvstore.GetKv(sqlDBKey)
+	sqlDBKv, exists, err = kvstore.GetKv(sqlDBKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if sqlDBKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, SQL DB: %s", sqlDBInfo.Id)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -776,7 +776,7 @@ func DeleteSqlDB(nsId string, sqlDbId string) (model.SimpleMsg, error) {
 	}
 
 	// Read the stored SQL DB info
-	sqlDBKv, err := kvstore.GetKv(sqlDbKey)
+	sqlDBKv, _, err := kvstore.GetKv(sqlDbKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -974,7 +974,7 @@ func GetRequestStatusOfSqlDB(nsId string, sqlDbId string, reqId string) (model.R
 	}
 
 	// Read the stored SQL DB info
-	sqlDBKv, err := kvstore.GetKv(sqlDBKey)
+	sqlDBKv, _, err := kvstore.GetKv(sqlDBKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err

--- a/src/core/resource/sshkey.go
+++ b/src/core/resource/sshkey.go
@@ -321,7 +321,7 @@ func UpdateSshKey(nsId string, sshKeyId string, fieldsToUpdate model.SshKeyInfo)
 		return emptyObj, err
 	}
 
-	keyValue, err := kvstore.GetKv(Key)
+	keyValue, _, err := kvstore.GetKv(Key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		err = fmt.Errorf("In UpdateSshKey(); kvstore.GetKv() returned an error.")

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -253,12 +253,12 @@ func CreateSubnet(nsId string, vNetId string, subnetReq *model.SubnetReq) (model
 	subnetKey := common.GenChildResourceKey(nsId, resourceType, vNetId, subnetInfo.Id)
 
 	// Read the saved vNet info
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vNetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -511,12 +511,12 @@ func GetSubnet(nsId string, vNetId string, subnetId string) (model.SubnetInfo, e
 	// }
 
 	// Read the stored subnet info
-	subnetKeyValue, err := kvstore.GetKv(subnetKey)
+	subnetKeyValue, exists, err := kvstore.GetKv(subnetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if subnetKeyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, subnet: %s", subnetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -663,12 +663,12 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 	subnetKey := common.GenChildResourceKey(nsId, resourceType, vNetId, subnetId)
 
 	// Read the stored vNet info
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vNetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -682,12 +682,12 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 	}
 
 	// Read the stored subnet info
-	subnetKeyValue, err := kvstore.GetKv(subnetKey)
+	subnetKeyValue, exists, err := kvstore.GetKv(subnetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if subnetKeyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, subnet: %s", subnetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -890,12 +890,12 @@ func RefineSubnet(nsId string, vNetId string, subnetId string) (model.SimpleMsg,
 	subnetKey := common.GenChildResourceKey(nsId, resourceType, vNetId, subnetId)
 
 	// Read the saved vNet info
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vNetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -908,12 +908,12 @@ func RefineSubnet(nsId string, vNetId string, subnetId string) (model.SimpleMsg,
 	}
 
 	// Read the stored subnet info
-	subnetKeyValue, err := kvstore.GetKv(subnetKey)
+	subnetKeyValue, exists, err := kvstore.GetKv(subnetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if subnetKeyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, subnet: %s", subnetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -1010,11 +1010,11 @@ func RefineSubnet(nsId string, vNetId string, subnetId string) (model.SimpleMsg,
 	}
 
 	// Get and check the subnet info still exists or not
-	subnetKv, err := kvstore.GetKv(subnetKey)
+	_, exists, err = kvstore.GetKv(subnetKey)
 	if err != nil {
 		log.Warn().Err(err).Msg("")
 	}
-	if subnetKv != (kvstore.KeyValue{}) {
+	if exists {
 		err := fmt.Errorf("fail to refine the subnet info (id: %s)", subnetId)
 		ret.Message = err.Error()
 		return ret, err
@@ -1088,12 +1088,12 @@ func RegisterSubnet(nsId string, vNetId string, subnetReq *model.RegisterSubnetR
 	subnetKey := common.GenChildResourceKey(nsId, resourceType, vNetId, subnetInfo.Id)
 
 	// Read the saved vNet info
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vNetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -1306,12 +1306,12 @@ func DeregisterSubnet(nsId string, vNetId string, subnetId string) (model.Simple
 	subnetKey := common.GenChildResourceKey(nsId, resourceType, vNetId, subnetId)
 
 	// Read the saved vNet info
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vNetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -1325,12 +1325,12 @@ func DeregisterSubnet(nsId string, vNetId string, subnetId string) (model.Simple
 	}
 
 	// Read the stored subnet info
-	subnetKv, err := kvstore.GetKv(subnetKey)
+	subnetKv, exists, err := kvstore.GetKv(subnetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if subnetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, subnet: %s", subnetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -765,12 +765,12 @@ func CreateVNet(nsId string, vNetReq *model.VNetReq) (model.VNetInfo, error) {
 	}
 
 	// Check if the vNet info is stored
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vNetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetInfo.Id)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -834,13 +834,13 @@ func GetVNet(nsId string, vNetId string) (model.VNetInfo, error) {
 	vNetKey := common.GenResourceKey(nsId, resourceType, vNetId)
 
 	// Read the stored vNet info
-	keyValue, err := kvstore.GetKv(vNetKey)
+	keyValue, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
 
-	if keyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -997,12 +997,12 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 	}
 
 	// Read the stored vNet info, which includes the updated subnets
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vNetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -1161,13 +1161,13 @@ func RefineVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 	vNetKey := common.GenResourceKey(nsId, resourceType, vNetId)
 
 	// Read the stored vNet info
-	keyValue, err := kvstore.GetKv(vNetKey)
+	keyValue, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
 
-	if keyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -1294,12 +1294,12 @@ func RefineVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 	}
 
 	// Get and check the subnet info still exists or not
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Warn().Err(err).Msg("")
 		// return emptyRet, err
 	}
-	if vNetKv != (kvstore.KeyValue{}) {
+	if exists {
 		err := fmt.Errorf("fail to refine the vNet info (%s)", vNetKv)
 		ret.Message = err.Error()
 		return ret, err
@@ -1550,9 +1550,9 @@ func RegisterVNet(nsId string, vNetRegisterReq *model.RegisterVNetReq) (model.VN
 	}
 
 	// Check if the vNet info is stored
-	keyValue, err := kvstore.GetKv(vNetKey)
+	keyValue, exists, err := kvstore.GetKv(vNetKey)
 
-	if keyValue == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetRegisterReq.Name)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -1666,12 +1666,12 @@ func DeregisterVNet(nsId string, vNetId string, withSubnets string) (model.Simpl
 	}
 
 	// Read the stored vNet info
-	vNetKv, err := kvstore.GetKv(vNetKey)
+	vNetKv, exists, err := kvstore.GetKv(vNetKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vNetKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err

--- a/src/core/resource/vpn.go
+++ b/src/core/resource/vpn.go
@@ -285,7 +285,7 @@ func CreateSiteToSiteVPN(nsId string, mciId string, vpnReq *model.RestPostVpnReq
 		}
 
 		// Read the stored VPN info
-		vpnKv, err := kvstore.GetKv(vpnKey)
+		vpnKv, _, err := kvstore.GetKv(vpnKey)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return emptyRet, err
@@ -547,12 +547,12 @@ func CreateSiteToSiteVPN(nsId string, mciId string, vpnReq *model.RestPostVpnReq
 	}
 
 	// Check if the vpn info is stored
-	vpnKv, err := kvstore.GetKv(vpnKey)
+	vpnKv, exists, err := kvstore.GetKv(vpnKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vpnKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vpn: %s", vpnInfo.Id)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -765,7 +765,7 @@ func GetSiteToSiteVPN(nsId string, mciId string, vpnId string, detail string) (m
 	}
 
 	// Read the stored VPN info
-	vpnKv, err := kvstore.GetKv(vpnKey)
+	vpnKv, _, err := kvstore.GetKv(vpnKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -883,12 +883,12 @@ func GetSiteToSiteVPN(nsId string, mciId string, vpnId string, detail string) (m
 	}
 
 	// Check if the vpn info is stored
-	vpnKv, err = kvstore.GetKv(vpnKey)
+	vpnKv, exists, err = kvstore.GetKv(vpnKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	if vpnKv == (kvstore.KeyValue{}) {
+	if !exists {
 		err := fmt.Errorf("does not exist, vpn: %s", vpnInfo.Id)
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -949,7 +949,7 @@ func DeleteSiteToSiteVPN(nsId string, mciId string, vpnId string) (model.SimpleM
 	}
 
 	// Read the stored VPN info
-	vpnKv, err := kvstore.GetKv(vpnKey)
+	vpnKv, exists, err := kvstore.GetKv(vpnKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
@@ -1132,7 +1132,7 @@ func GetRequestStatusOfSiteToSiteVpn(nsId string, mciId string, vpnId string, re
 	}
 
 	// Read the stored VPN info
-	vpnKv, err := kvstore.GetKv(vpnKey)
+	vpnKv, _, err := kvstore.GetKv(vpnKey)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return emptyRet, err

--- a/src/kvstore/kvstore/kvstore.go
+++ b/src/kvstore/kvstore/kvstore.go
@@ -20,12 +20,12 @@ type Store interface {
 	NewLock(ctx context.Context, session *concurrency.Session, lockKey string) (*concurrency.Mutex, error)
 	Put(key, value string) error
 	PutWith(ctx context.Context, key, value string) error
-	Get(key string) (string, error)
-	GetWith(ctx context.Context, key string) (string, error)
+	Get(key string) (string, bool, error)
+	GetWith(ctx context.Context, key string) (string, bool, error)
 	GetList(keyPrefix string) ([]string, error)
 	GetListWith(ctx context.Context, keyPrefix string) ([]string, error)
-	GetKv(key string) (KeyValue, error)
-	GetKvWith(ctx context.Context, key string) (KeyValue, error)
+	GetKv(key string) (KeyValue, bool, error)
+	GetKvWith(ctx context.Context, key string) (KeyValue, bool, error)
 	GetKvList(keyPrefix string) ([]KeyValue, error)
 	GetKvListWith(ctx context.Context, keyPrefix string) ([]KeyValue, error)
 	GetSortedKvList(keyPrefix string, sortBy clientv3.SortTarget, order clientv3.SortOrder) ([]KeyValue, error)
@@ -116,19 +116,19 @@ func PutWith(ctx context.Context, key, value string) error {
 }
 
 // Get retrieves a value for a given key
-func Get(key string) (string, error) {
+func Get(key string) (string, bool, error) {
 	store, err := getStore()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	return store.Get(key)
 }
 
 // GetWith retrieves a value for a given key with context
-func GetWith(ctx context.Context, key string) (string, error) {
+func GetWith(ctx context.Context, key string) (string, bool, error) {
 	store, err := getStore()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	return store.GetWith(ctx, key)
 }
@@ -152,19 +152,19 @@ func GetListWith(ctx context.Context, keyPrefix string) ([]string, error) {
 }
 
 // GetKv retrieves a key-value pair
-func GetKv(key string) (KeyValue, error) {
+func GetKv(key string) (KeyValue, bool, error) {
 	store, err := getStore()
 	if err != nil {
-		return KeyValue{}, err
+		return KeyValue{}, false, err
 	}
 	return store.GetKv(key)
 }
 
 // GetKvWith retrieves a key-value pair with context
-func GetKvWith(ctx context.Context, key string) (KeyValue, error) {
+func GetKvWith(ctx context.Context, key string) (KeyValue, bool, error) {
 	store, err := getStore()
 	if err != nil {
-		return KeyValue{}, err
+		return KeyValue{}, false, err
 	}
 	return store.GetKvWith(ctx, key)
 }


### PR DESCRIPTION
This pull request introduces a more robust method for **checking key existence in our kvstore operations by using an explicit `exists` flag**. 

**Key Changes**
* **Explicit Existence Checks**: Replaced ambiguous empty struct comparisons with clear boolean flag checks
  - Note - structs containing `map` cannot be directly compared like this pattern `if keyValue != (kvstore.KeyValue{})`
* **Better Error Handling**: Distinguished between actual errors and "key not found" scenarios
* **Incremental Migration**: Used `_` placeholder where full refactoring wasn't immediately feasible, marking areas for future improvement



Example Change
```diff
-	keyValue, err := kvstore.GetKv(key)
-	if keyValue != (kvstore.KeyValue{}) {
+	_, exists, err := kvstore.GetKv(key)
+	if exists {
        return true, nil
    }
```

**Benefits**
* Eliminates unreliable struct comparisons (especially for structs containing maps/slices)
* Provides clearer intent in code
* Improves debugging and error handling
* Sets foundation for complete kvstore operation standardization

**Test**
* 1 test case performed on MapUI: Create MCI on AWS.