### PR TITLE
Resolve container status unhealthy in docker compose ps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ## Stage 1 - Go Build
 ##############################################################
 
-FROM golang:1.25.0-bookworm AS builder
+FROM golang:1.25.0-alpine AS builder
 
 ENV GO111MODULE=on
 


### PR DESCRIPTION
## Summary
Replace curl-based healthcheck with bash built-in TCP socket check to eliminate curl dependency

## Problem
Previously, even when all services were functioning correctly, running `docker compose ps` would show CB-Tumblebug and CB-Spider containers as `unhealthy`. 

<img width="1424" height="207" alt="Image" src="https://github.com/user-attachments/assets/d2d71b3a-a6f5-4fe6-9779-8103d2cc2294" />

This was caused by the healthcheck command failing due to `curl` not being installed in the container environment where the healthcheck runs.

<img width="882" height="110" alt="Image" src="https://github.com/user-attachments/assets/fb024a31-d36f-43b6-b609-f1b213523394" />

## Motivation
The previous healthcheck implementation relied on the `curl` command, which caused healthcheck failures in environments where `curl` is not installed. 

<img width="636" height="124" alt="prev" src="https://github.com/user-attachments/assets/5824f611-1e08-4de0-b453-43c68e699ac9" />

To resolve this issue, I've replaced it with bash's built-in TCP socket feature (`/dev/tcp`), eliminating external dependencies

<img width="1213" height="120" alt="now" src="https://github.com/user-attachments/assets/28570e98-e531-40e4-a5b6-ddaa3c62879a" />

## Changes
- **CB-Tumblebug healthcheck**: Changed from `curl -f http://localhost:1323/tumblebug/readyz` to HTTP GET request using bash TCP socket
- **CB-Spider healthcheck**: Changed from `curl -f http://localhost:1024/spider/readyz` to HTTP GET request using bash TCP socket

## Rationale

Installing curl in the container image would add unnecessary overhead and increase the image size.  Instead, this PR leverages bash's built-in `/dev/tcp` functionality to perform healthchecks against the existing readyz endpoints.  This approach is more lightweight and eliminates the external dependency on curl while maintaining the same functionality. 

## Benefits
- ✅ Fixes the incorrect `unhealthy` status in `docker compose ps`
- ✅ Eliminates external tool (`curl`) dependency
- ✅ Enables lighter container images

## Testing
-  Confirm that `docker compose ps` shows containers as `healthy` when services are running

<img width="1492" height="211" alt="Image" src="https://github.com/user-attachments/assets/544e230d-865d-48d4-9b12-48cb920622dc" />
