### PR TITLE
Improve ID pattern of Node for registering CSP VM instance

### DIFF
--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -183,7 +183,12 @@ func createNodeGroup(ctx context.Context, nsId, infraId string, nodeRequest *mod
 
 	// Build Node ID list
 	for i := nodeStartIndex; i < nodeGroupSize+nodeStartIndex; i++ {
-		nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id+"-"+strconv.Itoa(i))
+		if nodeRequest.CspResourceId != "" {
+			// Register mode: node ID is the nodeGroup ID itself (no index suffix)
+			nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id)
+		} else {
+			nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id+"-"+strconv.Itoa(i))
+		}
 	}
 
 	// Marshal with error handling
@@ -665,7 +670,12 @@ func CreateInfraGroupNode(ctx context.Context, nsId string, infraId string, node
 	}
 
 	for i := nodeStartIndex; i < nodeGroupSize+nodeStartIndex; i++ {
-		nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id+"-"+strconv.Itoa(i))
+		if nodeRequest.CspResourceId != "" {
+			// Register mode: node ID is the nodeGroup ID itself (no index suffix)
+			nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id)
+		} else {
+			nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id+"-"+strconv.Itoa(i))
+		}
 	}
 
 	val, _ := json.Marshal(nodeGroupInfoData)
@@ -686,7 +696,12 @@ func CreateInfraGroupNode(ctx context.Context, nsId string, infraId string, node
 		nodeInfoData := model.NodeInfo{}
 
 		nodeInfoData.NodeGroupId = common.ToLower(nodeRequest.Name)
-		nodeInfoData.Name = common.ToLower(nodeRequest.Name) + "-" + strconv.Itoa(i)
+		if nodeRequest.CspResourceId != "" {
+			// Register mode: node name is the nodeGroup name itself (no index suffix)
+			nodeInfoData.Name = common.ToLower(nodeRequest.Name)
+		} else {
+			nodeInfoData.Name = common.ToLower(nodeRequest.Name) + "-" + strconv.Itoa(i)
+		}
 
 		log.Debug().Msg("nodeInfoData.Name: " + nodeInfoData.Name)
 
@@ -754,7 +769,12 @@ func CreateInfraGroupNode(ctx context.Context, nsId string, infraId string, node
 				break
 			}
 			nodeInfoData.NodeGroupId = common.ToLower(nodeRequest.Name)
-			nodeInfoData.Name = common.ToLower(nodeRequest.Name) + "-" + strconv.Itoa(i)
+			if nodeRequest.CspResourceId != "" {
+				// Register mode: node name is the nodeGroup name itself (no index suffix)
+				nodeInfoData.Name = common.ToLower(nodeRequest.Name)
+			} else {
+				nodeInfoData.Name = common.ToLower(nodeRequest.Name) + "-" + strconv.Itoa(i)
+			}
 		}
 		nodeInfoData.Id = nodeInfoData.Name
 		nodeId := nodeInfoData.Id
@@ -1074,7 +1094,12 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 				nodeInfo.Name = common.ToLower(nodeGroupReq.Name)
 			} else {
 				nodeInfo.NodeGroupId = common.ToLower(nodeGroupReq.Name)
-				nodeInfo.Name = common.ToLower(nodeGroupReq.Name) + "-" + strconv.Itoa(i)
+				if nodeGroupReq.CspResourceId != "" {
+					// Register mode: node name is the nodeGroup name itself (no index suffix)
+					nodeInfo.Name = common.ToLower(nodeGroupReq.Name)
+				} else {
+					nodeInfo.Name = common.ToLower(nodeGroupReq.Name) + "-" + strconv.Itoa(i)
+				}
 			}
 			nodeInfo.Id = nodeInfo.Name
 

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -184,8 +184,9 @@ func createNodeGroup(ctx context.Context, nsId, infraId string, nodeRequest *mod
 	// Build Node ID list
 	for i := nodeStartIndex; i < nodeGroupSize+nodeStartIndex; i++ {
 		if nodeRequest.CspResourceId != "" {
-			// Register mode: node ID is the nodeGroup ID itself (no index suffix)
+			// Register mode: one node per registration, no index suffix
 			nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id)
+			break
 		} else {
 			nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id+"-"+strconv.Itoa(i))
 		}
@@ -671,8 +672,9 @@ func CreateInfraGroupNode(ctx context.Context, nsId string, infraId string, node
 
 	for i := nodeStartIndex; i < nodeGroupSize+nodeStartIndex; i++ {
 		if nodeRequest.CspResourceId != "" {
-			// Register mode: node ID is the nodeGroup ID itself (no index suffix)
+			// Register mode: one node per registration, no index suffix
 			nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id)
+			break
 		} else {
 			nodeGroupInfoData.NodeId = append(nodeGroupInfoData.NodeId, nodeGroupInfoData.Id+"-"+strconv.Itoa(i))
 		}

--- a/src/core/infra/utility.go
+++ b/src/core/infra/utility.go
@@ -1075,17 +1075,17 @@ func RegisterCspNativeResources(ctx context.Context, nsId string, connConfig str
 			}
 			var registeredNodes []registeredNodeInfo
 
-			for idx, r := range res.Resources.OnCspOnly.Info {
-				// Generate a temporary unique nodegroup name for initial registration
-				tempNodeGroupName := common.ChangeIdString(fmt.Sprintf("reg-%s-%d", connConfig, idx))
+			for _, r := range res.Resources.OnCspOnly.Info {
+				// NodeGroup/Node name: use CSP resource ID for consistency with other resources (VNet, SG, etc.)
+				tempNodeGroupName := genName(r.CspResourceId)
 
 				var infraName string
 				if useSingleInfra {
 					// Use the same Infra name for all Nodes
 					infraName = singleInfraName
 				} else {
-					// Create separate Infra for each Node (use shorter name)
-					infraName = common.ChangeIdString(fmt.Sprintf("%s-%s", infraNamePrefix, r.RefNameOrId))
+					// Create separate Infra per Node; include CSP resource ID for traceability
+					infraName = common.ChangeIdString(fmt.Sprintf("%s-%s", infraNamePrefix, r.CspResourceId))
 				}
 
 				var nodeId string

--- a/src/core/infra/utility.go
+++ b/src/core/infra/utility.go
@@ -1074,10 +1074,16 @@ func RegisterCspNativeResources(ctx context.Context, nsId string, connConfig str
 				networkKey string
 			}
 			var registeredNodes []registeredNodeInfo
+			// Explicitly track which nodegroup names were created as temporaries in Phase 1,
+			// so Phase 2 cleanup does not rely on name prefix conventions.
+			tempNodeGroupNames := make(map[string]bool)
 
 			for _, r := range res.Resources.OnCspOnly.Info {
 				// NodeGroup/Node name: use CSP resource ID for consistency with other resources (VNet, SG, etc.)
 				tempNodeGroupName := genName(r.CspResourceId)
+				if useSingleInfra {
+					tempNodeGroupNames[tempNodeGroupName] = true
+				}
 
 				var infraName string
 				if useSingleInfra {
@@ -1192,8 +1198,8 @@ func RegisterCspNativeResources(ctx context.Context, nsId string, connConfig str
 						nodeInfo.NodeGroupId = newNodeGroupName
 						UpdateNodeInfo(nsId, singleInfraName, nodeInfo)
 
-						// Delete old nodegroup if it was temporary (starts with "reg-")
-						if oldNodeGroupId != "" && strings.HasPrefix(oldNodeGroupId, "reg-") && oldNodeGroupId != newNodeGroupName {
+						// Delete old nodegroup if it was a temporary one created in Phase 1
+						if oldNodeGroupId != "" && tempNodeGroupNames[oldNodeGroupId] && oldNodeGroupId != newNodeGroupName {
 							oldNodeGroupKey := common.GenInfraNodeGroupKey(nsId, singleInfraName, oldNodeGroupId)
 							kvstore.Delete(oldNodeGroupKey)
 						}


### PR DESCRIPTION
Improve ID pattern of Node for registering CSP VM instance
- to reveal csp-managed ID to CB-TB node ID intuitively.