### PR TITLE
Allow empty MCI and make it reusable

### DIFF
--- a/src/core/infra/monitoring.go
+++ b/src/core/infra/monitoring.go
@@ -250,6 +250,10 @@ func InstallMonitorAgentToMci(nsId string, mciId string, mciServiceType string, 
 		log.Error().Err(err).Msg("")
 		return content, err
 	}
+	if len(vmList) == 0 {
+		err := fmt.Errorf("MCI %s has no VMs to install monitoring agent (status: Empty)", mciId)
+		return content, err
+	}
 
 	log.Debug().Msg("[Install agent for each VM]")
 

--- a/src/core/infra/remoteCommand.go
+++ b/src/core/infra/remoteCommand.go
@@ -96,6 +96,10 @@ func RemoteCommandToMci(nsId string, mciId string, subGroupId string, vmId strin
 		log.Error().Err(err).Msg("")
 		return nil, err
 	}
+	if len(vmList) == 0 {
+		err := fmt.Errorf("MCI %s has no VMs to execute commands (status: Empty)", mciId)
+		return nil, err
+	}
 	if subGroupId != "" {
 		vmListInGroup, err := ListVmBySubGroup(nsId, mciId, subGroupId)
 		if err != nil {

--- a/src/core/model/mci.go
+++ b/src/core/model/mci.go
@@ -79,6 +79,9 @@ const (
 	// StatusUndefined is const for Undefined
 	StatusUndefined string = "Undefined"
 
+	// StatusEmpty is const for Empty (MCI has no VMs)
+	StatusEmpty string = "Empty"
+
 	// StatusComplete is const for Complete
 	StatusComplete string = "None"
 )


### PR DESCRIPTION
Allow empty MCI and make it reusable.

- allow empty MCI (MCI without any VM)
- add new MCI lifecycle status (`Empty`)
- manage those empty MCIs officially (we can add a new subgroup to MCI with the existing operations)
- block operations that require actual VM control to empty MCIs

<img width="869" height="532" alt="image" src="https://github.com/user-attachments/assets/8c258acd-915a-47a3-b32c-a3434114130c" />
