### PR TITLE
Support Azure ubuntu-24_04-lts:server image

### DIFF
--- a/assets/cloudimage.csv
+++ b/assets/cloudimage.csv
@@ -1,8 +1,14 @@
 providerName,regionName,cspImageName,osType,description,supportedInstance,infraType
-AZURE,all,Canonical:0001-com-ubuntu-pro-advanced-sla-airdig:18_04-gen2:18.04.202507300,Ubuntu 18.04,,,vm
+AZURE,all,Canonical:0001-com-ubuntu-pro-bionic:pro-18_04-lts-gen2:18.04.202510010,Ubuntu 18.04,,,vm
 AZURE,all,Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:20.04.202505200,Ubuntu 20.04,,,vm
-AZURE,all,Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202507300,Ubuntu 22.04,,,vm
-AZURE,all,Canonical:0001-com-ubuntu-pro-advanced-sla-airdig:24_04-gen2:24.04.202507310,Ubuntu 24.04,,,vm
+AZURE,all,Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:22.04.202510230,Ubuntu 22.04,,,vm
+AZURE,all,Canonical:ubuntu-24_04-lts:cvm:24.04.202509250,Ubuntu 24.04,,,vm
+AZURE,all,Canonical:ubuntu-24_04-lts:minimal:24.04.202509300,Ubuntu 24.04,,,vm
+AZURE,all,Canonical:ubuntu-24_04-lts:minimal-arm64:24.04.202509300,Ubuntu 24.04,,,vm
+AZURE,all,Canonical:ubuntu-24_04-lts:server:24.04.202510010,Ubuntu 24.04,,,vm
+AZURE,all,Canonical:ubuntu-24_04-lts:server-arm64:24.04.202510010,Ubuntu 24.04,,,vm
+AZURE,all,Canonical:ubuntu-24_04-lts:ubuntu-pro:24.04.202510020,Ubuntu 24.04,,,vm
+AZURE,all,Canonical:ubuntu-24_04-lts:ubuntu-pro-arm64:24.04.202510020,Ubuntu 24.04,,,vm
 AZURE,all,Debian:debian-10:10-gen2:0.20240430.1733,Debian 10,,,vm
 AZURE,all,Debian:debian-11:11-gen2:0.20250801.2191,Debian 11,,,vm
 AZURE,all,Debian:debian-12:12-gen2:0.20250814.2204,Debian 12,,,vm

--- a/assets/extractionpatterns.yaml
+++ b/assets/extractionpatterns.yaml
@@ -8,7 +8,7 @@ extractionPatterns:
       versions: ["16.04", "18.04", "20.04", "22.04", "22.10", "23.10", "23.04", "24.04", "24.10", "25.04"]
       defaultVersion: ""
       patterns: ["ubuntu", "canonical"]
-      patternsForBasicImage: ["Ubuntu * 64 bit", "ubuntu/images/*", "0001-com-ubuntu-server*", "Canonical, Ubuntu, * LTS Minimal*", "Ubuntu Linux * LTS*", "ubuntu-*-64bit-*", "ubuntu-*-base (Hypervisor:KVM)", "Ubuntu Server * LTS (*)", "Ubuntu Server * LTS 64bit", "ubuntu-*-base"]
+      patternsForBasicImage: ["Ubuntu * 64 bit", "ubuntu/images/*", "0001-com-ubuntu-server*", "Canonical, Ubuntu, * LTS Minimal*", "Canonical:ubuntu*server*", "Ubuntu Linux * LTS*", "ubuntu-*-64bit-*", "ubuntu-*-base (Hypervisor:KVM)", "Ubuntu Server * LTS (*)", "Ubuntu Server * LTS 64bit", "ubuntu-*-base"]
     centos:
       name: "CentOS"
       versions: ["7", "8", "9"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -163,7 +163,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.11.13
+    image: cloudbaristaorg/cb-spider:0.11.15
     container_name: cb-spider
     # build:
     #   context: ../cb-spider
@@ -187,6 +187,7 @@ services:
       - SPIDER_LOG_LEVEL=error
       - SPIDER_HISCALL_LOG_LEVEL=error
       - ID_TRANSFORM_MODE=OFF
+      - ADMINWEB=OFF
     healthcheck: # for CB-Spider
       test: ["CMD", "curl", "-f", "http://localhost:1024/spider/readyz"]
       interval: 1m

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -986,10 +986,10 @@ func GetMciStatus(nsId string, mciId string) (*model.MciStatusInfo, error) {
 
 	// Check if MCI is in a stable state (all VMs have same stable status)
 	isStableState := tmpMax == statusVmCount && tmpMax > 0
-	stableStatusName := ""
-	if isStableState && tmpMaxIndex < len(statusFlagStr) {
-		stableStatusName = statusFlagStr[tmpMaxIndex]
-	}
+	// stableStatusName := ""
+	// if isStableState && tmpMaxIndex < len(statusFlagStr) {
+	// 	stableStatusName = statusFlagStr[tmpMaxIndex]
+	// }
 
 	var numVm int
 	if isCreating {
@@ -1026,8 +1026,8 @@ func GetMciStatus(nsId string, mciId string) (*model.MciStatusInfo, error) {
 			numVm = tmpMax
 		}
 
-		log.Debug().Msgf("MCI %s is in stable state (%s): using stable VM count (%d) - actual: %d, status: %d, vmInfos: %d, stored: %d, dominant: %d",
-			mciId, stableStatusName, numVm, actualVmCount, statusVmCount, vmInfoCount, len(mciTmp.Vm), tmpMax)
+		// log.Debug().Msgf("MCI %s is in stable state (%s): using stable VM count (%d) - actual: %d, status: %d, vmInfos: %d, stored: %d, dominant: %d",
+		// 	mciId, stableStatusName, numVm, actualVmCount, statusVmCount, vmInfoCount, len(mciTmp.Vm), tmpMax)
 	} else {
 		// MCI creation completed, use actual VM count from status
 		numVm = statusVmCount


### PR DESCRIPTION
- Support Azure ubuntu-24_04-lts:server image

with minor changes for
- updating cb-spider version
- disable adminweb by default
- updating mechanism for asset image
- disable verbose status log