### PR TITLE
Improve query pattern to ETCD for performance

### DIFF
--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -1591,15 +1591,13 @@ func DeleteObject(key string) error {
 
 // DeleteObjects is func to delete objects
 func DeleteObjects(key string) error {
-	keyValue, _ := kvstore.GetKvList(key)
-	for _, v := range keyValue {
-		err := kvstore.Delete(v.Key)
-		if err != nil {
-			log.Error().Err(err).Msg("")
-			return err
-		}
+	trimmedKey := strings.TrimSpace(key)
+	if trimmedKey == "" {
+		err := fmt.Errorf("invalid empty key for prefix delete")
+		log.Error().Err(err).Msg("")
+		return err
 	}
-	return nil
+	return kvstore.DeleteWithPrefix(trimmedKey)
 }
 
 func CheckElement(a string, list []string) bool {

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -5471,14 +5471,8 @@ func CleanupCorruptedProvisioningLogs() error {
 
 	cleanupCount := 0
 	for _, key := range keys {
-		keyValue, _, err := kvstore.GetKv(key.Key)
-		if err != nil {
-			log.Warn().Err(err).Msgf("Failed to get value for key: %s", key.Key)
-			continue
-		}
-
-		// Check if the value is empty or invalid JSON
-		if keyValue.Value == "" {
+		// Check if the value is empty or invalid JSON (key already contains Value from GetKvList)
+		if key.Value == "" {
 			log.Debug().Msgf("Deleting empty provisioning log: %s", key.Key)
 			if deleteErr := kvstore.Delete(key.Key); deleteErr != nil {
 				log.Error().Err(deleteErr).Msgf("Failed to delete empty log: %s", key.Key)
@@ -5490,7 +5484,7 @@ func CleanupCorruptedProvisioningLogs() error {
 
 		// Test JSON validity
 		var testLog model.ProvisioningLog
-		if err := json.Unmarshal([]byte(keyValue.Value), &testLog); err != nil {
+		if err := json.Unmarshal([]byte(key.Value), &testLog); err != nil {
 			log.Debug().Msgf("Deleting corrupted provisioning log: %s", key.Key)
 			if deleteErr := kvstore.Delete(key.Key); deleteErr != nil {
 				log.Error().Err(deleteErr).Msgf("Failed to delete corrupted log: %s", key.Key)

--- a/src/kvstore/etcd/etcd.go
+++ b/src/kvstore/etcd/etcd.go
@@ -239,6 +239,20 @@ func (s *EtcdStore) DeleteWith(ctx context.Context, key string) error {
 	return nil
 }
 
+// DeleteWithPrefix removes all key-value pairs with the given prefix in a single etcd request.
+func (s *EtcdStore) DeleteWithPrefix(keyPrefix string) error {
+	return s.DeleteWithPrefixWith(s.ctx, keyPrefix)
+}
+
+// DeleteWithPrefixWith removes all key-value pairs with the given prefix in a single etcd request using the provided context.
+func (s *EtcdStore) DeleteWithPrefixWith(ctx context.Context, keyPrefix string) error {
+	_, err := s.cli.Delete(ctx, keyPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return fmt.Errorf("failed to delete keys with prefix %q: %w", keyPrefix, err)
+	}
+	return nil
+}
+
 // WatchKey watches for changes on the given key.
 func (s *EtcdStore) WatchKey(key string) clientv3.WatchChan {
 	return s.WatchKeyWith(s.ctx, key)

--- a/src/kvstore/kvstore/kvstore.go
+++ b/src/kvstore/kvstore/kvstore.go
@@ -36,6 +36,8 @@ type Store interface {
 	GetKvMapWith(ctx context.Context, keyPrefix string) (KeyValueMap, error)
 	Delete(key string) error
 	DeleteWith(ctx context.Context, key string) error
+	DeleteWithPrefix(keyPrefix string) error
+	DeleteWithPrefixWith(ctx context.Context, keyPrefix string) error
 	WatchKey(key string) clientv3.WatchChan
 	WatchKeyWith(ctx context.Context, key string) clientv3.WatchChan
 	WatchKeys(keyPrefix string) clientv3.WatchChan
@@ -262,6 +264,24 @@ func DeleteWith(ctx context.Context, key string) error {
 		return err
 	}
 	return store.DeleteWith(ctx, key)
+}
+
+// DeleteWithPrefix removes all key-value pairs with the given prefix in one request
+func DeleteWithPrefix(keyPrefix string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	return store.DeleteWithPrefix(keyPrefix)
+}
+
+// DeleteWithPrefixWith removes all key-value pairs with the given prefix in one request with context
+func DeleteWithPrefixWith(ctx context.Context, keyPrefix string) error {
+	store, err := getStore()
+	if err != nil {
+		return err
+	}
+	return store.DeleteWithPrefixWith(ctx, keyPrefix)
 }
 
 // WatchKey watches for changes on a specific key


### PR DESCRIPTION
1. fix N+1 query pattern

keys, err := kvstore.GetKvList(keyPattern)  
for _, key := range keys {
    keyValue, _, err := kvstore.GetKv(key.Key)  // here
}

2. loop Delete -> DeleteWith prefix 

for _, v := range keyValue {
    kvstore.Delete(v.Key) 
}
