### PR TITLE
Enhance image fetch skipping pattern

### DIFF
--- a/assets/cloudimage_ignore.yaml
+++ b/assets/cloudimage_ignore.yaml
@@ -12,14 +12,52 @@ csps:
   aws:
     description: "AWS image ignore patterns"
     global_patterns:
+      # ── Managed-service / internal AMIs (not for direct EC2/EKS provisioning) ──
       - "*parallelcluster*"          # AWS ParallelCluster AMIs — HPC cluster orchestration tool only, not for general VM use
       - "*elasticbeanstalk*"         # Elastic Beanstalk PaaS AMIs — managed by EB service, not for direct VM use
       - "*-ecs-*"                    # ECS-optimized AMIs — ECS container worker nodes (distinct from EKS), not for general VM use
       - "*ecs*optimized*"            # Windows ECS Optimized AMIs — underscore format not caught by *-ecs-*
       - "*ecs-managed-instances*"    # ECS managed node images — ECS internal managed images
       - "*lambda-managed-instances*" # Lambda internal worker images — not for user VM creation
+      - "*lambda-elevator*"          # Lambda microVM internal worker images — AWS internal use only
       - "*storage*gateway*"          # AWS Storage Gateway appliance AMIs — virtual storage appliance, not for general VM use
       - "*datasync*"                 # AWS DataSync appliance AMIs — managed data transfer service, not for general VM use
       - "*cloud9*"                   # AWS Cloud9 IDE AMIs — cloud IDE environment, not for general VM use
       - "*dcv-*"                     # NICE DCV AMIs — remote visualization streaming tool, not for general VM use
+      # ── EKS managed node group AMIs ──────────────────────────────────────────
+      # EKS managed node groups select images via AMI type (NodegroupAmiType,
+      # e.g. AL2023_x86_64_STANDARD, BOTTLEROCKET_x86_64), not by explicit AMI
+      # ID — AWS resolves the actual AMI internally at node group creation.
+      # Skipped here as they are not selected via direct image ID lookup.
+      - "amazon-eks-node-*"          # EKS-optimized AL2 / AL2023 node AMIs
+      - "amazon-eks-gpu-node-*"      # EKS-optimized GPU node AMIs (nvidia, neuron)
+      - "bottlerocket-aws-k8s-*"     # Bottlerocket OS AMIs for EKS node groups
+      # ── EKS Auto Mode internal AMIs ───────────────────────────────────────
+      # AWS-managed automatically in EKS Auto Mode; users cannot specify these
+      # AMI IDs in launch templates or node groups. Variants: standard, nvidia,
+      # neuron, amdgpu, amd. Pattern covers all K8s versions and architectures.
+      - "eks-auto-*"
+      # ── Mac dedicated-host AMIs ───────────────────────────────────────────────
+      # Only usable on mac1/mac2 dedicated hardware, not standard EC2 instances.
+      - "*amzn-ec2-macos*"           # Amazon macOS AMIs (arm64_mac / x86_64_mac)
+      - "*macos*sonoma*"             # macOS Sonoma
+      - "*macos*ventura*"            # macOS Ventura
+      - "*macos*monterey*"           # macOS Monterey
+      # ── Ubuntu pre-release / testing builds ───────────────────────────────────
+      # Unstable daily or testing images — not suitable for production VM/EKS use.
+      - "*images-testing*"           # Ubuntu images-testing path (pre-release)
+      - "*ubuntu*daily*"             # Ubuntu daily builds
+      # ── EOL operating systems ─────────────────────────────────────────────────
+      # Past vendor end-of-life: no security patches available.
+      - "*ubuntu*14.04*"             # Ubuntu 14.04 LTS — EOL Apr 2019
+      - "*ubuntu*16.04*"             # Ubuntu 16.04 LTS — EOL Apr 2021
+      - "*ubuntu*18.04*"             # Ubuntu 18.04 LTS — EOL Apr 2023
+      - "*-debian-9-*"               # Debian 9 Stretch — EOL Jun 2022
+      - "*debian*stretch*"           # Debian 9 Stretch (name variant)
+      - "*-debian-10-*"              # Debian 10 Buster — EOL Jun 2024
+      - "*debian*buster*"            # Debian 10 Buster (name variant)
+      - "*rhel-7*"                   # RHEL 7 — EOL Jun 2024
+      - "*rhel7*"                    # RHEL 7 (no-dash variant)
+      - "*sles-12*"                  # SUSE Linux Enterprise 12 — EOL Oct 2024
+      - "*sles12*"                   # SUSE Linux Enterprise 12 (no-dash variant)
     regions: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -148,7 +148,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.12.27
+    image: cloudbaristaorg/cb-spider:0.12.29
     container_name: cb-spider
     # build:
     #   context: ../cb-spider

--- a/src/core/common/client/client.go
+++ b/src/core/common/client/client.go
@@ -75,6 +75,12 @@ const (
 	LongDuration = 10 * time.Second
 	// VeryLongDuration is a duration for very long-term cache
 	VeryLongDuration = 300 * time.Second
+
+	// AvailabilityCheckTimeout is the per-request HTTP timeout used when probing
+	// whether a connection config is reachable via Spider. Kept separate from the
+	// cache-duration constants above because it controls network I/O, not caching.
+	// 60 s is generous enough for slow CSPs while preventing indefinite hangs.
+	AvailabilityCheckTimeout = 60 * time.Second
 )
 
 // NoBody is a constant for empty body

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -513,6 +513,7 @@ func CheckConnConfigAvailable(connConfigName string) (bool, error) {
 
 	var callResult model.SpiderAllListWrapper
 	client := clientManager.NewHttpClient()
+	client.SetTimeout(clientManager.AvailabilityCheckTimeout)
 	url := model.SpiderRestUrl + "/allkeypair"
 	method := "GET"
 	requestBody := model.SpiderConnectionName{}
@@ -1099,16 +1100,26 @@ func RegisterCredential(req model.CredentialReq) (model.CredentialInfo, error) {
 		var wg sync.WaitGroup
 		results := make(chan model.ConnConfig, len(filteredConnections.Connectionconfig))
 
+		total := len(filteredConnections.Connectionconfig)
+		log.Info().Msgf("[%s] Verifying %d connection(s) in parallel (timeout: %s each) ...",
+			req.ProviderName, total, clientManager.AvailabilityCheckTimeout)
+
 		for _, connConfig := range filteredConnections.Connectionconfig {
 			wg.Add(1)
 			go func(connConfig model.ConnConfig) {
 				defer wg.Done()
 				RandomSleep(0, 10*1000)
+				log.Info().Msgf("[%s] Checking availability: %s", req.ProviderName, connConfig.ConfigName)
 				verified, err := CheckConnConfigAvailable(connConfig.ConfigName)
 				if err != nil {
-					log.Error().Err(err).Msgf("Cannot check model.ConnConfig %s is available", connConfig.ConfigName)
+					log.Error().Err(err).Msgf("[%s] Cannot check ConnConfig %s (will mark unverified)", req.ProviderName, connConfig.ConfigName)
 				}
 				connConfig.Verified = verified
+				status := "✗"
+				if verified {
+					status = "✓"
+				}
+				log.Info().Msgf("[%s] %s %s", req.ProviderName, status, connConfig.ConfigName)
 				if verified {
 					regionInfo, err := GetRegion(connConfig.ProviderName, connConfig.RegionDetail.RegionName)
 					if err != nil {

--- a/src/core/resource/image.go
+++ b/src/core/resource/image.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
@@ -1530,7 +1529,7 @@ func fetchImagesForAllConnConfigsInternal(nsId string, option *model.ImageFetchO
 			// Adjust parallel connections for specific providers
 			providerParallelConn := parallelConnPerProvider
 			if csp.ResolveCloudPlatform(provider) == csp.AWS {
-				providerParallelConn = 3 // to handle more parallel connections
+				providerParallelConn = 2 // reduced to mitigate large DescribeImages response stream pressure
 			}
 			if csp.ResolveCloudPlatform(provider) == csp.Alibaba {
 				providerParallelConn = 2 // reduced to mitigate deadlock pressure
@@ -2992,6 +2991,75 @@ func loadCloudImageIgnoreConfig() (*model.CloudImageIgnoreConfig, error) {
 	return imageIgnoreConfig, imageIgnoreConfigErr
 }
 
+var (
+	imageIgnoreRegexpCache   = make(map[string]*regexp.Regexp)
+	imageIgnoreRegexpCacheMu sync.RWMutex
+)
+
+// compileIgnorePattern converts a glob pattern (supporting *, ?, and [abc]
+// character classes) into a compiled regexp that performs case-insensitive
+// substring matching. Unlike filepath.Match, the pattern is NOT anchored to
+// the whole string and '*' also matches '/'. This is required because the
+// matched text combines imageName + osDistribution, where the descriptive
+// name may appear anywhere (e.g. AWS prepends an opaque "ami-xxxx" ID).
+// Compiled patterns are cached for reuse.
+func compileIgnorePattern(pattern string) (*regexp.Regexp, error) {
+	imageIgnoreRegexpCacheMu.RLock()
+	if re, ok := imageIgnoreRegexpCache[pattern]; ok {
+		imageIgnoreRegexpCacheMu.RUnlock()
+		return re, nil
+	}
+	imageIgnoreRegexpCacheMu.RUnlock()
+
+	var sb strings.Builder
+	sb.WriteString("(?i)") // case-insensitive, substring (no ^...$ anchors)
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		switch c {
+		case '*':
+			sb.WriteString(".*")
+		case '?':
+			sb.WriteString(".")
+		case '[':
+			// Pass through a character class up to the matching ']'.
+			j := i + 1
+			for j < len(pattern) && pattern[j] != ']' {
+				j++
+			}
+			if j >= len(pattern) {
+				// No closing ']': treat '[' literally.
+				sb.WriteString(regexp.QuoteMeta("["))
+			} else {
+				sb.WriteString(pattern[i : j+1])
+				i = j
+			}
+		default:
+			sb.WriteString(regexp.QuoteMeta(string(c)))
+		}
+	}
+
+	re, err := regexp.Compile(sb.String())
+	if err != nil {
+		return nil, err
+	}
+
+	imageIgnoreRegexpCacheMu.Lock()
+	imageIgnoreRegexpCache[pattern] = re
+	imageIgnoreRegexpCacheMu.Unlock()
+	return re, nil
+}
+
+// matchIgnorePattern reports whether text matches the glob pattern using
+// case-insensitive substring semantics.
+func matchIgnorePattern(text, pattern, source string) bool {
+	re, err := compileIgnorePattern(pattern)
+	if err != nil {
+		log.Warn().Err(err).Str("pattern", pattern).Msgf("Invalid glob in cloudimage_ignore.yaml %s", source)
+		return false
+	}
+	return re.MatchString(text)
+}
+
 // shouldSkipImage returns true if the image matches any pattern in cloudimage_ignore.yaml.
 // combinedInfo should be imageName + " " + osDistribution (case-insensitive matching applied internally).
 func shouldSkipImage(imageName, osDistribution, providerName, regionName string) bool {
@@ -3000,16 +3068,11 @@ func shouldSkipImage(imageName, osDistribution, providerName, regionName string)
 		return false
 	}
 
-	combined := strings.ToLower(imageName + " " + osDistribution)
+	combined := imageName + " " + osDistribution
 
 	// Check global patterns
 	for _, pattern := range config.Global.Patterns {
-		matched, matchErr := filepath.Match(strings.ToLower(pattern), combined)
-		if matchErr != nil {
-			log.Warn().Err(matchErr).Str("pattern", pattern).Msg("Invalid glob in cloudimage_ignore.yaml global.patterns")
-			continue
-		}
-		if matched {
+		if matchIgnorePattern(combined, pattern, "global.patterns") {
 			return true
 		}
 	}
@@ -3022,24 +3085,14 @@ func shouldSkipImage(imageName, osDistribution, providerName, regionName string)
 	}
 
 	for _, pattern := range cspConfig.GlobalPatterns {
-		matched, matchErr := filepath.Match(strings.ToLower(pattern), combined)
-		if matchErr != nil {
-			log.Warn().Err(matchErr).Str("pattern", pattern).Msg("Invalid glob in cloudimage_ignore.yaml csps.*.global_patterns")
-			continue
-		}
-		if matched {
+		if matchIgnorePattern(combined, pattern, "csps.*.global_patterns") {
 			return true
 		}
 	}
 
 	if regionPatterns, ok := cspConfig.Regions[regionName]; ok {
 		for _, pattern := range regionPatterns.Patterns {
-			matched, matchErr := filepath.Match(strings.ToLower(pattern), combined)
-			if matchErr != nil {
-				log.Warn().Err(matchErr).Str("pattern", pattern).Msg("Invalid glob in cloudimage_ignore.yaml csps.*.regions")
-				continue
-			}
-			if matched {
+			if matchIgnorePattern(combined, pattern, "csps.*.regions") {
 				return true
 			}
 		}


### PR DESCRIPTION
Skip fetching aws images, so that only useful images are stored.
(EKS images especially. since we use image parameter value for EKS, not image ID directly)

### from

Asset Summary (DB-backed, by CSP)
Provider      Images    Specs    (Priced)
----------  --------  -------  ----------
alibaba          362     4340         96%
aws           421108    18323         98%
azure           1544    30398         96%
gcp              237    11397         92%
ibm              676     1798         97%
kt                33      220         14%
ncp              101      393         45%
nhn              129       71         92%
openstack          7        6          0%
tencent          146     3143        100%
Totals: specs=70089 (95% priced), images=424343

### to

Asset Summary (DB-backed, by CSP)
Provider      Images    Specs    (Priced)
----------  --------  -------  ----------
alibaba          362     4332         96%
aws           166384    18323         98%
azure           1544    30398         96%
gcp              238    11397         92%
ibm              676     1798         97%
kt                33      220         14%
ncp              101      393         45%
nhn              129       71         92%
openstack          7        6          0%
tencent          146     3143        100%
Totals: specs=70081 (95% priced), images=169620
