### PR TITLE
Update AWS EKS supported K8s versions to 1.33/1.34/1.35

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -22,20 +22,20 @@ k8scluster:
     requiredSubnetCount: 2
     version:
       - region: [common]
-        available:
+        available: # Updated: 2026-05-11 (verified with aws eks describe-cluster-versions --region ap-northeast-2)
+          - name: "1.35"
+            id: "1.35"
+          - name: "1.34"
+            id: "1.34"
           - name: "1.33"
             id: "1.33"
-          - name: "1.32"
-            id: "1.32"
-          - name: "1.31"
-            id: "1.31"
-          # Deprecated versions (not available in AWS console as of 2025-08)  
+          # Deprecated versions (not available in AWS console as of 2026-05)
+          # - name: "1.32"
+          #   id: "1.32"
+          # - name: "1.31"
+          #   id: "1.31"
           # - name: "1.30"
           #   id: "1.30"
-          # - name: "1.29"
-          #   id: "1.29"
-          # - name: "1.28"
-          #   id: "1.28"
     rootDisk:
       - region: [common]
         type:


### PR DESCRIPTION
- Updated supported K8s version list in `assets/k8sclusterinfo.yaml` to reflect current AWS console: `1.31/1.32/1.33` → `1.33/1.34/1.35` (verified via AWS CLI and console on 2026-05-11)
- Completed cluster and node group creation tests for all 13 AWS EKS AMI types registered in `cloudimage.csv`; confirmed that `WINDOWS_FULL/CORE_2025_x86_64` (requires K8s 1.35+), which previously failed, now works correctly with the updated default EKS version `1.35`

## AWS EKS AMI Type Test Results

| AMI Type | Instance | Result | Notes |
|---|---|:---:|---|
| `AL2023_x86_64_STANDARD` | t3.medium | ✅ | |
| `AL2023_ARM_64_STANDARD` | t4g.medium | ✅ | ARM — requires Graviton instance (t4g, m6g, c6g, etc.) |
| `BOTTLEROCKET_x86_64` | t3.medium | ✅ | |
| `BOTTLEROCKET_ARM_64` | t4g.medium | ✅ | ARM — requires Graviton instance (t4g, m6g, c6g, etc.) |
| `AL2023_x86_64_NVIDIA` | g4dn.xlarge | ✅ | NVIDIA GPU — requires g4dn/g5/p family |
| `AL2023_ARM_64_NVIDIA` | g5g.xlarge | ✅ | ARM(Graviton) + NVIDIA GPU — requires g5g family |
| `AL2023_x86_64_NEURON` | inf1.xlarge | ✅ | AWS Inferentia/Trainium — requires inf1/inf2/trn1 family |
| `WINDOWS_FULL_2019_x86_64` | t3.medium | ✅ | |
| `WINDOWS_CORE_2019_x86_64` | t3.medium | ✅ | |
| `WINDOWS_FULL_2022_x86_64` | t3.medium | ✅ | |
| `WINDOWS_CORE_2022_x86_64` | t3.medium | ✅ | |
| `WINDOWS_FULL_2025_x86_64` | t3.medium | ✅ | Requires K8s 1.35+ — AWS introduced Windows Server 2025 support with EKS 1.35 (released Jan 2026) |
| `WINDOWS_CORE_2025_x86_64` | t3.medium | ✅ | Requires K8s 1.35+ — same as above |

> All 13 AMI types successfully created clusters and node groups. Kubeconfig extraction and Headlamp-based nginx deployment were also attempted per cluster. For Windows AMI types, verification was limited to kubeconfig extraction (Linux-based nginx is not applicable on Windows nodes).