### PR TITLE
Validate type-identifier K8s images and refresh Tencent TKE image list

### DIFF
--- a/assets/cloudimage.csv
+++ b/assets/cloudimage.csv
@@ -39,3 +39,13 @@ AWS,all,WINDOWS_CORE_2025_x86_64,Windows Server 2025,"EKS Node - Windows Server 
 GCP,all,COS_CONTAINERD,Container-Optimized OS,"GKE Node - COS, containerd, x86_64/ARM64",,k8s,x86_64,COS_CONTAINERD
 GCP,all,UBUNTU_CONTAINERD,Ubuntu 22.04 LTS,"GKE Node - Ubuntu 22.04, containerd, x86_64/ARM64",,k8s,x86_64,UBUNTU_CONTAINERD
 GCP,all,WINDOWS_LTSC_CONTAINERD,Windows Server 2019 LTSC,"GKE Node - Windows Server 2019 LTSC, containerd, x86_64",,k8s,x86_64,WINDOWS_LTSC_CONTAINERD
+TENCENT,all,tlinux4_x86_64_public,TencentOS Server 4,"TKE Node - TencentOS Server 4, x86_64",,k8s,x86_64,tlinux4_x86_64_public
+TENCENT,all,tlinux3.1x86_64,TencentOS Server 3.1 (TK4),"TKE Node - TencentOS Server 3.1 (TK4), x86_64",,k8s,x86_64,tlinux3.1x86_64
+TENCENT,all,tlinux2.4(tkernel4)x86_64_HCC,TencentOS Server 2.4 (TK4) HCC,"TKE Node - TencentOS Server 2.4 (TK4) HCC, x86_64",,k8s,x86_64,tlinux2.4(tkernel4)x86_64_HCC
+TENCENT,all,tlinux2.4(tkernel4)x86_64,TencentOS Server 2.4 (TK4),"TKE Node - TencentOS Server 2.4 (TK4), x86_64",,k8s,x86_64,tlinux2.4(tkernel4)x86_64
+TENCENT,all,tlinux2.4x86_64,TencentOS Server 2.4,"TKE Node - TencentOS Server 2.4 (legacy), x86_64",,k8s,x86_64,tlinux2.4x86_64
+TENCENT,all,centos7.8.0_x64,CentOS 7.8,"TKE Node - CentOS 7.8, x86_64",,k8s,x86_64,centos7.8.0_x64
+TENCENT,all,centos8.0x86_64,CentOS 8.0,"TKE Node - CentOS 8.0, x86_64 (Beta)",,k8s,x86_64,centos8.0x86_64
+TENCENT,all,ubuntu20.04x86_64,Ubuntu 20.04,"TKE Node - Ubuntu 20.04, x86_64 (Beta)",,k8s,x86_64,ubuntu20.04x86_64
+TENCENT,all,ubuntu22.04x86_64,Ubuntu 22.04,"TKE Node - Ubuntu 22.04, x86_64",,k8s,x86_64,ubuntu22.04x86_64
+TENCENT,all,redhat7.9x86_64,Red Hat Enterprise Linux 7.9,"TKE Node - Red Hat Enterprise Linux 7.9, x86_64",,k8s,x86_64,redhat7.9x86_64

--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -166,10 +166,11 @@ k8scluster:
       - region: [ap-beijing, ap-chengdu, ap-chongqing, ap-guangzhou, ap-hongkong, ap-nanjing, ap-shanghai]
       - region: [common]
         available:
-          - name: "1.30"
-            id: "1.30.0"
-          - name: "1.28"
-            id: "1.28.3"
+          # Updated: 2026-05-19 (1.30 EOM Feb-2026, 1.28 EOFS Apr-2026 — no new clusters)
+          - name: "1.34"
+            id: "1.34.1"
+          - name: "1.32"
+            id: "1.32.2"
     rootDisk:
       - region: [common]
         type:

--- a/src/core/resource/image.go
+++ b/src/core/resource/image.go
@@ -60,6 +60,21 @@ func ImageReqStructLevelValidation(sl validator.StructLevel) {
 	}
 }
 
+// usesTypeIdentifierK8sImage returns true for CSPs whose K8s node images are
+// abstract type identifiers (e.g., AMI type, image family) registered via
+// cloudimage.csv, not real images discovered through the CSP image API.
+//
+// For these CSPs, IsKubernetesImage=true is set only by cloudimage.csv loading
+// (keyword-based detection on VM images is skipped), and K8s cluster creation
+// must validate that the requested imageId resolves to a registered entry.
+func usesTypeIdentifierK8sImage(providerName string) bool {
+	switch csp.ResolveCloudPlatform(providerName) {
+	case csp.AWS, csp.GCP, csp.Tencent:
+		return true
+	}
+	return false
+}
+
 // ConvertSpiderImageToTumblebugImage accepts an Spider image object, converts to and returns an TB image object
 func ConvertSpiderImageToTumblebugImage(nsId, connConfig string, spiderImage model.SpiderImageInfo) (model.ImageInfo, error) {
 
@@ -132,10 +147,10 @@ func ConvertSpiderImageToTumblebugImage(nsId, connConfig string, spiderImage mod
 	if common.IsGPUImage(searchStr) {
 		tumblebugImage.IsGPUImage = true
 	}
-	// Check if this is a Kubernetes image
-	// AWS/GCP do not use imageId for K8s node creation; skip keyword-based detection.
-	// IsKubernetesImage=true for AWS/GCP is set only via cloudimage.csv asset loading.
-	if platformName != csp.AWS && platformName != csp.GCP {
+	// Check if this is a Kubernetes image.
+	// Skip keyword-based detection for type-identifier CSPs (AWS/GCP/Tencent):
+	// their IsKubernetesImage=true is established via cloudimage.csv loading only.
+	if !usesTypeIdentifierK8sImage(platformName) {
 		if common.IsK8sImage(searchStr) {
 			tumblebugImage.IsKubernetesImage = true
 		}
@@ -841,56 +856,56 @@ func RegisterImageWithInfoInBulk(imageList []model.ImageInfo) error {
 
 				// Switch to individual processing if duplicate key error occurs
 				if strings.Contains(result.Error.Error(), "duplicate key value") {
-				log.Warn().Msg("Falling back to individual record processing due to duplicate key issue")
+					log.Warn().Msg("Falling back to individual record processing due to duplicate key issue")
 
-				// Process individual records
-				altTx := model.ORM.Begin()
-				for _, img := range batch {
-					var exists bool
-					altTx.Raw("SELECT EXISTS(SELECT 1 FROM image_infos WHERE namespace = ? AND provider_name = ? AND csp_image_name = ?)",
-						img.Namespace, img.ProviderName, img.CspImageName).Scan(&exists)
+					// Process individual records
+					altTx := model.ORM.Begin()
+					for _, img := range batch {
+						var exists bool
+						altTx.Raw("SELECT EXISTS(SELECT 1 FROM image_infos WHERE namespace = ? AND provider_name = ? AND csp_image_name = ?)",
+							img.Namespace, img.ProviderName, img.CspImageName).Scan(&exists)
 
-					if exists {
-						// Update - using composite key
-						if err := altTx.Model(&model.ImageInfo{}).
-							Where("namespace = ? AND provider_name = ? AND csp_image_name = ?",
-								img.Namespace, img.ProviderName, img.CspImageName).
-							Updates(img).Error; err != nil {
-							altTx.Rollback()
-							return err
-						}
-					} else {
-						// Insert
-						if err := altTx.Create(&img).Error; err != nil {
-							altTx.Rollback()
-							return err
+						if exists {
+							// Update - using composite key
+							if err := altTx.Model(&model.ImageInfo{}).
+								Where("namespace = ? AND provider_name = ? AND csp_image_name = ?",
+									img.Namespace, img.ProviderName, img.CspImageName).
+								Updates(img).Error; err != nil {
+								altTx.Rollback()
+								return err
+							}
+						} else {
+							// Insert
+							if err := altTx.Create(&img).Error; err != nil {
+								altTx.Rollback()
+								return err
+							}
 						}
 					}
+
+					if err := altTx.Commit().Error; err != nil {
+						return err
+					}
+
+					log.Info().Msgf("Individual processing completed for batch %d-%d", i, end-1)
+					break
 				}
 
-				if err := altTx.Commit().Error; err != nil {
+				if lastErr != nil {
+					log.Error().Err(lastErr).Msgf("Failed after %d deadlock retry attempts for batch %d-%d", maxRetries, i, end-1)
+					return lastErr
+				}
+
+				log.Error().Err(result.Error).Msg("Error inserting images in bulk")
+				return result.Error
+			} else {
+				// Success - commit and exit retry loop
+				if err := tx.Commit().Error; err != nil {
+					log.Error().Err(err).Msg("Failed to commit transaction")
 					return err
 				}
-
-				log.Info().Msgf("Individual processing completed for batch %d-%d", i, end-1)
 				break
 			}
-
-			if lastErr != nil {
-				log.Error().Err(lastErr).Msgf("Failed after %d deadlock retry attempts for batch %d-%d", maxRetries, i, end-1)
-				return lastErr
-			}
-
-			log.Error().Err(result.Error).Msg("Error inserting images in bulk")
-			return result.Error
-		} else {
-			// Success - commit and exit retry loop
-			if err := tx.Commit().Error; err != nil {
-				log.Error().Err(err).Msg("Failed to commit transaction")
-				return err
-			}
-			break
-		}
 		}
 
 		//log.Info().Msgf("Bulk insert/update success: %d records affected", result.RowsAffected)
@@ -1753,9 +1768,9 @@ func createBasicImageInfoFromCSV(nsId, providerName, regionName, cspImageName, c
 		imageInfo.OSDistribution = osDistribution
 	}
 
-	// AWS/GCP rows registered in cloudimage.csv are always K8s node image types.
-	// They are not real imageIds but type identifiers (ami-type / image-type).
-	if strings.EqualFold(csp.ResolveCloudPlatform(providerName), csp.AWS) || strings.EqualFold(csp.ResolveCloudPlatform(providerName), csp.GCP) {
+	// Type-identifier CSP rows registered in cloudimage.csv are always K8s node image types.
+	// They are not real imageIds but abstract type identifiers (ami-type / image-type / NodePoolOs).
+	if usesTypeIdentifierK8sImage(providerName) {
 		imageInfo.IsKubernetesImage = true
 	}
 
@@ -1807,9 +1822,9 @@ func mergeCSPDetails(target *model.ImageInfo, source *model.ImageInfo) {
 	target.CreationDate = source.CreationDate
 	target.ImageStatus = source.ImageStatus
 	target.IsGPUImage = source.IsGPUImage
-	// Do not overwrite IsKubernetesImage for AWS/GCP CSV-loaded images.
+	// Do not overwrite IsKubernetesImage for type-identifier CSPs (AWS/GCP/Tencent).
 	// Their IsKubernetesImage=true is set by policy (cloudimage.csv), not by CSP lookup.
-	if !strings.EqualFold(csp.ResolveCloudPlatform(target.ProviderName), csp.AWS) && !strings.EqualFold(csp.ResolveCloudPlatform(target.ProviderName), csp.GCP) {
+	if !usesTypeIdentifierK8sImage(target.ProviderName) {
 		target.IsKubernetesImage = source.IsKubernetesImage
 	}
 	target.Details = source.Details
@@ -1831,8 +1846,9 @@ func updateExistingImageFromCSV(existingImage model.ImageInfo, osType, descripti
 		existingImage.OSDistribution = osDistribution
 	}
 
-	// Re-apply policy: AWS/GCP CSV-registered images are always K8s node image types.
-	if strings.EqualFold(csp.ResolveCloudPlatform(existingImage.ProviderName), csp.AWS) || strings.EqualFold(csp.ResolveCloudPlatform(existingImage.ProviderName), csp.GCP) {
+	// Re-apply policy: type-identifier CSP images registered via cloudimage.csv
+	// are always K8s node image types.
+	if usesTypeIdentifierK8sImage(existingImage.ProviderName) {
 		existingImage.IsKubernetesImage = true
 	}
 

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -33,7 +33,6 @@ import (
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/label"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
-	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
 	validator "github.com/go-playground/validator/v10"
 	"github.com/rs/zerolog/log"
@@ -437,7 +436,7 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 				} else {
 					log.Info().Msgf("Use the Image %s in ns %s", spImgName, nsId)
 				}
-				// Validate: AWS/GCP must use isKubernetesImage=true images
+				// Validate: type-identifier CSPs (AWS/GCP/Tencent) must use registered K8s node image types
 				if createErr = validateK8sImageForProvider(nsId, connConfig.ProviderName, v.ImageId); createErr != nil {
 					return emptyObj, createErr
 				}
@@ -735,7 +734,7 @@ func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *m
 			} else {
 				log.Info().Msgf("Use the Image %s in ns %s", spImgName, nsId)
 			}
-			// Validate: AWS/GCP must use isKubernetesImage=true images
+			// Validate: type-identifier CSPs (AWS/GCP/Tencent) must use registered K8s node image types
 			if err = validateK8sImageForProvider(nsId, connConfig.ProviderName, u.ImageId); err != nil {
 				return emptyObj, err
 			}
@@ -2328,26 +2327,28 @@ func convertSpiderNodeGroupStatusToK8sNodeGroupStatus(spNodeGroupStatus model.Sp
 	return model.K8sNodeGroupInactive
 }
 
-// validateK8sImageForProvider validates that the provided imageId is a valid K8s node image
-// for AWS/GCP. These providers only support type-based image selection (not direct imageId).
+// validateK8sImageForProvider validates that the provided imageId is a registered
+// K8s node image type for CSPs that use the type-identifier model (AWS/GCP/Tencent).
+// For these CSPs, only image entries registered via cloudimage.csv
+// (IsKubernetesImage=true) are accepted.
 func validateK8sImageForProvider(nsId, providerName, imageId string) error {
-	switch strings.ToLower(providerName) {
-	case csp.AWS, csp.GCP:
-		imgInfo, err := GetImage(nsId, imageId)
+	if !usesTypeIdentifierK8sImage(providerName) {
+		return nil
+	}
+	imgInfo, err := GetImage(nsId, imageId)
+	if err != nil {
+		imgInfo, err = GetImage(model.SystemCommonNs, imageId)
 		if err != nil {
-			imgInfo, err = GetImage(model.SystemCommonNs, imageId)
-			if err != nil {
-				return fmt.Errorf("image(%s) not found", imageId)
-			}
+			return fmt.Errorf("image(%s) not found", imageId)
 		}
-		if !imgInfo.IsKubernetesImage {
-			return fmt.Errorf(
-				"provider(%s) only supports K8s node image types for cluster creation. "+
-					"Image(%s) is not a valid K8s node image type. "+
-					"Use searchImage(isKubernetesImage=true, provider=%s) to find valid options",
-				providerName, imageId, providerName,
-			)
-		}
+	}
+	if !imgInfo.IsKubernetesImage {
+		return fmt.Errorf(
+			"provider(%s) requires a registered K8s node image type for cluster creation. "+
+				"Image(%s) is not a valid K8s node image type. "+
+				"Use searchImage(isKubernetesImage=true, provider=%s) to find valid options",
+			providerName, imageId, providerName,
+		)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add Tencent K8s images in `assets/cloudimage.csv`
- Update Tencent K8s version in `assets/k8sclusterinfo.yaml`
- Verified Tencent TKE images — cluster create / nodegroup add / get / list / kubeconfig extract / nodegroup delete / cluster delete all pass. 
- Headlamp nginx deploy returns HTTP 502 because TKE's default kubeconfig points to the VPC-internal API server endpoint — to be addressed separately