### PR TITLE
fix: Update K8s version compatibility for Alibaba and NCP

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -116,8 +116,14 @@ k8scluster:
       # ap-northeast-1,ap-northeast-2,ap-southeast-1,ap-southeast-3,ap-southeast-5,us-west-1,us-east-1,eu-central-1,eu-west-1,cn-beijing,cn-hongkong,cn-shanghai,cn-huhehaote,cn-heyuan,cn-wulanchabu,cn-guangzhou
       - region: [common] 
         available:
-          - name: "1.33"
-            id: "1.33.3-aliyun.1"
+          # Versions 1.33 and 1.34 are officially released but not yet fully supported by Alibaba Cloud API
+          # CB-Spider fails with "failed to get valid runtime version" error when creating clusters with these versions
+          # This is due to incomplete runtime metadata availability in Alibaba Cloud's DescribeKubernetesVersionMetadata API
+          # Use 1.32 or 1.31 until Alibaba Cloud fully deploys these versions across all regions
+          # - name: "1.34"
+          #   id: "1.34.3-aliyun.1"
+          # - name: "1.33"
+          #   id: "1.33.3-aliyun.1"
           - name: "1.32"
             id: "1.32.7-aliyun.1"
           - name: "1.31"
@@ -184,12 +190,12 @@ k8scluster:
     version:
       - region: [kr]
         available:
+          - name: "1.33"
+            id: "1.33.4-nks.1"
           - name: "1.32"
-            id: "1.32.6-nks.1"
+            id: "1.32.8-nks.1"
           - name: "1.31"
             id: "1.31.7-nks.1"
-          - name: "1.30"
-            id: "1.30.8-nks.1"
     rootDisk:
       - region: [kr]
         type:


### PR DESCRIPTION
- Alibaba: Disable v1.33/v1.34 due to incomplete runtime metadata API
- NCP: Add v1.33 support, remove deprecated v1.30