### PR TITLE
Fix infinite VNet retry and Infra creation pending issue

### DIFF
--- a/src/core/common/client/client.go
+++ b/src/core/common/client/client.go
@@ -513,7 +513,7 @@ func ExecuteHttpRequest[B any, T any](
 
 		if method == "GET" {
 			requestDone(requestKey)
-			// Record circuit breaker failure for GET requests
+			// Record circuit breaker failure for GET requests (i.e., all HTTP errors (4xx and 5xx))
 			recordCircuitBreakerFailure(requestKey)
 		}
 		cleanedBody := cleanErrorMessage(string(resp.Body()))

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -830,7 +830,7 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 		nodeObjectErrors []model.NodeCreationError
 		nodeCreateErrors []model.NodeCreationError
 		totalNodeCount   int
-		errorMu        sync.Mutex
+		errorMu          sync.Mutex
 	)
 
 	// Count total VMs to be created (minimum 1 per nodeGroup)
@@ -847,7 +847,7 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 		errorMu.Lock()
 		defer errorMu.Unlock()
 		*errors = append(*errors, model.NodeCreationError{
-			NodeName:    nodeName,
+			NodeName:  nodeName,
 			Error:     errorMsg,
 			Phase:     phase,
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -877,9 +877,9 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 
 	// Pre-calculate VM configurations to avoid duplication
 	type nodeConfig struct {
-		nodeInfo        model.NodeInfo
+		nodeInfo      model.NodeInfo
 		nodeGroupSize int
-		nodeIndex       int
+		nodeIndex     int
 	}
 
 	var nodeConfigs []nodeConfig
@@ -977,8 +977,8 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 				DataDiskIds:      nodeGroupReq.DataDiskIds,
 				SshKeyId:         nodeGroupReq.SshKeyId,
 				Description:      nodeGroupReq.Description,
-				NodeUserName:       nodeGroupReq.NodeUserName,
-				NodeUserPassword:   nodeGroupReq.NodeUserPassword,
+				NodeUserName:     nodeGroupReq.NodeUserName,
+				NodeUserPassword: nodeGroupReq.NodeUserPassword,
 				RootDiskType:     nodeGroupReq.RootDiskType,
 				RootDiskSize:     nodeGroupReq.RootDiskSize,
 				Label:            nodeGroupReq.Label,
@@ -994,9 +994,9 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 			nodeInfo.Id = nodeInfo.Name
 
 			nodeConfigs = append(nodeConfigs, nodeConfig{
-				nodeInfo:        nodeInfo,
+				nodeInfo:      nodeInfo,
 				nodeGroupSize: nodeGroupSize,
-				nodeIndex:       i,
+				nodeIndex:     i,
 			})
 		}
 	}
@@ -1285,12 +1285,12 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 		}
 
 		infraResult.CreationErrors = &model.InfraCreationErrors{
-			NodeObjectCreationErrors:  nodeObjectErrors,
-			NodeCreationErrors:        nodeCreateErrors,
-			TotalNodeCount:            totalNodeCount,
-			SuccessfulNodeCount:       successfulNodeCount,
-			FailedNodeCount:           failedNodeCount,
-			FailureHandlingStrategy: failureStrategy,
+			NodeObjectCreationErrors: nodeObjectErrors,
+			NodeCreationErrors:       nodeCreateErrors,
+			TotalNodeCount:           totalNodeCount,
+			SuccessfulNodeCount:      successfulNodeCount,
+			FailedNodeCount:          failedNodeCount,
+			FailureHandlingStrategy:  failureStrategy,
 		}
 
 		log.Info().Msgf("Infra '%s' creation completed with %d successful VMs out of %d total (strategy: %s, refined: %t)",
@@ -1833,7 +1833,7 @@ func reviewSingleNodeGroupDynamicReq(ctx context.Context, nodeGroupDynamicReq mo
 
 	credentialHolder := common.CredentialHolderFromContext(ctx)
 	nodeReview := model.ReviewNodeGroupDynamicReqInfo{
-		NodeName:        nodeGroupDynamicReq.Name,
+		NodeName:      nodeGroupDynamicReq.Name,
 		NodeGroupSize: nodeGroupDynamicReq.NodeGroupSize,
 		CanCreate:     true,
 		Status:        "Ready",
@@ -2314,7 +2314,7 @@ func ReviewInfraDynamicReq(ctx context.Context, nsId string, req *model.InfraDyn
 	log.Debug().Msgf("Starting Infra dynamic request review for: %s", req.Name)
 
 	reviewResult := &model.ReviewInfraDynamicReqInfo{
-		InfraName:    req.Name,
+		InfraName:      req.Name,
 		TotalNodeCount: len(req.NodeGroups),
 		NodeReviews:    make([]model.ReviewNodeGroupDynamicReqInfo, 0),
 		ResourceSummary: model.ReviewResourceSummary{
@@ -2366,12 +2366,12 @@ func ReviewInfraDynamicReq(ctx context.Context, nsId string, req *model.InfraDyn
 
 	// Channel to collect VM review results
 	nodeReviewChan := make(chan struct {
-		index    int
+		index      int
 		nodeReview model.ReviewNodeGroupDynamicReqInfo
-		specInfo *model.SpecInfo
-		viable   bool
-		warning  bool
-		cost     float64
+		specInfo   *model.SpecInfo
+		viable     bool
+		warning    bool
+		cost       float64
 	}, len(req.NodeGroups))
 
 	// WaitGroup to wait for all goroutines to complete
@@ -2392,19 +2392,19 @@ func ReviewInfraDynamicReq(ctx context.Context, nsId string, req *model.InfraDyn
 
 			// Send result to channel
 			nodeReviewChan <- struct {
-				index    int
+				index      int
 				nodeReview model.ReviewNodeGroupDynamicReqInfo
-				specInfo *model.SpecInfo
-				viable   bool
-				warning  bool
-				cost     float64
+				specInfo   *model.SpecInfo
+				viable     bool
+				warning    bool
+				cost       float64
 			}{
-				index:    index,
+				index:      index,
 				nodeReview: nodeReview,
-				specInfo: specInfoPtr,
-				viable:   viable,
-				warning:  hasNodeWarning,
-				cost:     nodeCost,
+				specInfo:   specInfoPtr,
+				viable:     viable,
+				warning:    hasNodeWarning,
+				cost:       nodeCost,
 			}
 
 			log.Debug().Msgf("[%d] VM '%s' review completed: %s", index, nodeGroupDynamicReq.Name, nodeReview.Status)
@@ -3232,7 +3232,7 @@ func CreateNodeObject(wg *sync.WaitGroup, nsId string, infraId string, nodeInfoD
 
 // NodeCreateInfo represents Node creation information with grouping details
 type NodeCreateInfo struct {
-	NodeInfo       *model.NodeInfo
+	NodeInfo     *model.NodeInfo
 	ProviderName string
 	RegionName   string
 }
@@ -3262,7 +3262,7 @@ func CreateNodesInParallel(ctx context.Context, nsId, infraId string, nodeInfoLi
 		// Add VM to the appropriate group
 		nodeGroups[providerName][regionName] = append(nodeGroups[providerName][regionName], nodeInfo)
 		nodeGroupInfos[nodeInfo.Id] = NodeCreateInfo{
-			NodeInfo:       nodeInfo,
+			NodeInfo:     nodeInfo,
 			ProviderName: providerName,
 			RegionName:   regionName,
 		}
@@ -4725,7 +4725,7 @@ func RecordProvisioningEventsFromInfra(nsId string, infraInfo *model.InfraInfo) 
 			IsSuccess:    isSuccess,
 			ErrorMessage: errorMessage,
 			Timestamp:    time.Now(),
-			NodeName:       node.Id,
+			NodeName:     node.Id,
 			InfraId:      infraInfo.Id,
 		}
 

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -46,7 +47,7 @@ func SubnetReqStructLevelValidation(sl validator.StructLevel) {
 
 func ValidateSubnetReq(subnetReq *model.SubnetReq, existingVNet model.VNetInfo) error {
 	log.Debug().Msg("ValidateSubnetReq")
-	log.Debug().Msgf("Subnet: %+v", subnetReq)
+	log.Trace().Msgf("Subnet: %+v", subnetReq)
 
 	err := validate.Struct(subnetReq)
 	if err != nil {
@@ -117,7 +118,7 @@ func ValidateSubnetReq(subnetReq *model.SubnetReq, existingVNet model.VNetInfo) 
 	subnets = append(subnets, subnet)
 
 	network.Subnets = subnets
-	log.Debug().Msgf("network: %+v", network)
+	log.Trace().Msgf("network: %+v", network)
 
 	// Validate the network object
 	err = netutil.ValidateNetwork(network)
@@ -192,9 +193,7 @@ type spiderSubnetInfo struct {
 func CreateSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *model.SubnetReq) (model.SubnetInfo, error) {
 	log.Info().Msg("CreateSubnet")
 
-	log.Debug().Msgf("nsId: %s", nsId)
-	log.Debug().Msgf("vNetId: %s", vNetId)
-	log.Debug().Msgf("subnetReq: %+v", subnetReq)
+	log.Trace().Msgf("subnetReq: %+v", subnetReq)
 
 	// subnet objects
 	var emptyRet model.SubnetInfo
@@ -330,7 +329,7 @@ func CreateSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *mo
 	// API to create a subnet
 	url := fmt.Sprintf("%s/vpc/%s/subnet", model.SpiderRestUrl, vNetInfo.CspResourceName)
 
-	log.Debug().Msgf("[Request to Spider] Creating Subnet (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Creating Subnet: %s", url)
 
 	// Clean up the object when something goes wrong
 	defer func() {
@@ -354,7 +353,7 @@ func CreateSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *mo
 		}
 	}()
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -365,10 +364,14 @@ func CreateSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *mo
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Creating Subnet (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Creating Subnet: %+v", spResp)
 
 	if err != nil {
-		log.Error().Err(err).Msg("")
+		if restyResp != nil {
+			log.Error().Err(err).Int("statusCode", restyResp.StatusCode()).Msg("")
+		} else {
+			log.Error().Err(err).Msg("")
+		}
 		return emptyRet, err
 	}
 
@@ -390,7 +393,8 @@ func CreateSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *mo
 	model.SetCondition(&subnetInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "")
 	subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
 	subnetInfo.SystemMessage = ""
-	log.Debug().Msgf("subnetInfo: %+v", subnetInfo)
+	log.Debug().Msgf("Subnet created in CSP: id=%s, zone=%s, cidr=%s", subnetInfo.Id, subnetInfo.Zone, subnetInfo.IPv4_CIDR)
+	log.Trace().Msgf("subnetInfo: %+v", subnetInfo)
 	// Save subnet object into the key-value store
 	subnetObj, err := json.Marshal(subnetInfo)
 	if err != nil {
@@ -410,7 +414,7 @@ func CreateSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *mo
 	model.SetCondition(&vNetInfo.Conditions, model.ConditionChildrenReady, model.ConditionTrue, model.ReasonAllReady, "")
 	vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
 
-	log.Debug().Msgf("vNetInfo: %+v", vNetInfo)
+	log.Trace().Msgf("vNetInfo: %+v", vNetInfo)
 
 	// Save vNet object into the key-value store
 	vNetObj, err := json.Marshal(vNetInfo)
@@ -448,12 +452,13 @@ func CreateSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *mo
 		return emptyRet, err
 	}
 
+	log.Info().Msgf("Subnet created: id=%s, cidr=%s, zone=%s", subnetInfo.Id, subnetInfo.IPv4_CIDR, subnetInfo.Zone)
 	return subnetInfo, nil
 }
 
 // GetSubnet
 func GetSubnet(nsId string, vNetId string, subnetId string) (model.SubnetInfo, error) {
-	log.Info().Msg("GetSubnet")
+	log.Debug().Msg("GetSubnet")
 
 	// subnet objects
 	var emptyRet model.SubnetInfo
@@ -529,54 +534,12 @@ func GetSubnet(nsId string, vNetId string, subnetId string) (model.SubnetInfo, e
 		return emptyRet, err
 	}
 
-	// [Via Spider] Get a subnet
-	client := clientManager.NewHttpClient()
-	method := "GET"
-
-	// API to get a subnet
-	url := fmt.Sprintf("%s/vpc/%s/subnet/%s", model.SpiderRestUrl, subnetInfo.CspVNetName, subnetInfo.CspResourceName)
-	queryParams := "?ConnectionName=" + subnetInfo.ConnectionName
-	url += queryParams
-
-	spReqt := clientManager.NoBody
-
-	log.Debug().Msgf("[Request to Spider] Getting Subnet (url: %s, request body: %+v)", url, spReqt)
-
-	var spResp spiderSubnetInfo
-
-	_, err = clientManager.ExecuteHttpRequest(
-		client,
-		method,
-		url,
-		nil,
-		clientManager.SetUseBody(spReqt),
-		&spReqt,
-		&spResp,
-		clientManager.MediumDuration,
-	)
-
-	log.Debug().Msgf("[Response from Spider] Getting Subnet (response body: %+v)", spResp)
-
-	if err != nil {
-		log.Warn().Err(err).Msg("")
-		return emptyRet, err
-	}
-
-	// Set the subnet object with the response from the Spider
-	subnetInfo.CspResourceId = spResp.IId.SystemId
-	subnetInfo.CspResourceName = spResp.IId.NameId
-	subnetInfo.IPv4_CIDR = spResp.IPv4_CIDR
-	subnetInfo.Zone = spResp.Zone
-	subnetInfo.KeyValueList = spResp.KeyValueList
-
-	// TODO: Check if it's required or not to save the subnet object
-
 	return subnetInfo, nil
 }
 
 // ListSubnet
 func ListSubnet(nsId string, vNetId string) ([]model.SubnetInfo, error) {
-	log.Info().Msg("ListSubnet")
+	log.Debug().Msg("ListSubnet")
 
 	// subnet objects
 	var emptyRet []model.SubnetInfo
@@ -744,14 +707,14 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 	}
 	url += queryParams
 
-	log.Debug().Msgf("[Request to Spider] Deleting Subnet (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Deleting Subnet: %s", url)
 
 	var spResp spiderBooleanInfoResp
 
 	client := clientManager.NewHttpClient()
 	method := "DELETE"
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -762,45 +725,50 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Deleting Subnet (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Deleting Subnet: %+v", spResp)
 
 	if err != nil {
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deletion failed → mark as Failed to prevent stuck state
-		model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, err.Error())
-		subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
-		subnetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(subnetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(subnetKey, string(failVal))
+		if restyResp != nil && restyResp.StatusCode() == http.StatusNotFound {
+			log.Info().Msgf("Subnet (%s) not found on CSP, treating as already deleted and proceeding with local cleanup", subnetInfo.Id)
+		} else {
+			log.Error().Err(err).Msg("")
+			// [Conditions] Deletion failed → mark as Failed to prevent stuck state
+			model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, err.Error())
+			subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
+			subnetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(subnetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(subnetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
-	}
-	ok, err := strconv.ParseBool(spResp.Result)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deletion failed → mark as Failed to prevent stuck state
-		model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, err.Error())
-		subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
-		subnetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(subnetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(subnetKey, string(failVal))
+	} else {
+		ok, err := strconv.ParseBool(spResp.Result)
+		if err != nil {
+			log.Error().Err(err).Msg("")
+			// [Conditions] Deletion failed → mark as Failed to prevent stuck state
+			model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, err.Error())
+			subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
+			subnetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(subnetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(subnetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
-	}
-	if !ok {
-		err := fmt.Errorf("failed to delete the subnet (%s)", subnetInfo.Id)
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deletion failed → mark as Failed to prevent stuck state
-		model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, err.Error())
-		subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
-		subnetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(subnetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(subnetKey, string(failVal))
+		if !ok {
+			err := fmt.Errorf("failed to delete the subnet (%s)", subnetInfo.Id)
+			log.Error().Err(err).Msg("")
+			// [Conditions] Deletion failed → mark as Failed to prevent stuck state
+			model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, err.Error())
+			subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
+			subnetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(subnetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(subnetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
 	}
 
 	// Verify deletion by checking subnet status after deletion request
@@ -813,15 +781,20 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 		log.Debug().Msgf("Checking if subnet (%s) still exists", subnetInfo.Id)
 		_, checkErr := GetSubnet(nsId, vNetId, subnetId)
 
-		// If we get an error (subnet not found), it means deletion was successful
 		if checkErr != nil {
-			log.Info().Msgf("Confirmed subnet (%s) deletion", subnetInfo.Id)
-			break
+			errMsg := checkErr.Error()
+			// Only treat "not found" errors as confirmed deletion
+			if strings.Contains(errMsg, "does not exist") || strings.Contains(errMsg, "404") {
+				log.Info().Msgf("Confirmed subnet (%s) deletion", subnetInfo.Id)
+				break
+			}
+			// Other errors (5xx, transport) — cannot confirm deletion, log and retry
+			log.Warn().Err(checkErr).Msgf("Error checking subnet (%s) deletion status, will retry", subnetInfo.Id)
 		}
 
-		// If this was the last attempt and subnet still exists, log warning but continue
+		// If this was the last attempt and subnet still exists or status is unknown, log warning but continue
 		if i == maxRetries-1 {
-			log.Warn().Msgf("Subnet (%s) may still exist in CSP after %d attempts, but proceeding with local cleanup", subnetInfo.Id, maxRetries)
+			log.Warn().Msgf("Subnet (%s) deletion could not be confirmed after %d attempts, proceeding with local cleanup", subnetInfo.Id, maxRetries)
 		}
 	}
 
@@ -871,7 +844,7 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 		return emptyRet, err
 	}
 
-	log.Debug().Msgf("subnet (%s) has been deleted", subnetId)
+	log.Info().Msgf("Subnet (%s) has been deleted", subnetId)
 
 	// [Output] the message
 	ret.Message = fmt.Sprintf("the subnet (%s) has been deleted", subnetId)
@@ -976,11 +949,11 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string) (model.SimpleM
 
 	spReqt := clientManager.NoBody
 
-	log.Debug().Msgf("[Request to Spider] Reconciling Subnet (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Reconciling Subnet: %s", url)
 
 	var spResp spiderSubnetInfo
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -991,12 +964,16 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string) (model.SimpleM
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Reconciling Subnet (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Reconciling Subnet: %+v", spResp)
 
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("")
-	// 	return emptyRet, err
-	// }
+	// Only proceed with cleanup when the subnet is confirmed not found (404).
+	// For server errors (5xx) or transport errors, return the error without cleanup
+	// to prevent accidental data loss during Spider/CSP outages.
+	if err != nil && (restyResp == nil || restyResp.StatusCode() != http.StatusNotFound) {
+		log.Error().Err(err).Msg("failed to get subnet from Spider, skipping reconciliation")
+		return emptyRet, err
+	}
+
 	if err == nil {
 		// [Output]
 		err := fmt.Errorf("may not be reconciled, subnet info (id: %s) exists", subnetId)
@@ -1188,7 +1165,7 @@ func RegisterSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *
 	url := fmt.Sprintf("%s/regsubnet", model.SpiderRestUrl)
 	// [Note] Spider doesn't provide "GET /vpc{VPCName}/subnet" API
 
-	log.Debug().Msgf("[Request to Spider] Registering Subnet (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Registering Subnet: %s", url)
 
 	// Defer function to ensure cleanup object
 	defer func() {
@@ -1212,7 +1189,7 @@ func RegisterSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *
 		}
 	}()
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -1223,10 +1200,14 @@ func RegisterSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Registering Subnet (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Registering Subnet: %+v", spResp)
 
 	if err != nil {
-		log.Error().Err(err).Msg("")
+		if restyResp != nil {
+			log.Error().Err(err).Int("statusCode", restyResp.StatusCode()).Msg("")
+		} else {
+			log.Error().Err(err).Msg("")
+		}
 		return emptyRet, err
 	}
 
@@ -1243,7 +1224,8 @@ func RegisterSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *
 	subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
 	subnetInfo.SystemMessage = ""
 
-	log.Debug().Msgf("subnetInfo: %+v", subnetInfo)
+	log.Debug().Msgf("Subnet registered: id=%s, zone=%s, cidr=%s", subnetInfo.Id, subnetInfo.Zone, subnetInfo.IPv4_CIDR)
+	log.Trace().Msgf("subnetInfo: %+v", subnetInfo)
 
 	// Save subnet object into the key-value store
 	subnetObj, err := json.Marshal(subnetInfo)
@@ -1264,7 +1246,7 @@ func RegisterSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *
 	model.SetCondition(&vNetInfo.Conditions, model.ConditionChildrenReady, model.ConditionTrue, model.ReasonAllReady, "")
 	vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
 
-	log.Debug().Msgf("vNetInfo: %+v", vNetInfo)
+	log.Trace().Msgf("vNetInfo: %+v", vNetInfo)
 
 	// Save vNet object into the key-value store
 	vNetObj, err := json.Marshal(vNetInfo)
@@ -1302,6 +1284,7 @@ func RegisterSubnet(ctx context.Context, nsId string, vNetId string, subnetReq *
 		return emptyRet, err
 	}
 
+	log.Info().Msgf("Subnet registered: id=%s, cidr=%s, zone=%s", subnetInfo.Id, subnetInfo.IPv4_CIDR, subnetInfo.Zone)
 	return subnetInfo, nil
 }
 
@@ -1419,14 +1402,14 @@ func DeregisterSubnet(nsId string, vNetId string, subnetId string) (model.Simple
 	// API to deregister subnet
 	url := fmt.Sprintf("%s/regsubnet/%s", model.SpiderRestUrl, subnetInfo.CspResourceName)
 
-	log.Debug().Msgf("[Request to Spider] Deregistering Subnet (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Deregistering Subnet: %s", url)
 
 	var spResp spiderBooleanInfoResp
 
 	client := clientManager.NewHttpClient()
 	method := "DELETE"
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -1437,45 +1420,56 @@ func DeregisterSubnet(nsId string, vNetId string, subnetId string) (model.Simple
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Deregistering Subnet (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Deregistering Subnet: %+v", spResp)
 
 	if err != nil {
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
-		model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
-		subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
-		subnetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(subnetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(subnetKey, string(failVal))
+		if restyResp != nil && restyResp.StatusCode() == http.StatusNotFound {
+			// Spider returned 404: resource already gone from Spider
+			// Proceed with local cleanup (same as success path)
+			log.Info().Msgf("Subnet (%s) not found on Spider (404), proceeding with local cleanup", subnetInfo.Id)
+		} else {
+			if restyResp != nil {
+				log.Error().Err(err).Int("statusCode", restyResp.StatusCode()).Msg("")
+			} else {
+				log.Error().Err(err).Msg("")
+			}
+			// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
+			model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
+			subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
+			subnetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(subnetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(subnetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
-	}
-	ok, err := strconv.ParseBool(spResp.Result)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
-		model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
-		subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
-		subnetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(subnetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(subnetKey, string(failVal))
+	} else {
+		ok, err := strconv.ParseBool(spResp.Result)
+		if err != nil {
+			log.Error().Err(err).Msg("")
+			// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
+			model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
+			subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
+			subnetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(subnetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(subnetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
-	}
-	if !ok {
-		err := fmt.Errorf("failed to deregister the subnet (%s)", subnetId)
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
-		model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
-		subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
-		subnetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(subnetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(subnetKey, string(failVal))
+		if !ok {
+			err := fmt.Errorf("failed to deregister the subnet (%s)", subnetId)
+			log.Error().Err(err).Msg("")
+			// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
+			model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
+			subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
+			subnetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(subnetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(subnetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
 	}
 
 	// Delete the saved the subnet info
@@ -1527,6 +1521,7 @@ func DeregisterSubnet(nsId string, vNetId string, subnetId string) (model.Simple
 
 	// [Output] the message
 	ret.Message = fmt.Sprintf("the subnet (%s) has been deregistered", subnetId)
+	log.Info().Msgf("Subnet deregistered: id=%s", subnetId)
 
 	return ret, nil
 }

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +31,7 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
+	resty "github.com/go-resty/resty/v2"
 	validator "github.com/go-playground/validator/v10"
 	"github.com/rs/zerolog/log"
 )
@@ -97,7 +99,7 @@ func VNetReqStructLevelValidation(sl validator.StructLevel) {
 
 func ValidateVNetReq(vNetReq *model.VNetReq) error {
 	log.Debug().Msg("ValidateVNetReq")
-	log.Debug().Msgf("vNetReq: %+v", vNetReq)
+	log.Trace().Msgf("vNetReq: %+v", vNetReq)
 
 	// * 1. Validates that each struct fields follows the rules in its 'validate' tags.
 	err := validate.Struct(vNetReq)
@@ -191,7 +193,7 @@ func ValidateVNetReq(vNetReq *model.VNetReq) error {
 		subnets = append(subnets, subnet)
 	}
 	network.Subnets = subnets
-	log.Debug().Msgf("network: %+v", network)
+	log.Trace().Msgf("network: %+v", network)
 
 	// Validate the network object
 	err = netutil.ValidateNetwork(network)
@@ -527,7 +529,7 @@ func CreateVNet(ctx context.Context, nsId string, vNetReq *model.VNetReq) (model
 		})
 	}
 
-	log.Debug().Msgf("vNetInfo(initial): %+v", vNetInfo)
+	log.Trace().Msgf("vNetInfo(initial): %+v", vNetInfo)
 
 	// Set a vNetKey for the vNet object
 	vNetKey := common.GenResourceKey(nsId, resourceType, vNetInfo.Id)
@@ -583,7 +585,7 @@ func CreateVNet(ctx context.Context, nsId string, vNetReq *model.VNetReq) (model
 		})
 	}
 
-	log.Debug().Msgf("spReqt: %+v", spReqt)
+	log.Trace().Msgf("spReqt: %+v", spReqt)
 
 	client := clientManager.NewHttpClient()
 	method := "POST"
@@ -592,7 +594,7 @@ func CreateVNet(ctx context.Context, nsId string, vNetReq *model.VNetReq) (model
 	// API to create a vNet
 	url := fmt.Sprintf("%s/vpc", model.SpiderRestUrl)
 
-	log.Debug().Msgf("[Request to Spider] Creating VPC (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Creating VPC: %s", url)
 
 	// Cleanup object when something goes wrong
 	defer func() {
@@ -628,7 +630,7 @@ func CreateVNet(ctx context.Context, nsId string, vNetReq *model.VNetReq) (model
 		}
 	}()
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -639,10 +641,14 @@ func CreateVNet(ctx context.Context, nsId string, vNetReq *model.VNetReq) (model
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Creating VPC (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Creating VPC: %+v", spResp)
 
 	if err != nil {
-		log.Error().Err(err).Msg("")
+		if restyResp != nil {
+			log.Error().Err(err).Int("statusCode", restyResp.StatusCode()).Msg("")
+		} else {
+			log.Error().Err(err).Msg("")
+		}
 		return emptyRet, err
 	}
 
@@ -693,7 +699,8 @@ func CreateVNet(ctx context.Context, nsId string, vNetReq *model.VNetReq) (model
 	vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
 	vNetInfo.SystemMessage = ""
 
-	log.Debug().Msgf("vNetInfo(filled): %+v", vNetInfo)
+	log.Debug().Msgf("VNet created in CSP: id=%s, cspId=%s, cidr=%s", vNetInfo.Id, vNetInfo.CspResourceId, vNetInfo.CidrBlock)
+	log.Trace().Msgf("vNetInfo(filled): %+v", vNetInfo)
 
 	// Store vNet object into the key-value store
 	value, err := json.Marshal(vNetInfo)
@@ -784,11 +791,12 @@ func CreateVNet(ctx context.Context, nsId string, vNetReq *model.VNetReq) (model
 		return emptyRet, err
 	}
 
+	log.Info().Msgf("VNet created: id=%s, cidr=%s, subnets=%d", vNetInfo.Id, vNetInfo.CidrBlock, len(vNetInfo.SubnetInfoList))
 	return vNetInfo, nil
 }
 
 func GetVNet(nsId string, vNetId string) (model.VNetInfo, error) {
-	log.Info().Msg("GetVNet")
+	log.Debug().Msg("GetVNet")
 
 	// vNet object
 	var emptyRet model.VNetInfo
@@ -834,62 +842,14 @@ func GetVNet(nsId string, vNetId string) (model.VNetInfo, error) {
 		return emptyRet, err
 	}
 
-	log.Debug().Msgf("vNetInfo: %+v", vNetInfo)
-
-	/*
-	 *	Get vNet info
-	 */
-
-	// [Via Spider] Get a vNet and subnets
-	client := clientManager.NewHttpClient()
-	method := "GET"
-	spReqt := clientManager.NoBody
-	var spResp spiderVPCInfo
-
-	// API to create a vNet
-	url := fmt.Sprintf("%s/vpc/%s", model.SpiderRestUrl, vNetInfo.CspResourceName)
-	queryParams := "?ConnectionName=" + vNetInfo.ConnectionName
-	url += queryParams
-
-	log.Debug().Msgf("[Request to Spider] Getting VPC (url: %s, request body: %+v)", url, spReqt)
-
-	_, err = clientManager.ExecuteHttpRequest(
-		client,
-		method,
-		url,
-		nil,
-		clientManager.SetUseBody(spReqt),
-		&spReqt,
-		&spResp,
-		clientManager.MediumDuration,
-	)
-
-	log.Debug().Msgf("[Response from Spider] Getting VPC (response body: %+v)", spResp)
-
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
+	// Derive status from conditions stored in KV store
+	vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
+	for i := range vNetInfo.SubnetInfoList {
+		vNetInfo.SubnetInfoList[i].Status = model.DeriveSubnetStatus(vNetInfo.SubnetInfoList[i].Conditions)
 	}
 
-	// Set the vNet object with the response from the Spider
-	vNetInfo.CspResourceId = spResp.IId.SystemId
-	vNetInfo.CspResourceName = spResp.IId.NameId
-	// Intentionally use the user-provided vNet CIDR block managed by Tumblebug for multi-cloud network management purpose
-	// vNetInfo.CidrBlock = spResp.IPv4_CIDR
-	vNetInfo.KeyValueList = spResp.KeyValueList
-
-	// TODO: Check if it's required or not to save the vNet object
-	// val, err := json.Marshal(vNetInfo)
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("")
-	// 	return emptyRet, err
-	// }
-
-	// err = kvstore.Put(vNetKey, string(val))
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("")
-	// 	return emptyRet, err
-	// }
+	log.Debug().Msgf("VNet retrieved: id=%s, status=%s", vNetInfo.Id, vNetInfo.Status)
+	log.Trace().Msgf("vNetInfo: %+v", vNetInfo)
 
 	return vNetInfo, nil
 }
@@ -936,7 +896,8 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	log.Debug().Msgf("subnetsKv: %+v", subnetsKv)
+	log.Debug().Msgf("Deleting VNet: %s (action: %s, subnets: %d)", vNetId, action, len(subnetsKv))
+	log.Trace().Msgf("subnetsKv: %+v", subnetsKv)
 
 	// normal case: action == ""
 	if action == ActionNone && len(subnetsKv) > 0 {
@@ -1027,6 +988,7 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 
 	trials := 2
 	seconds := uint64(3)
+	var restyResp *resty.Response
 	ok := false
 	// Sleep and retry if the vNet deletion fails
 	for i := range trials {
@@ -1036,14 +998,14 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 		// Sleep for a while before retrying
 		time.Sleep(time.Duration(seconds) * time.Second)
 
-		log.Debug().Msgf("[Request to Spider] Deleting VPC (url: %s, request body: %+v)", url, spReqt)
+		log.Debug().Msgf("[Request to Spider] Deleting VPC: %s", url)
 
 		var spResp spiderBooleanInfoResp
 
 		client := clientManager.NewHttpClient()
 		method := "DELETE"
 
-		_, err = clientManager.ExecuteHttpRequest(
+		restyResp, err = clientManager.ExecuteHttpRequest(
 			client,
 			method,
 			url,
@@ -1054,9 +1016,15 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 			clientManager.MediumDuration,
 		)
 
-		log.Debug().Msgf("[Response from Spider] Deleting VPC (response body: %+v)", spResp)
+		log.Trace().Msgf("[Response from Spider] Deleting VPC: %+v", spResp)
 
 		if err != nil {
+			if restyResp != nil && restyResp.StatusCode() == http.StatusNotFound {
+				log.Info().Msgf("VPC (%s) not found on CSP, treating as already deleted", vNetId)
+				ok = true
+				err = nil
+				break
+			}
 			log.Error().Err(err).Msg("")
 			continue
 		}
@@ -1193,9 +1161,9 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 	queryParams := "?ConnectionName=" + vNetInfo.ConnectionName
 	url += queryParams
 
-	log.Debug().Msgf("[Request to Spider] Reconciling VPC (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Reconciling VPC: %s", url)
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -1206,12 +1174,15 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Reconciling VPC (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Reconciling VPC: %+v", spResp)
 
-	// if err != nil {
-	// 	log.Error().Err(err).Msg("")
-	// 	return emptyRet, err
-	// }
+	// Only proceed with cleanup when the VPC is confirmed not found (404).
+	// For server errors (5xx) or transport errors, return the error without cleanup
+	// to prevent accidental data loss during Spider/CSP outages.
+	if err != nil && (restyResp == nil || restyResp.StatusCode() != http.StatusNotFound) {
+		log.Error().Err(err).Msg("failed to get VPC from Spider, skipping reconciliation")
+		return emptyRet, err
+	}
 
 	if err == nil {
 		err = fmt.Errorf("may not be reconciled, vNet info (id: %s) exists", vNetId)
@@ -1232,7 +1203,7 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 				log.Warn().Err(err2).Msg("")
 				// return emptyRet, err
 			}
-			log.Debug().Msgf("subnetInfo: %+v", subnetInfo)
+			log.Trace().Msgf("subnetInfo: %+v", subnetInfo)
 
 			_, err2 := ReconcileSubnet(nsId, vNetId, subnetInfo.Id)
 			if err2 != nil {
@@ -1414,7 +1385,7 @@ func RegisterVNet(ctx context.Context, nsId string, vNetRegisterReq *model.Regis
 		spReqt = spiderVPCRegisterRequest{}
 	}
 
-	log.Debug().Msgf("[Request to Spider] Registering VPC (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Registering VPC: %s", url)
 
 	// Clean up the vNet object when something goes wrong
 	defer func() {
@@ -1450,7 +1421,7 @@ func RegisterVNet(ctx context.Context, nsId string, vNetRegisterReq *model.Regis
 		}
 	}()
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -1461,10 +1432,14 @@ func RegisterVNet(ctx context.Context, nsId string, vNetRegisterReq *model.Regis
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Registering VPC (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Registering VPC: %+v", spResp)
 
 	if err != nil {
-		log.Error().Err(err).Msg("")
+		if restyResp != nil {
+			log.Error().Err(err).Int("statusCode", restyResp.StatusCode()).Msg("")
+		} else {
+			log.Error().Err(err).Msg("")
+		}
 		return emptyRet, err
 	}
 
@@ -1542,7 +1517,8 @@ func RegisterVNet(ctx context.Context, nsId string, vNetRegisterReq *model.Regis
 
 	}
 
-	log.Debug().Msgf("vNetInfo: %+v", vNetInfo)
+	log.Debug().Msgf("VNet registered: id=%s, cspId=%s, cidr=%s", vNetInfo.Id, vNetInfo.CspResourceId, vNetInfo.CidrBlock)
+	log.Trace().Msgf("vNetInfo: %+v", vNetInfo)
 
 	// [Conditions] VNet registration succeeded → mark as ready, synced, and update children status
 	model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionTrue, model.ReasonAvailable, "")
@@ -1656,7 +1632,8 @@ func DeregisterVNet(nsId string, vNetId string, withSubnets string) (model.Simpl
 		log.Error().Err(err).Msg("")
 		return emptyRet, err
 	}
-	log.Debug().Msgf("subnetsKv: %+v", subnetsKv)
+	log.Debug().Msgf("Deregistering VNet: %s (withSubnets: %s, subnets: %d)", vNetId, withSubnets, len(subnetsKv))
+	log.Trace().Msgf("subnetsKv: %+v", subnetsKv)
 
 	if withSubnets == "false" && len(subnetsKv) > 0 {
 		err := fmt.Errorf("cannot deregister vNet (%s): has %d subnet(s); set withSubnets=true", vNetId, len(subnetsKv))
@@ -1726,14 +1703,14 @@ func DeregisterVNet(nsId string, vNetId string, withSubnets string) (model.Simpl
 	// API to delete a vNet
 	url := fmt.Sprintf("%s/regvpc/%s", model.SpiderRestUrl, vNetInfo.CspResourceName)
 
-	log.Debug().Msgf("[Request to Spider] Deregistering VPC (url: %s, request body: %+v)", url, spReqt)
+	log.Debug().Msgf("[Request to Spider] Deregistering VPC: %s", url)
 
 	var spResp spiderBooleanInfoResp
 
 	client := clientManager.NewHttpClient()
 	method := "DELETE"
 
-	_, err = clientManager.ExecuteHttpRequest(
+	restyResp, err := clientManager.ExecuteHttpRequest(
 		client,
 		method,
 		url,
@@ -1744,45 +1721,56 @@ func DeregisterVNet(nsId string, vNetId string, withSubnets string) (model.Simpl
 		clientManager.MediumDuration,
 	)
 
-	log.Debug().Msgf("[Response from Spider] Deregistering VPC (response body: %+v)", spResp)
+	log.Trace().Msgf("[Response from Spider] Deregistering VPC: %+v", spResp)
 
 	if err != nil {
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
-		model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
-		vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
-		vNetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(vNetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(vNetKey, string(failVal))
+		if restyResp != nil && restyResp.StatusCode() == http.StatusNotFound {
+			// Spider returned 404: resource already gone from Spider
+			// Proceed with local cleanup (same as success path)
+			log.Info().Msgf("VNet (%s) not found on Spider (404), proceeding with local cleanup", vNetInfo.Id)
+		} else {
+			if restyResp != nil {
+				log.Error().Err(err).Int("statusCode", restyResp.StatusCode()).Msg("")
+			} else {
+				log.Error().Err(err).Msg("")
+			}
+			// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
+			model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
+			vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
+			vNetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(vNetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(vNetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
-	}
-	ok, err := strconv.ParseBool(spResp.Result)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
-		model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
-		vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
-		vNetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(vNetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(vNetKey, string(failVal))
+	} else {
+		ok, err := strconv.ParseBool(spResp.Result)
+		if err != nil {
+			log.Error().Err(err).Msg("")
+			// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
+			model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
+			vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
+			vNetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(vNetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(vNetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
-	}
-	if !ok {
-		err := fmt.Errorf("failed to deregister the vNet (%s)", vNetId)
-		log.Error().Err(err).Msg("")
-		// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
-		model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
-		vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
-		vNetInfo.SystemMessage = err.Error()
-		failVal, marshalErr := json.Marshal(vNetInfo)
-		if marshalErr == nil {
-			_ = kvstore.Put(vNetKey, string(failVal))
+		if !ok {
+			err := fmt.Errorf("failed to deregister the vNet (%s)", vNetId)
+			log.Error().Err(err).Msg("")
+			// [Conditions] Deregistration failed → mark as Failed to prevent stuck state
+			model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeregisterFailed, err.Error())
+			vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
+			vNetInfo.SystemMessage = err.Error()
+			failVal, marshalErr := json.Marshal(vNetInfo)
+			if marshalErr == nil {
+				_ = kvstore.Put(vNetKey, string(failVal))
+			}
+			return emptyRet, err
 		}
-		return emptyRet, err
 	}
 
 	// Delete the saved the vNet info

--- a/src/interface/rest/server/resource/vnet.go
+++ b/src/interface/rest/server/resource/vnet.go
@@ -339,7 +339,7 @@ func RestPostRegisterVNet(c echo.Context) error {
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param vNetId path string true "VNet ID"
 // @Param withSubnets query string false "Delete subnets as well" Enums(true,false)
-// @Success 201 {object} model.VNetInfo
+// @Success 200 {object} model.VNetInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-request-id header string false "Custom request ID for tracking"
@@ -382,5 +382,5 @@ func RestDeleteDeregisterVNet(c echo.Context) error {
 	}
 
 	// [Output] Return the deregistered result
-	return c.JSON(http.StatusCreated, resp)
+	return c.JSON(http.StatusOK, resp)
 }


### PR DESCRIPTION
- Return VNetInfo or SubnetInfo from KV store without live Spider GET calls
- Handle CSP/Spider 404 as already-deleted in Delete/Deregister flows
- Skip Reconcile cleanup on 5xx and transport errors to prevent data loss
- Reduce Debug noise by moving raw struct dumps to Trace and adding concise key-field messages
- Fix DeregisterVNet HTTP response status from 201 to 200


**Test result by MapUI**

1. Select the `global-infra-test` template
<img width="1921" height="1197" alt="image" src="https://github.com/user-attachments/assets/eee065ed-7360-4cf2-8a3a-cd6031daebe5" />


2. Leave only IBM Infra
<img width="1921" height="1198" alt="image" src="https://github.com/user-attachments/assets/52416904-da2e-44a4-820c-8a9a8728b33b" />


3. Result
<img width="1927" height="1198" alt="image" src="https://github.com/user-attachments/assets/1ee46290-493f-417c-9c8a-33423ae08e66" />


