### PR TITLE
Prioritize HTTP status code and fall back to message patterns in apierr

### DIFF
--- a/src/core/common/apierr/apierr.go
+++ b/src/core/common/apierr/apierr.go
@@ -82,14 +82,18 @@ func IsNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	if containsAny(err.Error(), notFoundPatterns) {
-		return true
-	}
 	var se *StatusError
-	if errors.As(err, &se) && se.StatusCode == http.StatusNotFound {
-		return true
+	if errors.As(err, &se) {
+		if se.StatusCode == http.StatusNotFound {
+			return true
+		}
+		// 5xx: server-side error — never infer "not found" from message alone.
+		if se.StatusCode >= 500 {
+			return false
+		}
 	}
-	return false
+	// No HTTP status (transport error) or non-5xx: fall back to message patterns.
+	return containsAny(err.Error(), notFoundPatterns)
 }
 
 // IsConflict reports whether err represents a conflict / already-exists condition.
@@ -97,14 +101,18 @@ func IsConflict(err error) bool {
 	if err == nil {
 		return false
 	}
-	if containsAny(err.Error(), conflictPatterns) {
-		return true
-	}
 	var se *StatusError
-	if errors.As(err, &se) && se.StatusCode == http.StatusConflict {
-		return true
+	if errors.As(err, &se) {
+		if se.StatusCode == http.StatusConflict {
+			return true
+		}
+		// 5xx: server-side error — never infer "conflict" from message alone.
+		if se.StatusCode >= 500 {
+			return false
+		}
 	}
-	return false
+	// No HTTP status (transport error) or non-5xx: fall back to message patterns.
+	return containsAny(err.Error(), conflictPatterns)
 }
 
 var notFoundPatterns = []string{


### PR DESCRIPTION
- Check StatusError HTTP code first in IsNotFound and IsConflict
- Short-circuit on 5xx to avoid false positives from message matching
- Fall back to message pattern matching only when no HTTP status is set