### PR TITLE
Apply cb-spider:0.12.5 and its API changes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -164,7 +164,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.12.0
+    image: cloudbaristaorg/cb-spider:0.12.5
     container_name: cb-spider
     # build:
     #   context: ../cb-spider

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -1505,10 +1505,12 @@ func LookupPriceList(connConfig model.ConnConfig) (model.SpiderCloudPrice, error
 	var callResult model.SpiderCloudPrice
 	client := resty.New()
 	client.SetTimeout(10 * time.Minute)
-	url := model.SpiderRestUrl + "/priceinfo/vm/" + connConfig.RegionZoneInfo.AssignedRegion + "?simple=true"
-	method := "POST"
-	requestBody := model.SpiderConnectionName{}
-	requestBody.ConnectionName = connConfig.ConfigName
+	url := model.SpiderRestUrl + "/priceinfo/vm/" +
+		connConfig.RegionZoneInfo.AssignedRegion +
+		"?ConnectionName=" + connConfig.ConfigName +
+		"&simple=true"
+	method := "GET"
+	requestBody := clientManager.NoBody
 
 	err := clientManager.ExecuteHttpRequest(
 		client,


### PR DESCRIPTION
Apply cb-spider:0.12.5 and its API changes


[ v0.12.3](https://github.com/cloud-barista/cb-spider/tree/v0.12.3)

API Changes
Get VM Price Info:
- Changed HTTP method: POST → GET
- Removed filterList parameter from request body
- Now uses ConnectionName as query parameter only

Also, this PR enhance init.py progress bar