### PR TITLE
Add GET /kubeconfig endpoint for CSP native kubeconfig support

### DIFF
--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -483,6 +483,11 @@ type K8sClusterTokenResponse struct {
 	ExecCredential ExecCredential `json:"execCredential"`
 }
 
+// K8sClusterKubeconfigResponse is the response struct for the K8sCluster kubeconfig API.
+type K8sClusterKubeconfigResponse struct {
+	Kubeconfig string `json:"kubeconfig" example:"apiVersion: v1\nkind: Config\n..."`
+}
+
 // K8sClusterConnectionConfigCandidatesReq is struct for a request to check requirements to create a new K8sCluster instance dynamically (with default resource option)
 type K8sClusterConnectionConfigCandidatesReq struct {
 	// SpecId is field for id of a spec in common namespace

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -1226,6 +1226,67 @@ func GetK8sClusterToken(nsId string, k8sClusterId string) (*model.K8sClusterToke
 	return fetchSpiderClusterToken(tbK8sCInfo.CspResourceName, tbK8sCInfo.ConnectionName)
 }
 
+// fetchSpiderClusterKubeconfig calls Spider's GetCluster API with KubeconfigType=native
+// and returns the CSP native kubeconfig YAML string.
+func fetchSpiderClusterKubeconfig(cspResourceName, connectionName string) (*model.K8sClusterKubeconfigResponse, error) {
+	client := clientManager.NewHttpClient()
+	client.SetTimeout(30 * time.Second)
+
+	spiderUrl := fmt.Sprintf("%s/cluster/%s?KubeconfigType=native",
+		model.SpiderRestUrl,
+		url.PathEscape(cspResourceName),
+	)
+
+	type JsonTemplate struct {
+		ConnectionName string
+	}
+	requestBody := JsonTemplate{
+		ConnectionName: connectionName,
+	}
+
+	var spClusterRes model.SpiderClusterRes
+	_, err := clientManager.ExecuteHttpRequest(
+		client,
+		"GET",
+		spiderUrl,
+		nil,
+		clientManager.SetUseBody(requestBody),
+		&requestBody,
+		&spClusterRes,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get native kubeconfig from CB-Spider (cluster=%s): %w", cspResourceName, err)
+	}
+
+	kubeconfig := spClusterRes.AccessInfo.Kubeconfig
+	if kubeconfig == "" {
+		return nil, fmt.Errorf("CB-Spider returned empty kubeconfig for cluster(%s)", cspResourceName)
+	}
+
+	return &model.K8sClusterKubeconfigResponse{Kubeconfig: kubeconfig}, nil
+}
+
+// GetK8sClusterKubeconfig resolves nsId/k8sClusterId and returns a CSP native kubeconfig.
+func GetK8sClusterKubeconfig(nsId string, k8sClusterId string) (*model.K8sClusterKubeconfigResponse, error) {
+	log.Info().Msgf("GetK8sClusterKubeconfig: nsId=%s, k8sClusterId=%s", nsId, k8sClusterId)
+
+	check, err := CheckK8sCluster(nsId, k8sClusterId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check K8sCluster(%s): %w", k8sClusterId, err)
+	}
+	if !check {
+		return nil, fmt.Errorf("K8sCluster(%s) not found", k8sClusterId)
+	}
+
+	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get K8sCluster info(%s): %w", k8sClusterId, err)
+	}
+
+	return fetchSpiderClusterKubeconfig(tbK8sCInfo.CspResourceName, tbK8sCInfo.ConnectionName)
+}
+
 // CheckK8sCluster returns the existence of the TB K8sCluster object in bool form.
 func CheckK8sCluster(nsId string, k8sClusterId string) (bool, error) {
 

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -1226,7 +1226,7 @@ func GetK8sClusterToken(nsId string, k8sClusterId string) (*model.K8sClusterToke
 	return fetchSpiderClusterToken(tbK8sCInfo.CspResourceName, tbK8sCInfo.ConnectionName)
 }
 
-// fetchSpiderClusterKubeconfig calls Spider's GetCluster API with KubeconfigType=native
+// fetchSpiderClusterKubeconfig calls Spider's kubeconfig query API with KubeconfigType=native
 // and returns the CSP native kubeconfig YAML string.
 func fetchSpiderClusterKubeconfig(cspResourceName, connectionName string) (*model.K8sClusterKubeconfigResponse, error) {
 	client := clientManager.NewHttpClient()

--- a/src/interface/rest/server/resource/k8scluster.go
+++ b/src/interface/rest/server/resource/k8scluster.go
@@ -439,6 +439,31 @@ func RestGetK8sClusterToken(c echo.Context) error {
 	return clientManager.EndRequestWithLog(c, err, res)
 }
 
+// RestGetK8sClusterKubeconfig func is a rest api wrapper for GetK8sClusterKubeconfig.
+// RestGetK8sClusterKubeconfig godoc
+// @ID GetK8sClusterKubeconfig
+// @Summary Get CSP native kubeconfig for K8sCluster
+// @Description Get a CSP native kubeconfig for the specified K8sCluster.
+// @Description Returns a kubeconfig using CSP native auth plugins (e.g., aws-iam-authenticator for EKS, gke-gcloud-auth-plugin for GKE).
+// @Tags [Kubernetes] Cluster Management
+// @Accept  json
+// @Produce  json
+// @Param nsId path string true "Namespace ID" default(default)
+// @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster01)
+// @Success 200 {object} model.K8sClusterKubeconfigResponse
+// @Failure 404 {object} model.SimpleMsg
+// @Failure 500 {object} model.SimpleMsg
+// @Param x-request-id header string false "Custom request ID for tracking"
+// @Param x-credential-holder header string false "Credential holder ID for selecting which credentials to use (default: system default holder)"
+// @Router /ns/{nsId}/k8sCluster/{k8sClusterId}/kubeconfig [get]
+func RestGetK8sClusterKubeconfig(c echo.Context) error {
+	nsId := c.Param("nsId")
+	k8sClusterId := c.Param("k8sClusterId")
+
+	res, err := resource.GetK8sClusterKubeconfig(nsId, k8sClusterId)
+	return clientManager.EndRequestWithLog(c, err, res)
+}
+
 // Response structure for RestGetAllK8sCluster
 type RestGetAllK8sClusterResponse struct {
 	K8sCluster []model.K8sClusterInfo `json:"K8sClusterInfo"`

--- a/src/interface/rest/server/server.go
+++ b/src/interface/rest/server/server.go
@@ -569,6 +569,9 @@ func RunServer() {
 	g.GET("/:nsId/k8sCluster/:k8sClusterId/token", rest_resource.RestGetK8sClusterToken,
 		middleware.TimeoutWithConfig(timeoutConfig),
 		middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(2)))
+	g.GET("/:nsId/k8sCluster/:k8sClusterId/kubeconfig", rest_resource.RestGetK8sClusterKubeconfig,
+		middleware.TimeoutWithConfig(timeoutConfig),
+		middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(2)))
 
 	e.POST("/tumblebug/k8sClusterRecommendNode", rest_resource.RestRecommendK8sNode)
 	e.POST("/tumblebug/k8sClusterDynamicCheckRequest", rest_resource.RestPostK8sClusterDynamicCheckRequest)


### PR DESCRIPTION
## Add K8sCluster CSP Native Kubeconfig Endpoint

- Add `GET /:nsId/k8sCluster/:k8sClusterId/kubeconfig` endpoint that proxies CB-Spider's `KubeconfigType=native` option
- For AWS (aws-iam-authenticator) and GCP (gke-gcloud-auth-plugin), returns a kubeconfig usable with kubectl without requiring a Spider server
- Static Token CSPs (Azure, Alibaba, Tencent, IBM, NHN) return the default kubeconfig as-is
- NCP does not support CSP Native; the default kubeconfig is returned, and the `/token` endpoint should be used instead [Guide to Using kubectl with CB-Spider Kubeconfig](https://github.com/cloud-barista/cb-spider/wiki/Guide-to-Using-kubectl-with-CB%E2%80%90Spider-Kubeconfig).
- Verified with integration tests against AWS, GCP, and NCP clusters; AWS and GCP kubeconfig + kubectl access confirmed working
- Resolves https://github.com/cloud-barista/cb-tumblebug/issues/2348