### PR TITLE
Add credential registeration step to OpenBao in RegisterCloudInfo

### DIFF
--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -15,6 +15,7 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -1022,7 +1023,7 @@ func RegisterCredential(req model.CredentialReq) (model.CredentialInfo, error) {
 	if model.VaultToken != "" {
 		secretPath := csp.BuildSecretPathForHolder(req.CredentialHolder, req.ProviderName)
 		secretData := csp.ApplyCredentialKeyMap(req.ProviderName, decryptedKeyValueList)
-		if err := csp.WriteOpenBaoSecret(secretPath, secretData); err != nil {
+		if err := csp.WriteOpenBaoSecret(context.Background(), secretPath, secretData); err != nil {
 			log.Warn().Err(err).Msgf("Failed to register credential in OpenBao (non-fatal): provider=%s holder=%s", req.ProviderName, req.CredentialHolder)
 		} else {
 			log.Info().Msgf("Registered credential in OpenBao: path=%s", secretPath)

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -37,8 +37,9 @@ import (
 	"encoding/pem"
 
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
+	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
-	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
+	modelcsp "github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvutil"
 	"github.com/rs/zerolog/log"
@@ -687,10 +688,10 @@ func RegisterAllCloudInfo() error {
 	for providerName, cspDetail := range RuntimeCloudInfo.CSPs {
 		if cspDetail.CloudPlatform != "" {
 			// Derived CSP: maps to the base platform (e.g., openstack-new01 → openstack)
-			csp.RegisterCloudPlatform(providerName, cspDetail.CloudPlatform)
+			modelcsp.RegisterCloudPlatform(providerName, cspDetail.CloudPlatform)
 		} else {
 			// Standard CSP: identity mapping (e.g., aws → aws)
-			csp.RegisterCloudPlatform(providerName, providerName)
+			modelcsp.RegisterCloudPlatform(providerName, providerName)
 		}
 	}
 
@@ -720,7 +721,7 @@ func RegisterCloudInfo(providerName string) error {
 	// Resolve the cloud platform type for Spider registration.
 	// Spider uses ProviderName to select the correct driver handler,
 	// so it must be the platform type (e.g., "OPENSTACK") not the CSP instance name (e.g., "OPENSTACK-NEW01").
-	platformName := csp.ResolveCloudPlatform(providerName)
+	platformName := modelcsp.ResolveCloudPlatform(providerName)
 
 	client := clientManager.NewHttpClient()
 	url := model.SpiderRestUrl + "/driver"
@@ -764,7 +765,7 @@ func RegisterRegionZone(providerName string, regionName string) error {
 
 	// Use platform name for Spider's ProviderName (driver selection),
 	// but keep CSP instance name in RegionName for uniqueness.
-	platformName := csp.ResolveCloudPlatform(providerName)
+	platformName := modelcsp.ResolveCloudPlatform(providerName)
 	requestBody := model.SpiderRegionZoneInfo{ProviderName: strings.ToUpper(platformName), RegionName: regionName}
 
 	// register representative regionZone (region only)
@@ -984,7 +985,7 @@ func RegisterCredential(req model.CredentialReq) (model.CredentialInfo, error) {
 	// Resolve cloud platform type for Spider registration.
 	// Spider uses ProviderName to select the correct driver handler,
 	// so it must be the platform type (e.g., "OPENSTACK") not the CSP instance name (e.g., "OPENSTACK-NEW01").
-	platformName := csp.ResolveCloudPlatform(req.ProviderName)
+	platformName := modelcsp.ResolveCloudPlatform(req.ProviderName)
 
 	reqToSpider := model.CredentialInfo{
 		CredentialName:   genneratedCredentialName,
@@ -1016,6 +1017,17 @@ func RegisterCredential(req model.CredentialReq) (model.CredentialInfo, error) {
 		return model.CredentialInfo{}, err
 	}
 	//PrintJsonPretty(callResult)
+
+	// Register credentials in OpenBao for runtime CSP access (non-fatal: warn and continue if unavailable)
+	if model.VaultToken != "" {
+		secretPath := csp.BuildSecretPathForHolder(req.CredentialHolder, req.ProviderName)
+		secretData := csp.ApplyCredentialKeyMap(req.ProviderName, decryptedKeyValueList)
+		if err := csp.WriteOpenBaoSecret(secretPath, secretData); err != nil {
+			log.Warn().Err(err).Msgf("Failed to register credential in OpenBao (non-fatal): provider=%s holder=%s", req.ProviderName, req.CredentialHolder)
+		} else {
+			log.Info().Msgf("Registered credential in OpenBao: path=%s", secretPath)
+		}
+	}
 
 	callResult.CredentialHolder = req.CredentialHolder
 	callResult.ProviderName = strings.ToLower(callResult.ProviderName)
@@ -1229,7 +1241,7 @@ func RegisterConnectionConfig(connConfig model.ConnConfig) (model.ConnConfig, er
 	requestBody.ConfigName = connConfig.ConfigName
 	// Spider needs the platform type (e.g., "OPENSTACK") for driver selection,
 	// not the CSP instance name (e.g., "openstack-new01")
-	requestBody.ProviderName = strings.ToUpper(csp.ResolveCloudPlatform(connConfig.ProviderName))
+	requestBody.ProviderName = strings.ToUpper(modelcsp.ResolveCloudPlatform(connConfig.ProviderName))
 	requestBody.DriverName = connConfig.DriverName
 	requestBody.CredentialName = connConfig.CredentialName
 	requestBody.RegionName = connConfig.RegionZoneInfoName

--- a/src/core/csp/csp.go
+++ b/src/core/csp/csp.go
@@ -113,6 +113,125 @@ func GetBatchVMControlHandler(provider, action string) (BatchVMControlFunc, bool
 	}
 }
 
+// credentialKeyMap maps each CSP's YAML credential keys to the environment variable
+// names expected by OpenTofu providers and cb-tumblebug's runtime credential lookup.
+// Must stay in sync with init/openbao/openbao-register-creds.py KEY_MAP.
+var credentialKeyMap = map[string]map[string]string{
+	"aws": {
+		"aws_access_key_id":     "AWS_ACCESS_KEY_ID",
+		"aws_secret_access_key": "AWS_SECRET_ACCESS_KEY",
+	},
+	"azure": {
+		"clientId":       "ARM_CLIENT_ID",
+		"clientSecret":   "ARM_CLIENT_SECRET",
+		"tenantId":       "ARM_TENANT_ID",
+		"subscriptionId": "ARM_SUBSCRIPTION_ID",
+		"S3AccessKey":    "ARM_STORAGE_ACCOUNT_NAME",
+		"S3SecretKey":    "ARM_ACCESS_KEY",
+	},
+	"gcp": {
+		"project_id":     "project_id",
+		"client_email":   "client_email",
+		"private_key":    "private_key",
+		"private_key_id": "private_key_id",
+		"client_id":      "client_id",
+		"S3AccessKey":    "GCP_S3_ACCESS_KEY",
+		"S3SecretKey":    "GCP_S3_SECRET_KEY",
+	},
+	"alibaba": {
+		"AccessKeyId":     "ALIBABA_CLOUD_ACCESS_KEY_ID",
+		"AccessKeySecret": "ALIBABA_CLOUD_ACCESS_KEY_SECRET",
+	},
+	"ibm": {
+		"ApiKey":    "IC_API_KEY",
+		"S3AccessKey": "IBM_S3_ACCESS_KEY",
+		"S3SecretKey": "IBM_S3_SECRET_KEY",
+	},
+	"ncp": {
+		"ncloud_access_key": "NCLOUD_ACCESS_KEY",
+		"ncloud_secret_key": "NCLOUD_SECRET_KEY",
+	},
+	"tencent": {
+		"SecretId": "TENCENTCLOUD_SECRET_ID",
+		"SecretKey": "TENCENTCLOUD_SECRET_KEY",
+	},
+	"kt": {
+		"IdentityEndpoint": "KT_IDENTITY_ENDPOINT",
+		"Username":         "KT_USERNAME",
+		"Password":         "KT_PASSWORD",
+		"DomainName":       "KT_DOMAIN_NAME",
+		"ProjectID":        "KT_PROJECT_ID",
+		"S3AccessKey":      "KT_S3_ACCESS_KEY",
+		"S3SecretKey":      "KT_S3_SECRET_KEY",
+	},
+	"nhn": {
+		"IdentityEndpoint": "NHN_IDENTITY_ENDPOINT",
+		"Username":         "NHN_USERNAME",
+		"Password":         "NHN_PASSWORD",
+		"DomainName":       "NHN_DOMAIN_NAME",
+		"TenantId":         "NHN_TENANT_ID",
+		"S3AccessKey":      "NHN_S3_ACCESS_KEY",
+		"S3SecretKey":      "NHN_S3_SECRET_KEY",
+	},
+	"openstack": {
+		"IdentityEndpoint": "OS_AUTH_URL",
+		"Username":         "OS_USERNAME",
+		"Password":         "OS_PASSWORD",
+		"DomainName":       "OS_DOMAIN_NAME",
+		"ProjectID":        "OS_PROJECT_ID",
+		"S3AccessKey":      "OS_S3_ACCESS_KEY",
+		"S3SecretKey":      "OS_S3_SECRET_KEY",
+	},
+}
+
+// ApplyCredentialKeyMap transforms a credential key-value list using the CSP-specific
+// key mapping. Keys not present in the map are passed through unchanged.
+func ApplyCredentialKeyMap(provider string, kvList []model.KeyValue) map[string]interface{} {
+	keyMap := credentialKeyMap[strings.ToLower(provider)]
+	result := make(map[string]interface{}, len(kvList))
+	for _, kv := range kvList {
+		targetKey := kv.Key
+		if keyMap != nil {
+			if mapped, ok := keyMap[kv.Key]; ok {
+				targetKey = mapped
+			}
+		}
+		result[targetKey] = kv.Value
+	}
+	return result
+}
+
+// BuildSecretPathForHolder builds the OpenBao secret path using holder and provider directly.
+func BuildSecretPathForHolder(holder, provider string) string {
+	if strings.EqualFold(holder, model.DefaultCredentialHolder) {
+		return fmt.Sprintf("secret/data/csp/%s", provider)
+	}
+	return fmt.Sprintf("secret/data/users/%s/csp/%s", holder, provider)
+}
+
+// WriteOpenBaoSecret writes key-value data to OpenBao at the given KV v2 path (upsert).
+func WriteOpenBaoSecret(path string, data map[string]interface{}) error {
+	if model.VaultToken == "" {
+		return fmt.Errorf("VAULT_TOKEN is not set")
+	}
+
+	vaultConfig := api.DefaultConfig()
+	vaultConfig.Address = model.VaultAddr
+	client, err := api.NewClient(vaultConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create OpenBao client: %w", err)
+	}
+	client.SetToken(model.VaultToken)
+
+	_, err = client.Logical().Write(path, map[string]interface{}{
+		"data": data,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write secret to OpenBao at %s: %w", path, err)
+	}
+	return nil
+}
+
 // ReadOpenBaoSecret reads a secret from OpenBao at the given path and returns the data map.
 // It validates that VaultToken is set and the secret exists.
 // A context is used for request-scoped cancellation and timeout.

--- a/src/core/csp/csp.go
+++ b/src/core/csp/csp.go
@@ -202,7 +202,10 @@ func ApplyCredentialKeyMap(provider string, kvList []model.KeyValue) map[string]
 }
 
 // BuildSecretPathForHolder builds the OpenBao secret path using holder and provider directly.
+// Both holder and provider are lowercased to stay consistent with BuildSecretPath.
 func BuildSecretPathForHolder(holder, provider string) string {
+	holder = strings.ToLower(holder)
+	provider = strings.ToLower(provider)
 	if strings.EqualFold(holder, model.DefaultCredentialHolder) {
 		return fmt.Sprintf("secret/data/csp/%s", provider)
 	}
@@ -210,7 +213,8 @@ func BuildSecretPathForHolder(holder, provider string) string {
 }
 
 // WriteOpenBaoSecret writes key-value data to OpenBao at the given KV v2 path (upsert).
-func WriteOpenBaoSecret(path string, data map[string]interface{}) error {
+// ctx allows request-scoped cancellation and timeout, consistent with ReadOpenBaoSecret.
+func WriteOpenBaoSecret(ctx context.Context, path string, data map[string]interface{}) error {
 	if model.VaultToken == "" {
 		return fmt.Errorf("VAULT_TOKEN is not set")
 	}
@@ -223,7 +227,7 @@ func WriteOpenBaoSecret(path string, data map[string]interface{}) error {
 	}
 	client.SetToken(model.VaultToken)
 
-	_, err = client.Logical().Write(path, map[string]interface{}{
+	_, err = client.Logical().WriteWithContext(ctx, path, map[string]interface{}{
 		"data": data,
 	})
 	if err != nil {
@@ -275,7 +279,7 @@ func BuildSecretPath(ctx context.Context, provider string) string {
 		holder = v
 	}
 
-	if holder == "admin" {
+	if strings.EqualFold(holder, model.DefaultCredentialHolder) {
 		return fmt.Sprintf("secret/data/csp/%s", provider)
 	}
 	return fmt.Sprintf("secret/data/users/%s/csp/%s", holder, provider)


### PR DESCRIPTION
This PR adds credentials registration step to OpenBao in RegisterCloudInfo (RegisterCredential).
So, CB-TB register CSP credentials to both CB-SP and OpenBao so that CB-TB fully utilizes them.
Whereas current `make init` initialization client support it already, this server-side support will help a simpler M-CMP configuration.