### PR TITLE
update: purge Spider metadata via force delete during reconcile

### DIFF
--- a/src/core/resource/objectStorage.go
+++ b/src/core/resource/objectStorage.go
@@ -1101,6 +1101,30 @@ func ReconcileObjectStorage(nsId, osId string) (model.ObjectStorageReconcileResp
 	result.CspResourceStatus = "NotFound"
 	log.Warn().Err(headErr).Msgf("ReconcileObjectStorage: bucket '%s' not found on CSP; removing orphaned metadata", uid)
 
+	// [Via Spider] Purge Spider bucket metadata by force delete (CSP resource already gone).
+	// Note: Spider sends a force delete request to the CSP and removes its own metadata
+	// regardless of whether the CSP-side deletion succeeds or fails.
+	forceDelURL := fmt.Sprintf("%s/s3/%s?ConnectionName=%s&force=true", model.SpiderRestUrl, uid, connName)
+	log.Debug().Msgf("[ReconcileObjectStorage] Purge Spider bucket metadata by force delete: %s", forceDelURL)
+	spForceDelReq := clientManager.NoBody
+	spForceDelResp := clientManager.NoBody
+	restyForceDelResp, forceDelErr := clientManager.ExecuteHttpRequest(
+		clientManager.NewHttpClient(),
+		"DELETE",
+		forceDelURL,
+		spiderS3JSONHeaders,
+		clientManager.SetUseBody(spForceDelReq),
+		&spForceDelReq,
+		&spForceDelResp,
+		clientManager.ShortDuration,
+	)
+	forceDelErr = clientManager.HandleHttpResponse(restyForceDelResp, forceDelErr)
+	if forceDelErr != nil {
+		log.Warn().Err(forceDelErr).Msgf("ReconcileObjectStorage: Purge Spider bucket metadata by force delete failed for %s (continuing reconcile)", uid)
+	} else {
+		log.Info().Msgf("ReconcileObjectStorage: Purge Spider bucket metadata by force delete succeeded for %s", uid)
+	}
+
 	// Remove metadata from kvstore
 	if delErr := kvstore.Delete(objStrgKey); delErr != nil {
 		log.Error().Err(delErr).Msg("ReconcileObjectStorage: failed to delete orphaned metadata")

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -1048,6 +1048,31 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string) (model.SimpleM
 	 *	Delete the subnet info in case of the subnet does not exist
 	 */
 
+	// [Via Spider] Purge Spider subnet metadata by force delete (CSP resource already gone).
+	// Note: Spider sends a force delete request to the CSP and removes its own metadata
+	// regardless of whether the CSP-side deletion succeeds or fails.
+	spForceDelReqt := spiderSubnetRemoveReq{ConnectionName: subnetInfo.ConnectionName}
+	forceDelURL := fmt.Sprintf("%s/vpc/%s/subnet/%s?force=true",
+		model.SpiderRestUrl, subnetInfo.CspVNetName, subnetInfo.CspResourceName)
+	log.Debug().Msgf("[Request to Spider] Purge Spider subnet metadata by force delete: %s", forceDelURL)
+	var spForceDelResp spiderBooleanInfoResp
+	restyForceDelResp, forceDelErr := clientManager.ExecuteHttpRequest(
+		clientManager.NewHttpClient(),
+		"DELETE",
+		forceDelURL,
+		nil,
+		clientManager.SetUseBody(spForceDelReqt),
+		&spForceDelReqt,
+		&spForceDelResp,
+		clientManager.MediumDuration,
+	)
+	forceDelErr = clientManager.HandleHttpResponse(restyForceDelResp, forceDelErr)
+	if forceDelErr != nil {
+		log.Warn().Err(forceDelErr).Msgf("Purge Spider subnet metadata by force delete failed for %s (continuing reconcile)", subnetInfo.CspResourceName)
+	} else {
+		log.Info().Msgf("Purge Spider subnet metadata by force delete succeeded for %s", subnetInfo.CspResourceName)
+	}
+
 	// Delete the saved the subnet info
 	err = kvstore.Delete(subnetKey)
 	if err != nil {

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -1286,6 +1286,30 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 	 * delete the information of vNet and subnets from the key-value stores
 	 */
 
+	// [Via Spider] Purge Spider VPC metadata by force delete (CSP resource already gone).
+	// Note: Spider sends a force delete request to the CSP and removes its own metadata
+	// regardless of whether the CSP-side deletion succeeds or fails.
+	spForceDelReqt := spiderVpcDeleteReq{ConnectionName: vNetInfo.ConnectionName}
+	forceDelURL := fmt.Sprintf("%s/vpc/%s?force=true", model.SpiderRestUrl, vNetInfo.CspResourceName)
+	log.Debug().Msgf("[Request to Spider] Purge Spider VPC metadata by force delete: %s", forceDelURL)
+	var spForceDelResp spiderBooleanInfoResp
+	restyForceDelResp, forceDelErr := clientManager.ExecuteHttpRequest(
+		clientManager.NewHttpClient(),
+		"DELETE",
+		forceDelURL,
+		nil,
+		clientManager.SetUseBody(spForceDelReqt),
+		&spForceDelReqt,
+		&spForceDelResp,
+		clientManager.MediumDuration,
+	)
+	forceDelErr = clientManager.HandleHttpResponse(restyForceDelResp, forceDelErr)
+	if forceDelErr != nil {
+		log.Warn().Err(forceDelErr).Msgf("Purge Spider VPC metadata by force delete failed for %s (continuing reconcile)", vNetInfo.CspResourceName)
+	} else {
+		log.Info().Msgf("Purge Spider VPC metadata by force delete succeeded for %s", vNetInfo.CspResourceName)
+	}
+
 	// Delete subnet objects from the key-value store
 	// Read the stored subnets
 	subnetKvList, err := kvstore.GetKvList(vNetKey + "/subnet")


### PR DESCRIPTION
- Add Spider force delete call before removing orphaned kvstore entries
- Applies consistently to VNet, Subnet, and ObjectStorage reconciliation
- Ensures Spider's internal state is cleaned up when CSP resource is gone