### PR TITLE
Fix spec recommendation multi-providers input bug

### DIFF
--- a/src/core/infra/recommendation.go
+++ b/src/core/infra/recommendation.go
@@ -72,7 +72,14 @@ func setFieldCondition(field reflect.Value, condition model.Operation) error {
 		}
 		return applyRange(field, condition.Operator, float32(operand))
 	} else if field.Kind() == reflect.String {
-		field.SetString(condition.Operand)
+		// For string fields, accumulate multiple values comma-separated
+		// so FilterSpecsByRange can use an IN clause (e.g. multiple providerName conditions)
+		existing := field.String()
+		if existing == "" {
+			field.SetString(condition.Operand)
+		} else {
+			field.SetString(existing + "," + condition.Operand)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fix spec recommendation multi-providers input bug

Enable following multiple CSPs selection request. (currently, multiple requests overwrite into one)
```
{
					"condition": [
						{
							"operand": "aws",
							"operator": "=="
						},
						{
							"operand": "azure",
							"operator": "=="
						},
						{
							"operand": "alibaba",
							"operator": "=="
						}
					],
					"metric": "providerName"
				}
```