### PR TITLE
Enhance resource registration descriptions and update VNet status logic

### DIFF
--- a/src/core/infra/utility.go
+++ b/src/core/infra/utility.go
@@ -809,7 +809,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciNamePrefix st
 			for _, r := range res.Resources.OnCspOnly.Info {
 				req := model.RegisterVNetReq{
 					ConnectionName: connConfig, CspResourceId: r.CspResourceId, Name: genName(r.CspResourceId),
-					Description: "Ref: " + r.RefNameOrId,
+					Description: "Ref name: " + r.RefNameOrId + ". CSP managed VNet (registered to CB-TB)",
 				}
 				_, err = resource.RegisterVNet(nsId, &req)
 				appendResult(&result, model.StrVNet, req.Name, err, &result.RegisterationOverview.VNet)
@@ -825,7 +825,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciNamePrefix st
 			for _, r := range res.Resources.OnCspOnly.Info {
 				req := model.SecurityGroupReq{
 					ConnectionName: connConfig, CspResourceId: r.CspResourceId, Name: genName(r.CspResourceId),
-					VNetId: "not defined", Description: "Ref: " + r.RefNameOrId,
+					VNetId: "not defined", Description: "Ref name: " + r.RefNameOrId + ". CSP managed Security Group (registered to CB-TB)",
 				}
 				_, err = resource.CreateSecurityGroup(nsId, &req, optionFlag)
 				appendResult(&result, model.StrSecurityGroup, req.Name, err, &result.RegisterationOverview.SecurityGroup)
@@ -842,7 +842,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciNamePrefix st
 				req := model.SshKeyReq{
 					ConnectionName: connConfig, CspResourceId: r.CspResourceId, Name: genName(r.CspResourceId),
 					Username: "unknown", Fingerprint: "unknown", PublicKey: "unknown", PrivateKey: "unknown",
-					Description: "Ref: " + r.RefNameOrId,
+					Description: "Ref name: " + r.RefNameOrId + ". CSP managed SSH Key (registered to CB-TB)",
 				}
 				_, err = resource.CreateSshKey(nsId, &req, optionFlag)
 				appendResult(&result, model.StrSSHKey, req.Name, err, &result.RegisterationOverview.SshKey)
@@ -863,7 +863,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciNamePrefix st
 					Name: mciName, Description: "MCI for CSP managed VMs", InstallMonAgent: "no",
 					SubGroups: []model.CreateSubGroupReq{{
 						ConnectionName: connConfig, CspResourceId: r.CspResourceId, Name: subGroupName,
-						Description: "Ref: " + r.RefNameOrId,
+						Description: "Ref name: " + r.RefNameOrId + ". CSP managed VM (registered to CB-TB)",
 						Label:       map[string]string{model.LabelRegistered: "true"},
 						// Placeholders
 						ImageId: "unknown", SpecId: "unknown", SshKeyId: "unknown",
@@ -884,6 +884,7 @@ func RegisterCspNativeResources(nsId string, connConfig string, mciNamePrefix st
 			for _, r := range res.Resources.OnCspOnly.Info {
 				req := model.DataDiskReq{
 					ConnectionName: connConfig, CspResourceId: r.CspResourceId, Name: genName(r.CspResourceId),
+					Description: "Ref name: " + r.RefNameOrId + ". CSP managed Data Disk (registered to CB-TB)",
 				}
 				_, err = resource.CreateDataDisk(nsId, &req, optionFlag)
 				appendResult(&result, model.StrDataDisk, req.Name, err, &result.RegisterationOverview.DataDisk)


### PR DESCRIPTION
**Description:**
This PR improves the metadata readability for registered resources and fixes issues with missing fields in VNet and Subnet registration logic.

**Key Changes:**

**1. Improved Resource Description Format**

* Updated the `Description` field for registered resources (VNet, SecurityGroup, SSHKey, VM, DataDisk) to provide better clarity and consistency.


<img width="674" height="42" alt="image" src="https://github.com/user-attachments/assets/53ce5ee9-ad96-4acc-97b3-ed9412111964" />


**2. Populated Missing Fields for VNet & Subnet**

**VNet:** Implemented dynamic status assignment based on the existence of subnets, **aligning the logic with the resource creation process.** ( `available` / `inuse` / `unknown` )


**Subnet:** Populated missing fields for registered subnets.
* Set the correct `Status`(unknown -> available) and `ResourceType` (previously missing).