### PR TITLE
Potential fix for code scanning alert no. 518: Incorrect conversion between integer types

### DIFF
--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -972,7 +972,12 @@ func UpdateSpecsFromAsset(nsId string) error {
 		acceleratorModel := row[18]
 		acceleratorCount := 0
 		if s, err := strconv.Atoi(strings.ReplaceAll(row[19], " ", "")); err == nil {
-			acceleratorCount = s
+			// Enforce bounds for uint8 before conversion
+			if s < 0 || s > 255 {
+				acceleratorCount = 0 // or choose another safe default, e.g., 255
+			} else {
+				acceleratorCount = s
+			}
 		}
 		acceleratorMemoryGB := 0.0
 		if s, err := strconv.ParseFloat(strings.ReplaceAll(row[20], " ", ""), 32); err == nil {


### PR DESCRIPTION
Potential fix for [https://github.com/cloud-barista/cb-tumblebug/security/code-scanning/518](https://github.com/cloud-barista/cb-tumblebug/security/code-scanning/518)

The best way to fix this is to check that the parsed value of `acceleratorCount` is within the valid bounds for the `uint8` type, i.e., in the interval [0, 255], before converting and assigning to `specInfo.AcceleratorCount`. If the parsed value is out of bounds, set it to a safe default (for example, zero) or handle it as appropriate for your application context (could log a warning and discard, or set to max value, etc.).

Change required: In src/core/resource/spec.go, after line 976 (after parsing and setting `acceleratorCount`), add a bounds check to make sure `acceleratorCount` is within [0, 255]. Then, in the assignment to `specInfo.AcceleratorCount`, you can safely cast to `uint8`.

No additional imports are necessary, as [0, 255] are constant values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
