### PR TITLE
Support vGPU type instance driver installation

### DIFF
--- a/scripts/usecases/llm/installCudaDriver.sh
+++ b/scripts/usecases/llm/installCudaDriver.sh
@@ -335,7 +335,7 @@ if [ "$IS_VGPU" = false ] && sudo lspci -nnk 2>/dev/null | grep -i nvidia | grep
     IS_VGPU=true
 fi
 # Method 2: Check for NVIDIA GRID/vGPU signals in driver state (after driver is present)
-if [ -d /proc/driver/nvidia/gpus ] && grep -q -ri "vGPU\|GRID" /proc/driver/nvidia/ 2>/dev/null; then
+if [ "$IS_VGPU" = false ] && [ -d /proc/driver/nvidia/gpus ] && grep -q -ri "vGPU\|GRID" /proc/driver/nvidia/ 2>/dev/null; then
     IS_VGPU=true
 fi
 # Method 3: Check for mediated device (mdev) / vGPU VFIO indicators

--- a/scripts/usecases/llm/installGpuDriver.sh
+++ b/scripts/usecases/llm/installGpuDriver.sh
@@ -351,7 +351,7 @@ EOF
     # Cloud instances (AWS g6, Azure NCas, etc.) often expose GPUs as vGPU,
     # which requires proprietary (closed-source) kernel modules.
     # Detect vGPU by checking for GRID/vGPU branding, mediated devices,
-    # cloud instance metadata, or NVIDIA driver vGPU indicators.
+    # or NVIDIA driver vGPU indicators.
     # Avoid relying on PCI class alone (e.g. "3D controller").
     IS_VGPU=false
     # If --vgpu flag was passed, skip auto-detection entirely
@@ -364,11 +364,11 @@ EOF
         IS_VGPU=true
     fi
     # Method 2: Check for mediated-device (mdev) instances, commonly used for vGPU
-    if [ -d /sys/bus/mdev/devices ] && ls -1 /sys/bus/mdev/devices 2>/dev/null | grep -q .; then
+    if [ "$IS_VGPU" = false ] && [ -d /sys/bus/mdev/devices ] && ls -1 /sys/bus/mdev/devices 2>/dev/null | grep -q .; then
         IS_VGPU=true
     fi
     # Method 3: Check for NVIDIA GRID/vGPU device files or modules (after driver install)
-    if [ -d /proc/driver/nvidia/gpus ] && grep -q -ri "vGPU\\|GRID" /proc/driver/nvidia/ 2>/dev/null; then
+    if [ "$IS_VGPU" = false ] && [ -d /proc/driver/nvidia/gpus ] && grep -q -ri "vGPU\\|GRID" /proc/driver/nvidia/ 2>/dev/null; then
         IS_VGPU=true
     fi
     # Method 4: Detect fractional/vGPU via PCI BAR (memory region) size.


### PR DESCRIPTION
NVIDIA driver installation script cannot support some instances with **vGPU** (for instance, g6f.2xlarge, g6f.4xlarge, gr6f.4xlarge)
n	CSP	Region	SpecName	Arch	vCPU	Mem(Gi)	Cost($/h)	Accelerator
1	AWS	us-east-2	g6f.2xlarge	x86_64	8	32	$0.475	NVIDIA L4 (C:**undefined** 5)
2	AWS	us-east-2	g6f.4xlarge	x86_64	16	64	$0.95	NVIDIA L4 (C:**undefined** 11)
3	AWS	us-east-2	g6.2xlarge	x86_64	8	32	$0.9776	NVIDIA L4 (C:1 23)
4	AWS	us-east-2	gr6f.4xlarge	x86_64	16	128	$1.066	NVIDIA L4 (C:**undefined** 11)
5	AWS	us-east-2	g6.4xlarge	x86_64	16	64	$1.3232	NVIDIA L4 (C:1 23)

This PR adds a parameter for vGPU instances.