### PR TITLE
docs: Update K8s multi-cluster API example with tested European regions

### DIFF
--- a/src/interface/rest/server/resource/k8scluster.go
+++ b/src/interface/rest/server/resource/k8scluster.go
@@ -625,7 +625,7 @@ func RestPostK8sClusterDynamic(c echo.Context) error {
 // @Description **Example request body:**
 // @Description ```json
 // @Description {
-// @Description   "namePrefix": "eu-cluster",
+// @Description   "namePrefix": "across",
 // @Description   "clusters": [
 // @Description     {
 // @Description       "imageId": "default",


### PR DESCRIPTION
- Update PostK8sMultiClusterDynamic API example in Swagger documentation
  - AWS (eu-west-2, UK) 
  - Azure (germanywestcentral, Germany) with nodeGroupName parameter
  - GCP (europe-west9, France) with nodeGroupName parameter
- Add nodeGroupName parameter for Azure/GCP to avoid AKS naming constraint
  (Azure AKS requires node pool names ≤12 chars, lowercase+numbers only)