### PR TITLE
Update schedule registration API to return error codes for invalid requests

### DIFF
--- a/src/core/infra/scheduler.go
+++ b/src/core/infra/scheduler.go
@@ -305,6 +305,13 @@ func (sm *SchedulerManager) CreateScheduledJob(req model.ScheduleJobRequest) (*S
 		return nil, fmt.Errorf("interval must be at least %d seconds", minimumInterval)
 	}
 
+	// Validate option parameters early (before job creation)
+	if req.JobType == "registerCspResources" || req.JobType == "registerCspResourcesAll" {
+		if _, err := getValidatedOptionMap(req.Option); err != nil {
+			return nil, err
+		}
+	}
+
 	// Generate job ID
 	jobId := fmt.Sprintf("%s-%s-%d", req.JobType, req.NsId, time.Now().Unix())
 

--- a/src/interface/rest/server/infra/schedule.go
+++ b/src/interface/rest/server/infra/schedule.go
@@ -112,6 +112,14 @@ func RestPostScheduleRegisterCspResources(c echo.Context) error {
 			})
 		}
 
+		// Check if it's a validation error
+		if strings.Contains(err.Error(), "Validation Failed") {
+			log.Warn().Err(err).Msg("Invalid registration options")
+			return c.JSON(http.StatusUnprocessableEntity, model.SimpleMsg{
+				Message: err.Error(),
+			})
+		}
+
 		// Other errors
 		log.Error().Err(err).Msg("Failed to create scheduled job")
 		return c.JSON(http.StatusInternalServerError, model.SimpleMsg{


### PR DESCRIPTION
**Description**
This PR modifies the schedule job registration API to return an explicit error code (`HTTP 422 Unprocessable Entity`) instead of `200 OK` when validation fails.

**Why**
Previously, the updated registration logic was applied only to the direct Registration API and was **not reflected in the Job Scheduling flow**.
Consequently, the scheduler returned `200 OK` even when validation errors occurred, failing to signal the error to the client.

**Impact**
This change ensures that the client (Map UI) can instantly catch validation errors (e.g., invalid resource combinations) and display an error message to the user.

Updates to the Map UI to accommodate this change are planned to follow immediately.