### PR TITLE
Configure NCP subnets to use single zone for cluster creation

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -23,16 +23,19 @@ k8scluster:
     version:
       - region: [common]
         available:
+          - name: "1.33"
+            id: "1.33"
           - name: "1.32"
             id: "1.32"
           - name: "1.31"
             id: "1.31"
-          - name: "1.30"
-            id: "1.30"
-          - name: "1.29"
-            id: "1.29"
-          - name: "1.28"
-            id: "1.28"
+          # Deprecated versions (not available in AWS console as of 2025-08)  
+          # - name: "1.30"
+          #   id: "1.30"
+          # - name: "1.29"
+          #   id: "1.29"
+          # - name: "1.28"
+          #   id: "1.28"
     rootDisk:
       - region: [common]
         type:
@@ -165,6 +168,28 @@ k8scluster:
             id: "1.28.3"
     rootDisk:
       - region: [common]
+        type:
+          - name: default
+            id: default
+        size:
+          min: 10
+          max: 40
+  ncp:
+    nodeGroupsOnCreation: true
+    nodeImageDesignation: false
+    requiredSubnetCount: 1
+    nodeGroupNamingRule: '^[a-z][a-z0-9-]{1,18}[a-z0-9]$'
+    version:
+      - region: [kr]
+        available:
+          - name: "1.32"
+            id: "1.32.6-nks.1"
+          - name: "1.31"
+            id: "1.31.7-nks.1"
+          - name: "1.30"
+            id: "1.30.8-nks.1"
+    rootDisk:
+      - region: [kr]
         type:
           - name: default
             id: default

--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -1659,7 +1659,10 @@ func CreateSharedResource(nsId string, resType string, connectionName string) er
 				// ref IBM VPC Network structure: https://cloud.ibm.com/docs/vpc?topic=vpc-about-networking-for-vpc&locale=en
 				// IBM VPC Network requires Address Prefix setup for each zone. (but there is limitation in CB-Spider implementation.)
 				// So, we will create 2 subnets in a zone within the limited address space.
-				if provider == csp.IBM {
+				// ref NCP AZ issue: https://github.com/cloud-barista/cb-tumblebug/issues/2136
+				// NCP K8s cluster requires all subnets (including LB subnets) to be within the same AZ.
+				// So, we will create all subnets in the same zone.
+				if provider == csp.IBM || provider == csp.NCP {
 					subnet.Zone = zones[0]
 				}
 			}


### PR DESCRIPTION
## Problem
NCP K8s cluster creation requires all subnets (including LB subnets) to be within the same availability zone, unlike other CSPs that support multi-AZ deployments. Current logic was assigning subnets to different zones, causing K8s cluster creation failures.

## Solution
- Modified NCP subnet creation logic to use the same zone (zones[0]) instead of zones[1]
- Added explanatory comments with reference to issue #2136
- Added NCP to k8sclusterinfo.yaml

## Testing
- [x] Verified NCP K8s cluster creation works with single-zone subnets

## Testing Details
**API Used:** `k8sClusterDynamic`
**Request Body:**
```json
{
  "imageId": "default",
  "specId": "ncp+kr+ci2-g3",
  "connectionName": "ncp-kr",
  "name": "k8scluster02",
  "nodeGroupName": "k8sng02"
}
```

Fixes #2136