### PR TITLE
refactor: Implement S3-standard authentication for Object Storage APIs

### DIFF
--- a/src/interface/rest/docs/docs.go
+++ b/src/interface/rest/docs/docs.go
@@ -12056,18 +12056,10 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12114,18 +12106,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12179,18 +12163,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12236,18 +12212,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12284,18 +12252,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12337,18 +12297,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12394,18 +12346,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12439,18 +12383,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12489,18 +12425,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12543,18 +12471,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12597,18 +12517,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12644,18 +12556,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12694,18 +12598,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12742,18 +12638,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12798,18 +12686,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12864,18 +12744,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12919,18 +12791,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12972,18 +12836,10 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is ` + "`" + `{csp-region}` + "`" + ` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],

--- a/src/interface/rest/docs/swagger.json
+++ b/src/interface/rest/docs/swagger.json
@@ -12049,18 +12049,10 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12107,18 +12099,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12172,18 +12156,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12229,18 +12205,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12277,18 +12245,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12330,18 +12290,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12387,18 +12339,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12432,18 +12376,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12482,18 +12418,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12536,18 +12464,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12590,18 +12510,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12637,18 +12549,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12687,18 +12591,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12735,18 +12631,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     },
                     {
@@ -12791,18 +12679,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12857,18 +12737,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12912,18 +12784,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],
@@ -12965,18 +12829,10 @@
                     },
                     {
                         "type": "string",
-                        "default": "aws",
-                        "description": "Provider",
-                        "name": "provider",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "default": "ap-northeast-2",
-                        "description": "Region",
-                        "name": "region",
-                        "in": "query",
+                        "default": "aws-ap-northeast-2",
+                        "description": "This represents a credential or an access key ID. The required format is `{csp-region}` (i.e., the connection name).",
+                        "name": "credential",
+                        "in": "header",
                         "required": true
                     }
                 ],

--- a/src/interface/rest/docs/swagger.yaml
+++ b/src/interface/rest/docs/swagger.yaml
@@ -9887,20 +9887,14 @@ paths:
         ```
       operationId: ListObjectStorages
       parameters:
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -9939,20 +9933,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -9979,20 +9967,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -10049,20 +10031,14 @@ paths:
         schema:
           type: boolean
           default: true
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       requestBody:
         description: List of objects to delete
         content:
@@ -10092,20 +10068,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "204":
           description: No Content
@@ -10124,20 +10094,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -10167,20 +10131,14 @@ paths:
         schema:
           type: string
           default: test-object.txt
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "204":
           description: No Content
@@ -10210,20 +10168,14 @@ paths:
         schema:
           type: string
           default: test-object.txt
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -10278,20 +10230,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -10346,20 +10292,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       requestBody:
         description: CORS Configuration in XML format
         content:
@@ -10386,20 +10326,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "204":
           description: No Content
@@ -10429,20 +10363,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -10477,20 +10405,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -10525,20 +10447,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       requestBody:
         description: Versioning Configuration
         content:
@@ -10598,20 +10514,14 @@ paths:
         schema:
           type: string
           default: globally-unique-bucket-hctdx3
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "200":
           description: OK
@@ -10648,20 +10558,14 @@ paths:
         schema:
           type: string
           default: yb4PgjnFVD2LfRZHXBjjsHBkQRHlu.TZ
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       responses:
         "204":
           description: No Content
@@ -10704,20 +10608,14 @@ paths:
         schema:
           type: string
           default: test-object.txt
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       - name: expires
         in: query
         description: Expiration time in seconds for the presigned URL
@@ -10769,20 +10667,14 @@ paths:
         schema:
           type: string
           default: test-object.txt
-      - name: provider
-        in: query
-        description: Provider
+      - name: credential
+        in: header
+        description: "This represents a credential or an access key ID. The required\
+          \ format is `{csp-region}` (i.e., the connection name)."
         required: true
         schema:
           type: string
-          default: aws
-      - name: region
-        in: query
-        description: Region
-        required: true
-        schema:
-          type: string
-          default: ap-northeast-2
+          default: aws-ap-northeast-2
       - name: expires
         in: query
         description: Expiration time in seconds for the presigned URL


### PR DESCRIPTION
* Adopt AWS4-HMAC-SHA256 credential header format for S3 compatibility
* Replace query-based auth with S3-compatible credential header format
* Skip basic auth middleware for S3-standard credential headers
* Align Object Storage APIs with de-facto S3 authentication standards