### PR TITLE
Staging cb-tumblebug:0.12.13

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ x-default-healthcheck: &default-healthcheck
 services:
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.12.12
+    image: cloudbaristaorg/cb-tumblebug:0.12.13
     container_name: cb-tumblebug
     build:
       context: .
@@ -148,7 +148,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.12.23
+    image: cloudbaristaorg/cb-spider:0.12.24
     container_name: cb-spider
     # build:
     #   context: ../cb-spider

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -148,7 +148,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.12.24
+    image: cloudbaristaorg/cb-spider:0.12.26
     container_name: cb-spider
     # build:
     #   context: ../cb-spider

--- a/init/init.py
+++ b/init/init.py
@@ -598,30 +598,34 @@ def print_assets_summary(ns_id="system"):
 
         rows = []
         for p in providers:
+            total = p.get("specCount", 0)
+            priced = p.get("pricedSpecCount", 0)
+            pct = f"{round(priced / total * 100)}%" if total > 0 else "N/A"
             rows.append(
                 [
                     p.get("providerName", ""),
-                    p.get("specCount", 0),
-                    p.get("pricedSpecCount", 0),
-                    p.get("unpricedSpecCount", 0),
                     p.get("imageCount", 0),
+                    total,
+                    pct,
                 ]
             )
 
         print(
             tabulate(
                 rows,
-                headers=["Provider", "Specs", "Specs(priced)", "Specs(price-NA)", "Images"],
+                headers=["Provider", "Images", "Specs", "(Priced)"],
                 tablefmt="simple",
+                colalign=("left", "right", "right", "right"),
             )
         )
 
+        total_specs = payload.get('totalSpecCount', 0)
+        total_priced = payload.get('pricedSpecCount', 0)
+        total_pct = f"{round(total_priced / total_specs * 100)}%" if total_specs > 0 else "N/A"
         print(
             Fore.CYAN
             + "Totals: "
-            + f"specs={payload.get('totalSpecCount', 0)}, "
-            + f"priced={payload.get('pricedSpecCount', 0)}, "
-            + f"price-NA={payload.get('unpricedSpecCount', 0)}, "
+            + f"specs={total_specs} ({total_pct} priced), "
             + f"images={payload.get('totalImageCount', 0)}"
         )
     except requests.RequestException as e:

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -174,6 +174,9 @@ func ConvertSpiderSpecToTumblebugSpec(connConfig model.ConnConfig, spiderSpec mo
 			}
 		}
 
+		// Correct manufacturer when Spider reports incorrect info (e.g., IBM labels Gaudi/MI300X as NVIDIA)
+		tumblebugSpec.AcceleratorModel = normalizeAcceleratorModel(tumblebugSpec.AcceleratorModel)
+
 		// Log if there are multiple GPUs defined
 		if len(spiderSpec.Gpu) > 1 {
 			log.Warn().Msgf("Spec %s has multiple GPUs defined (%d GPUs). Only using the first GPU information.",
@@ -182,6 +185,32 @@ func ConvertSpiderSpecToTumblebugSpec(connConfig model.ConnConfig, spiderSpec mo
 	}
 
 	return tumblebugSpec, nil
+}
+
+// normalizeAcceleratorModel corrects the manufacturer prefix based on known GPU model names.
+// Spider drivers may report incorrect manufacturer info (e.g., IBM labels Intel Gaudi and AMD MI300X as NVIDIA).
+// Models not listed here are left unchanged and trusted as-is.
+func normalizeAcceleratorModel(model string) string {
+	upper := strings.ToUpper(model)
+
+	// Intel GPU models (order matters: longer/more specific first)
+	for _, m := range []string{"GAUDI3", "GAUDI2", "GAUDI"} {
+		if strings.Contains(upper, m) {
+			return "Intel " + m
+		}
+	}
+
+	// AMD GPU models
+	for _, m := range []string{
+		"RADEON PRO V710", "RADEON PRO V620",
+		"MI300X", "MI300A", "MI300", "MI250X", "MI250", "MI210", "MI100", "INSTINCT",
+	} {
+		if strings.Contains(upper, m) {
+			return "AMD " + m
+		}
+	}
+
+	return model
 }
 
 // extractArchitecture extracts architecture information based on CSP-specific logic


### PR DESCRIPTION
- [Fix misleading spec info from CB-SP](https://github.com/cloud-barista/cb-tumblebug/commit/41e2edb4e451f2d2c83b390a5f69e10556bb25de)
- [Use cb-sp 0.12.26](https://github.com/cloud-barista/cb-tumblebug/commit/920f2ba9561571b115cfc49379ee1aec7f82ebbb)
- [Update assets/assets.dump.gz latest](https://github.com/cloud-barista/cb-tumblebug/commit/4655a72a0904b65aa1aa4ea5ef786167c680de4c)
- [Refine make init output format](https://github.com/cloud-barista/cb-tumblebug/commit/d38a45d89cdac423ddc44c3fe9a6b00aaacad7ae)

Totals: specs=69870 (95% priced), images=568521
```
Provider      Images    Specs  Priced
----------  --------  -------  -------
alibaba          360     4609     96%
aws           553564    18273     98%
azure           1566    30061     95%
gcp            11864    11296     93%
ibm              753     1798     97%
kt                33      220     14%
ncp              101      393     45%
nhn              129       71     92%
openstack          7        6      0%
tencent          144     3143    100%
```