### PR TITLE
Support preloaded status to reduce redundant GetCspResourceStatus calls

### DIFF
--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -588,7 +588,7 @@ func markSubnetDeleteFailedThenReconcile(nsId, vNetId, subnetId, subnetKey strin
 		_ = kvstore.Put(subnetKey, string(failVal))
 	}
 	// Self-heal: opportunistic single-shot Reconcile after recording Failed state.
-	if _, recErr := ReconcileSubnet(nsId, vNetId, subnetId); recErr != nil {
+	if _, recErr := ReconcileSubnet(nsId, vNetId, subnetId, nil); recErr != nil {
 		log.Warn().Err(recErr).Msgf("auto-reconcile after delete failure failed for subnet %s/%s/%s", nsId, vNetId, subnetId)
 	}
 }
@@ -862,7 +862,9 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 	return ret, nil
 }
 
-func ReconcileSubnet(nsId string, vNetId string, subnetId string) (model.SimpleMsg, error) {
+// ReconcileSubnet checks if the CSP/Spider subnet still exists and reconciles metadata accordingly.
+// optPreloadedSubnetStatus: optional pre-fetched subnet status; if nil, will be fetched internally.
+func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSubnetStatus *model.CspResourceStatusResponse) (model.SimpleMsg, error) {
 	log.Info().Msg("ReconcileSubnet")
 
 	/*
@@ -949,11 +951,20 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string) (model.SimpleM
 	 */
 
 	// [Via Spider] Get subnet resource status to determine the exact Spider/CSP state.
-	log.Debug().Msgf("[Request to Spider] Getting subnet resource status for connection: %s", subnetInfo.ConnectionName)
-	subnetStatusResp, err := GetCspResourceStatus(subnetInfo.ConnectionName, model.StrSubnet)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to get subnet resource status from Spider, skipping reconciliation")
-		return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile subnet '%s'", subnetId))
+	var subnetStatusResp model.CspResourceStatusResponse
+	if optPreloadedSubnetStatus != nil && len(optPreloadedSubnetStatus.AllList.MappedList) > 0 {
+		// Use preloaded status if available
+		subnetStatusResp = *optPreloadedSubnetStatus
+		log.Debug().Msgf("Using preloaded subnet status for reconciliation (connection: %s)", subnetInfo.ConnectionName)
+	} else {
+		// No preloaded status, fetch from Spider
+		log.Debug().Msgf("[Request to Spider] Getting subnet resource status for connection: %s", subnetInfo.ConnectionName)
+		var err error
+		subnetStatusResp, err = GetCspResourceStatus(subnetInfo.ConnectionName, model.StrSubnet)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to get subnet resource status from Spider, skipping reconciliation")
+			return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile subnet '%s'", subnetId))
+		}
 	}
 
 	subnetState := getResourceState(subnetInfo.CspResourceName, subnetStatusResp)

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -859,7 +859,7 @@ func markVNetDeleteFailedThenReconcile(nsId, vNetId, vNetKey string, vNetInfo *m
 		_ = kvstore.Put(vNetKey, string(failVal))
 	}
 	// Self-heal: opportunistic single-shot Reconcile after recording Failed state.
-	if _, recErr := ReconcileVNet(nsId, vNetId); recErr != nil {
+	if _, recErr := ReconcileVNet(nsId, vNetId, nil); recErr != nil {
 		log.Warn().Err(recErr).Msgf("auto-reconcile after delete failure failed for vNet %s/%s", nsId, vNetId)
 	}
 }
@@ -1108,7 +1108,9 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 	return ret, nil
 }
 
-func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
+// ReconcileVNet checks if the CSP/Spider VNet still exists and reconciles metadata accordingly.
+// optPreloadedVNetStatus: optional pre-fetched VNet status; if nil, will be fetched internally.
+func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.CspResourceStatusResponse) (model.SimpleMsg, error) {
 	log.Info().Msg("ReconcileVNet")
 
 	/*
@@ -1169,11 +1171,20 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 	 */
 
 	// [Via Spider] List all VPCs to determine the exact Spider/CSP state.
-	log.Debug().Msgf("[Request to Spider] Listing all VPCs for connection: %s", vNetInfo.ConnectionName)
-	vpcStatusResp, err := GetCspResourceStatus(vNetInfo.ConnectionName, model.StrVNet)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to get VPC resource status from Spider, skipping reconciliation")
-		return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile vNet '%s'", vNetId))
+	var vpcStatusResp model.CspResourceStatusResponse
+	if optPreloadedVNetStatus != nil && len(optPreloadedVNetStatus.AllList.MappedList) > 0 {
+		// Use preloaded status if available
+		vpcStatusResp = *optPreloadedVNetStatus
+		log.Debug().Msgf("Using preloaded VNet status for reconciliation (connection: %s)", vNetInfo.ConnectionName)
+	} else {
+		// No preloaded status, fetch from Spider
+		log.Debug().Msgf("[Request to Spider] Listing all VPCs for connection: %s", vNetInfo.ConnectionName)
+		var err error
+		vpcStatusResp, err = GetCspResourceStatus(vNetInfo.ConnectionName, model.StrVNet)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to get VPC resource status from Spider, skipping reconciliation")
+			return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile vNet '%s'", vNetId))
+		}
 	}
 
 	vpcState := getResourceState(vNetInfo.CspResourceName, vpcStatusResp)
@@ -1192,6 +1203,19 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 			return emptyRet, err2
 		}
 
+		// Fetch subnet status once for all subnets to optimize API calls
+		var optPreloadedSubnetStatus *model.CspResourceStatusResponse
+		if len(subnetKvList) > 0 {
+			log.Debug().Msgf("[Request to Spider] Listing all Subnets for connection: %s", vNetInfo.ConnectionName)
+			subnetStatus, subnetErr := GetCspResourceStatus(vNetInfo.ConnectionName, model.StrSubnet)
+			if subnetErr != nil {
+				log.Warn().Err(subnetErr).Msg("failed to get subnet status; each ReconcileSubnet will retry individually")
+				optPreloadedSubnetStatus = nil // nil means each ReconcileSubnet will fetch individually
+			} else {
+				optPreloadedSubnetStatus = &subnetStatus
+			}
+		}
+
 		for _, subnetKv := range subnetKvList {
 			subnetInfo := model.SubnetInfo{}
 			if uErr := json.Unmarshal([]byte(subnetKv.Value), &subnetInfo); uErr != nil {
@@ -1200,7 +1224,7 @@ func ReconcileVNet(nsId string, vNetId string) (model.SimpleMsg, error) {
 			}
 			log.Trace().Msgf("subnetInfo: %+v", subnetInfo)
 
-			if _, sErr := ReconcileSubnet(nsId, vNetId, subnetInfo.Id); sErr != nil {
+			if _, sErr := ReconcileSubnet(nsId, vNetId, subnetInfo.Id, optPreloadedSubnetStatus); sErr != nil {
 				log.Warn().Err(sErr).Msg("")
 			}
 		}

--- a/src/interface/rest/server/resource/subnet.go
+++ b/src/interface/rest/server/resource/subnet.go
@@ -282,7 +282,7 @@ func RestDelSubnet(c echo.Context) error {
 		}
 	case resource.ActionReconcile:
 		// [Process]
-		resp, err = resource.ReconcileSubnet(nsId, vNetId, subnetId)
+		resp, err = resource.ReconcileSubnet(nsId, vNetId, subnetId, nil)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return c.JSON(apierr.Code(err), model.SimpleMsg{Message: err.Error()})

--- a/src/interface/rest/server/resource/vnet.go
+++ b/src/interface/rest/server/resource/vnet.go
@@ -243,7 +243,7 @@ func RestDelVNet(c echo.Context) error {
 		}
 	case resource.ActionReconcile:
 		// [Process]
-		resp, err = resource.ReconcileVNet(nsId, vNetId)
+		resp, err = resource.ReconcileVNet(nsId, vNetId, nil)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return c.JSON(apierr.Code(err), model.SimpleMsg{Message: err.Error()})


### PR DESCRIPTION
- Add optional preloaded status (list) parameter to ReconcileVNet/ReconcileSubnet
- Prefetch resource status once and reuse for multiple reconciliations
- Reduce redundant GetCspResourceStatus calls (fetches all resources per connection)
- Falls back to internal fetch when preloaded status is nil/empty