### PR TITLE
Fix minor MCP server errer

### DIFF
--- a/src/interface/mcp/tb-mcp.py
+++ b/src/interface/mcp/tb-mcp.py
@@ -4516,7 +4516,7 @@ def execute_remote_commands_enhanced(
 @mcp.tool()
 def analyze_provisioning_risk(
     spec_id: str,
-    image_name: Optional[str] = None
+    csp_image_name: str
 ) -> Dict:
     """
     Analyze the likelihood of provisioning failure based on historical data for a specific VM specification and image combination.
@@ -4555,8 +4555,8 @@ def analyze_provisioning_risk(
     
     Args:
         spec_id: VM specification ID (e.g., "aws+ap-northeast-2+t2.small")
-        image_name: Optional image name for combined risk analysis
-    
+        csp_image_name: CSP-specific image name/ID (required, e.g., "ami-0c02fb55956c7d316" for AWS)
+
     Returns:
         Risk analysis results including:
         - overall_risk: Risk level (high/medium/low/unknown)
@@ -4568,28 +4568,26 @@ def analyze_provisioning_risk(
     """
     try:
         url = f"/provisioning/risk/{spec_id}"
-        params = {}
-        if image_name:
-            params["imageName"] = image_name
-        
+        params = {"cspImageName": csp_image_name}
+
         result = api_request("GET", url, params=params)
-        
+
         # Store interaction for future reference
         store_interaction_memory(
-            user_request=f"Analyze provisioning risk for spec '{spec_id}'" + (f" with image '{image_name}'" if image_name else ""),
+            user_request=f"Analyze provisioning risk for spec '{spec_id}' with image '{csp_image_name}'",
             llm_response=f"Risk analysis completed - Level: {result.get('riskLevel', 'unknown')}",
             operation_type="risk_analysis",
-            context_data={"spec_id": spec_id, "image_name": image_name, "risk_level": result.get('riskLevel')},
+            context_data={"spec_id": spec_id, "csp_image_name": csp_image_name, "risk_level": result.get('riskLevel')},
             status="completed"
         )
         
         return result
-        
+
     except Exception as e:
         return {
             "error": f"Failed to analyze provisioning risk: {str(e)}",
             "spec_id": spec_id,
-            "suggestion": "Check if spec ID format is correct (provider+region+spec_name)"
+            "suggestion": "Check spec ID format (provider+region+spec_name) and provide a valid cspImageName"
         }
 
 
@@ -4597,7 +4595,7 @@ def analyze_provisioning_risk(
 @mcp.tool()
 def get_detailed_provisioning_risk(
     spec_id: str,
-    image_name: Optional[str] = None
+    csp_image_name: str
 ) -> Dict:
     """
     Get comprehensive provisioning risk analysis with separate spec and image risk assessment.
@@ -4631,12 +4629,12 @@ def get_detailed_provisioning_risk(
     
     Args:
         spec_id: VM specification ID for detailed analysis
-        image_name: Optional image name for combined detailed analysis
-    
+        csp_image_name: CSP-specific image name/ID (required, e.g., "ami-0c02fb55956c7d316" for AWS)
+
     Returns:
         Detailed risk analysis including:
         - spec_risk: Detailed spec-specific risk assessment
-        - image_risk: Image-specific risk analysis (if image provided)
+        - image_risk: Image-specific risk analysis
         - combined_risk: Overall risk when using spec+image together
         - detailed_recommendations: Specific actionable recommendations
         - risk_factors: Breakdown of individual risk contributors
@@ -4645,21 +4643,19 @@ def get_detailed_provisioning_risk(
     """
     try:
         url = "/provisioning/risk/detailed"
-        params = {"specId": spec_id}
-        if image_name:
-            params["imageName"] = image_name
-        
+        params = {"specId": spec_id, "cspImageName": csp_image_name}
+
         result = api_request("GET", url, params=params)
         
         # Store detailed analysis for future reference
         store_interaction_memory(
-            user_request=f"Get detailed provisioning risk analysis for spec '{spec_id}'" + (f" with image '{image_name}'" if image_name else ""),
+            user_request=f"Get detailed provisioning risk analysis for spec '{spec_id}' with image '{csp_image_name}'",
             llm_response=f"Detailed risk analysis completed - Spec Risk: {result.get('specRisk', {}).get('riskLevel', 'unknown')}, Overall: {result.get('overallRisk', {}).get('riskLevel', 'unknown')}",
             operation_type="detailed_risk_analysis",
-            context_data={"spec_id": spec_id, "image_name": image_name, "analysis_type": "detailed"},
+            context_data={"spec_id": spec_id, "csp_image_name": csp_image_name, "analysis_type": "detailed"},
             status="completed"
         )
-        
+
         return result
         
     except Exception as e:


### PR DESCRIPTION
### Bug Fixes

| # | Location | Issue | Fix |
|---|---|---|---|
| 1 | `execute_command_infra` | Query param `vmId` not recognized by REST API | Changed to `nodeId` |
| 2 | `execute_remote_commands_enhanced` | Same `vmId` bug passed through to `execute_command_infra` | Changed to `node_id` |
| 3 | `transfer_file_infra` | Query param `vmId` not recognized by REST API | Changed to `nodeId` |
| 4 | `get_detailed_provisioning_risk` | URL `/tumblebug/provisioning/risk/detailed` had double `/tumblebug` prefix (base URL already includes it) | Fixed to `/provisioning/risk/detailed` |
| 5 | `check_infra_status_and_handle_failures` | Read `target_infra_status.get("vm", [])` but `InfraStatusInfo` JSON field is `"node"` | Changed to `"node"` |
| 6 | `check_infra_status_and_handle_failures` | Read `vm.get("cspVmId")` which does not exist in `NodeStatusInfo` | Changed to `cspResourceId` |
| 7 | `analyze_provisioning_risk` | Used `imageName` query param (optional); REST API requires `cspImageName` (mandatory) | Renamed param to `csp_image_name: str` (required) |
| 8 | `get_detailed_provisioning_risk` | Same `imageName` vs `cspImageName` mismatch | Renamed param to `csp_image_name: str` (required) |

---

### Test

| Category | Tools Tested | Result |
|---|---|---|
| Namespace | `get_namespaces`, `get_namespace`, `validate_namespace`, `check_and_prepare_namespace` | ✅ All pass |
| Connection | `get_connections`, `get_connections_with_options` (208 connections verified) | ✅ All pass |
| Resources | `get_vnets`, `get_security_groups`, `get_ssh_keys`, `check_resource_exists` | ✅ All pass |
| Infra | `get_infra_list`, `get_infra_list_with_options` | ✅ All pass |
| Spec / Image | `get_recommend_spec_options`, `get_image_search_options` | ✅ All pass |
| Provisioning Risk | `analyze_provisioning_risk`, `get_detailed_provisioning_risk`, `get_provisioning_history` | ✅ All pass |
| Labels | `create_or_update_labels`, `get_labels`, `get_resources_by_label` | ✅ All pass |
| New tool signatures | 15 new/updated tool signatures verified | ✅ All pass |

**Key validation confirmed during testing:**

- `InfraStatusInfo` status response uses `"node"` field (not `"vm"`) — verified at runtime
- `GET /provisioning/risk/detailed` resolves correctly without double `/tumblebug` prefix
- `cspImageName` (required) correctly replaces `imageName` (optional) for provisioning risk APIs
- HTTP 204 No Content from provisioning log API handled gracefully → `{"message": "Success (No content)"}`


---

### Renamed / Updated Tool Interfaces

| Tool | Change |
|---|---|
| `get_vms` | Renamed to `get_nodes_in_nodegroup` to match current terminology |
| `execute_command_infra` | Parameter `vm_id` → `node_id` |
| `transfer_file_infra` | Parameter `vm_id` → `node_id` |
| `execute_remote_commands_enhanced` | Parameter `vm_id` → `node_id` |
| `analyze_provisioning_risk` | Parameter `image_name: Optional[str]` → `csp_image_name: str` |
| `get_detailed_provisioning_risk` | Parameter `image_name: Optional[str]` → `csp_image_name: str` |

---

### New Tools Added

Eight new tools were added to cover APIs introduced in v0.11.9–v0.11.13.

| Tool | HTTP | Description |
|---|---|---|
| `list_node_command_status` | `GET /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus` | List remote command execution history for a node (supports filtering by status, requestId, and pagination) |
| `get_node_command_status` | `GET /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatus/{index}` | Get a specific command status record by index |
| `clear_all_node_command_status` | `DELETE /ns/{nsId}/infra/{infraId}/node/{nodeId}/commandStatusAll` | Clear all command history for a node |
| `get_node_handling_command_count` | `GET /ns/{nsId}/infra/{infraId}/node/{nodeId}/handlingCount` | Get the number of in-progress commands on a node |
| `get_infra_handling_command_count` | `GET /ns/{nsId}/infra/{infraId}/handlingCount` | Get total in-progress command count across all nodes in an Infra |
| `check_available_region_zones_for_spec` | `POST /availableRegionZonesForSpec` | Verify which region zones can provision a given spec |
| `check_available_region_zones_for_spec_list` | `POST /availableRegionZonesForSpecList` | Batch version of the above for multiple specs |
| `update_existing_spec_list_by_available_region_zones` | `POST /ns/{nsId}/updateExistingSpecListByAvailableRegionZones` | Refresh spec availability data from CSP |

---