### PR TITLE
Fix: Skip spider call when CspResourceName is not yet assigned during K8s cluster provisioning

### DIFF
--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -1121,6 +1121,18 @@ func GetK8sCluster(nsId string, k8sClusterId string) (*model.K8sClusterInfo, err
 		return emptyObj, err
 	}
 
+	// CspResourceName is assigned only after the spider cluster creation call returns.
+	// If it is still empty the cluster is being provisioned — return stored info as-is
+	// rather than calling spider with an empty name, which would hit the list endpoint.
+	if tbK8sCInfo.CspResourceName == "" {
+		log.Debug().Msgf("K8sCluster(%s) CspResourceName not yet assigned (still provisioning), returning stored info", k8sClusterId)
+		// Add label info when available (keeps response consistent with the normal GetK8sCluster path).
+		if labelInfo, labelErr := label.GetLabels(model.StrK8s, tbK8sCInfo.Uid); labelErr == nil && labelInfo.Labels != nil {
+			tbK8sCInfo.Label = labelInfo.Labels
+		}
+		return tbK8sCInfo, nil
+	}
+
 	// Update model.K8sClusterInfo from CB-Spider
 	client := clientManager.NewHttpClient()
 	client.SetTimeout(10 * time.Minute)


### PR DESCRIPTION
During NCP managed K8s cluster provisioning, 

GetK8sCluster() was repeatedly called (by the async polling loop) before the spider creation response returned
meaning CspResourceName was still empty.

This caused the spider URL to become /cluster/ (trailing slash) instead of 
/cluster/{name}, which triggered a 301 redirect to the list endpoint. 
- note: I am not sure why this trailing was added to cb-spider. It supposed to return appropriate error message not calling an unexpected API endpoint.

The list endpoint requires a ConnectionName header that was lost in the redirect, producing repeated "ConnectionName is empty!" errors in the logs. 

Added a guard in GetK8sCluster() to return the locally stored info as-is when CspResourceName is empty, skipping the spider call until provisioning completes.