### PR TITLE
Update strUidPrefix by removing special charactor

### DIFF
--- a/src/core/model/common.go
+++ b/src/core/model/common.go
@@ -201,7 +201,7 @@ var ORM *gorm.DB
 
 const (
 	StrManager               string = "cb-tumblebug"
-	StrUidPrefix             string = "tb-"
+	StrUidPrefix             string = "tb"
 	StrSpiderRestUrl         string = "TB_SPIDER_REST_URL"
 	StrDragonflyRestUrl      string = "TB_DRAGONFLY_REST_URL"
 	StrTerrariumRestUrl      string = "TB_TERRARIUM_REST_URL"


### PR DESCRIPTION
3:"NodeGroup 'g16-tencent-na-siliconvalley': failed to create default SSHKey for VM 'g16-tencent-na-siliconvalley' in namespace 'default' using connection 'tencent-na-siliconvalley': [TencentCloudSDKError] Code=InvalidParameterValue, Message=The specified key pair name `tb-d7krs1hbfk1gle8r7ud0` is include illegal character `-`., RequestId=19f814da-6e4e-4485-aea7-08ad5bfd1488 (from cb-spider:1024/spider/keypair (500 Internal Server Error)). This may be due to CSP quotas, permissions, or key generation issues"


 [TencentCloudSDKError] Code=InvalidParameterValue, Message=The specified key pair name `tb-d7krs1hbfk1gle8r7ud0` is include illegal character `-`.

:)