### PR TITLE
Reduce racing condition for mci dynamic

### DIFF
--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -1073,7 +1073,7 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 	// Check for VM object creation errors
 	if len(createErrors) > 0 {
 		// Add VM object creation errors to MCI SystemMessage
-		mciTmp, err := GetMciObject(nsId, mciId)
+		mciTmp, _, err := GetMciObject(nsId, mciId)
 		if err == nil {
 			// Add VM object creation error summary
 			errorSummary := fmt.Sprintf("VM object creation failed for %d out of %d VMs", len(createErrors), len(vmConfigs))
@@ -1148,7 +1148,7 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 	// Check for VM creation errors
 	if len(createErrors) > 0 {
 		// Add VM creation errors to MCI SystemMessage
-		mciTmp, err := GetMciObject(nsId, mciId)
+		mciTmp, _, err := GetMciObject(nsId, mciId)
 		if err == nil {
 			// Add VM creation error summary
 			errorSummary := fmt.Sprintf("VM creation failed for %d out of %d VMs", len(createErrors), len(vmConfigs))
@@ -1215,7 +1215,7 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 	if err := handleMonitoringAgent(nsId, mciId, mciTmp, option); err != nil {
 		log.Error().Err(err).Msg("Failed to install monitoring agent, but continuing")
 		// Add monitoring agent error to SystemMessage
-		mciTmp, mciErr := GetMciObject(nsId, mciId)
+		mciTmp, _, mciErr := GetMciObject(nsId, mciId)
 		if mciErr == nil {
 			errorMsg := fmt.Sprintf("Monitoring agent installation failed: %s", err.Error())
 			mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorMsg)
@@ -1227,7 +1227,7 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 	if err := handlePostCommands(nsId, mciId, mciTmp); err != nil {
 		log.Error().Err(err).Msg("Failed to execute post-deployment commands, but continuing")
 		// Add post-command error to SystemMessage
-		mciTmp, mciErr := GetMciObject(nsId, mciId)
+		mciTmp, _, mciErr := GetMciObject(nsId, mciId)
 		if mciErr == nil {
 			errorMsg := fmt.Sprintf("Post-deployment commands failed: %s", err.Error())
 			mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorMsg)
@@ -1539,7 +1539,7 @@ func CreateMciDynamic(reqID string, nsId string, req *model.MciDynamicReq, deplo
 		// If there were any errors, add error messages to MCI SystemMessage
 		if hasError {
 			// Add error messages to MCI SystemMessage
-			mciTmp, err := GetMciObject(nsId, mciId)
+			mciTmp, _, err := GetMciObject(nsId, mciId)
 			if err == nil {
 				// Add general error summary
 				errorSummary := fmt.Sprintf("Resource preparation failed for %d VM(s) out of %d total VMs", len(failedVMs), len(failedVMs)+len(successfulVMs))

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -831,7 +831,7 @@ func CreateMciGroupVm(nsId string, mciId string, vmRequest *model.CreateSubGroup
 	vmList, err := ListVmBySubGroup(nsId, mciId, tentativeVmId)
 
 	if err != nil {
-		mciTmp.SystemMessage = err.Error()
+		mciTmp.SystemMessage = append(mciTmp.SystemMessage, err.Error())
 	}
 	if vmList != nil {
 		mciTmp.NewVmList = vmList
@@ -1072,6 +1072,27 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 
 	// Check for VM object creation errors
 	if len(createErrors) > 0 {
+		// Add VM object creation errors to MCI SystemMessage
+		mciTmp, err := GetMciObject(nsId, mciId)
+		if err == nil {
+			// Add VM object creation error summary
+			errorSummary := fmt.Sprintf("VM object creation failed for %d out of %d VMs", len(createErrors), len(vmConfigs))
+			mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorSummary)
+			
+			// Add each VM object creation error
+			for _, vmError := range vmObjectErrors {
+				errorDetail := fmt.Sprintf("VM '%s' object creation failed: %s", vmError.VmName, vmError.Error)
+				mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorDetail)
+			}
+			
+			// Add policy information
+			policyMsg := fmt.Sprintf("Failure handling policy: %s", req.PolicyOnPartialFailure)
+			mciTmp.SystemMessage = append(mciTmp.SystemMessage, policyMsg)
+			
+			UpdateMciInfo(nsId, mciTmp)
+			log.Info().Msgf("Added %d VM object creation errors to MCI SystemMessage", len(createErrors)+2)
+		}
+		
 		switch req.PolicyOnPartialFailure {
 		case model.PolicyRollback:
 			log.Warn().Msgf("VM object creation failed for %d VMs, rolling back entire MCI due to policy=rollback", len(createErrors))
@@ -1126,6 +1147,27 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 
 	// Check for VM creation errors
 	if len(createErrors) > 0 {
+		// Add VM creation errors to MCI SystemMessage
+		mciTmp, err := GetMciObject(nsId, mciId)
+		if err == nil {
+			// Add VM creation error summary
+			errorSummary := fmt.Sprintf("VM creation failed for %d out of %d VMs", len(createErrors), len(vmConfigs))
+			mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorSummary)
+			
+			// Add each VM creation error
+			for _, vmError := range vmCreateErrors {
+				errorDetail := fmt.Sprintf("VM '%s' creation failed: %s", vmError.VmName, vmError.Error)
+				mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorDetail)
+			}
+			
+			// Add policy information
+			policyMsg := fmt.Sprintf("Failure handling policy: %s", req.PolicyOnPartialFailure)
+			mciTmp.SystemMessage = append(mciTmp.SystemMessage, policyMsg)
+			
+			UpdateMciInfo(nsId, mciTmp)
+			log.Info().Msgf("Added %d VM creation errors to MCI SystemMessage", len(createErrors)+2)
+		}
+		
 		switch req.PolicyOnPartialFailure {
 		case model.PolicyRollback:
 			log.Error().Msgf("VM creation failed for %d VMs, rolling back entire MCI due to policy=rollback", len(createErrors))
@@ -1172,11 +1214,25 @@ func CreateMci(nsId string, req *model.MciReq, option string, isReqFromDynamic b
 	// Install monitoring agent if requested
 	if err := handleMonitoringAgent(nsId, mciId, mciTmp, option); err != nil {
 		log.Error().Err(err).Msg("Failed to install monitoring agent, but continuing")
+		// Add monitoring agent error to SystemMessage
+		mciTmp, mciErr := GetMciObject(nsId, mciId)
+		if mciErr == nil {
+			errorMsg := fmt.Sprintf("Monitoring agent installation failed: %s", err.Error())
+			mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorMsg)
+			UpdateMciInfo(nsId, mciTmp)
+		}
 	}
 
 	// Execute post-deployment commands
 	if err := handlePostCommands(nsId, mciId, mciTmp); err != nil {
 		log.Error().Err(err).Msg("Failed to execute post-deployment commands, but continuing")
+		// Add post-command error to SystemMessage
+		mciTmp, mciErr := GetMciObject(nsId, mciId)
+		if mciErr == nil {
+			errorMsg := fmt.Sprintf("Post-deployment commands failed: %s", err.Error())
+			mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorMsg)
+			UpdateMciInfo(nsId, mciTmp)
+		}
 	}
 
 	// Execute refine action if policy is set to refine and there were failures
@@ -1399,14 +1455,53 @@ func CreateMciDynamic(reqID string, nsId string, req *model.MciDynamicReq, deplo
 		}
 		resultChan := make(chan vmResult, len(subGroupReqs))
 
-		// Process all vmRequests in parallel
-		for _, k := range subGroupReqs {
+		// Group subGroupReqs by connectionName for sequential processing
+		connectionGroups := make(map[string][]model.CreateSubGroupDynamicReq)
+		
+		// First, determine the connection name for each subGroup
+		for _, subGroupReq := range subGroupReqs {
+			// Get spec info to determine connection
+			specInfo, err := resource.GetSpec(model.SystemCommonNs, subGroupReq.SpecId)
+			if err != nil {
+				log.Error().Err(err).Msgf("Failed to get spec info for grouping: %s", subGroupReq.SpecId)
+				continue
+			}
+			
+			connectionName := specInfo.ConnectionName
+			if subGroupReq.ConnectionName != "" {
+				connectionName = subGroupReq.ConnectionName
+			}
+			
+			// Group by connection name
+			connectionGroups[connectionName] = append(connectionGroups[connectionName], subGroupReq)
+		}
+		
+		log.Info().Msgf("Grouped %d SubGroups into %d connection groups", len(subGroupReqs), len(connectionGroups))
+
+		// Process each connection group in parallel, but VMs within each group sequentially
+		for connectionName, subGroupsInConnection := range connectionGroups {
 			wg.Add(1)
-			go func(subGroupDynamicReq model.CreateSubGroupDynamicReq) {
+			go func(connName string, subGroups []model.CreateSubGroupDynamicReq) {
 				defer wg.Done()
-				result, err := getSubGroupReqFromDynamicReq(reqID, nsId, &subGroupDynamicReq)
-				resultChan <- vmResult{result: result, err: err}
-			}(k)
+				
+				log.Info().Msgf("Processing %d SubGroups for connection '%s' sequentially", len(subGroups), connName)
+				
+				// Process SubGroups in this connection sequentially
+				for i, subGroupDynamicReq := range subGroups {
+					log.Debug().Msgf("[%s][%d/%d] Processing SubGroup '%s' sequentially", 
+						connName, i+1, len(subGroups), subGroupDynamicReq.Name)
+					
+					// Add small delay between sequential requests to avoid rate limiting
+					if i > 0 {
+						time.Sleep(2 * time.Second)
+					}
+					
+					result, err := getSubGroupReqFromDynamicReq(reqID, nsId, &subGroupDynamicReq)
+					resultChan <- vmResult{result: result, err: err}
+				}
+				
+				log.Info().Msgf("Completed processing SubGroups for connection '%s'", connName)
+			}(connectionName, subGroupsInConnection)
 		}
 
 		// Wait for all goroutines to complete
@@ -1441,52 +1536,72 @@ func CreateMciDynamic(reqID string, nsId string, req *model.MciDynamicReq, deplo
 			}
 		}
 
-		// If there were any errors, rollback all created resources
+		// If there were any errors, add error messages to MCI SystemMessage
 		if hasError {
-			// Count resources by type for detailed rollback info
-			resourceSummary := make(map[string]int)
-			for _, resource := range allCreatedResources {
-				resourceSummary[resource.Type]++
-			}
-
-			log.Info().Msgf("Resource preparation failed for %d VM(s): %v", len(failedVMs), failedVMs)
-			log.Info().Msgf("Successfully prepared %d VM(s): %v", len(successfulVMs), successfulVMs)
-			log.Info().Msgf("Rolling back %d created resources: %+v", len(allCreatedResources), resourceSummary)
-
-			time.Sleep(5 * time.Second)
-			rollbackErr := rollbackCreatedResources(nsId, allCreatedResources)
-
-			// Build comprehensive error message
-			errorMsg := fmt.Sprintf("MCI '%s' creation failed due to resource preparation errors:\n", req.Name)
-			errorMsg += fmt.Sprintf("- Failed VMs (%d): %v\n", len(failedVMs), failedVMs)
-			if len(successfulVMs) > 0 {
-				errorMsg += fmt.Sprintf("- Successfully prepared VMs (%d): %v\n", len(successfulVMs), successfulVMs)
-			}
-
-			if len(allCreatedResources) > 0 {
-				errorMsg += fmt.Sprintf("- Rollback attempted for %d resources: ", len(allCreatedResources))
-				for resType, count := range resourceSummary {
-					errorMsg += fmt.Sprintf("%s(%d) ", resType, count)
+			// Add error messages to MCI SystemMessage
+			mciTmp, err := GetMciObject(nsId, mciId)
+			if err == nil {
+				// Add general error summary
+				errorSummary := fmt.Sprintf("Resource preparation failed for %d VM(s) out of %d total VMs", len(failedVMs), len(failedVMs)+len(successfulVMs))
+				mciTmp.SystemMessage = append(mciTmp.SystemMessage, errorSummary)
+				
+				// Add detailed error messages for each failed VM
+				for _, detail := range errorDetails {
+					mciTmp.SystemMessage = append(mciTmp.SystemMessage, detail)
 				}
-				errorMsg += "\n"
+				
+				UpdateMciInfo(nsId, mciTmp)
 			}
+			
+			// // Count resources by type for detailed rollback info
+			// resourceSummary := make(map[string]int)
+			// for _, resource := range allCreatedResources {
+			// 	resourceSummary[resource.Type]++
+			// }
 
-			// Clean up MCI object on validation failure
-			DelMci(nsId, mciId, "force")
+			// log.Info().Msgf("Resource preparation failed for %d VM(s): %v", len(failedVMs), failedVMs)
+			// log.Info().Msgf("Successfully prepared %d VM(s): %v", len(successfulVMs), successfulVMs)
+			// log.Info().Msgf("Rolling back %d created resources: %+v", len(allCreatedResources), resourceSummary)
 
-			errorMsg += "Detailed errors:\n"
-			for _, detail := range errorDetails {
-				errorMsg += fmt.Sprintf("  • %s\n", detail)
-			}
+			// time.Sleep(5 * time.Second)
+			// rollbackErr := rollbackCreatedResources(nsId, allCreatedResources)
 
-			if rollbackErr != nil {
-				errorMsg += fmt.Sprintf("CRITICAL: Rollback operation failed: %s\n", rollbackErr.Error())
-				errorMsg += "Manual cleanup may be required for created resources."
-				return emptyMci, fmt.Errorf("%s", errorMsg)
-			} else {
-				errorMsg += "All created resources have been successfully rolled back."
-				return emptyMci, fmt.Errorf("%s", errorMsg)
-			}
+			// // Build comprehensive error message
+			// errorMsg := fmt.Sprintf("MCI '%s' creation failed due to resource preparation errors:\n", req.Name)
+			// errorMsg += fmt.Sprintf("- Failed VMs (%d): %v\n", len(failedVMs), failedVMs)
+			// if len(successfulVMs) > 0 {
+			// 	errorMsg += fmt.Sprintf("- Successfully prepared VMs (%d): %v\n", len(successfulVMs), successfulVMs)
+			// }
+
+			// if len(allCreatedResources) > 0 {
+			// 	errorMsg += fmt.Sprintf("- Rollback attempted for %d resources: ", len(allCreatedResources))
+			// 	for resType, count := range resourceSummary {
+			// 		errorMsg += fmt.Sprintf("%s(%d) ", resType, count)
+			// 	}
+			// 	errorMsg += "\n"
+			// }
+
+			// // Clean up MCI object on validation failure
+			// DelMci(nsId, mciId, "force")
+
+			// errorMsg += "Detailed errors:\n"
+			// for _, detail := range errorDetails {
+			// 	errorMsg += fmt.Sprintf("  • %s\n", detail)
+			// }
+
+			// if rollbackErr != nil {
+			// 	errorMsg += fmt.Sprintf("CRITICAL: Rollback operation failed: %s\n", rollbackErr.Error())
+			// 	errorMsg += "Manual cleanup may be required for created resources."
+			// 	return emptyMci, fmt.Errorf("%s", errorMsg)
+			// } else {
+			// 	errorMsg += "All created resources have been successfully rolled back."
+			// 	return emptyMci, fmt.Errorf("%s", errorMsg)
+			// }
+
+			// cancel is also one of the options
+			// // Return error but keep MCI object so user can see the error messages
+			// errorMsg := fmt.Sprintf("MCI '%s' resource preparation failed. Check MCI SystemMessage for detailed error information.", req.Name)
+			// return emptyMci, fmt.Errorf("%s", errorMsg)
 		}
 	}
 

--- a/src/core/model/mci.go
+++ b/src/core/model/mci.go
@@ -172,7 +172,7 @@ type MciInfo struct {
 	SystemLabel string `json:"systemLabel" example:"Managed by CB-Tumblebug" default:""`
 
 	// Latest system message such as error message
-	SystemMessage string `json:"systemMessage" example:"Failed because ..." default:""` // systeam-given string message
+	SystemMessage []string `json:"systemMessage"` // systeam-given string message
 
 	PlacementAlgo string   `json:"placementAlgo,omitempty"`
 	Description   string   `json:"description"`

--- a/src/interface/rest/docs/docs.go
+++ b/src/interface/rest/docs/docs.go
@@ -15054,8 +15054,10 @@ const docTemplate = `{
                 },
                 "systemMessage": {
                     "description": "Latest system message such as error message",
-                    "type": "string",
-                    "example": "Failed because ..."
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "targetAction": {
                     "type": "string"

--- a/src/interface/rest/docs/swagger.json
+++ b/src/interface/rest/docs/swagger.json
@@ -15047,8 +15047,10 @@
                 },
                 "systemMessage": {
                     "description": "Latest system message such as error message",
-                    "type": "string",
-                    "example": "Failed because ..."
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "targetAction": {
                     "type": "string"

--- a/src/interface/rest/docs/swagger.yaml
+++ b/src/interface/rest/docs/swagger.yaml
@@ -12098,9 +12098,10 @@ components:
             can be used) for special System purpose
           example: Managed by CB-Tumblebug
         systemMessage:
-          type: string
+          type: array
           description: Latest system message such as error message
-          example: Failed because ...
+          items:
+            type: string
         targetAction:
           type: string
         targetStatus:


### PR DESCRIPTION
fix #2123

Reduced racing condition for mci dynamic.
Extreamly tested in parallel.

## japan-tokyo-cost-optimized-mci VM tested in parallel

| 순위 | VM 이름 | 스펙 | 시간당 비용 | vCPU | 메모리 |
|------|---------|------|-------------|------|--------|
| 1 | vm-t3a-nano-1 | t3a.nano | $0.0061 | 2 | 0.5GB |
| 2 | vm-t3-nano-1 | t3.nano | $0.0068 | 2 | 0.5GB |
| 3 | vm-t2-nano-1 | t2.nano | $0.0076 | 1 | 0.5GB |
| 4 | vm-t3a-micro-1 | t3a.micro | $0.0122 | 2 | 1GB |
| 5 | vm-t3-micro-1 | t3.micro | $0.0136 | 2 | 1GB |
| 6 | vm-t2-micro-1 | t2.micro | $0.0152 | 1 | 1GB |
| 7 | vm-t3a-small-1 | t3a.small | $0.0245 | 2 | 2GB |
| 8 | vm-t3-small-1 | t3.small | $0.0272 | 2 | 2GB |
| 9 | vm-t2-small-1 | t2.small | $0.0304 | 1 | 2GB |
| 10 | vm-t3a-medium-1 | t3a.medium | $0.0490 | 2 | 4GB |
| 11 | vm-t3-medium-1 | t3.medium | $0.0544 | 2 | 4GB |
| 12 | vm-t2-medium-1 | t2.medium | $0.0608 | 2 | 4GB |
| 13 | vm-c7a-medium-1 | c7a.medium | $0.0646 | 2 | 4GB |
| 14 | vm-m7a-medium-1 | m7a.medium | $0.0749 | 2 | 8GB |
| 15 | vm-r7a-medium-1 | r7a.medium | $0.0918 | 2 | 16GB |
| 16 | vm-c5a-large-1 | c5a.large | $0.0960 | 2 | 4GB |
| 17 | vm-c6a-large-1 | c6a.large | $0.0963 | 2 | 8GB |
| 18 | vm-t3a-large-1 | t3a.large | $0.0979 | 2 | 8GB |
| 19 | vm-c7i-flex-large-1 | c7i-flex.large | $0.1067 | 2 | 8GB |
| 20 | vm-c5-large-1 | c5.large | $0.1070 | 2 | 4GB |
| 21 | vm-c6i-large-1 | c6i.large | $0.1070 | 2 | 8GB |
| 22 | vm-t3-large-1 | t3.large | $0.1088 | 2 | 8GB |
| 23 | vm-m6a-large-1 | m6a.large | $0.1116 | 2 | 8GB |
| 24 | vm-m5a-large-1 | m5a.large | $0.1120 | 2 | 8GB |
| 25 | vm-c7i-large-1 | c7i.large | $0.1124 | 2 | 8GB |
| 26 | vm-t2-large-1 | t2.large | $0.1216 | 2 | 8GB |
| 27 | vm-c5d-large-1 | c5d.large | $0.1220 | 2 | 8GB |
| 28 | vm-m7i-flex-large-1 | m7i-flex.large | $0.1237 | 2 | 8GB |
| 29 | vm-m5-large-1 | m5.large | $0.1240 | 2 | 8GB |
| 30 | vm-m6i-large-1 | m6i.large | $0.1240 | 2 | 8GB |
| 31 | vm-c4-large-1 | c4.large | $0.1260 | 2 | 3.75GB |
| 32 | vm-c6id-large-1 | c6id.large | $0.1281 | 2 | 8GB |
| 33 | vm-m4-large-1 | m4.large | $0.1290 | 2 | 8GB |
| 34 | vm-c7a-large-1 | c7a.large | $0.1292 | 2 | 8GB |
| 35 | vm-m7i-large-1 | m7i.large | $0.1302 | 2 | 8GB |
| 36 | vm-m5ad-large-1 | m5ad.large | $0.1340 | 2 | 8GB |
| 37 | vm-c5n-large-1 | c5n.large | $0.1360 | 2 | 5.25GB |
| 38 | vm-r6a-large-1 | r6a.large | $0.1368 | 2 | 16GB |
| 39 | vm-r5a-large-1 | r5a.large | $0.1370 | 2 | 16GB |
| 40 | vm-c6in-large-1 | c6in.large | $0.1428 | 2 | 8GB |
| 41 | vm-m5d-large-1 | m5d.large | $0.1460 | 2 | 8GB |
| 42 | vm-m7a-large-1 | m7a.large | $0.1497 | 2 | 8GB |
| 43 | vm-r5-large-1 | r5.large | $0.1520 | 2 | 16GB |
| 44 | vm-r6i-large-1 | r6i.large | $0.1520 | 2 | 16GB |
| 45 | vm-m5n-large-1 | m5n.large | $0.1530 | 2 | 8GB |
| 46 | vm-m6id-large-1 | m6id.large | $0.1533 | 2 | 8GB |
| 47 | vm-r5ad-large-1 | r5ad.large | $0.1590 | 2 | 16GB |
| 48 | vm-r7i-large-1 | r7i.large | $0.1596 | 2 | 16GB |
| 49 | vm-r4-large-1 | r4.large | $0.1600 | 2 | 15.25GB |
| 50 | vm-r5d-large-1 | r5d.large | $0.1740 | 2 | 16GB |


<img width="857" height="762" alt="image" src="https://github.com/user-attachments/assets/d3f22a46-18df-4660-8f29-2192f84c72de" />