### PR TITLE
Enhance failure handing in vNet and subnet deletion

### DIFF
--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
@@ -729,7 +728,7 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 
 	if err != nil {
 		if errutil.IsNotFoundError(err) {
-			log.Info().Msgf("Subnet (%s) not found on CSP, treating as already deleted and proceeding with local cleanup", subnetInfo.Id)
+			log.Info().Msgf("Subnet (%s) not found on CSP, treating as already deleted", subnetInfo.Id)
 		} else {
 			log.Error().Err(err).Msg("")
 			// [Conditions] Deletion failed → mark as Failed to prevent stuck state
@@ -757,46 +756,44 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 			return emptyRet, err
 		}
 		if !ok {
-			err := fmt.Errorf("failed to delete the subnet (%s)", subnetInfo.Id)
-			log.Error().Err(err).Msg("")
-			// [Conditions] Deletion failed → mark as Failed to prevent stuck state
-			model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, err.Error())
-			subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
-			subnetInfo.SystemMessage = err.Error()
-			failVal, marshalErr := json.Marshal(subnetInfo)
-			if marshalErr == nil {
-				_ = kvstore.Put(subnetKey, string(failVal))
+			// Spider returned HTTP 200 + Result:false. Some CSPs (e.g. GCP) return 404
+			// for a subnet that is already gone, but Spider does not always propagate
+			// that 404 status — it may wrap it as HTTP 200 + false instead.
+			// Verify via a Spider GET before treating this as a hard failure.
+			verifyURL := fmt.Sprintf("%s/vpc/%s/subnet/%s?ConnectionName=%s",
+				model.SpiderRestUrl, subnetInfo.CspVNetName, subnetInfo.CspResourceName, subnetInfo.ConnectionName)
+			verifyClient := clientManager.NewHttpClient()
+			var verifyResp spiderSubnetInfo
+			verifyNoBody := clientManager.NoBody
+			verifyRestyResp, verifyErr := clientManager.ExecuteHttpRequest(
+				verifyClient, "GET", verifyURL, nil,
+				clientManager.SetUseBody(verifyNoBody),
+				&verifyNoBody,
+				&verifyResp,
+				clientManager.MediumDuration,
+			)
+			verifyErr = clientManager.HandleHttpResponse(verifyRestyResp, verifyErr)
+			if errutil.IsNotFoundError(verifyErr) {
+				log.Info().Msgf("Subnet (%s) not found on CSP, treating as already deleted", subnetInfo.Id)
+			} else {
+				if verifyErr != nil {
+					log.Warn().Err(verifyErr).Msgf("Subnet (%s) deletion could not be verified — treating as failure", subnetInfo.Id)
+				}
+				delErr := fmt.Errorf("failed to delete the subnet (%s)", subnetInfo.Id)
+				log.Error().Err(delErr).Msg("")
+				// [Conditions] Deletion failed → mark as Failed to prevent stuck state
+				model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, delErr.Error())
+				subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
+				subnetInfo.SystemMessage = delErr.Error()
+				failVal, marshalErr := json.Marshal(subnetInfo)
+				if marshalErr == nil {
+					_ = kvstore.Put(subnetKey, string(failVal))
+				}
+				return emptyRet, delErr
 			}
-			return emptyRet, err
 		}
 	}
 
-	// Verify deletion by checking subnet status after deletion request
-	maxRetries := 5
-	for i := 0; i < maxRetries; i++ {
-		log.Debug().Msgf("Waiting 3 seconds (attempt %d/%d) before checking subnet deletion status via GetSubnet", i+1, maxRetries)
-		time.Sleep(3 * time.Second)
-
-		// Use GetSubnet to check if subnet still exists
-		log.Debug().Msgf("Checking if subnet (%s) still exists", subnetInfo.Id)
-		_, checkErr := GetSubnet(nsId, vNetId, subnetId)
-
-		if checkErr != nil {
-			errMsg := checkErr.Error()
-			// Only treat "not found" errors as confirmed deletion
-			if strings.Contains(errMsg, "does not exist") || strings.Contains(errMsg, "404") {
-				log.Info().Msgf("Confirmed subnet (%s) deletion", subnetInfo.Id)
-				break
-			}
-			// Other errors (5xx, transport) — cannot confirm deletion, log and retry
-			log.Warn().Err(checkErr).Msgf("Error checking subnet (%s) deletion status, will retry", subnetInfo.Id)
-		}
-
-		// If this was the last attempt and subnet still exists or status is unknown, log warning but continue
-		if i == maxRetries-1 {
-			log.Warn().Msgf("Subnet (%s) deletion could not be confirmed after %d attempts, proceeding with local cleanup", subnetInfo.Id, maxRetries)
-		}
-	}
 
 	// Delete the saved the subnet info
 	err = kvstore.Delete(subnetKey)

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -988,9 +988,8 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 	for i := range trials {
 		if i > 0 {
 			log.Warn().Msgf("Retrying to delete vNet (%s) after %d seconds...", vNetId, seconds)
+			time.Sleep(time.Duration(seconds) * time.Second)
 		}
-		// Sleep for a while before retrying
-		time.Sleep(time.Duration(seconds) * time.Second)
 
 		log.Debug().Msgf("[Request to Spider] Deleting VPC: %s", url)
 


### PR DESCRIPTION
This PR enhances failure handing in vNet and subnet deletion.
To resolve issues identified during massive resource clearing up (register existing CSP resources -> delete unused resources) :)

When deleting 100 GCP vNets in parallel, **33 succeeded / 67 failed**. (overall, 736 vNets from GCP)
The failed vNets left behind "dangling records" in CB-TB's etcd (resources already gone from GCP but still tracked locally)

<img width="1139" height="627" alt="image" src="https://github.com/user-attachments/assets/4bec43da-f9e5-4885-9d18-be010cb04ca2" />


### cause of the 67 failures

Fix 1's bug caused GCP resources to be deleted while CB-TB's etcd records remained,
accumulating dangling records over prior deletion attempts.

```
Attempt 1:  GCP subnet deletion succeeds
            → Spider returns HTTP 200 + false  (Fix 2 bug)
            → CB-TB treats as failure → etcd record kept

Attempt 2:  Subnet no longer exists on GCP
            → Spider returns HTTP 200 + false  (same bug)
            → CB-TB (before fix): fails again
            → CB-TB (after fix):  GET confirms 404 → etcd cleaned up → success
```


---

## Fix 1 - Spider wraps GCP Subnet 404 as **HTTP 200** + **false**

When a subnet no longer exists on GCP (404), Spider does not propagate the
404 HTTP status to CB-TB. 
Instead, it returns **HTTP 200 + `{"Result":"false"}`**.

Because CB-TB receives HTTP 200, `errutil.IsNotFoundError` never fires, and
`Result:false` is treated unconditionally as a deletion failure.

```
Spider log: googleapi: Error 404: The resource ... was not found, notFound
CB-TB recv: responseBody={"Result":"false"} status=200
```

| Case | Spider → CB-TB | CB-TB behavior (before fix) |
|---|---|---|
| VPC 404 | HTTP 404 | `IsNotFoundError` works → handled correctly ✓ |
| Subnet 404 | **HTTP 200 + false** | `IsNotFoundError` skipped → reported as failure ✗ |

**Fix**: Instead of treating `Result:false` as an immediate hard failure, issue a Spider
GET to verify whether the subnet still exists on the CSP.

```go
// Before
if !ok {
    return emptyRet, fmt.Errorf("failed to delete the subnet (%s)", ...)
}

// After
if !ok {
    verifyURL := fmt.Sprintf("%s/vpc/%s/subnet/%s?ConnectionName=%s", ...)
    // Spider GET call
    verifyErr = clientManager.HandleHttpResponse(verifyRestyResp, verifyErr)

    if errutil.IsNotFoundError(verifyErr) {
        // GET returned 404 → subnet is gone → fall through to etcd cleanup
        log.Info().Msgf("Subnet (%s) not found on CSP, treating as already deleted", ...)
    } else {
        if verifyErr != nil {
            // GET itself failed (5xx, network error, etc.) → state uncertain
            log.Warn().Err(verifyErr).Msgf("Subnet (%s) deletion could not be verified — treating as failure", ...)
        }
        // GET returned 200 → subnet still exists, or verification failed → real failure
        return emptyRet, fmt.Errorf("failed to delete the subnet (%s)", ...)
    }
}
```

**Final decision tree**:

```
Spider DELETE response

├─ err != nil, IsNotFoundError   →  already gone → clean up etcd, return success
├─ err != nil (other)            →  return error
├─ ok == true                    →  deleted successfully → clean up etcd, return success
└─ ok == false (Result:false)    →  Spider GET to verify
   ├─ GET → 404                  →  already gone → clean up etcd, return success
   ├─ GET → 200                  →  subnet still exists → return error
   └─ GET → other error          →  state uncertain → log Warn + return error
```

---

## Fix 2 - Removal of post-deletion verification loop

After a Spider DELETE call, a loop polled `GetSubnet` up to 5 times with a
3-second sleep between each attempt to "verify" CSP-side deletion. 

However,
`GetSubnet` reads only from **etcd**, and `kvstore.Delete` (the actual etcd removal)
runs *after* the loop. 

This means the subnet record is always present in etcd
throughout the loop, so the "not found" condition can never be met. 

As a result,
every single subnet deletion (regardless of outcome) incurred a 15-second delay
(3s × 5) and always emitted a misleading `"deletion could not be confirmed after 5 attempts"` warning.

```go
// Before - removed entirely
for i := 0; i < maxRetries; i++ {
    time.Sleep(3 * time.Second)
    _, checkErr := GetSubnet(...)  // reads etcd only → subnet always found here
    if checkErr != nil { ... }
    if i == maxRetries-1 {
        log.Warn().Msgf("deletion could not be confirmed after %d attempts", maxRetries)
    }
}
```

**Fix**: Loop removed entirely. Deletion is considered confirmed once Spider returns
`Result:true` or NotFound. The `Result:false` case is handled by the GET verification
in Fix 1.

---

## Minor Fix - Unnecessary 3-second sleep before first VPC deletion attempt

time.Sleep in the retry loop executed even on the first attempt (`i=0`),
adding an unnecessary 3-second delay before every VPC deletion.

```go
// Before
for i := range trials {
    if i > 0 {
        log.Warn().Msgf("Retrying to delete vNet (%s) ...", vNetId, seconds)
    }
    time.Sleep(...)  // executed even for i=0
    // Spider DELETE call
}

// After
for i := range trials {
    if i > 0 {
        log.Warn().Msgf("Retrying to delete vNet (%s) ...", vNetId, seconds)
        time.Sleep(...)  // only between retries
    }
    // Spider DELETE call
}
```

---

## Verification

After applying all three fixes, 100 GCP vNets were deleted in parallel batches of 10.
**All 736 deletions completed successfully.** 

Also, deletions in AWS has been passed.