### PR TITLE
Extend interal call cache window for safty

### DIFF
--- a/src/core/common/client/client.go
+++ b/src/core/common/client/client.go
@@ -68,6 +68,8 @@ const (
 	MediumDuration = 5 * time.Second
 	// LongDuration is a duration for long-term cache
 	LongDuration = 10 * time.Second
+	// VeryLongDuration is a duration for very long-term cache
+	VeryLongDuration = 300 * time.Second
 )
 
 // NoBody is a constant for empty body

--- a/src/core/resource/customimage.go
+++ b/src/core/resource/customimage.go
@@ -118,7 +118,7 @@ func LookupMyImage(connConfig string, myImageId string) (model.SpiderMyImageInfo
 		clientManager.SetUseBody(requestBody),
 		&requestBody,
 		&callResult,
-		clientManager.MediumDuration,
+		clientManager.VeryLongDuration,
 	)
 
 	if err != nil {

--- a/src/core/resource/image.go
+++ b/src/core/resource/image.go
@@ -336,7 +336,7 @@ func lookupRegularImageOnly(connConfig string, imageId string) (model.SpiderImag
 		clientManager.SetUseBody(requestBody),
 		&requestBody,
 		&callResult,
-		clientManager.MediumDuration,
+		clientManager.VeryLongDuration,
 	)
 
 	if err != nil {

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -342,7 +342,7 @@ func LookupSpecList(connConfig string) (model.SpiderSpecList, error) {
 		clientManager.SetUseBody(requestBody),
 		&requestBody,
 		&callResult,
-		clientManager.MediumDuration,
+		clientManager.VeryLongDuration,
 	)
 
 	if err != nil {
@@ -389,7 +389,7 @@ func LookupSpec(connConfig string, specName string) (model.SpiderSpecInfo, error
 			clientManager.SetUseBody(requestBody),
 			&requestBody,
 			&callResult,
-			clientManager.MediumDuration,
+			clientManager.VeryLongDuration,
 		)
 		return err
 	}, "LookupSpec", specName)
@@ -1525,7 +1525,7 @@ func LookupPriceList(connConfig model.ConnConfig) (model.SpiderCloudPrice, error
 		clientManager.SetUseBody(requestBody),
 		&requestBody,
 		&callResult,
-		clientManager.MediumDuration,
+		clientManager.VeryLongDuration,
 	)
 
 	if err != nil {
@@ -1592,7 +1592,7 @@ func GetAvailableRegionZonesForSpec(provider string, cspSpecName string) (model.
 		clientManager.SetUseBody(requestBody),
 		&requestBody,
 		&apiResponse,
-		clientManager.MediumDuration,
+		clientManager.VeryLongDuration,
 	)
 
 	if err != nil {


### PR DESCRIPTION
This PR invites 

// VeryLongDuration is a duration for very long-term cache
-	VeryLongDuration = 300 * time.Second

and apply it to some internal API calls to enhance API call stability (especially for Azure API call)