### PR TITLE
feat(reconcile): add VNet reconciler and deletion failure handling

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,7 +74,7 @@ services:
       - VAULT_TOKEN=${VAULT_TOKEN:-}
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:1323/tumblebug/readyz" ]
+      test: ["CMD", "curl", "-f", "http://localhost:1323/tumblebug/readyz"]
       <<: *default-healthcheck
 
   # CB-Tumblebug ETCD
@@ -119,7 +119,7 @@ services:
       - simple
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "/usr/local/bin/etcdctl", "endpoint", "health", "--endpoints=http://localhost:2379" ]
+      test: ["CMD", "/usr/local/bin/etcdctl", "endpoint", "health", "--endpoints=http://localhost:2379"]
       <<: *default-healthcheck
 
   # CB-Tumblebug PostgreSQL
@@ -140,7 +140,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-tumblebug}
       - POSTGRES_DB=${POSTGRES_DB:-tumblebug}
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER" ]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -173,7 +173,7 @@ services:
       - SPIDER_BACKUP_ENABLED=false
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:1024/spider/readyz" ]
+      test: ["CMD", "curl", "-f", "http://localhost:1024/spider/readyz"]
       <<: *default-healthcheck
 
   # CB-MapUI
@@ -276,7 +276,7 @@ services:
       - VAULT_ADDR=http://openbao:8200
       - VAULT_TOKEN=${VAULT_TOKEN:-}
     healthcheck:
-      test: [ "CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8055/terrarium/readyz" ]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8055/terrarium/readyz"]
       <<: *default-healthcheck
     depends_on:
       openbao:
@@ -313,7 +313,7 @@ services:
       - BAO_ADDR=http://0.0.0.0:8200 # BAO_ADDR is for binding listener inside container
       - SKIP_SETCAP=true
     # Fix bind-mount ownership (host UID 1000 → container openbao UID 100)
-    entrypoint: [ "sh", "-c" ]
+    entrypoint: ["sh", "-c"]
     command:
       - |
         chown -R openbao:openbao /openbao/data || { echo "ERROR: chown failed on /openbao/data"; exit 1; }
@@ -338,7 +338,7 @@ services:
       # 'bao status' exit codes:
       #   0 = unsealed, 1 = sealed but running, 2 = uninitialized (first run)
       # All three mean the OpenBao process is up and accepting API calls.
-      test: [ "CMD", "sh", "-c", "rc=0; bao status || rc=$$?; [ $$rc -le 2 ]" ]
+      test: ["CMD", "sh", "-c", "rc=0; bao status || rc=$$?; [ $$rc -le 2 ]"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/src/core/reconcile/manager.go
+++ b/src/core/reconcile/manager.go
@@ -1,0 +1,53 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/cloud-barista/cb-tumblebug/src/core/model"
+)
+
+// Reconciler is an interface that every resource-specific reconciler must implement.
+type Reconciler interface {
+	Reconcile(ctx context.Context, nsId string, resourceId string, optPreloadedStatus *model.CspResourceStatusResponse) (any, error)
+}
+
+// Manager is a singleton registry that holds and routes reconcile requests to appropriate Reconcilers.
+type Manager struct {
+	reconcilers map[string]Reconciler
+	mux         sync.RWMutex
+}
+
+var instance *Manager
+var once sync.Once
+
+// GetManager returns the singleton instance of the Manager.
+func GetManager() *Manager {
+	once.Do(func() {
+		instance = &Manager{
+			reconcilers: make(map[string]Reconciler),
+		}
+	})
+	return instance
+}
+
+// RegisterReconciler registers a specific Reconciler for a given resourceType.
+func (m *Manager) RegisterReconciler(resourceType string, reconciler Reconciler) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+	m.reconcilers[resourceType] = reconciler
+}
+
+// RunReconcile routes the reconcile request to the registered Reconciler based on resourceType.
+func (m *Manager) RunReconcile(ctx context.Context, nsId string, resourceType string, resourceId string, optPreloadedStatus *model.CspResourceStatusResponse) (any, error) {
+	m.mux.RLock()
+	reconciler, exists := m.reconcilers[resourceType]
+	m.mux.RUnlock()
+
+	if !exists {
+		return nil, fmt.Errorf("no reconciler registered for resource type: %s", resourceType)
+	}
+
+	return reconciler.Reconcile(ctx, nsId, resourceId, optPreloadedStatus)
+}

--- a/src/core/reconcile/vnetReconcile.go
+++ b/src/core/reconcile/vnetReconcile.go
@@ -1,0 +1,113 @@
+package reconcile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/cloud-barista/cb-tumblebug/src/core/common"
+	"github.com/cloud-barista/cb-tumblebug/src/core/model"
+	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
+	"github.com/cloud-barista/cb-tumblebug/src/kvstore/kvstore"
+	"github.com/rs/zerolog/log"
+)
+
+// VNetReconciler implements the Reconciler interface for VNet resources.
+type VNetReconciler struct{}
+
+func init() {
+	GetManager().RegisterReconciler(model.StrVNet, &VNetReconciler{})
+}
+
+// Reconcile performs the state machine logic for VNet and delegates the actual sync to SyncVNetState.
+func (r *VNetReconciler) Reconcile(ctx context.Context, nsId string, resourceId string, optPreloadedVNetStatus *model.CspResourceStatusResponse) (any, error) {
+	log.Info().Msgf("Reconcile started for VNet: %s/%s", nsId, resourceId)
+
+	// 1. Retrieve the Expected State from DB
+	vNetKey := common.GenResourceKey(nsId, model.StrVNet, resourceId)
+	// TODO: distributed-lock [ACQUIRE] key=vNetKey
+	// Lock must be acquired here — before the first kvstore read — so that the entire
+	// read → routing decision → SyncVNetState execution is a single atomic critical section.
+	// TODO: distributed-lock [RELEASE] defer unlock immediately after acquire (covers all return paths)
+	keyValue, exists, err := kvstore.GetKv(vNetKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read vNet from DB: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("does not exist, vNet: %s", resourceId)
+	}
+
+	var vNetInfo model.VNetInfo
+	if err := json.Unmarshal([]byte(keyValue.Value), &vNetInfo); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal vNet info: %w", err)
+	}
+
+	// 2. Resolve CSP status — Reconciler is responsible for fetching it once.
+	//    If a preloaded cache is provided (e.g., from a batch reconcile), use it directly.
+	//    Otherwise fetch from Spider here so that all downstream calls receive a non-nil status.
+	var vpcStatusResp model.CspResourceStatusResponse
+	if optPreloadedVNetStatus != nil {
+		vpcStatusResp = *optPreloadedVNetStatus
+		log.Debug().Msgf("Using preloaded VNet status (connection: %s)", vNetInfo.ConnectionName)
+	} else {
+		log.Debug().Msgf("[Request to Spider] Listing all VPCs for connection: %s", vNetInfo.ConnectionName)
+		var fetchErr error
+		vpcStatusResp, fetchErr = resource.GetCspResourceStatus(vNetInfo.ConnectionName, model.StrVNet)
+		if fetchErr != nil {
+			log.Error().Err(fetchErr).Msg("failed to get VPC resource status from Spider, skipping reconciliation")
+			return model.SimpleMsg{}, fmt.Errorf("failed to reconcile vNet '%s': %w", resourceId, fetchErr)
+		}
+	}
+
+	// 3. State Machine Handling based on Current DB Status
+	switch vNetInfo.Status {
+	case model.NetworkStatusFailed:
+		// Check condition if it's DeletionFailed
+		cond := model.GetCondition(vNetInfo.Conditions, model.ConditionReady)
+		if cond != nil && cond.Reason == model.ReasonDeletionFailed {
+			log.Info().Msgf("vNet (%s) failed during deletion. Checking CSP status for self-healing...", resourceId)
+			// Delegate the actual diffing to the lower-level Sync function
+			return resource.SyncVNetState(nsId, &vNetInfo, &vpcStatusResp)
+		}
+		// TODO: Handle creation failures
+		return resource.SyncVNetState(nsId, &vNetInfo, &vpcStatusResp)
+
+	case model.NetworkStatusCreating:
+		// Handle stuck creation
+		log.Warn().Msgf("vNet (%s) is stuck in Creating. Verifying CSP status...", resourceId)
+		return r.handleCreation(nsId, resourceId, &vNetInfo, &vpcStatusResp)
+
+	case model.NetworkStatusDeleting:
+		// Handle stuck deletion
+		log.Warn().Msgf("vNet (%s) is stuck in Deleting. Re-triggering deletion logic...", resourceId)
+		return r.handleDeletion(nsId, resourceId, &vNetInfo, &vpcStatusResp)
+
+	case model.NetworkStatusAvailable:
+		// Periodic sync: even in a normal state, detect differences between DB and CSP.
+		return resource.SyncVNetState(nsId, &vNetInfo, &vpcStatusResp)
+
+	default:
+		// Unknown state
+		return model.SimpleMsg{}, fmt.Errorf("invalid resource status: %s", vNetInfo.Status)
+	}
+}
+
+func (r *VNetReconciler) handleCreation(nsId string, resourceId string, vNetInfo *model.VNetInfo, optPreloadedVNetStatus *model.CspResourceStatusResponse) (interface{}, error) {
+	// TODO: Implement dedicated creation recovery logic here.
+	// optPreloadedVNetStatus is already resolved by the caller (Reconcile).
+	// Future Implementation Steps:
+	// 1. If the resource exists and is fully provisioned on CSP → Update DB status to Available.
+	// 2. If the resource does not exist → Mark DB status as Failed(CreationFailed).
+	// 3. If the resource is still provisioning → Keep Creating state and wait for the next Reconcile cycle.
+	return model.SimpleMsg{Message: "Creation recovery logic is under construction (skeleton)"}, nil
+}
+
+func (r *VNetReconciler) handleDeletion(nsId string, resourceId string, vNetInfo *model.VNetInfo, optPreloadedVNetStatus *model.CspResourceStatusResponse) (interface{}, error) {
+	// TODO: Implement dedicated deletion recovery logic here.
+	// optPreloadedVNetStatus is already resolved by the caller (Reconcile).
+	// Future Implementation Steps:
+	// 1. If the resource no longer exists on CSP → Clean up DB metadata (deletion complete).
+	// 2. If the resource still exists on CSP → Attempt deletion again via CSP API (retry).
+	// 3. If deletion fails permanently (e.g., due to dependencies) → Mark DB status as Failed(DeletionFailed).
+	return model.SimpleMsg{Message: "Deletion recovery logic is under construction (skeleton)"}, nil
+}

--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand/v2"
 	"runtime"
 	"slices"
 	"sort"
@@ -434,6 +433,10 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	var url string
 	uid := ""
 
+	// vNetInfoForMark is populated in the StrVNet switch case so that
+	// markVNetDeleteFailed can be called from the shared error paths below.
+	var vNetInfoForMark *model.VNetInfo
+
 	// Create Req body
 	type JsonTemplate struct {
 		ConnectionName string
@@ -515,6 +518,7 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 		url = model.SpiderRestUrl + "/vpc/" + temp.CspResourceName
 		childResources = temp.SubnetInfoList
 		uid = temp.Uid
+		vNetInfoForMark = &temp
 
 	case model.StrSecurityGroup:
 		temp := model.SecurityGroupInfo{}
@@ -580,6 +584,9 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	)
 
 	if err != nil {
+		if resourceType == model.StrVNet && vNetInfoForMark != nil {
+			markVNetDeleteFailed(nsId, resourceId, key, vNetInfoForMark, err)
+		}
 		log.Error().Err(err).Msg("")
 		return err
 	}
@@ -588,9 +595,12 @@ func DelResource(nsId string, resourceType string, resourceId string, forceFlag 
 	// Spider returns {"Result": "true"} on successful deletion, {"Result": "false"} when deletion was not performed.
 	// Previously this was not checked, causing CB-TB to delete its kvstore entry even when Spider didn't actually delete the resource.
 	if !strings.EqualFold(callResult.Result, "true") {
-		err := fmt.Errorf("Spider returned Result=%q for DELETE %s/%s (resource may still exist on Spider/CSP)", callResult.Result, resourceType, resourceId)
-		log.Error().Err(err).Msg("Resource deletion not confirmed by Spider")
-		return err
+		resultErr := fmt.Errorf("Spider returned Result=%q for DELETE %s/%s (resource may still exist on Spider/CSP)", callResult.Result, resourceType, resourceId)
+		if resourceType == model.StrVNet && vNetInfoForMark != nil {
+			markVNetDeleteFailed(nsId, resourceId, key, vNetInfoForMark, resultErr)
+		}
+		log.Error().Err(resultErr).Msg("Resource deletion not confirmed by Spider")
+		return resultErr
 	}
 	log.Debug().Msgf("Spider confirmed deletion (Result=%s) for %s/%s", callResult.Result, resourceType, resourceId)
 
@@ -2974,32 +2984,17 @@ func GetCspResourceId(nsId string, resourceType string, resourceId string) (stri
 	}
 }
 
-// GetCspResourceStatus retrieves resource status from CB-Spider for a specific connection and resource type
-//
-// This function queries CB-Spider to get comprehensive resource information including:
-// - Resources managed by both Tumblebug and Spider (MappedList)
-// - Resources only managed by Spider (OnlySpiderList)
-// - Resources only existing in CSP (OnlyCSPList)
-//
-// Parameters:
-//   - connConfig: Connection configuration name for the target CSP
-//   - resourceType: Type of resource to query (e.g., model.StrNode, model.StrVNet, etc.)
-//
-// Returns:
-//   - model.CspResourceStatusResponse: Structured response containing resource lists and metadata
-//   - error: Error if the operation fails
-//
-// Example usage:
-//
-//	response, err := GetCspResourceStatus("aws-connection", model.StrNode)
-//	if err != nil {
-//	    log.Error().Err(err).Msg("Failed to get CSP resource status")
-//	    return err
-//	}
-//
-//	fmt.Printf("Found %d VMs mapped in Spider\n", len(response.AllList.MappedList))
-//	fmt.Printf("Found %d VMs only in CSP\n", len(response.AllList.OnlyCSPList))
-func GetCspResourceStatus(connConfig string, resourceType string) (model.CspResourceStatusResponse, error) {
+// ResourceStatusFilter scopes GetCspResourceStatus to a specific parent resource.
+type ResourceStatusFilter struct {
+	// ParentResourceId is the parent's Spider NameId (e.g., VPC NameId for StrSubnet).
+	// Empty means no scoping.
+	ParentResourceId string
+}
+
+// GetCspResourceStatus returns Mapped/SpiderOnly/CspOnly resource lists from CB-Spider.
+// Pass a ResourceStatusFilter to scope child resources to a specific parent
+// (e.g., VPC NameId when querying StrSubnet).
+func GetCspResourceStatus(connConfig string, resourceType string, filter ...ResourceStatusFilter) (model.CspResourceStatusResponse, error) {
 	var response model.CspResourceStatusResponse
 
 	// Initialize response with basic information
@@ -3070,11 +3065,15 @@ func GetCspResourceStatus(connConfig string, resourceType string) (model.CspReso
 			return response, fmt.Errorf("failed to request CB-Spider: %w", err)
 		}
 
-		// Extract subnet classification from VPC info
-		// See spider-api-response-analysis.md for detailed explanation
-		response.AllList = getCspSubnetResourceStatus(callResult, connConfig)
+		// Extract subnet classification from VPC info.
+		// When a filter is provided, only the matching VPC's subnets are returned.
+		parentVpcNameId := ""
+		if len(filter) > 0 {
+			parentVpcNameId = filter[0].ParentResourceId
+		}
+		response.AllList = getCspSubnetResourceStatus(callResult, connConfig, parentVpcNameId)
 
-		log.Debug().
+		log.Trace().
 			Int("mapped", len(response.AllList.MappedList)).
 			Int("spiderOnly", len(response.AllList.OnlySpiderList)).
 			Int("cspOnly", len(response.AllList.OnlyCSPList)).
@@ -3111,66 +3110,62 @@ func GetCspResourceStatus(connConfig string, resourceType string) (model.CspReso
 	response.SystemMessage = fmt.Sprintf("Successfully retrieved %s resources from %s: %d mapped, %d spider-only, %d csp-only",
 		resourceType, connConfig, mappedCount, spiderOnlyCount, cspOnlyCount)
 
-	log.Info().Str("connection", connConfig).Str("resourceType", resourceType).
+	log.Trace().Str("connection", connConfig).Str("resourceType", resourceType).
 		Int("mapped", mappedCount).Int("spiderOnly", spiderOnlyCount).Int("cspOnly", cspOnlyCount).
-		Msg("Successfully retrieved CSP resource status")
+		Msgf("Successfully retrieved '%s' resource status", resourceType)
 
 	return response, nil
 }
 
-// getCspSubnetResourceStatus extracts subnet classification from VPC info.
-// Verifies each subnet's registration status in Spider with rate limiting.
-func getCspSubnetResourceStatus(vpcAllInfo model.SpiderAllVpcInfoWrapper, connConfig string) model.SpiderAllList {
-	// Create HTTP client once and reuse for all subnet verification calls
+// getCspSubnetResourceStatus classifies subnets into Mapped/SpiderOnly/CspOnly using
+// SystemId matching (allvpcinfo always returns NameId="" for subnets — confirmed Spider bug).
+// When parentVpcNameId != "", only subnets of that Mapped VPC are classified (Phases 2/3 skipped).
+func getCspSubnetResourceStatus(vpcAllInfo model.SpiderAllVpcInfoWrapper, connConfig string, parentVpcNameId string) model.SpiderAllList {
 	client := clientManager.NewHttpClient()
 	client.SetAllowGetMethodPayload(true)
 
 	var mappedSubnets, spiderOnlySubnets, cspOnlySubnets []model.SpiderNameIdSystemId
 
-	// MappedInfoList: VPC is registered but subnets need individual verification
-	subnetCount := 0
-	for _, vpc := range vpcAllInfo.AllListInfo.MappedInfoList {
-		for _, subnet := range vpc.SubnetInfoList {
-			// Rate limiting: 3~7ms between requests, 90~110ms every 10 requests
-			if subnetCount > 0 {
-				time.Sleep(time.Duration(3+rand.IntN(5)) * time.Millisecond)
+	if parentVpcNameId != "" {
+		// Scoped: classify subnets of the target Mapped VPC only.
+		for _, vpc := range vpcAllInfo.AllListInfo.MappedInfoList {
+			if vpc.IId.NameId == parentVpcNameId {
+				m, s, c := classifyMappedVpcSubnets(client, vpc, connConfig)
+				mappedSubnets = append(mappedSubnets, m...)
+				spiderOnlySubnets = append(spiderOnlySubnets, s...)
+				cspOnlySubnets = append(cspOnlySubnets, c...)
+				break
 			}
-			if subnetCount > 0 && subnetCount%10 == 0 {
-				time.Sleep(time.Duration(90+rand.IntN(21)) * time.Millisecond)
-			}
+		}
+	} else {
+		// Unscoped: classify subnets across all VPCs and all phases.
 
-			if checkSubnetRegistrationInSpider(client, vpc.IId.NameId, subnet.IId.NameId, connConfig) {
-				mappedSubnets = append(mappedSubnets, model.SpiderNameIdSystemId{
+		// [Phase 1] Mapped VPC subnets — classify each subnet individually.
+		for _, vpc := range vpcAllInfo.AllListInfo.MappedInfoList {
+			m, s, c := classifyMappedVpcSubnets(client, vpc, connConfig)
+			mappedSubnets = append(mappedSubnets, m...)
+			spiderOnlySubnets = append(spiderOnlySubnets, s...)
+			cspOnlySubnets = append(cspOnlySubnets, c...)
+		}
+
+		// [Phase 2] SpiderOnly VPC subnets — all subnets of a SpiderOnly VPC are SpiderOnly.
+		for _, vpc := range vpcAllInfo.AllListInfo.OnlySpiderList {
+			for _, subnet := range vpc.SubnetInfoList {
+				spiderOnlySubnets = append(spiderOnlySubnets, model.SpiderNameIdSystemId{
 					NameId:   subnet.IId.NameId,
 					SystemId: subnet.IId.SystemId,
 				})
-			} else {
+			}
+		}
+
+		// [Phase 3] CspOnly VPC subnets — all subnets of a CspOnly VPC are CspOnly.
+		for _, vpc := range vpcAllInfo.AllListInfo.OnlyCSPInfoList {
+			for _, subnet := range vpc.SubnetInfoList {
 				cspOnlySubnets = append(cspOnlySubnets, model.SpiderNameIdSystemId{
 					NameId:   subnet.IId.NameId,
 					SystemId: subnet.IId.SystemId,
 				})
 			}
-			subnetCount++
-		}
-	}
-
-	// OnlySpiderList: VPC deleted from CSP but remains in Spider
-	for _, vpc := range vpcAllInfo.AllListInfo.OnlySpiderList {
-		for _, subnet := range vpc.SubnetInfoList {
-			spiderOnlySubnets = append(spiderOnlySubnets, model.SpiderNameIdSystemId{
-				NameId:   subnet.IId.NameId,
-				SystemId: subnet.IId.SystemId,
-			})
-		}
-	}
-
-	// OnlyCSPInfoList: VPC not registered in Spider, so subnets are not registered
-	for _, vpc := range vpcAllInfo.AllListInfo.OnlyCSPInfoList {
-		for _, subnet := range vpc.SubnetInfoList {
-			cspOnlySubnets = append(cspOnlySubnets, model.SpiderNameIdSystemId{
-				NameId:   subnet.IId.NameId,
-				SystemId: subnet.IId.SystemId,
-			})
 		}
 	}
 
@@ -3181,15 +3176,71 @@ func getCspSubnetResourceStatus(vpcAllInfo model.SpiderAllVpcInfoWrapper, connCo
 	}
 }
 
-// checkSubnetRegistrationInSpider verifies if a subnet is registered in Spider.
-// Returns true if registered (IID exists), false if not found.
-func checkSubnetRegistrationInSpider(client *resty.Client, vpcNameId, subnetNameId, connConfig string) bool {
-	url := fmt.Sprintf("%s/vpc/%s/subnet/%s?ConnectionName=%s",
-		model.SpiderRestUrl, vpcNameId, subnetNameId, connConfig)
+// classifyMappedVpcSubnets classifies subnets of a single Mapped VPC into
+// Mapped / SpiderOnly / CspOnly using SystemId matching against Spider's IID registry.
+func classifyMappedVpcSubnets(client *resty.Client, vpc model.SpiderVpcInfo, connConfig string) (
+	mapped, spiderOnly, cspOnly []model.SpiderNameIdSystemId,
+) {
+	// Step 1. Fetch Spider's IID registry for this VPC.
+	// spiderSystemIds: SystemId set for classification
+	// spiderNameIds:   SystemId → NameId for name resolution
+	spiderSystemIds := make(map[string]bool)
+	spiderNameIds := make(map[string]string)
+	spiderVpcInfo, err := fetchSpiderVpcInfo(client, vpc.IId.NameId, connConfig)
+	if err != nil {
+		log.Warn().Err(err).Msgf("Failed to query Spider VPC info for %s", vpc.IId.NameId)
+	} else {
+		for _, sub := range spiderVpcInfo.SubnetInfoList {
+			if sub.IId.SystemId == "" {
+				continue
+			}
+			spiderSystemIds[sub.IId.SystemId] = true
+			if sub.IId.NameId != "" {
+				spiderNameIds[sub.IId.SystemId] = sub.IId.NameId
+			}
+		}
+	}
 
+	// Step 2. Classify CSP subnets: Mapped if SystemId is in Spider registry, CspOnly otherwise.
+	cspSubnetSystemIds := make(map[string]bool)
+	for _, subnet := range vpc.SubnetInfoList {
+		if subnet.IId.SystemId == "" {
+			continue
+		}
+		cspSubnetSystemIds[subnet.IId.SystemId] = true
+
+		if spiderSystemIds[subnet.IId.SystemId] {
+			mapped = append(mapped, model.SpiderNameIdSystemId{
+				NameId:   spiderNameIds[subnet.IId.SystemId],
+				SystemId: subnet.IId.SystemId,
+			})
+		} else {
+			cspOnly = append(cspOnly, model.SpiderNameIdSystemId{
+				NameId:   "",
+				SystemId: subnet.IId.SystemId,
+			})
+		}
+	}
+
+	// Step 3. Subnets in Spider's IID registry but absent from CSP → SpiderOnly.
+	for _, sub := range spiderVpcInfo.SubnetInfoList {
+		if sub.IId.SystemId == "" || cspSubnetSystemIds[sub.IId.SystemId] {
+			continue
+		}
+		spiderOnly = append(spiderOnly, model.SpiderNameIdSystemId{
+			NameId:   sub.IId.NameId,
+			SystemId: sub.IId.SystemId,
+		})
+	}
+
+	return mapped, spiderOnly, cspOnly
+}
+
+// fetchSpiderVpcInfo queries Spider's IID registry for a VPC and its registered subnets.
+func fetchSpiderVpcInfo(client *resty.Client, vpcNameId, connConfig string) (model.SpiderVpcInfo, error) {
+	url := fmt.Sprintf("%s/vpc/%s?ConnectionName=%s", model.SpiderRestUrl, vpcNameId, connConfig)
 	noBody := clientManager.NoBody
-	var result any
-
+	var spiderVpcInfo model.SpiderVpcInfo
 	_, err := clientManager.ExecuteHttpRequest(
 		client,
 		"GET",
@@ -3197,18 +3248,18 @@ func checkSubnetRegistrationInSpider(client *resty.Client, vpcNameId, subnetName
 		nil,
 		clientManager.SetUseBody(noBody),
 		&noBody,
-		&result,
-		clientManager.VeryShortDuration,
+		&spiderVpcInfo,
+		clientManager.MediumDuration,
 	)
-	return err == nil
+	return spiderVpcInfo, err
 }
 
 // getResourceState returns the state of a resource across Spider and CSP:
 // "exists", "spiderOnly", "cspOnly", or "absent".
-func getResourceState(resourceName string, statusResp model.CspResourceStatusResponse) string {
+func getResourceState(resourceName string, resourceSystemId string, statusResp model.CspResourceStatusResponse) string {
 	allList := statusResp.AllList
 	for _, item := range allList.MappedList {
-		if item.NameId == resourceName {
+		if item.NameId == resourceName || (resourceSystemId != "" && item.SystemId == resourceSystemId) {
 			return "exists"
 		}
 	}
@@ -3218,7 +3269,7 @@ func getResourceState(resourceName string, statusResp model.CspResourceStatusRes
 		}
 	}
 	for _, item := range allList.OnlyCSPList {
-		if item.NameId == resourceName {
+		if item.NameId == resourceName || (resourceSystemId != "" && item.SystemId == resourceSystemId) {
 			return "cspOnly"
 		}
 	}

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -40,7 +40,7 @@ func SubnetReqStructLevelValidation(sl validator.StructLevel) {
 
 	err := common.CheckString(u.Name)
 	if err != nil {
-		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
+		// ReportError(field any, fieldName, structFieldName, tag, param string)
 		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
@@ -572,13 +572,12 @@ func ListSubnet(nsId string, vNetId string) ([]model.SubnetInfo, error) {
 	return subnetInfoList, nil
 }
 
-// markSubnetDeleteFailedThenReconcile persists the subnet as
-// Failed(DeletionFailed) and then runs a single-shot self-heal ReconcileSubnet
-// (any reconcile error is logged at WARN only).
+// markSubnetDeleteFailed persists the subnet as
+// Failed(DeletionFailed).
 //
 // `cause` is the original delete error; it populates both the Condition
 // message and SystemMessage. The caller decides what error to return.
-func markSubnetDeleteFailedThenReconcile(nsId, vNetId, subnetId, subnetKey string, subnetInfo *model.SubnetInfo, cause error) {
+func markSubnetDeleteFailed(nsId, vNetId, subnetId, subnetKey string, subnetInfo *model.SubnetInfo, cause error) {
 	log.Error().Err(cause).Msg("")
 	// [Conditions] Deletion failed → mark as Failed to prevent stuck state
 	model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, cause.Error())
@@ -586,10 +585,6 @@ func markSubnetDeleteFailedThenReconcile(nsId, vNetId, subnetId, subnetKey strin
 	subnetInfo.SystemMessage = cause.Error()
 	if failVal, marshalErr := json.Marshal(subnetInfo); marshalErr == nil {
 		_ = kvstore.Put(subnetKey, string(failVal))
-	}
-	// Self-heal: opportunistic single-shot Reconcile after recording Failed state.
-	if _, recErr := ReconcileSubnet(nsId, vNetId, subnetId, nil); recErr != nil {
-		log.Warn().Err(recErr).Msgf("auto-reconcile after delete failure failed for subnet %s/%s/%s", nsId, vNetId, subnetId)
 	}
 }
 
@@ -685,9 +680,9 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 			log.Warn().Err(err).Msg("Failed to check subnet usage, but continuing with deletion")
 		}
 		if inUse {
-			err := fmt.Errorf("cannot delete subnet (%s): currently referenced by VMs; use action=force", subnetId)
-			log.Error().Err(err).Msg("")
-			return emptyRet, err
+			delErr := fmt.Errorf("cannot delete subnet (%s): currently referenced by VMs; use action=force", subnetId)
+			markSubnetDeleteFailed(nsId, vNetId, subnetId, subnetKey, &subnetInfo, delErr)
+			return emptyRet, delErr
 		}
 	}
 
@@ -785,13 +780,13 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 	// Check final result after all trials
 	if err != nil {
 		// A network/transport error persisted through all retries.
-		markSubnetDeleteFailedThenReconcile(nsId, vNetId, subnetId, subnetKey, &subnetInfo, err)
+		markSubnetDeleteFailed(nsId, vNetId, subnetId, subnetKey, &subnetInfo, err)
 		return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to delete subnet '%s'", subnetInfo.Id))
 	}
 	if !ok {
 		// Spider returned Result:false on every attempt — treat as a hard deletion failure.
 		delErr := fmt.Errorf("failed to delete the subnet (%s)", subnetInfo.Id)
-		markSubnetDeleteFailedThenReconcile(nsId, vNetId, subnetId, subnetKey, &subnetInfo, delErr)
+		markSubnetDeleteFailed(nsId, vNetId, subnetId, subnetKey, &subnetInfo, delErr)
 		return emptyRet, delErr
 	}
 
@@ -862,14 +857,65 @@ func DeleteSubnet(nsId string, vNetId string, subnetId string, actionParam strin
 	return ret, nil
 }
 
-// ReconcileSubnet checks if the CSP/Spider subnet still exists and reconciles metadata accordingly.
+// subnetSyncSummary holds counts of outcomes from a single syncSubnetsForVNet call.
+type subnetSyncSummary struct {
+	Total    int // total TB-registered subnets examined
+	NoAction int // exist and consistent; no change needed
+	Restored int // restored from a terminal-failure state (e.g., DeletionFailed)
+	Cleaned  int // removed from TB (spiderOnly or absent on CSP)
+	CspOnly  int // CSP resource exists but Spider IID was lost; TB metadata preserved
+	Errors   int // subnets that could not be processed
+}
+
+// syncSubnetsForVNet iterates TB-registered subnets under a VPC and reconciles each one.
+// TB metadata is the source of truth; resources that exist in CSP/Spider but are not
+// registered in TB are not in scope for this reconciliation pass.
+// subnetKvList: raw KV entries from kvstore.GetKvList(vNetKey + "/subnet").
+// status: optional pre-fetched subnet status; passed through to syncSubnetState.
+func syncSubnetsForVNet(nsId string, subnetKvList []kvstore.KeyValue, vNetInfo *model.VNetInfo, status *model.CspResourceStatusResponse) (subnetSyncSummary, error) {
+	log.Info().Msg("syncSubnetsForVNet")
+	var summary subnetSyncSummary
+
+	for _, subnetKv := range subnetKvList {
+		summary.Total++
+		var subnetInfo model.SubnetInfo
+		if uErr := json.Unmarshal([]byte(subnetKv.Value), &subnetInfo); uErr != nil {
+			log.Warn().Err(uErr).Msg("failed to unmarshal subnet info; skipping")
+			summary.Errors++
+			continue
+		}
+		log.Trace().Msgf("subnetInfo: %+v", subnetInfo)
+		msg, sErr := syncSubnetState(nsId, &subnetInfo, vNetInfo, status)
+		if sErr != nil {
+			log.Warn().Err(sErr).Msg("")
+			summary.Errors++
+			continue
+		}
+		switch {
+		case strings.Contains(msg.Message, "restored"):
+			summary.Restored++
+		case strings.Contains(msg.Message, "no action needed"):
+			summary.NoAction++
+		case strings.Contains(msg.Message, "cspOnly"):
+			summary.CspOnly++
+		default:
+			// "has been reconciled" → cleaned (spiderOnly or absent)
+			summary.Cleaned++
+		}
+	}
+	return summary, nil
+}
+
+// syncSubnetState checks if the CSP/Spider subnet still exists and reconciles metadata accordingly.
+// Called exclusively by the reconciler via syncSubnetsForVNet, which guarantees
+// nsId, subnetInfo and vNetInfo are valid.
 // optPreloadedSubnetStatus: optional pre-fetched subnet status; if nil, will be fetched internally.
-func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSubnetStatus *model.CspResourceStatusResponse) (model.SimpleMsg, error) {
-	log.Info().Msg("ReconcileSubnet")
+func syncSubnetState(nsId string, subnetInfo *model.SubnetInfo, vNetInfo *model.VNetInfo, optPreloadedSubnetStatus *model.CspResourceStatusResponse) (model.SimpleMsg, error) {
+	// log.Info().Msg("syncSubnetState")
 
 	/*
 	 *	[NOTE]
-	 *	"Reconcile" checks whether the CSP/Spider resource still exists.
+	 *	"Sync" checks whether the CSP/Spider resource still exists.
 	 *	If the resource is gone, it removes orphaned Tumblebug metadata.
 	 *	If the resource still exists, it keeps the metadata intact.
 	 */
@@ -877,77 +923,30 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSu
 	// subnet objects
 	var emptyRet model.SimpleMsg
 	var ret model.SimpleMsg
-	var vNetInfo model.VNetInfo
-	var subnetInfo model.SubnetInfo
 
 	// Set the resource type
 	parentResourceType := model.StrVNet
 	resourceType := model.StrSubnet
 
-	/*
-	 *	Validate the input parameters
-	 */
-
-	// Validate the input parameters
-	err := common.CheckString(nsId)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
+	// Caller (reconciler) is responsible for passing valid, non-nil structs.
+	if subnetInfo == nil {
+		return emptyRet, fmt.Errorf("subnetInfo must not be nil")
 	}
-	err = common.CheckString(vNetId)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-	err = common.CheckString(subnetId)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
+	if vNetInfo == nil {
+		return emptyRet, fmt.Errorf("vNetInfo must not be nil")
 	}
 
-	// Set a key for the subnet object
-	vNetKey := common.GenResourceKey(nsId, parentResourceType, vNetId)
-	subnetKey := common.GenChildResourceKey(nsId, resourceType, vNetId, subnetId)
-
-	// Read the saved vNet info
-	vNetKv, exists, err := kvstore.GetKv(vNetKey)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-	if !exists {
-		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-	// vNet object
-	err = json.Unmarshal([]byte(vNetKv.Value), &vNetInfo)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-
-	// Read the stored subnet info
-	subnetKeyValue, exists, err := kvstore.GetKv(subnetKey)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-	if !exists {
-		err := fmt.Errorf("does not exist, subnet: %s", subnetId)
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-
-	// subnet object
-	err = json.Unmarshal([]byte(subnetKeyValue.Value), &subnetInfo)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
+	// Set a key for the vNet object (always valid; vNetInfo is guaranteed non-nil).
+	vNetKey := common.GenResourceKey(nsId, parentResourceType, vNetInfo.Id)
+	// subnetKey is only valid for TB-registered subnets (subnetInfo.Id != "").
+	// For externally created (CspOnly) subnets, subnetInfo.Id is empty and no kvstore key exists.
+	var subnetKey string
+	if subnetInfo.Id != "" {
+		subnetKey = common.GenChildResourceKey(nsId, resourceType, vNetInfo.Id, subnetInfo.Id)
 	}
 
 	/*
-	 *	Check and reconcile the subnet info
+	 *	Reconcile the subnet info
 	 */
 
 	// [Via Spider] Get subnet resource status to determine the exact Spider/CSP state.
@@ -963,11 +962,11 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSu
 		subnetStatusResp, err = GetCspResourceStatus(subnetInfo.ConnectionName, model.StrSubnet)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to get subnet resource status from Spider, skipping reconciliation")
-			return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile subnet '%s'", subnetId))
+			return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile subnet '%s'", subnetInfo.Id))
 		}
 	}
 
-	subnetState := getResourceState(subnetInfo.CspResourceName, subnetStatusResp)
+	subnetState := getResourceState(subnetInfo.CspResourceName, subnetInfo.CspResourceId, subnetStatusResp)
 	log.Debug().Msgf("Subnet '%s' state in Spider: %q", subnetInfo.CspResourceName, subnetState)
 
 	switch subnetState {
@@ -999,8 +998,8 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSu
 			// Reflect the restored subnet status into the parent vNet's
 			// SubnetInfoList and recompute ChildrenReady.
 			for i, s := range vNetInfo.SubnetInfoList {
-				if s.Id == subnetId {
-					vNetInfo.SubnetInfoList[i] = subnetInfo
+				if s.Id == subnetInfo.Id {
+					vNetInfo.SubnetInfoList[i] = *subnetInfo
 					break
 				}
 			}
@@ -1016,20 +1015,20 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSu
 				}
 			}
 
-			ret.Message = fmt.Sprintf("subnet (%s) status restored to Available from %s; CSP resource exists", subnetId, prevReason)
+			ret.Message = fmt.Sprintf("subnet (%s) status restored to Available from %s; CSP resource exists", subnetInfo.Id, prevReason)
 			log.Info().Msg(ret.Message)
 			return ret, nil
 		}
 
-		ret.Message = fmt.Sprintf("subnet (%s) exists on CSP; metadata is consistent (no action needed)", subnetId)
+		ret.Message = fmt.Sprintf("subnet (%s) exists on CSP; metadata is consistent (no action needed)", subnetInfo.Id)
 		log.Info().Msg(ret.Message)
 		return ret, nil
 
 	case "cspOnly":
-		// CSP resource still exists but Spider has no IID.
+		// TB-registered subnet whose Spider IID was lost.
 		// Preserve TB metadata — deleting it would orphan the CSP resource.
 		// TODO: consider re-registering the CSP-only subnet into Spider.
-		ret.Message = fmt.Sprintf("subnet (%s) exists on CSP but has no Spider IID (cspOnly); TB metadata preserved", subnetId)
+		ret.Message = fmt.Sprintf("subnet (%s) exists on CSP but has no Spider IID (cspOnly); TB metadata preserved", subnetInfo.Id)
 		log.Warn().Msg(ret.Message)
 		return ret, nil
 
@@ -1066,16 +1065,16 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSu
 		// No Spider IID to purge; the resource is gone from both Spider and CSP.
 	}
 
-	// Delete the saved the subnet info
+	// TB metadata cleanup (spiderOnly / absent).
+	var err error
 	err = kvstore.Delete(subnetKey)
 	if err != nil {
 		log.Warn().Err(err).Msg("")
-		// return emptyRet, err
 	}
 
 	// Update the vNet info
 	for i, s := range vNetInfo.SubnetInfoList {
-		if s.Id == subnetId {
+		if s.Id == subnetInfo.Id {
 			vNetInfo.SubnetInfoList = append(vNetInfo.SubnetInfoList[:i], vNetInfo.SubnetInfoList[i+1:]...)
 			break
 		}
@@ -1093,12 +1092,10 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSu
 	val, err := json.Marshal(vNetInfo)
 	if err != nil {
 		log.Warn().Err(err).Msg("")
-		// return emptyRet, err
 	}
 	err = kvstore.Put(vNetKey, string(val))
 	if err != nil {
 		log.Warn().Err(err).Msg("")
-		// return emptyRet, err
 	}
 
 	err = label.DeleteLabelObject(model.StrSubnet, subnetInfo.Uid)
@@ -1107,19 +1104,17 @@ func ReconcileSubnet(nsId string, vNetId string, subnetId string, optPreloadedSu
 	}
 
 	// Get and check the subnet info still exists or not
-	_, exists, err = kvstore.GetKv(subnetKey)
+	_, exists, err := kvstore.GetKv(subnetKey)
 	if err != nil {
 		log.Warn().Err(err).Msg("")
 	}
 	if exists {
-		err := fmt.Errorf("fail to reconcile the subnet info (id: %s)", subnetId)
+		err := fmt.Errorf("fail to reconcile the subnet info (id: %s)", subnetInfo.Id)
 		ret.Message = err.Error()
 		return ret, err
 	}
 
-	// [Output] the message
-	ret.Message = fmt.Sprintf("the subnet info (%s) has been reconciled", subnetId)
-
+	ret.Message = fmt.Sprintf("the subnet info (%s) has been reconciled", subnetInfo.Id)
 	return ret, nil
 }
 

--- a/src/core/resource/vnet.go
+++ b/src/core/resource/vnet.go
@@ -92,7 +92,7 @@ func VNetReqStructLevelValidation(sl validator.StructLevel) {
 
 	err := common.CheckString(u.Name)
 	if err != nil {
-		// ReportError(field interface{}, fieldName, structFieldName, tag, param string)
+		// ReportError(field any, fieldName, structFieldName, tag, param string)
 		sl.ReportError(u.Name, "name", "Name", err.Error(), "")
 	}
 }
@@ -843,13 +843,11 @@ func GetVNet(nsId string, vNetId string) (model.VNetInfo, error) {
 	return vNetInfo, nil
 }
 
-// markVNetDeleteFailedThenReconcile persists the vNet as Failed(DeletionFailed)
-// and then runs a single-shot self-heal ReconcileVNet (any reconcile error is
-// logged at WARN only).
+// markVNetDeleteFailed persists the vNet as Failed(DeletionFailed).
 //
 // `cause` is the original delete error; it populates both the Condition
 // message and SystemMessage. The caller decides what error to return.
-func markVNetDeleteFailedThenReconcile(nsId, vNetId, vNetKey string, vNetInfo *model.VNetInfo, cause error) {
+func markVNetDeleteFailed(nsId, vNetId, vNetKey string, vNetInfo *model.VNetInfo, cause error) {
 	log.Error().Err(cause).Msg("")
 	// [Conditions] Deletion failed → mark as Failed to prevent stuck state
 	model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, cause.Error())
@@ -857,10 +855,6 @@ func markVNetDeleteFailedThenReconcile(nsId, vNetId, vNetKey string, vNetInfo *m
 	vNetInfo.SystemMessage = cause.Error()
 	if failVal, marshalErr := json.Marshal(vNetInfo); marshalErr == nil {
 		_ = kvstore.Put(vNetKey, string(failVal))
-	}
-	// Self-heal: opportunistic single-shot Reconcile after recording Failed state.
-	if _, recErr := ReconcileVNet(nsId, vNetId, nil); recErr != nil {
-		log.Warn().Err(recErr).Msgf("auto-reconcile after delete failure failed for vNet %s/%s", nsId, vNetId)
 	}
 }
 
@@ -1059,13 +1053,13 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 	// Check final result after all trials
 	if err != nil {
 		// A network/transport error persisted through all retries.
-		markVNetDeleteFailedThenReconcile(nsId, vNetId, vNetKey, &vNetInfo, err)
+		markVNetDeleteFailed(nsId, vNetId, vNetKey, &vNetInfo, err)
 		return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to delete vNet '%s'", vNetId))
 	}
 	if !ok {
 		// Spider returned Result:false on every attempt — treat as a hard deletion failure.
 		delErr := fmt.Errorf("failed to delete the vNet (%s)", vNetId)
-		markVNetDeleteFailedThenReconcile(nsId, vNetId, vNetKey, &vNetInfo, delErr)
+		markVNetDeleteFailed(nsId, vNetId, vNetKey, &vNetInfo, delErr)
 		return emptyRet, delErr
 	}
 
@@ -1108,10 +1102,11 @@ func DeleteVNet(nsId string, vNetId string, actionParam string) (model.SimpleMsg
 	return ret, nil
 }
 
-// ReconcileVNet checks if the CSP/Spider VNet still exists and reconciles metadata accordingly.
+// SyncVNetState checks if the CSP/Spider VNet still exists and synchronizes metadata accordingly.
+// Called exclusively by the reconciler, which guarantees nsId and vNetInfo are valid.
 // optPreloadedVNetStatus: optional pre-fetched VNet status; if nil, will be fetched internally.
-func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.CspResourceStatusResponse) (model.SimpleMsg, error) {
-	log.Info().Msg("ReconcileVNet")
+func SyncVNetState(nsId string, vNetInfo *model.VNetInfo, optPreloadedVNetStatus *model.CspResourceStatusResponse) (model.SimpleMsg, error) {
+	log.Info().Msg("SyncVNetState")
 
 	/*
 	 *	[NOTE]
@@ -1123,79 +1118,47 @@ func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.Csp
 	// vNet object
 	var emptyRet model.SimpleMsg
 	var ret model.SimpleMsg
-	var vNetInfo model.VNetInfo
-
 	// Set the resource type
 	resourceType := model.StrVNet
 
-	/*
-	 *	Validate the input parameters
-	 */
-
-	// Check the input parameters
-	err := common.CheckString(nsId)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-	err = common.CheckString(vNetId)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
+	// Caller (reconciler) is responsible for passing a valid, non-nil vNetInfo.
+	if vNetInfo == nil {
+		return emptyRet, fmt.Errorf("vNetInfo must not be nil")
 	}
 
 	// Set a vNetKey for the vNet object
-	vNetKey := common.GenResourceKey(nsId, resourceType, vNetId)
-
-	// Read the stored vNet info
-	keyValue, exists, err := kvstore.GetKv(vNetKey)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-
-	if !exists {
-		err := fmt.Errorf("does not exist, vNet: %s", vNetId)
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
-
-	err = json.Unmarshal([]byte(keyValue.Value), &vNetInfo)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return emptyRet, err
-	}
+	vNetKey := common.GenResourceKey(nsId, resourceType, vNetInfo.Id)
 
 	/*
 	 *	Check and reconcile the info of vNet and associated subnets
 	 */
 
 	// [Via Spider] List all VPCs to determine the exact Spider/CSP state.
+	// Prefer the preloaded status passed in by the Reconciler (avoids redundant API calls).
+	// Fall back to a direct Spider query when called outside the Reconciler path.
 	var vpcStatusResp model.CspResourceStatusResponse
-	if optPreloadedVNetStatus != nil && len(optPreloadedVNetStatus.AllList.MappedList) > 0 {
-		// Use preloaded status if available
+	if optPreloadedVNetStatus != nil {
 		vpcStatusResp = *optPreloadedVNetStatus
 		log.Debug().Msgf("Using preloaded VNet status for reconciliation (connection: %s)", vNetInfo.ConnectionName)
 	} else {
-		// No preloaded status, fetch from Spider
 		log.Debug().Msgf("[Request to Spider] Listing all VPCs for connection: %s", vNetInfo.ConnectionName)
 		var err error
 		vpcStatusResp, err = GetCspResourceStatus(vNetInfo.ConnectionName, model.StrVNet)
 		if err != nil {
 			log.Error().Err(err).Msg("failed to get VPC resource status from Spider, skipping reconciliation")
-			return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile vNet '%s'", vNetId))
+			return emptyRet, apierr.Wrap(err, fmt.Sprintf("failed to reconcile vNet '%s'", vNetInfo.Id))
 		}
 	}
 
-	vpcState := getResourceState(vNetInfo.CspResourceName, vpcStatusResp)
-	log.Debug().Msgf("VPC '%s' state in Spider: %q", vNetInfo.CspResourceName, vpcState)
+	vnetState := getResourceState(vNetInfo.CspResourceName, vNetInfo.CspResourceId, vpcStatusResp)
+	log.Debug().Msgf("VPC '%s' state in Spider: %q", vNetInfo.CspResourceName, vnetState)
 
-	switch vpcState {
+	switch vnetState {
 	case "exists":
 		// VPC exists on CSP. Recurse into child subnets first so that any
 		// per-subnet drift (orphaned metadata, stuck statuses) is settled
 		// before evaluating the parent vNet status.
-		log.Info().Msgf("vNet (%s) exists on CSP; reconciling child subnets", vNetId)
+		log.Info().Msgf("vNet (%s) exists on CSP; reconciling child subnets", vNetInfo.Id)
 
 		subnetKvList, err2 := kvstore.GetKvList(vNetKey + "/subnet")
 		if err2 != nil {
@@ -1203,33 +1166,27 @@ func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.Csp
 			return emptyRet, err2
 		}
 
-		// Fetch subnet status once for all subnets to optimize API calls
+		// Fetch subnet status scoped to this VPC.
+		log.Debug().Msgf("[Request to Spider] Listing Subnets for VPC %s (connection: %s)",
+			vNetInfo.CspResourceName, vNetInfo.ConnectionName)
+		subnetStatus, subnetErr := GetCspResourceStatus(
+			vNetInfo.ConnectionName,
+			model.StrSubnet,
+			ResourceStatusFilter{ParentResourceId: vNetInfo.CspResourceName},
+		)
 		var optPreloadedSubnetStatus *model.CspResourceStatusResponse
-		if len(subnetKvList) > 0 {
-			log.Debug().Msgf("[Request to Spider] Listing all Subnets for connection: %s", vNetInfo.ConnectionName)
-			subnetStatus, subnetErr := GetCspResourceStatus(vNetInfo.ConnectionName, model.StrSubnet)
-			if subnetErr != nil {
-				log.Warn().Err(subnetErr).Msg("failed to get subnet status; each ReconcileSubnet will retry individually")
-				optPreloadedSubnetStatus = nil // nil means each ReconcileSubnet will fetch individually
-			} else {
-				optPreloadedSubnetStatus = &subnetStatus
-			}
+		if subnetErr != nil {
+			log.Warn().Err(subnetErr).Msg("failed to get subnet status; each syncSubnetState will retry individually")
+		} else {
+			optPreloadedSubnetStatus = &subnetStatus
 		}
 
-		for _, subnetKv := range subnetKvList {
-			subnetInfo := model.SubnetInfo{}
-			if uErr := json.Unmarshal([]byte(subnetKv.Value), &subnetInfo); uErr != nil {
-				log.Warn().Err(uErr).Msg("")
-				continue
-			}
-			log.Trace().Msgf("subnetInfo: %+v", subnetInfo)
-
-			if _, sErr := ReconcileSubnet(nsId, vNetId, subnetInfo.Id, optPreloadedSubnetStatus); sErr != nil {
-				log.Warn().Err(sErr).Msg("")
-			}
+		subnetSummary, sErr := syncSubnetsForVNet(nsId, subnetKvList, vNetInfo, optPreloadedSubnetStatus)
+		if sErr != nil {
+			log.Warn().Err(sErr).Msg("")
 		}
 
-		// Re-read vNet info because ReconcileSubnet may have updated
+		// Re-read vNet info because syncSubnetsForVNet may have updated
 		// SubnetInfoList and ChildrenReady.
 		latestKv, latestExists, latestErr := kvstore.GetKv(vNetKey)
 		if latestErr == nil && latestExists {
@@ -1265,12 +1222,14 @@ func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.Csp
 				log.Error().Err(pErr).Msg("")
 				return emptyRet, pErr
 			}
-			ret.Message = fmt.Sprintf("vNet (%s) status restored to Available from %s; CSP resource exists", vNetId, prevReason)
+			ret.Message = fmt.Sprintf("vNet (%s) status restored to Available from %s; CSP resource exists", vNetInfo.Id, prevReason)
 			log.Info().Msg(ret.Message)
 			return ret, nil
 		}
 
-		ret.Message = fmt.Sprintf("vNet (%s) exists on CSP; metadata is consistent (no action needed)", vNetId)
+		ret.Message = fmt.Sprintf(
+			"vNet (%s) reconciled: VPC exists on CSP; subnets: %d checked / %d consistent / %d restored / %d cleaned / %d csp-only / %d error(s)",
+			vNetInfo.Id, subnetSummary.Total, subnetSummary.NoAction, subnetSummary.Restored, subnetSummary.Cleaned, subnetSummary.CspOnly, subnetSummary.Errors)
 		log.Info().Msg(ret.Message)
 		return ret, nil
 
@@ -1278,7 +1237,7 @@ func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.Csp
 		// CSP resource still exists but Spider has no IID.
 		// Preserve TB metadata — deleting it would orphan the CSP resource.
 		// TODO: consider re-registering the CSP-only VPC into Spider.
-		ret.Message = fmt.Sprintf("vNet (%s) exists on CSP but has no Spider IID (cspOnly); TB metadata preserved", vNetId)
+		ret.Message = fmt.Sprintf("vNet (%s) exists on CSP but has no Spider IID (cspOnly); TB metadata preserved", vNetInfo.Id)
 		log.Warn().Msg(ret.Message)
 		return ret, nil
 
@@ -1313,6 +1272,10 @@ func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.Csp
 		// No Spider IID to purge; the resource is gone from both Spider and CSP.
 	}
 
+	// TODO: distributed-lock [ACQUIRE] key=vNetKey
+	// If SyncVNetState is called outside the reconciler (e.g., directly from an API handler),
+	// the lock must be acquired here — before any kvstore delete — to prevent a concurrent
+	// reconcile cycle from racing against these irreversible delete operations.
 	// Delete subnet objects from the key-value store
 	// Read the stored subnets
 	subnetKvList, err := kvstore.GetKvList(vNetKey + "/subnet")
@@ -1353,6 +1316,7 @@ func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.Csp
 		log.Warn().Err(err).Msg("")
 		// return emptyRet, err
 	}
+	// TODO: distributed-lock [RELEASE] key=vNetKey
 
 	// Get and check the subnet info still exists or not
 	vNetKv, exists, err := kvstore.GetKv(vNetKey)
@@ -1367,9 +1331,9 @@ func ReconcileVNet(nsId string, vNetId string, optPreloadedVNetStatus *model.Csp
 	}
 
 	// [Output] the message
-	ret.Message = fmt.Sprintf("the vNet info (%s) has been reconciled", vNetId)
+	ret.Message = fmt.Sprintf("the vNet info (%s) has been reconciled", vNetInfo.Id)
 
-	log.Info().Msgf("vNet (%s) has been reconciled", vNetId)
+	log.Info().Msgf("vNet (%s) has been reconciled", vNetInfo.Id)
 	return ret, nil
 }
 

--- a/src/interface/rest/server/resource/common.go
+++ b/src/interface/rest/server/resource/common.go
@@ -23,6 +23,7 @@ import (
 
 	clientManager "github.com/cloud-barista/cb-tumblebug/src/core/common/client"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
+	"github.com/cloud-barista/cb-tumblebug/src/core/reconcile"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
 )
 
@@ -47,6 +48,17 @@ func RestDelAllResources(c echo.Context) error {
 	log.Info().Msgf("Starting DelAllResources for nsId: %s, resourceType: %s", nsId, resourceType)
 
 	content, err := resource.DelAllResources(nsId, resourceType, subString, forceFlag)
+
+	for _, result := range content.Results {
+		if result.ResourceType == model.StrVNet && !result.Success {
+			// Trigger Self-healing upon deletion failure
+			log.Warn().Msgf("DeleteVNet failed. Triggering Reconcile: %s", result.ResourceId)
+			manager := reconcile.GetManager()
+			if _, recErr := manager.RunReconcile(c.Request().Context(), nsId, model.StrVNet, result.ResourceId, nil); recErr != nil {
+				log.Warn().Err(recErr).Msgf("auto-reconcile failed for VNet: %s", result.ResourceId)
+			}
+		}
+	}
 
 	log.Info().Msgf("DelAllResources completed for nsId: %s, resourceType: %s — total: %d, success: %d, failed: %d", nsId, resourceType, content.Total, content.SuccessCount, content.FailedCount)
 
@@ -74,6 +86,16 @@ func RestDelResource(c echo.Context) error {
 	forceFlag := c.QueryParam("force")
 
 	err := resource.DelResource(nsId, resourceType, resourceId, forceFlag)
+
+	// If deletion failed for a VNet, trigger Reconcile to attempt self-healing (e.g., by removing dangling references from VMs and retrying deletion).
+	if err != nil && resourceType == model.StrVNet {
+		log.Warn().Msgf("DeleteVNet failed. Triggering Reconcile: %s", resourceId)
+		manager := reconcile.GetManager()
+		if _, recErr := manager.RunReconcile(c.Request().Context(), nsId, model.StrVNet, resourceId, nil); recErr != nil {
+			log.Warn().Err(recErr).Msgf("auto-reconcile failed for VNet: %s", resourceId)
+		}
+	}
+
 	content := map[string]string{"message": "The " + resourceType + " " + resourceId + " has been deleted"}
 	return clientManager.EndRequestWithLog(c, err, content)
 }
@@ -396,6 +418,18 @@ func RestDelAllSharedResources(c echo.Context) error {
 	nsId := c.Param("nsId")
 
 	content, err := resource.DeleteSharedResources(nsId)
+
+	for _, result := range content.Results {
+		if result.ResourceType == model.StrVNet && !result.Success {
+			// Trigger Self-healing upon deletion failure
+			log.Warn().Msgf("DeleteVNet failed. Triggering Reconcile: %s", result.ResourceId)
+			manager := reconcile.GetManager()
+			if _, recErr := manager.RunReconcile(c.Request().Context(), nsId, model.StrVNet, result.ResourceId, nil); recErr != nil {
+				log.Warn().Err(recErr).Msgf("auto-reconcile failed for VNet: %s", result.ResourceId)
+			}
+		}
+	}
+
 	return clientManager.EndRequestWithLog(c, err, content)
 }
 

--- a/src/interface/rest/server/resource/subnet.go
+++ b/src/interface/rest/server/resource/subnet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/apierr"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
+	"github.com/cloud-barista/cb-tumblebug/src/core/reconcile"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
@@ -281,11 +282,16 @@ func RestDelSubnet(c echo.Context) error {
 			return c.JSON(apierr.Code(err), model.SimpleMsg{Message: err.Error()})
 		}
 	case resource.ActionReconcile:
-		// [Process]
-		resp, err = resource.ReconcileSubnet(nsId, vNetId, subnetId, nil)
+		manager := reconcile.GetManager()
+		res, err := manager.RunReconcile(c.Request().Context(), nsId, model.StrVNet, vNetId, nil)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return c.JSON(apierr.Code(err), model.SimpleMsg{Message: err.Error()})
+		}
+		if simpleMsg, ok := res.(model.SimpleMsg); ok {
+			resp = simpleMsg
+		} else {
+			resp = model.SimpleMsg{Message: "reconcile completed"}
 		}
 	default:
 		errMsg := fmt.Errorf("invalid action (%s)", action)

--- a/src/interface/rest/server/resource/vnet.go
+++ b/src/interface/rest/server/resource/vnet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/common"
 	"github.com/cloud-barista/cb-tumblebug/src/core/common/apierr"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
+	"github.com/cloud-barista/cb-tumblebug/src/core/reconcile"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
@@ -239,14 +240,28 @@ func RestDelVNet(c echo.Context) error {
 		resp, err = resource.DeleteVNet(nsId, vNetId, action.String())
 		if err != nil {
 			log.Error().Err(err).Msg("")
+
+			// Trigger Self-healing upon deletion failure
+			log.Warn().Msgf("DeleteVNet failed. Triggering Reconcile: %s", vNetId)
+			manager := reconcile.GetManager()
+			if _, recErr := manager.RunReconcile(c.Request().Context(), nsId, model.StrVNet, vNetId, nil); recErr != nil {
+				log.Warn().Err(recErr).Msgf("auto-reconcile failed for VNet: %s", vNetId)
+			}
+
 			return c.JSON(apierr.Code(err), model.SimpleMsg{Message: err.Error()})
 		}
 	case resource.ActionReconcile:
 		// [Process]
-		resp, err = resource.ReconcileVNet(nsId, vNetId, nil)
+		manager := reconcile.GetManager()
+		res, err := manager.RunReconcile(c.Request().Context(), nsId, model.StrVNet, vNetId, nil)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return c.JSON(apierr.Code(err), model.SimpleMsg{Message: err.Error()})
+		}
+		if simpleMsg, ok := res.(model.SimpleMsg); ok {
+			resp = simpleMsg
+		} else {
+			resp = model.SimpleMsg{Message: "reconcile completed"}
 		}
 	default:
 		errMsg := fmt.Errorf("invalid action (%s)", action)


### PR DESCRIPTION
- Add reconcile.Manager registry and VNetReconciler with state machine routing
- Record DeletionFailed condition in all VNet/Subnet deletion paths
- Auto-trigger reconcile from REST handlers after VNet deletion failures
- Improve subnet classification with SystemId matching (remove rate-limited checks)
- Add subnetSyncSummary to show actual reconcile work performed

Note - Since subnets are resources dependent on vnets, subnet-only reconciliation was intentionally excluded.

ref) Phase 1 and 2 in https://github.com/cloud-barista/cb-tumblebug/issues/2509