### PR TITLE
Enhance VNet/Subnet reconcile with Spider allvpc state scan

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -389,6 +389,7 @@ github.com/Nerzal/gocloak/v13 v13.9.0 h1:YWsJsdM5b0yhM2Ba3MLydiOlujkBry4TtdzfIzS
 github.com/Nerzal/gocloak/v13 v13.9.0/go.mod h1:YYuDcXZ7K2zKECyVP7pPqjKxx2AzYSpKDj8d6GuyM10=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/go-metrics v0.4.0/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -524,6 +525,8 @@ github.com/gorilla/sessions v1.3.0 h1:XYlkq7KcpOB2ZhHBPv5WpjMIxrQosiZanfoy1HLZFz
 github.com/gorilla/sessions v1.3.0/go.mod h1:ePLdVu+jbEgHH+KWw8I1z2wqd0BAdAQh/8LRvBeoNcQ=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
@@ -561,6 +564,7 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
 github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
@@ -605,9 +609,14 @@ github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Q
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
+github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
 github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
@@ -677,6 +686,7 @@ golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJ
 golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
+golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=
 golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/term v0.38.0 h1:PQ5pkm/rLO6HnxFR7N2lJHOZX6Kez5Y1gDSJla6jo7Q=
 golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=

--- a/src/core/common/apierr/apierr.go
+++ b/src/core/common/apierr/apierr.go
@@ -16,6 +16,11 @@ limitations under the License.
 //
 // Use Wrap in the resource layer to attach a message to downstream errors,
 // and Code in REST handlers to derive the HTTP status code.
+//
+// IsNotFound and IsConflict classify errors in priority order:
+// (1) Spider IID pattern — most reliable, set before any CSP call (Spider PR #1623).
+// (2) Message patterns — CSP text Spider proxies as HTTP 500.
+// (3) HTTP status — lowest priority; Spider's status is inconsistent (VPC always 500).
 package apierr
 
 import (
@@ -23,6 +28,30 @@ import (
 	"net/http"
 	"strings"
 )
+
+// Spider's most reliable message patterns from Spider.
+// https://github.com/cloud-barista/cb-spider/pull/1623
+const (
+	spiderNotFoundPattern = "does not exist in connection"
+	spiderConflictPattern = "already exists in connection"
+)
+
+// normalNotFoundPatterns matches CSP-originated "not found" error text.
+// Spider passes CSP errors through as HTTP 500, so message matching is required.
+var normalNotFoundPatterns = []string{
+	"not found",
+	"does not exist",
+	"no such",
+	"resource not found",
+}
+
+// normalConflictPatterns matches CSP-originated "already exists" error text.
+var normalConflictPatterns = []string{
+	"already exists",
+	"conflict",
+	"duplicate",
+	"bucket name already",
+}
 
 // StatusError is the error type used throughout the Tumblebug pipeline.
 // HandleHttpResponse sets StatusCode and Cause; Wrap sets Message.
@@ -49,8 +78,7 @@ func (e *StatusError) Error() string {
 // Unwrap implements the errors unwrap interface.
 func (e *StatusError) Unwrap() error { return e.Cause }
 
-// Wrap attaches message to err, preserving StatusCode and Cause if err is already
-// a *StatusError (the common case after HandleHttpResponse).
+// Wrap attaches message to err, preserving StatusCode and Cause.
 func Wrap(err error, message string) error {
 	if err == nil {
 		return errors.New(message)
@@ -77,23 +105,31 @@ func Code(err error) int {
 	}
 }
 
+// spiderMsg returns the raw Spider/CSP error text from StatusError.Cause,
+// bypassing any TB-level Wrap message.
+func spiderMsg(err error) string {
+	var se *StatusError
+	if errors.As(err, &se) && se.Cause != nil {
+		return se.Cause.Error()
+	}
+	return err.Error()
+}
+
 // IsNotFound reports whether err represents a not-found condition.
 func IsNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	var se *StatusError
-	if errors.As(err, &se) {
-		if se.StatusCode == http.StatusNotFound {
-			return true
-		}
-		// 5xx: server-side error — never infer "not found" from message alone.
-		if se.StatusCode >= 500 {
-			return false
-		}
+	msg := spiderMsg(err)
+
+	if strings.Contains(strings.ToLower(msg), spiderNotFoundPattern) { // Not found in/via Spider
+		return true
 	}
-	// No HTTP status (transport error) or non-5xx: fall back to message patterns.
-	return containsAny(err.Error(), notFoundPatterns)
+	if containsAny(msg, normalNotFoundPatterns) { // CSP message patterns
+		return true
+	}
+	var se *StatusError // HTTP 404 fallback (e.g. Terrarium)
+	return errors.As(err, &se) && se.StatusCode == http.StatusNotFound
 }
 
 // IsConflict reports whether err represents a conflict / already-exists condition.
@@ -101,33 +137,16 @@ func IsConflict(err error) bool {
 	if err == nil {
 		return false
 	}
-	var se *StatusError
-	if errors.As(err, &se) {
-		if se.StatusCode == http.StatusConflict {
-			return true
-		}
-		// 5xx: server-side error — never infer "conflict" from message alone.
-		if se.StatusCode >= 500 {
-			return false
-		}
+	msg := spiderMsg(err)
+
+	if strings.Contains(strings.ToLower(msg), spiderConflictPattern) { // Conflict in/via Spider
+		return true
 	}
-	// No HTTP status (transport error) or non-5xx: fall back to message patterns.
-	return containsAny(err.Error(), conflictPatterns)
-}
-
-var notFoundPatterns = []string{
-	"not found",
-	"does not exist",
-	"cannot get",
-	"no such",
-	"resource not found",
-}
-
-var conflictPatterns = []string{
-	"already exists",
-	"conflict",
-	"duplicate",
-	"bucket name already",
+	if containsAny(msg, normalConflictPatterns) { // CSP message patterns
+		return true
+	}
+	var se *StatusError // HTTP 409 fallback
+	return errors.As(err, &se) && se.StatusCode == http.StatusConflict
 }
 
 func containsAny(s string, patterns []string) bool {

--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -29,8 +29,8 @@ import (
 	"time"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
-	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/apierr"
+	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/label"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
@@ -3273,4 +3273,109 @@ func CheckAssociatedCspResourceExistence(nsId string, resourceType string, resou
 	log.Debug().Str("cspResourceId", cspResourceId).Str("connection", connConfig).
 		Str("resourceType", resourceType).Msg("Resource not found in any list")
 	return false, false, nil
+}
+
+// deepScanResourcesOn queries Spider's all-resource endpoint and returns the
+// three-way classification list (MappedList, OnlySpiderList, OnlyCSPList).
+// StrSubnet is not supported here; use deepScanVpcInfoOn instead.
+func deepScanResourcesOn(connName, resourceType string) (model.SpiderAllList, error) {
+	var spiderURL string
+	switch resourceType {
+	case model.StrNLB:
+		spiderURL = model.SpiderRestUrl + "/allnlb"
+	case model.StrNode:
+		spiderURL = model.SpiderRestUrl + "/allvm"
+	case model.StrVNet:
+		spiderURL = model.SpiderRestUrl + "/allvpc"
+	case model.StrSecurityGroup:
+		spiderURL = model.SpiderRestUrl + "/allsecuritygroup"
+	case model.StrSSHKey:
+		spiderURL = model.SpiderRestUrl + "/allkeypair"
+	case model.StrDataDisk:
+		spiderURL = model.SpiderRestUrl + "/alldisk"
+	case model.StrCustomImage:
+		spiderURL = model.SpiderRestUrl + "/allmyimage"
+	default:
+		return model.SpiderAllList{}, fmt.Errorf("unsupported resource type for fetchSpiderAllList: %s", resourceType)
+	}
+	body := model.CspResourceStatusRequest{ConnectionName: connName}
+	var result model.SpiderAllListWrapper
+	client := clientManager.NewHttpClient()
+	client.SetAllowGetMethodPayload(true)
+	restyResp, err := clientManager.ExecuteHttpRequest(
+		client, "GET", spiderURL, nil,
+		clientManager.SetUseBody(body), &body, &result, clientManager.MediumDuration,
+	)
+	if err = clientManager.HandleHttpResponse(restyResp, err); err != nil {
+		return model.SpiderAllList{}, err
+	}
+	return result.AllList, nil
+}
+
+// deepScanVpcInfoOn queries Spider's /allvpcinfo endpoint and returns the full VPC
+// list including per-VPC subnet lists, preserving the VPC-Subnet relationship.
+func deepScanVpcInfoOn(connName string) (model.SpiderAllVpcListInfo, error) {
+	noBody := clientManager.NoBody
+	url := fmt.Sprintf("%s/allvpcinfo?ConnectionName=%s", model.SpiderRestUrl, connName)
+	var result model.SpiderAllVpcInfoWrapper
+	restyResp, err := clientManager.ExecuteHttpRequest(
+		clientManager.NewHttpClient(), "GET", url, nil,
+		clientManager.SetUseBody(noBody), &noBody, &result, clientManager.MediumDuration,
+	)
+	if err = clientManager.HandleHttpResponse(restyResp, err); err != nil {
+		return model.SpiderAllVpcListInfo{}, err
+	}
+	return result.AllListInfo, nil
+}
+
+// vpcStateInSpiderAllList returns the state of a VPC name across Spider and CSP:
+// "exists", "spiderOnly", "cspOnly", or "absent".
+func vpcStateInSpiderAllList(name string, all model.SpiderAllList) string {
+	for _, item := range all.MappedList {
+		if item.NameId == name {
+			return "exists"
+		}
+	}
+	for _, item := range all.OnlySpiderList {
+		if item.NameId == name {
+			return "spiderOnly"
+		}
+	}
+	for _, item := range all.OnlyCSPList {
+		if item.NameId == name {
+			return "cspOnly"
+		}
+	}
+	return "absent"
+}
+
+// subnetStateInAllVpcInfo returns the state of a subnet across Spider and CSP:
+// "exists", "spiderOnly", "cspOnly", or "absent".
+func subnetStateInAllVpcInfo(vpcName, subnetName string, allListInfo model.SpiderAllVpcListInfo) string {
+	for _, vpc := range allListInfo.MappedInfoList {
+		if vpc.IId.NameId == vpcName {
+			for _, subnet := range vpc.SubnetInfoList {
+				if subnet.IId.NameId == subnetName {
+					return "exists"
+				}
+			}
+			return "spiderOnly" // VPC in CSP but subnet gone
+		}
+	}
+	for _, vpc := range allListInfo.OnlySpiderList {
+		if vpc.IId.NameId == vpcName {
+			return "spiderOnly" // VPC IID in Spider but CSP has no trace
+		}
+	}
+	for _, vpc := range allListInfo.OnlyCSPInfoList {
+		if vpc.IId.NameId == vpcName {
+			for _, subnet := range vpc.SubnetInfoList {
+				if subnet.IId.NameId == subnetName {
+					return "cspOnly" // CSP has the subnet but Spider has no IID
+				}
+			}
+			return "absent" // VPC in CSP but subnet truly gone
+		}
+	}
+	return "absent" // VPC not found anywhere
 }

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -948,47 +948,19 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string) (model.SimpleM
 	 *	Check and reconcile the subnet info
 	 */
 
-	// [Via Spider] Get the subnet
-	client := clientManager.NewHttpClient()
-	method := "GET"
-
-	// API to get a subnet
-	url := fmt.Sprintf("%s/vpc/%s/subnet/%s", model.SpiderRestUrl, subnetInfo.CspVNetName, subnetInfo.CspResourceName)
-	queryParams := "?ConnectionName=" + subnetInfo.ConnectionName
-	url += queryParams
-
-	spReqt := clientManager.NoBody
-
-	log.Debug().Msgf("[Request to Spider] Reconciling Subnet: %s", url)
-
-	var spResp spiderSubnetInfo
-
-	// restyResp is captured so HandleHttpResponse can wrap the error with the
-	// HTTP status code; this lets apierr.IsNotFound use the status code
-	// as a secondary signal when the error message alone is ambiguous.
-	restyResp, err := clientManager.ExecuteHttpRequest(
-		client,
-		method,
-		url,
-		nil,
-		clientManager.SetUseBody(spReqt),
-		&spReqt,
-		&spResp,
-		clientManager.MediumDuration,
-	)
-	err = clientManager.HandleHttpResponse(restyResp, err)
-
-	log.Trace().Msgf("[Response from Spider] Reconciling Subnet: %+v", spResp)
-
-	// Only proceed with cleanup when the subnet is confirmed not found (404).
-	// For server errors (5xx) or transport errors, return the error without cleanup
-	// to prevent accidental data loss during Spider/CSP outages.
-	if err != nil && !apierr.IsNotFound(err) {
-		log.Error().Err(err).Msg("failed to get subnet from Spider, skipping reconciliation")
-		return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile subnet '%s'", subnetId))
+	// [Via Spider] List all VPC info to determine the exact Spider/CSP state of the subnet.
+	log.Debug().Msgf("[Request to Spider] Listing all VPC info for connection: %s", subnetInfo.ConnectionName)
+	allListInfo, allVpcErr := deepScanVpcInfoOn(subnetInfo.ConnectionName)
+	if allVpcErr != nil {
+		log.Error().Err(allVpcErr).Msg("failed to list VPC info from Spider, skipping reconciliation")
+		return emptyRet, apierr.Wrap(allVpcErr, fmt.Sprintf("failed to reconcile subnet '%s'", subnetId))
 	}
 
-	if err == nil {
+	subnetState := subnetStateInAllVpcInfo(subnetInfo.CspVNetName, subnetInfo.CspResourceName, allListInfo)
+	log.Debug().Msgf("Subnet '%s' state in Spider: %q", subnetInfo.CspResourceName, subnetState)
+
+	switch subnetState {
+	case "exists":
 		// Subnet exists on CSP. Restore status only when metadata is stuck in
 		// a terminal-failure state (e.g., DeletionFailed) — typically caused
 		// by a dependency that has since been resolved.
@@ -1041,35 +1013,47 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string) (model.SimpleM
 		ret.Message = fmt.Sprintf("subnet (%s) exists on CSP; metadata is consistent (no action needed)", subnetId)
 		log.Info().Msg(ret.Message)
 		return ret, nil
-	}
 
-	/*
-	 *	Delete the subnet info in case of the subnet does not exist
-	 */
+	case "cspOnly":
+		// CSP resource still exists but Spider has no IID.
+		// Preserve TB metadata — deleting it would orphan the CSP resource.
+		// TODO: consider re-registering the CSP-only subnet into Spider.
+		ret.Message = fmt.Sprintf("subnet (%s) exists on CSP but has no Spider IID (cspOnly); TB metadata preserved", subnetId)
+		log.Warn().Msg(ret.Message)
+		return ret, nil
 
-	// [Via Spider] Purge Spider subnet metadata by force delete (CSP resource already gone).
-	// Note: Spider sends a force delete request to the CSP and removes its own metadata
-	// regardless of whether the CSP-side deletion succeeds or fails.
-	spForceDelReqt := spiderSubnetRemoveReq{ConnectionName: subnetInfo.ConnectionName}
-	forceDelURL := fmt.Sprintf("%s/vpc/%s/subnet/%s?force=true",
-		model.SpiderRestUrl, subnetInfo.CspVNetName, subnetInfo.CspResourceName)
-	log.Debug().Msgf("[Request to Spider] Purge Spider subnet metadata by force delete: %s", forceDelURL)
-	var spForceDelResp spiderBooleanInfoResp
-	restyForceDelResp, forceDelErr := clientManager.ExecuteHttpRequest(
-		clientManager.NewHttpClient(),
-		"DELETE",
-		forceDelURL,
-		nil,
-		clientManager.SetUseBody(spForceDelReqt),
-		&spForceDelReqt,
-		&spForceDelResp,
-		clientManager.MediumDuration,
-	)
-	forceDelErr = clientManager.HandleHttpResponse(restyForceDelResp, forceDelErr)
-	if forceDelErr != nil {
-		log.Warn().Err(forceDelErr).Msgf("Purge Spider subnet metadata by force delete failed for %s (continuing reconcile)", subnetInfo.CspResourceName)
-	} else {
-		log.Info().Msgf("Purge Spider subnet metadata by force delete succeeded for %s", subnetInfo.CspResourceName)
+
+	case "spiderOnly":
+		/*
+		 *	Subnet is gone from CSP (or was never registered in Spider).
+		 *	Purge the Spider IID only when Spider still tracks it, then remove TB metadata.
+		 */
+
+		// Spider still has the IID but the CSP resource is gone: force-delete to purge the IID.
+		spForceDelReqt := spiderSubnetRemoveReq{ConnectionName: subnetInfo.ConnectionName}
+		forceDelURL := fmt.Sprintf("%s/vpc/%s/subnet/%s?force=true",
+			model.SpiderRestUrl, subnetInfo.CspVNetName, subnetInfo.CspResourceName)
+		log.Debug().Msgf("[Request to Spider] Purge Spider subnet metadata by force delete: %s", forceDelURL)
+		var spForceDelResp spiderBooleanInfoResp
+		restyForceDelResp, forceDelErr := clientManager.ExecuteHttpRequest(
+			clientManager.NewHttpClient(),
+			"DELETE",
+			forceDelURL,
+			nil,
+			clientManager.SetUseBody(spForceDelReqt),
+			&spForceDelReqt,
+			&spForceDelResp,
+			clientManager.MediumDuration,
+		)
+		forceDelErr = clientManager.HandleHttpResponse(restyForceDelResp, forceDelErr)
+		if forceDelErr != nil {
+			log.Warn().Err(forceDelErr).Msgf("Purge Spider subnet metadata by force delete failed for %s (continuing reconcile)", subnetInfo.CspResourceName)
+		} else {
+			log.Info().Msgf("Purge Spider subnet metadata by force delete succeeded for %s", subnetInfo.CspResourceName)
+		}
+
+	case "absent":
+		// No Spider IID to purge; the resource is gone from both Spider and CSP.
 	}
 
 	// Delete the saved the subnet info

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
-	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/apierr"
+	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/label"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/netutil"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -1172,44 +1172,19 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 	 *	Check and reconcile the info of vNet and associated subnets
 	 */
 
-	// [Via Spider] Get a vNet
-	client := clientManager.NewHttpClient()
-	method := "GET"
-	spReqt := clientManager.NoBody
-	var spResp spiderVPCInfo
-
-	// API to get a vNet
-	url := fmt.Sprintf("%s/vpc/%s", model.SpiderRestUrl, vNetInfo.CspResourceName)
-	queryParams := "?ConnectionName=" + vNetInfo.ConnectionName
-	url += queryParams
-
-	log.Debug().Msgf("[Request to Spider] Reconciling VPC: %s", url)
-
-	// restyResp is captured so HandleHttpResponse can wrap the error with the
-	// HTTP status code; this lets apierr.IsNotFound use the status code
-	// as a secondary signal when the error message alone is ambiguous.
-	restyResp, err := clientManager.ExecuteHttpRequest(
-		client,
-		method,
-		url,
-		nil,
-		clientManager.SetUseBody(spReqt),
-		&spReqt,
-		&spResp,
-		clientManager.MediumDuration,
-	)
-	err = clientManager.HandleHttpResponse(restyResp, err)
-
-	log.Trace().Msgf("[Response from Spider] Reconciling VPC: %+v", spResp)
-
-	// Only proceed with cleanup when the VPC is confirmed not found (404).
-	// For server errors (5xx) or transport errors, return the error without cleanup
-	// to prevent accidental data loss during Spider/CSP outages.
-	if err != nil && !apierr.IsNotFound(err) {
-		log.Error().Err(err).Msg("failed to get VPC from Spider, skipping reconciliation")
+	// [Via Spider] List all VPCs to determine the exact Spider/CSP state.
+	log.Debug().Msgf("[Request to Spider] Listing all VPCs for connection: %s", vNetInfo.ConnectionName)
+	allVpcList, err := deepScanResourcesOn(vNetInfo.ConnectionName, model.StrVNet)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to list VPCs from Spider, skipping reconciliation")
 		return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile vNet '%s'", vNetId))
 	}
-	if err == nil {
+
+	vpcState := vpcStateInSpiderAllList(vNetInfo.CspResourceName, allVpcList)
+	log.Debug().Msgf("VPC '%s' state in Spider: %q", vNetInfo.CspResourceName, vpcState)
+
+	switch vpcState {
+	case "exists":
 		// VPC exists on CSP. Recurse into child subnets first so that any
 		// per-subnet drift (orphaned metadata, stuck statuses) is settled
 		// before evaluating the parent vNet status.
@@ -1278,35 +1253,44 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 		ret.Message = fmt.Sprintf("vNet (%s) exists on CSP; metadata is consistent (no action needed)", vNetId)
 		log.Info().Msg(ret.Message)
 		return ret, nil
-	}
 
-	/*
-	 * In case of the VPC info/resource does not exist in Spider/CSP
-	 * delete the information of vNet and subnets from the key-value stores
-	 */
+	case "cspOnly":
+		// CSP resource still exists but Spider has no IID.
+		// Preserve TB metadata — deleting it would orphan the CSP resource.
+		// TODO: consider re-registering the CSP-only VPC into Spider.
+		ret.Message = fmt.Sprintf("vNet (%s) exists on CSP but has no Spider IID (cspOnly); TB metadata preserved", vNetId)
+		log.Warn().Msg(ret.Message)
+		return ret, nil
 
-	// [Via Spider] Purge Spider VPC metadata by force delete (CSP resource already gone).
-	// Note: Spider sends a force delete request to the CSP and removes its own metadata
-	// regardless of whether the CSP-side deletion succeeds or fails.
-	spForceDelReqt := spiderVpcDeleteReq{ConnectionName: vNetInfo.ConnectionName}
-	forceDelURL := fmt.Sprintf("%s/vpc/%s?force=true", model.SpiderRestUrl, vNetInfo.CspResourceName)
-	log.Debug().Msgf("[Request to Spider] Purge Spider VPC metadata by force delete: %s", forceDelURL)
-	var spForceDelResp spiderBooleanInfoResp
-	restyForceDelResp, forceDelErr := clientManager.ExecuteHttpRequest(
-		clientManager.NewHttpClient(),
-		"DELETE",
-		forceDelURL,
-		nil,
-		clientManager.SetUseBody(spForceDelReqt),
-		&spForceDelReqt,
-		&spForceDelResp,
-		clientManager.MediumDuration,
-	)
-	forceDelErr = clientManager.HandleHttpResponse(restyForceDelResp, forceDelErr)
-	if forceDelErr != nil {
-		log.Warn().Err(forceDelErr).Msgf("Purge Spider VPC metadata by force delete failed for %s (continuing reconcile)", vNetInfo.CspResourceName)
-	} else {
-		log.Info().Msgf("Purge Spider VPC metadata by force delete succeeded for %s", vNetInfo.CspResourceName)
+	case "spiderOnly":
+		/*
+		 * VPC is gone from CSP (or was never registered in Spider).
+		 * Purge the Spider IID only when Spider still tracks it, then remove TB metadata.
+		 */
+		// Spider still has the IID but the CSP resource is gone: force-delete to purge the IID.
+		spForceDelReqt := spiderVpcDeleteReq{ConnectionName: vNetInfo.ConnectionName}
+		forceDelURL := fmt.Sprintf("%s/vpc/%s?force=true", model.SpiderRestUrl, vNetInfo.CspResourceName)
+		log.Debug().Msgf("[Request to Spider] Purge Spider VPC metadata by force delete: %s", forceDelURL)
+		var spForceDelResp spiderBooleanInfoResp
+		restyForceDelResp, forceDelErr := clientManager.ExecuteHttpRequest(
+			clientManager.NewHttpClient(),
+			"DELETE",
+			forceDelURL,
+			nil,
+			clientManager.SetUseBody(spForceDelReqt),
+			&spForceDelReqt,
+			&spForceDelResp,
+			clientManager.MediumDuration,
+		)
+		forceDelErr = clientManager.HandleHttpResponse(restyForceDelResp, forceDelErr)
+		if forceDelErr != nil {
+			log.Warn().Err(forceDelErr).Msgf("Purge Spider VPC metadata by force delete failed for %s (continuing reconcile)", vNetInfo.CspResourceName)
+		} else {
+			log.Info().Msgf("Purge Spider VPC metadata by force delete succeeded for %s", vNetInfo.CspResourceName)
+		}
+
+	case "absent":
+		// No Spider IID to purge; the resource is gone from both Spider and CSP.
 	}
 
 	// Delete subnet objects from the key-value store


### PR DESCRIPTION
- Replace direct GET (Spider returns 500 for VPCs) with allvpc/allvpcinfo three-way scan
- Classify each resource as exists/spiderOnly/cspOnly/absent before acting
- Skip force-delete and preserve TB metadata when resource is cspOnly
- Refactor apierr IsNotFound/IsConflict to prioritize Spider IID patterns over HTTP status

---

(Additional note of error classification order)
```
// IsNotFound and IsConflict classify errors in priority order:
// (1) Spider IID pattern — most reliable, set before any CSP call (Spider PR #1623).
// (2) Message patterns — CSP text Spider proxies as HTTP 500.
// (3) HTTP status — lowest priority; Spider's status is inconsistent (VPC always 500).
```