### PR TITLE
docs: Update the bcrypt README

### DIFF
--- a/cmd/bcrypt/README.md
+++ b/cmd/bcrypt/README.md
@@ -1,5 +1,18 @@
 # TB API Password Configuration Guide
 
+## Security & Concepts
+
+### 1. Security & Usability
+
+- **Protection**: Plaintext passwords must not be exposed in public repositories (e.g., GitHub upstream), even for development. Storing them as **bcrypt hashes** eliminates this risk.
+- **User Experience**: Users can use **plaintext passwords** naturally when making API calls.
+
+### 2. Implementation Requirements
+
+- **Secure Transmission**: Since the API receives plaintext passwords, **End-to-End Encryption (e.g., HTTPS)** is mandatory to ensure secure delivery.
+- **Special Character Handling**: Bcrypt hashes contain special characters (e.g., `$`). These must be escaped differently depending on the configuration format.
+  - _See the [Configuring the Password](#configuring-the-password) section for examples (e.g., `$$` in `docker-compose`)._
+
 ## Generating Password Hash
 
 1. From the CB-Tumblebug root directory, generate a bcrypt hash of your password using:


### PR DESCRIPTION
- Describe bcrypt security benefits and user experience
- Explain HTTPS transmission requirement for API calls
- Document hash escaping rules for config formats