### PR TITLE
Update K8s cluster versions for GCP and Azure (2025-10-30)

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -51,27 +51,27 @@ k8scluster:
     nodeGroupNamingRule: ^[a-z][a-z0-9]*$
     version:
       - region: [westeurope,westus]
-        available: # not tested
+        available: # Updated: 2025-10-30 (verified with az aks get-versions)
           - name: "1.33"
-            id: "1.33.0"
+            id: "1.33.3"
           - name: "1.32"
-            id: "1.32.3"
+            id: "1.32.7"
           - name: "1.31"
-            id: "1.31.6"
+            id: "1.31.11"
           - name: "1.30"
-            id: "1.30.9"
+            id: "1.30.100"
       - region: [westindia]
         # no available version
       - region: [common]
         available:
           - name: "1.33"
-            id: "1.33.0"
+            id: "1.33.3"
           - name: "1.32"
-            id: "1.32.3"
+            id: "1.32.7"
           - name: "1.31"
-            id: "1.31.6"
+            id: "1.31.11"
           - name: "1.30"
-            id: "1.30.9"
+            id: "1.30.100"
     rootDisk:
       - region: [common]
         type:
@@ -86,15 +86,16 @@ k8scluster:
     requiredSubnetCount: 1
     version:
       - region: [common]
-        # ref: https://cloud.google.com/kubernetes-engine/docs/release-notes
+        # ref: https://cloud.google.com/kubernetes-engine/docs/release-notes-stable
+        # Updated: 2025-10-30 (latest stable channel versions)
         # gcloud container get-server-config --region=asia-northeast3 --format=json | jq '{validMasterVersions, channels: [.channels[] | {channel, defaultVersion, validVersions}]}'
-        available: # stable channel
+        available: # stable channel versions as of 2025-10-29
           - name: "1.33"
-            id: "1.33.4-gke.1172000"
+            id: "1.33.5-gke.1125000"
           - name: "1.32"      
-            id: "1.32.8-gke.1134000"
+            id: "1.32.9-gke.1092000"
           - name: "1.31"
-            id: "1.31.11-gke.1036000"
+            id: "1.31.13-gke.1008000"
       - region: [africa-south1]
         # addnodegroup unavailble
     rootDisk:


### PR DESCRIPTION
## 📌 Overview
Updates Kubernetes cluster version information for GCP GKE and Azure AKS to reflect the latest stable and LTS versions as of October 30, 2025.

## 🔄 Changes

### **GCP GKE**
Verified using `gcloud container get-server-config --region=asia-northeast3` ([Release Notes](https://cloud.google.com/kubernetes-engine/docs/release-notes-stable))

- **1.33:** Updated to `1.33.5-gke.1125000` (stable channel, 2025-10-29)
- **1.32:** Updated to `1.32.9-gke.1092000` (stable channel)
- **1.31:** Updated to `1.31.13-gke.1008000` (stable channel)

### **Azure AKS**
Verified using `az aks get-versions --location eastus` ([Azure AKS Releases](https://github.com/Azure/AKS/releases))

- **1.33:** Updated to `1.33.3` (KubernetesOfficial + AKSLongTermSupport)
- **1.32:** Updated to `1.32.7` (KubernetesOfficial + AKSLongTermSupport)
- **1.31:** Updated to `1.31.11` (KubernetesOfficial + AKSLongTermSupport)
- **1.30:** Updated to `1.30.100` (AKSLongTermSupport)

**Note:** Azure AKS may automatically map requested versions to stable patch versions during cluster creation (e.g., requesting `1.33` might create `1.33.0`). This is Azure's internal policy to ensure cluster stability.

## ✅ Verification
- Successfully created and tested K8s clusters with all updated versions on both GCP and Azure
- Also tested AWS EKS versions (1.33, 1.32, 1.31) - confirmed current configurations are up-to-date with no changes needed
- Verified compatibility with CB-Tumblebug's cluster creation and management APIs

## 📂 Files Changed
- `assets/k8sclusterinfo.yaml`