### PR TITLE
Refactor internal API calls to use centralized HTTP client for applying API Auth in common

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,14 +64,13 @@ services:
       - TB_POSTGRES_USER=tumblebug
       - TB_POSTGRES_PASSWORD=tumblebug
       # - TB_TERRARIUM_API_USERNAME=default
-      # - TB_TERRARIUM_API_PASSWORD=default
+      # - TB_TERRARIUM_API_PASSWORD=$$2a$$10$$4PKzCuJ6fPYsbCF.HR//ieLjaCzBAdwORchx62F2JRXQsuR3d9T0q
       # - TB_ALLOW_ORIGINS=*
       # - TB_AUTH_ENABLED=true
       # - TB_AUTH_MODE=jwt
-      # - TB_API_USERNAME=default
-      # - TB_API_PASSWORD=$$2a$$10$$4PKzCuJ6fPYsbCF.HR//ieLjaCzBAdwORchx62F2JRXQsuR3d9T0q
+      - TB_API_USERNAME=default
+      - TB_API_PASSWORD=$$2a$$10$$4PKzCuJ6fPYsbCF.HR//ieLjaCzBAdwORchx62F2JRXQsuR3d9T0q
       # - TB_AUTOCONTROL_DURATION_MS=10000
-      # - TB_DRAGONFLY_REST_URL=http://cb-dragonfly:9090/dragonfly
       # - TB_DEFAULT_NAMESPACE=default
       # - TB_DEFAULT_CREDENTIALHOLDER=admin
       # - TB_LOGFILE_PATH=/app/log/tumblebug.log
@@ -182,9 +181,9 @@ services:
     environment:
       - PLUGIN_SW=OFF
       - SERVER_ADDRESS=0.0.0.0:1024
-      # if you leave these values empty, REST Auth will be disabled.
-      # - API_USERNAME=
-      # - API_PASSWORD=
+      # Should match with TB_API_USERNAME and TB_API_PASSWORD in cb-tumblebug
+      - API_USERNAME=default
+      - API_PASSWORD=$$2a$$10$$4PKzCuJ6fPYsbCF.HR//ieLjaCzBAdwORchx62F2JRXQsuR3d9T0q
       - SPIDER_LOG_LEVEL=error
       - SPIDER_HISCALL_LOG_LEVEL=error
       - ID_TRANSFORM_MODE=OFF

--- a/src/core/common/client/client.go
+++ b/src/core/common/client/client.go
@@ -72,6 +72,24 @@ const (
 // NoBody is a constant for empty body
 const NoBody = "NOBODY"
 
+// NewHttpClient creates a new HTTP client with Basic Auth configured.
+// It uses the global APIUsername and APIPassword from model package.
+// This is useful for internal API calls that require authentication (e.g., Spider, Terrarium).
+// Note: SetDisableWarn(true) suppresses the "Using Basic Auth in HTTP mode" warning
+// since internal service communication is within trusted network.
+func NewHttpClient() *resty.Client {
+	client := resty.New().SetCloseConnection(true)
+	client.SetDisableWarn(true)
+	client.SetBasicAuth(model.APIUsername, model.APIPassword)
+	return client
+}
+
+// NewHttpClientBasic creates a new HTTP client without any authentication.
+func NewHttpClientBasic() *resty.Client {
+	client := resty.New()
+	return client
+}
+
 // MaxDebugBodyLength is the maximum length of response body for debug logs
 const MaxDebugBodyLength = 50000
 
@@ -675,7 +693,7 @@ func UpdateRequestProgress(reqID string, progressData interface{}) {
 
 // ForwardRequestToAny forwards the given request to the specified path
 func ForwardRequestToAny(reqPath string, method string, requestBody interface{}) (interface{}, error) {
-	client := resty.New()
+	client := NewHttpClient()
 	var callResult interface{}
 
 	url := model.SpiderRestUrl + "/" + reqPath

--- a/src/core/common/config.go
+++ b/src/core/common/config.go
@@ -177,6 +177,12 @@ func UpdateGlobalVariable(id string) error {
 	case model.StrTerrariumRestUrl:
 		model.TerrariumRestUrl = configInfo.Value
 		log.Debug().Msg("<TB_TERRARIUM_REST_URL> " + model.TerrariumRestUrl)
+	case model.StrAPIUsername:
+		model.APIUsername = configInfo.Value
+		log.Debug().Msg("<TB_API_USERNAME> " + model.APIUsername)
+	case model.StrAPIPassword:
+		model.APIPassword = configInfo.Value
+		log.Debug().Msg("<TB_API_PASSWORD> ********")
 	case model.StrDBUrl:
 		model.DBUrl = configInfo.Value
 		log.Debug().Msg("<TB_POSTGRES_ENDPOINT> " + model.DBUrl)
@@ -214,6 +220,12 @@ func InitConfig(id string) error {
 	case model.StrTerrariumRestUrl:
 		model.TerrariumRestUrl = NVL(os.Getenv("TB_TERRARIUM_REST_URL"), "http://localhost:8055/terrarium")
 		log.Debug().Msg("<TB_TERRARIUM_REST_URL> " + model.TerrariumRestUrl)
+	case model.StrAPIUsername:
+		model.APIUsername = NVL(os.Getenv("TB_API_USERNAME"), "default")
+		log.Debug().Msg("<TB_API_USERNAME> " + model.APIUsername)
+	case model.StrAPIPassword:
+		model.APIPassword = NVL(os.Getenv("TB_API_PASSWORD"), "default")
+		log.Debug().Msg("<TB_API_PASSWORD> ********")
 	case model.StrDBUrl:
 		model.DBUrl = NVL(os.Getenv("TB_POSTGRES_ENDPOINT"), "localhost:3306")
 		log.Debug().Msg("<TB_POSTGRES_ENDPOINT> " + model.DBUrl)

--- a/src/core/common/label/label.go
+++ b/src/core/common/label/label.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvutil"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -471,7 +470,7 @@ func GetResourcesByLabelSelector(labelType, labelSelector string) ([]interface{}
 // UpdateCSPResourceLabel best-effort updates the labels of a resource in the CSP
 func UpdateCSPResourceLabel(labelType, uid string, labels map[string]string, connectionName string) {
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/tag"
 	method := "POST"
 	var callResult model.KeyValue
@@ -509,7 +508,7 @@ func UpdateCSPResourceLabel(labelType, uid string, labels map[string]string, con
 // RemoveCSPResourceLabel best-effort removes the labels of a resource in the CSP
 func RemoveCSPResourceLabel(labelType, uid string, key string, connectionName string) {
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := fmt.Sprintf("%s/tag/%s", model.SpiderRestUrl, key)
 	method := "DELETE"
 	var callResult model.KeyValue
@@ -604,7 +603,7 @@ func ListCSPResourceLabel(labelType, uid string, connectionName string) (labels 
 	resourceType := convertTermToSpider(labelType)
 	resourceName := uid
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := fmt.Sprintf("%s/tag?ConnectionName=%s&ResourceType=%s&ResourceName=%s", model.SpiderRestUrl, connectionName, resourceType, resourceName)
 	method := "GET"
 	var callResult jsonResult

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -46,8 +46,6 @@ import (
 
 	"encoding/json"
 	"fmt"
-
-	"github.com/go-resty/resty/v2"
 )
 
 // Assets path management
@@ -380,7 +378,7 @@ func GetProviderNameFromConnConfig(ConnConfigName string) (string, error) {
 func CheckConnConfigAvailable(connConfigName string) (bool, error) {
 
 	var callResult interface{}
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/allkeypair"
 	method := "GET"
 	requestBody := model.SpiderConnectionName{}
@@ -409,7 +407,7 @@ func CheckConnConfigAvailable(connConfigName string) (bool, error) {
 func CheckSpiderReady() error {
 
 	var callResult interface{}
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/readyz"
 	method := "GET"
 	requestBody := clientManager.NoBody
@@ -521,7 +519,7 @@ func RegisterCloudInfo(providerName string) error {
 
 	driverName := RuntimeCloudInfo.CSPs[providerName].Driver
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/driver"
 	method := "POST"
 	var callResult model.CloudDriverInfo
@@ -556,7 +554,7 @@ func RegisterCloudInfo(providerName string) error {
 
 // RegisterRegionZone is func to register all regions to CB-Spider
 func RegisterRegionZone(providerName string, regionName string) error {
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/region"
 	method := "POST"
 	var callResult model.SpiderRegionZoneInfo
@@ -779,7 +777,7 @@ func RegisterCredential(req model.CredentialReq) (model.CredentialInfo, error) {
 		KeyValueInfoList: decryptedKeyValueList,
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/credential"
 	method := "POST"
 	var callResult model.CredentialInfo
@@ -1000,7 +998,7 @@ func RegisterCredential(req model.CredentialReq) (model.CredentialInfo, error) {
 
 // RegisterConnectionConfig is func to register connection config to CB-Spider
 func RegisterConnectionConfig(connConfig model.ConnConfig) (model.ConnConfig, error) {
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/connectionconfig"
 	method := "POST"
 	var callResult model.SpiderConnConfig
@@ -1165,7 +1163,7 @@ func RetrieveRegionListFromCsp() (model.RetrievedRegionList, error) {
 
 	url := model.SpiderRestUrl + "/region"
 
-	client := resty.New().SetCloseConnection(true)
+	client := clientManager.NewHttpClient()
 
 	resp, err := client.R().
 		SetResult(&model.RetrievedRegionList{}).

--- a/src/core/infra/control.go
+++ b/src/core/infra/control.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -638,7 +637,7 @@ func ControlVmAsync(wg *sync.WaitGroup, nsId string, mciId string, vmId string, 
 
 	UpdateVmInfo(nsId, mciId, temp)
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(10 * time.Minute)
 
 	// Set longer timeout for NCP (VPC)

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -829,7 +828,7 @@ func GetVmIdNameInDetail(nsId string, mciId string, vmId string) (*model.IdNameI
 
 	callResult := spiderResTmp{}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := fmt.Sprintf("%s/cspresourcename/%s", model.SpiderRestUrl, idDetails.IdInSp)
 	method := "GET"
 	client.SetTimeout(5 * time.Minute)
@@ -1270,7 +1269,7 @@ func GetVmCurrentPublicIp(nsId string, mciId string, vmId string) (model.VmStatu
 		SSHAccessPoint string
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(2 * time.Minute)
 	url := model.SpiderRestUrl + "/vm/" + cspResourceName
 	method := "GET"
@@ -1614,7 +1613,7 @@ func FetchVmStatus(nsId string, mciId string, vmId string) (model.VmStatusInfo, 
 	callResult.Status = ""
 
 	if vmInfo.Status != model.StatusTerminated && cspResourceName != "" {
-		client := resty.New()
+		client := clientManager.NewHttpClient()
 		url := model.SpiderRestUrl + "/vmstatus/" + cspResourceName
 		method := "GET"
 		client.SetTimeout(60 * time.Second)
@@ -2145,7 +2144,7 @@ func AttachDetachDataDisk(nsId string, mciId string, vmId string, command string
 	dataDisk := model.DataDiskInfo{}
 	json.Unmarshal([]byte(keyValue.Value), &dataDisk)
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "PUT"
 	var callResult interface{}
 	//var requestBody interface{}

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	validator "github.com/go-playground/validator/v10"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -3290,7 +3289,7 @@ func CreateVm(wg *sync.WaitGroup, nsId string, mciId string, vmInfoData *model.V
 	log.Info().Msg("VM request body to CB-Spider")
 	common.PrintJsonPretty(requestBody)
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "POST"
 	client.SetTimeout(20 * time.Minute)
 

--- a/src/core/infra/snapshot.go
+++ b/src/core/infra/snapshot.go
@@ -22,7 +22,6 @@ import (
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -63,7 +62,7 @@ func CreateVmSnapshot(nsId string, mciId string, vmId string, snapshotReq model.
 
 	// Create VM snapshot using ExecuteHttpRequest
 	var tempSpiderMyImageInfo model.SpiderMyImageInfo
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(5 * time.Minute)
 	url := fmt.Sprintf("%s/myimage", model.SpiderRestUrl)
 	method := "POST"

--- a/src/core/model/common.go
+++ b/src/core/model/common.go
@@ -116,6 +116,8 @@ var SystemReady bool
 var SpiderRestUrl string
 var DragonflyRestUrl string
 var TerrariumRestUrl string
+var APIUsername string
+var APIPassword string
 var DBUrl string
 var DBDatabase string
 var DBUser string
@@ -136,6 +138,8 @@ const (
 	StrSpiderRestUrl         string = "TB_SPIDER_REST_URL"
 	StrDragonflyRestUrl      string = "TB_DRAGONFLY_REST_URL"
 	StrTerrariumRestUrl      string = "TB_TERRARIUM_REST_URL"
+	StrAPIUsername           string = "TB_API_USERNAME"
+	StrAPIPassword           string = "TB_API_PASSWORD"
 	StrDBUrl                 string = "TB_POSTGRES_ENDPOINT"
 	StrDBDatabase            string = "TB_POSTGRES_DATABASE"
 	StrDBUser                string = "TB_POSTGRES_USER"

--- a/src/core/resource/customimage.go
+++ b/src/core/resource/customimage.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	validator "github.com/go-playground/validator/v10"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -104,7 +103,7 @@ func LookupMyImage(connConfig string, myImageId string) (model.SpiderMyImageInfo
 	}
 
 	var callResult model.SpiderMyImageInfo
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(2 * time.Minute)
 	url := model.SpiderRestUrl + "/myimage/" + url.QueryEscape(myImageId)
 	method := "GET"
@@ -213,7 +212,7 @@ func RegisterCustomImageWithId(nsId string, u *model.CustomImageReq) (model.Imag
 		return model.ImageInfo{}, err
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(2 * time.Minute)
 	url := ""
 	method := ""

--- a/src/core/resource/image.go
+++ b/src/core/resource/image.go
@@ -30,7 +30,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm/clause"
 
@@ -315,7 +314,7 @@ func lookupRegularImageOnly(connConfig string, imageId string) (model.SpiderImag
 		return model.SpiderImageInfo{}, fmt.Errorf("lookupRegularImageOnly() called with empty imageId")
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(2 * time.Minute)
 	apiUrl := model.SpiderRestUrl + "/vmimage/" + url.QueryEscape(imageId)
 	method := "GET"
@@ -670,7 +669,7 @@ func RegisterImageWithInfo(nsId string, content *model.ImageInfo, update bool) (
 func LookupImageList(connConfigName string) (model.SpiderImageList, error) {
 
 	var callResult model.SpiderImageList
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(100 * time.Minute)
 
 	url := model.SpiderRestUrl + "/vmimage"
@@ -712,7 +711,7 @@ func LookupImage(connConfig string, imageId string) (model.SpiderImageInfo, erro
 		return content, err
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(2 * time.Minute)
 	apiUrl := model.SpiderRestUrl + "/vmimage/" + url.QueryEscape(imageId)
 	method := "GET"

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	validator "github.com/go-playground/validator/v10"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 
 	corev1 "k8s.io/api/core/v1"
@@ -490,7 +489,7 @@ func CreateK8sCluster(nsId string, req *model.K8sClusterReq, option string, skip
 
 	// Randomly sleep within 20 Secs to avoid rateLimit from CSP
 	//common.RandomSleep(0, 20)
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "POST"
 	client.SetTimeout(20 * time.Minute)
 
@@ -782,7 +781,7 @@ func AddK8sNodeGroup(nsId string, k8sClusterId string, u *model.K8sNodeGroupReq)
 		},
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "POST"
 	client.SetTimeout(20 * time.Minute)
 
@@ -852,7 +851,7 @@ func RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, option string) (bo
 		ConnectionName: tbK8sCInfo.ConnectionName,
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/cluster/" + tbK8sCInfo.CspResourceName + "/nodegroup/" + k8sNodeGroupName
 	if option == "force" {
 		url += "?force=true"
@@ -949,7 +948,7 @@ func SetK8sNodeGroupAutoscaling(nsId string, k8sClusterId string, k8sNodeGroupNa
 		},
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/cluster/" + tbK8sCInfo.CspResourceName + "/nodegroup/" + k8sNodeGroupName + "/onautoscaling"
 	method := "PUT"
 
@@ -1039,7 +1038,7 @@ func ChangeK8sNodeGroupAutoscaleSize(nsId string, k8sClusterId string, k8sNodeGr
 		},
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/cluster/" + tbK8sCInfo.CspResourceName + "/nodegroup/" + k8sNodeGroupName + "/autoscalesize"
 	method := "PUT"
 
@@ -1096,7 +1095,7 @@ func GetK8sCluster(nsId string, k8sClusterId string) (*model.K8sClusterInfo, err
 	}
 
 	// Update model.K8sClusterInfo from CB-Spider
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(10 * time.Minute)
 	url := model.SpiderRestUrl + "/cluster/" + tbK8sCInfo.CspResourceName
 	method := "GET"
@@ -1320,7 +1319,7 @@ func DeleteK8sCluster(nsId, k8sClusterId, option string) (bool, error) {
 		ConnectionName: tbK8sCInfo.ConnectionName,
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/cluster/" + tbK8sCInfo.CspResourceName
 	if option == "force" {
 		url += "?force=true"
@@ -1468,7 +1467,7 @@ func UpgradeK8sCluster(nsId string, k8sClusterId string, u *model.UpgradeK8sClus
 		},
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/cluster/" + tbK8sCInfo.CspResourceName + "/upgrade"
 	method := "PUT"
 	client.SetTimeout(10 * time.Minute)

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	validator "github.com/go-playground/validator/v10"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
@@ -326,7 +325,7 @@ func LookupSpecList(connConfig string) (model.SpiderSpecList, error) {
 	}
 
 	var callResult model.SpiderSpecList
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(10 * time.Minute)
 	url := model.SpiderRestUrl + "/vmspec"
 	method := "GET"
@@ -370,7 +369,7 @@ func LookupSpec(connConfig string, specName string) (model.SpiderSpecInfo, error
 		return content, err
 	}
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(2 * time.Minute)
 	url := model.SpiderRestUrl + "/vmspec/" + specName
 	method := "GET"
@@ -1503,7 +1502,7 @@ func sortConnectionsByCSPRotation(configs []model.ConnConfig) {
 func LookupPriceList(connConfig model.ConnConfig) (model.SpiderCloudPrice, error) {
 
 	var callResult model.SpiderCloudPrice
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(10 * time.Minute)
 	url := model.SpiderRestUrl + "/priceinfo/vm/" +
 		connConfig.RegionZoneInfo.AssignedRegion +
@@ -1562,7 +1561,7 @@ func GetAvailableRegionZonesForSpec(provider string, cspSpecName string) (model.
 	}
 
 	// Prepare API call
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	client.SetTimeout(120 * time.Second)
 	url := model.SpiderRestUrl + "/anycall"
 	method := "POST"

--- a/src/core/resource/sqlDb.go
+++ b/src/core/resource/sqlDb.go
@@ -17,7 +17,6 @@ package resource
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
@@ -26,7 +25,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	terrariumModel "github.com/cloud-barista/mc-terrarium/pkg/api/rest/model"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -227,10 +225,7 @@ func CreateSqlDB(nsId string, sqlDbReq *model.RestPostSqlDBRequest, retry string
 	 */
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_API_USERNAME")
-	apiPass := os.Getenv("TB_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	// Set Terrarium endpoint
 	epTerrarium := model.TerrariumRestUrl
@@ -628,10 +623,7 @@ func GetSqlDB(nsId string, sqlDbId string, detail string) (model.SqlDBInfo, erro
 	}
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_API_USERNAME")
-	apiPass := os.Getenv("TB_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	trId := sqlDBInfo.Uid
 
@@ -802,10 +794,7 @@ func DeleteSqlDB(nsId string, sqlDbId string) (model.SimpleMsg, error) {
 	}
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_API_USERNAME")
-	apiPass := os.Getenv("TB_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	trId := sqlDBInfo.Uid
 
@@ -987,10 +976,7 @@ func GetRequestStatusOfSqlDB(nsId string, sqlDbId string, reqId string) (model.R
 	}
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_API_USERNAME")
-	apiPass := os.Getenv("TB_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	trId := sqlDBInfo.Uid
 

--- a/src/core/resource/sshkey.go
+++ b/src/core/resource/sshkey.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	validator "github.com/go-playground/validator/v10"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -136,7 +135,7 @@ func CreateSshKey(nsId string, u *model.SshKeyReq, option string) (model.SshKeyI
 
 	var tempSpiderKeyPairInfo model.SpiderKeyPairInfo
 
-	client := resty.New().SetCloseConnection(true)
+	client := clientManager.NewHttpClient()
 
 	var url string
 	var method string

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	validator "github.com/go-playground/validator/v10"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -318,7 +317,7 @@ func CreateSubnet(nsId string, vNetId string, subnetReq *model.SubnetReq) (model
 	// todo: restore the tag list later
 	// spReqt.ReqInfo.TagList = subnetReq.TagList
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "POST"
 	var spResp spiderVPCInfo
 
@@ -530,7 +529,7 @@ func GetSubnet(nsId string, vNetId string, subnetId string) (model.SubnetInfo, e
 	}
 
 	// [Via Spider] Get a subnet
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "GET"
 
 	// API to get a subnet
@@ -742,7 +741,7 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 
 	var spResp spiderBooleanInfoResp
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "DELETE"
 
 	err = clientManager.ExecuteHttpRequest(
@@ -931,7 +930,7 @@ func RefineSubnet(nsId string, vNetId string, subnetId string) (model.SimpleMsg,
 	 */
 
 	// [Via Spider] Get the subnet
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "GET"
 
 	// API to get a subnet
@@ -1138,7 +1137,7 @@ func RegisterSubnet(nsId string, vNetId string, subnetReq *model.RegisterSubnetR
 	spReqt.ReqInfo.Zone = subnetReq.Zone
 	spReqt.ReqInfo.CSPId = subnetReq.CspResourceId
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "POST"
 	var spResp spiderSubnetInfo
 
@@ -1381,7 +1380,7 @@ func DeregisterSubnet(nsId string, vNetId string, subnetId string) (model.Simple
 
 	var spResp spiderBooleanInfoResp
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "DELETE"
 
 	err = clientManager.ExecuteHttpRequest(

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	validator "github.com/go-playground/validator/v10"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -609,7 +608,7 @@ func CreateVNet(nsId string, vNetReq *model.VNetReq) (model.VNetInfo, error) {
 
 	log.Debug().Msgf("spReqt: %+v", spReqt)
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "POST"
 	var spResp spiderVPCInfo
 
@@ -859,7 +858,7 @@ func GetVNet(nsId string, vNetId string) (model.VNetInfo, error) {
 	 */
 
 	// [Via Spider] Get a vNet and subnets
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "GET"
 	spReqt := clientManager.NoBody
 	var spResp spiderVPCInfo
@@ -1057,7 +1056,7 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 
 		var spResp spiderBooleanInfoResp
 
-		client := resty.New()
+		client := clientManager.NewHttpClient()
 		method := "DELETE"
 
 		err = clientManager.ExecuteHttpRequest(
@@ -1184,7 +1183,7 @@ func RefineVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 	 */
 
 	// [Via Spider] Get a vNet
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "GET"
 	spReqt := clientManager.NoBody
 	var spResp spiderVPCInfo
@@ -1396,7 +1395,7 @@ func RegisterVNet(nsId string, vNetRegisterReq *model.RegisterVNetReq) (model.VN
 	spReqt.ReqInfo.Name = vNetInfo.Uid
 	spReqt.ReqInfo.CSPId = vNetRegisterReq.CspResourceId
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "POST"
 	var spResp spiderVPCInfo
 
@@ -1716,7 +1715,7 @@ func DeregisterVNet(nsId string, vNetId string, withSubnets string) (model.Simpl
 
 	var spResp spiderBooleanInfoResp
 
-	client := resty.New()
+	client := clientManager.NewHttpClient()
 	method := "DELETE"
 
 	err = clientManager.ExecuteHttpRequest(

--- a/src/core/resource/vpn.go
+++ b/src/core/resource/vpn.go
@@ -19,19 +19,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"time"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/label"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/netutil"
-	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
-
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
+	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	terrariumModel "github.com/cloud-barista/mc-terrarium/pkg/api/rest/model"
-	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -317,10 +314,7 @@ func CreateSiteToSiteVPN(nsId string, mciId string, vpnReq *model.RestPostVpnReq
 	 */
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_TERRARIUM_API_USERNAME")
-	apiPass := os.Getenv("TB_TERRARIUM_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	// Set Terrarium endpoint
 	epTerrarium := model.TerrariumRestUrl
@@ -588,10 +582,7 @@ func retrieveEnrichmentsInfoInTerrarium(ctx context.Context, trId string, enrich
 	var emptyRet model.Response
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_TERRARIUM_API_USERNAME")
-	apiPass := os.Getenv("TB_TERRARIUM_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	// Set Terrarium endpoint
 	epTerrarium := model.TerrariumRestUrl
@@ -777,10 +768,7 @@ func GetSiteToSiteVPN(nsId string, mciId string, vpnId string, detail string) (m
 	}
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_TERRARIUM_API_USERNAME")
-	apiPass := os.Getenv("TB_TERRARIUM_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	trId := vpnInfo.Uid
 
@@ -974,10 +962,7 @@ func DeleteSiteToSiteVPN(nsId string, mciId string, vpnId string) (model.SimpleM
 	}
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_TERRARIUM_API_USERNAME")
-	apiPass := os.Getenv("TB_TERRARIUM_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	trId := vpnInfo.Uid
 
@@ -1144,10 +1129,7 @@ func GetRequestStatusOfSiteToSiteVpn(nsId string, mciId string, vpnId string, re
 	}
 
 	// Initialize resty client with basic auth
-	client := resty.New()
-	apiUser := os.Getenv("TB_TERRARIUM_API_USERNAME")
-	apiPass := os.Getenv("TB_TERRARIUM_API_PASSWORD")
-	client.SetBasicAuth(apiUser, apiPass)
+	client := clientManager.NewHttpClient()
 
 	trId := vpnInfo.Uid
 

--- a/src/interface/rest/server/middlewares/authmw/authmw.go
+++ b/src/interface/rest/server/middlewares/authmw/authmw.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
-	"github.com/go-resty/resty/v2"
 	"github.com/golang-jwt/jwt/v5"
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
@@ -19,7 +18,7 @@ func InitJwtAuthMw(iamEndpoint string, pubkeyUrl string) error {
 	log.Debug().Msg("Start - InitJwtAuthMw")
 
 	// Check readiness of MC-IAM-Manager
-	client := resty.New()
+	client := clientManager.NewHttpClientBasic()
 
 	method := "GET"
 	url := fmt.Sprintf("%s/readyz", iamEndpoint)

--- a/src/interface/rest/server/middlewares/checkReadiness.go
+++ b/src/interface/rest/server/middlewares/checkReadiness.go
@@ -5,7 +5,6 @@ import (
 
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
-	"github.com/go-resty/resty/v2"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
@@ -14,7 +13,7 @@ func CheckReadiness(url string, apiUser string, apiPass string) echo.MiddlewareF
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 
-			client := resty.New()
+			client := clientManager.NewHttpClient()
 			if apiUser != "" && apiPass != "" {
 				client.SetBasicAuth(apiUser, apiPass)
 			}

--- a/src/main.go
+++ b/src/main.go
@@ -54,6 +54,8 @@ func init() {
 	model.SpiderRestUrl = common.NVL(os.Getenv("TB_SPIDER_REST_URL"), "http://localhost:1024/spider")
 	model.DragonflyRestUrl = common.NVL(os.Getenv("TB_DRAGONFLY_REST_URL"), "http://localhost:9090/dragonfly")
 	model.TerrariumRestUrl = common.NVL(os.Getenv("TB_TERRARIUM_REST_URL"), "http://localhost:8055/terrarium")
+	model.APIUsername = common.NVL(os.Getenv("TB_API_USERNAME"), "default")
+	model.APIPassword = common.NVL(os.Getenv("TB_API_PASSWORD"), "default")
 	model.DBUrl = common.NVL(os.Getenv("TB_POSTGRES_ENDPOINT"), "localhost:3306")
 	model.DBDatabase = common.NVL(os.Getenv("TB_POSTGRES_DATABASE"), "tumblebug")
 	model.DBUser = common.NVL(os.Getenv("TB_POSTGRES_USER"), "tumblebug")


### PR DESCRIPTION
## Refactor internal API calls to use centralized HTTP client

### Summary
Refactored all internal API call patterns to use common functions `clientManager.NewHttpClient()` and `clientManager.ExecuteHttpRequest()` for better maintainability and consistency.

### Changes
- **Centralized HTTP client creation**: All internal API calls now use `clientManager.NewHttpClient()` instead of directly calling `resty.New()`
- **Unified Basic Auth handling**: Removed repeated `os.Getenv()` calls for credentials by using global variables (`model.APIUsername`, `model.APIPassword`)
- **Applied Basic Auth to CB-Spider API calls**: Spider API calls now use Basic Auth by default, consistent with Terrarium API calls
- **Reduced code duplication**: Eliminated redundant client initialization patterns across multiple files

### Assumptions
- Internal subsystems (CB-Spider, Terrarium) use Basic Auth with the same credentials as CB-Tumblebug API
- These subsystems are initiated/managed by Tumblebug within a trusted network (Docker network)

### Benefits
- Reduced maintenance overhead by centralizing HTTP client configuration
- Improved consistency across all internal API calls
- Easier to update authentication logic in one place
- Suppressed unnecessary security warnings for internal HTTP communication
