### PR TITLE
chore(assets): update Alibaba k8s versions in k8sclusterinfo.yaml

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -116,8 +116,10 @@ k8scluster:
       # ap-northeast-1,ap-northeast-2,ap-southeast-1,ap-southeast-3,ap-southeast-5,us-west-1,us-east-1,eu-central-1,eu-west-1,cn-beijing,cn-hongkong,cn-shanghai,cn-huhehaote,cn-heyuan,cn-wulanchabu,cn-guangzhou
       - region: [common] 
         available:
+          - name: "1.35"
+            id: "1.35.2-aliyun.1"
           - name: "1.34"
-            id: "1.34.1-aliyun.1"
+            id: "1.34.3-aliyun.1"
           - name: "1.33"
             id: "1.33.3-aliyun.1"
           - name: "1.32"


### PR DESCRIPTION
- Remove deprecated 1.34.1-aliyun.1 and add 1.35.2-aliyun.1, 1.34.3-aliyun.1.
- Verified against Alibaba ACK API on 2026-05-18 (ap-northeast-2).