### PR TITLE
Fix security group protocol handling for ALL and ICMP types

### DIFF
--- a/src/core/resource/securitygroup.go
+++ b/src/core/resource/securitygroup.go
@@ -63,7 +63,7 @@ func ConvertSpiderToFirewallRuleInfo(s model.SpiderSecurityRuleInfo) model.Firew
 	if s.FromPort != s.ToPort {
 		ports = s.FromPort + "-" + s.ToPort
 	}
-	if strings.EqualFold(s.IPProtocol, "ICMP") {
+	if strings.EqualFold(s.IPProtocol, "ICMP") || strings.EqualFold(s.IPProtocol, "ALL") {
 		ports = ""
 	}
 	// if one of FromPort or ToPort is empty or "-1", set ports to empty string
@@ -83,8 +83,9 @@ func ConvertSpiderToFirewallRuleInfo(s model.SpiderSecurityRuleInfo) model.Firew
 func ConvertTbToSpiderSecurityRuleInfo(t model.FirewallRuleInfo) model.SpiderSecurityRuleInfo {
 	var from, to string
 
-	// if Port is empty or "-1", set both from, to to "-1"
-	if t.Port == "" || t.Port == "-1" {
+	if strings.EqualFold(t.Protocol, "ALL") || strings.EqualFold(t.Protocol, "ICMP") {
+		from, to = "-1", "-1"
+	} else if t.Port == "" || t.Port == "-1" { // if Port is empty or "-1", set both from, to to "-1"
 		from, to = "-1", "-1"
 	} else {
 		from, to = parsePortsToFromTo(t.Port)
@@ -253,7 +254,7 @@ func CreateSecurityGroup(nsId string, u *model.SecurityGroupReq, option string) 
 
 			for _, rule := range expandedRules {
 
-				if !strings.EqualFold(rule.Protocol, "ICMP") {
+				if !strings.EqualFold(rule.Protocol, "ICMP") && !strings.EqualFold(rule.Protocol, "ALL") {
 					if !isValidPorts(rule.Port) {
 						err := fmt.Errorf("invalid port range in rule: %v", rule)
 						return model.SecurityGroupInfo{}, err


### PR DESCRIPTION
This PR will update the security group handling logic. 

* When Protocol is ALL, the requirement of the Spider Security Group creation API is that FromPort and ToPort be set to -1. This has been reflected. (see https://github.com/cloud-barista/cm-beetle/issues/240#issuecomment-3489250854)
* When retrieving Security Groups, it also reflects the conversion of Spider's response to Tumblebug's response.

Updated
- Handle ALL and ICMP protocols by setting FromPort/ToPort to "-1" for Spider API
- Skip port validation for ALL and ICMP protocols in security group creation
- Add ALL protocol check in Spider-to-Tumblebug conversion to set empty port string

Note
- Due to Beetle integration testing work, this PR has been modified based on Tumblebug v0.11.15.