### PR TITLE
Update Multi-Cloud Support Matrix image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
 - [📖 Overview](https://github.com/cloud-barista/cb-tumblebug/wiki/CB‐Tumblebug-Overview) | [✨ Features](https://github.com/cloud-barista/cb-tumblebug/wiki/CB‐Tumblebug-Features) | [🏗️ Architecture](https://github.com/cloud-barista/cb-tumblebug/wiki/CB‐Tumblebug-Architecture)
 - [☁️ Supported Cloud Providers & Resources](https://docs.google.com/spreadsheets/d/1idBoaTxEMzuVACKUIMIE9OY1rPO-7yZ0y7Rs1dBG0og/edit?usp=sharing)
 
-  ![Multi-Cloud Support Matrix](https://github.com/user-attachments/assets/35efa629-e864-4092-abb0-b455df4fd3c4)
-  
+  ![Multi-Cloud Support Matrix](https://github.com/user-attachments/assets/c83d7ad0-1308-42ba-bddd-afe2ce82e99f)
+
   > 📌 **Note**: Reference only - functionality not guaranteed. Regular updates are made.  
   > Kubernetes support is currently WIP with limited features available.
 


### PR DESCRIPTION
Updated the Multi-Cloud Support Matrix image link in the documentation.