### PR TITLE
Update init.py execution path to use cd and uv run

### DIFF
--- a/init/README.md
+++ b/init/README.md
@@ -32,7 +32,7 @@ Would you like to use the backup database? (y/n):
 
 **Auto-yes mode**: Use `-y` flag to automatically use backup without prompting:
 ```bash
-./init/init.py -y
+cd ./init && uv run init.py -y
 ```
 
 ## Features


### PR DESCRIPTION
## Description

Fixed the command example in the "Auto-yes mode" section to correctly execute `init.py` with dependencies.

## Problem

The previous command `./init/init.py -y` fails because `uv` cannot locate `pyproject.toml`, which resides in the `./init` directory. When running the script directly from the repository root, `uv` looks for `pyproject.toml` in the current directory instead of the script's directory.

## Solution

Changed the command from:
```bash
./init/init.py -y
```
to:

```bash
cd ./init && uv run init.py -y
```

This ensures that: 
1. The working directory is changed to `./init` where `pyproject.toml` is located
2. `uv` can properly resolve all Python dependencies defined in `pyproject.toml`
3. The script executes successfully with the `-y` flag