### PR TITLE
feat(k8s): add Alibaba ACK image_type support for K8s node pools

### DIFF
--- a/assets/cloudimage.csv
+++ b/assets/cloudimage.csv
@@ -49,3 +49,5 @@ TENCENT,all,centos8.0x86_64,CentOS 8.0,"TKE Node - CentOS 8.0, x86_64 (Beta)",,k
 TENCENT,all,ubuntu20.04x86_64,Ubuntu 20.04,"TKE Node - Ubuntu 20.04, x86_64 (Beta)",,k8s,x86_64,ubuntu20.04x86_64
 TENCENT,all,ubuntu22.04x86_64,Ubuntu 22.04,"TKE Node - Ubuntu 22.04, x86_64",,k8s,x86_64,ubuntu22.04x86_64
 TENCENT,all,redhat7.9x86_64,Red Hat Enterprise Linux 7.9,"TKE Node - Red Hat Enterprise Linux 7.9, x86_64",,k8s,x86_64,redhat7.9x86_64
+ALIBABA,all,AliyunLinux3ContainerOptimized,Alibaba Cloud Linux 3 (Container Optimized),"ACK Node - Alibaba Cloud Linux 3, Container Optimized, cgroup v2, x86_64 (default image type)",,k8s,x86_64,AliyunLinux3ContainerOptimized
+ALIBABA,all,Ubuntu,Ubuntu (Latest),"ACK Node - Ubuntu latest (ACK image_type alias, resolves dynamically), cgroup v2, x86_64",,k8s,x86_64,Ubuntu

--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -110,6 +110,7 @@ k8scluster:
     nodeGroupsOnCreation: false
     nodeImageDesignation: true
     requiredSubnetCount: 1
+    initialNodeGroupManagedByCluster: true
     version:
       # ServiceUnavailable or NotSupportedSLB
       - region: [me-east-1, cn-zhangjiakou, cn-hangzhou, cn-shenzhen, cn-chengdu, ap-south-1, ap-sourtheast-2]
@@ -159,6 +160,7 @@ k8scluster:
     nodeGroupsOnCreation: false
     nodeImageDesignation: true
     requiredSubnetCount: 1
+    initialNodeGroupManagedByCluster: true
     version:
       # ServiceUnavailable
       - region: [ap-mumbai, eu-moscow, na-toronto]

--- a/src/core/common/label/label.go
+++ b/src/core/common/label/label.go
@@ -665,6 +665,8 @@ func convertTermToSpider(labelType string) string {
 		return model.StrKeypair
 	} else if strings.EqualFold(labelType, model.StrNode) {
 		return model.StrSpiderVM // CB-Spider uses "vm" for VM resources
+	} else if strings.EqualFold(labelType, model.StrK8s) {
+		return "cluster" // CB-Spider uses "cluster" for K8s cluster resources
 	} else {
 		return labelType
 	}

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -1850,6 +1850,21 @@ func GetModelK8sRequiredSubnetCount(providerName string) (*model.K8sClusterRequi
 
 const DefaultNamingRule = "^.*$" // Wildcard Pattern
 
+// GetK8sInitialNodeGroupManagedByCluster returns whether the initial node group
+// created during cluster creation is lifecycle-bound to the cluster (i.e., cannot
+// be deleted independently via the node group API).
+// This applies to CSPs such as Alibaba ACK and Tencent TKE.
+func GetK8sInitialNodeGroupManagedByCluster(providerName string) (bool, error) {
+	providerName = strings.ToLower(providerName)
+
+	k8sClusterDetail := getK8sClusterDetail(providerName)
+	if k8sClusterDetail == nil {
+		return false, fmt.Errorf("unsupported provider(%s) for kubernetes cluster", providerName)
+	}
+
+	return k8sClusterDetail.InitialNodeGroupManagedByCluster, nil
+}
+
 // GetK8sNodeGroupNamingRule is func to get nodegroup's naming rule
 func GetK8sNodeGroupNamingRule(providerName string) (string, error) {
 	//

--- a/src/core/model/config.go
+++ b/src/core/model/config.go
@@ -190,13 +190,17 @@ type K8sClusterRequiredSubnetCount struct {
 
 // K8sClusterDetail is structure for kubernetes cluster detail information
 type K8sClusterDetail struct {
-	NodeGroupsOnCreation bool                        `mapstructure:"nodeGroupsOnCreation" json:"nodegroups_on_creation"`
-	NodeImageDesignation bool                        `mapstructure:"nodeImageDesignation" json:"node_image_designation"`
-	RequiredSubnetCount  int                         `mapstructure:"requiredSubnetCount" json:"required_subnet_count"`
-	NodeGroupNamingRule  string                      `mapstructure:"nodeGroupNamingRule" json:"nodegroup_naming_rule"`
-	Version              []K8sClusterVersionDetail   `mapstructure:"version" json:"versions"`
-	NodeImage            []K8sClusterNodeImageDetail `mapstructure:"nodeImage" json:"node_images"`
-	RootDisk             []K8sClusterRootDiskDetail  `mapstructure:"rootDisk" json:"root_disks"`
+	NodeGroupsOnCreation             bool                        `mapstructure:"nodeGroupsOnCreation" json:"nodegroups_on_creation"`
+	NodeImageDesignation             bool                        `mapstructure:"nodeImageDesignation" json:"node_image_designation"`
+	RequiredSubnetCount              int                         `mapstructure:"requiredSubnetCount" json:"required_subnet_count"`
+	NodeGroupNamingRule              string                      `mapstructure:"nodeGroupNamingRule" json:"nodegroup_naming_rule"`
+	// InitialNodeGroupManagedByCluster indicates that the initial node group created during
+	// cluster creation is lifecycle-bound to the cluster and cannot be deleted independently
+	// via the node group API (e.g., Alibaba ACK, Tencent TKE).
+	InitialNodeGroupManagedByCluster bool                        `mapstructure:"initialNodeGroupManagedByCluster" json:"initial_nodegroup_managed_by_cluster"`
+	Version                          []K8sClusterVersionDetail   `mapstructure:"version" json:"versions"`
+	NodeImage                        []K8sClusterNodeImageDetail `mapstructure:"nodeImage" json:"node_images"`
+	RootDisk                         []K8sClusterRootDiskDetail  `mapstructure:"rootDisk" json:"root_disks"`
 }
 
 // K8sClusterVersionDetail is structure for kubernetes cluster version detail information

--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -422,6 +422,11 @@ type K8sNodeGroupInfo struct {
 	K8sNodes        []K8sNodeInfo      `json:"k8sNodes"`
 	KeyValueList    []KeyValue         `json:"keyValueList"`
 
+	// IsInitialNodeGroup indicates whether this node group was created during cluster creation.
+	// For some CSPs (Alibaba ACK, Tencent TKE), this node group cannot be deleted independently;
+	// it is automatically removed when the cluster is deleted.
+	IsInitialNodeGroup bool `json:"isInitialNodeGroup,omitempty"`
+
 	// CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.
 	CspResourceName string `json:"cspResourceName,omitempty" example:"we12fawefadf1221edcf"`
 

--- a/src/core/resource/image.go
+++ b/src/core/resource/image.go
@@ -70,7 +70,7 @@ func ImageReqStructLevelValidation(sl validator.StructLevel) {
 // must validate that the requested imageId resolves to a registered entry.
 func usesTypeIdentifierK8sImage(providerName string) bool {
 	switch csp.ResolveCloudPlatform(providerName) {
-	case csp.AWS, csp.GCP, csp.Tencent:
+	case csp.AWS, csp.GCP, csp.Tencent, csp.Alibaba:
 		return true
 	}
 	return false
@@ -793,28 +793,18 @@ func RegisterImageWithInfoInBulk(imageList []model.ImageInfo) error {
 				dbImage.RegionList = make([]string, 0)
 			}
 
-			// Merge new region information
-			regionsAdded := false
-			for _, newRegion := range img.RegionList {
-				regionExists := slices.Contains(dbImage.RegionList, newRegion)
-
-				if !regionExists {
-					// log.Debug().Msgf("Adding region %s to DB image %s",
-					// 	newRegion, key)
-					dbImage.RegionList = append(dbImage.RegionList, newRegion)
-					regionsAdded = true
+			// Merge DB regions into incoming img (preserve all field updates from img).
+			// DB is used only to carry over regions not present in the incoming entry —
+			// all other fields (e.g. IsKubernetesImage, OSType) come from img so that
+			// policy updates from updateExistingImageFromCSV are not silently discarded.
+			for _, dbRegion := range dbImage.RegionList {
+				if !slices.Contains(img.RegionList, dbRegion) {
+					img.RegionList = append(img.RegionList, dbRegion)
 				}
 			}
+			sort.Strings(img.RegionList)
 
-			if regionsAdded {
-				// Sort regions
-				sort.Strings(dbImage.RegionList)
-
-				// log.Info().Msgf("Merged regions for image %s: %v",
-				// 	key, dbImage.RegionList)
-			}
-
-			dedupedImageList = append(dedupedImageList, dbImage)
+			dedupedImageList = append(dedupedImageList, img)
 		} else {
 			// Add new image if not found in DB
 			//log.Debug().Msgf("Image not found in DB, will insert new: %s", key)
@@ -2000,11 +1990,10 @@ func UpdateImagesFromAsset(nsId string) (*FetchImagesAsyncResult, error) {
 				tmpImageInfo := createBasicImageInfoFromCSV(nsId, providerName, regionName, imageReqTmp.CspImageName,
 					imageReqTmp.ConnectionName, osType, description, infraType, osArchitecture, osDistribution)
 
-				// AWS/GCP K8s image type identifiers (e.g., BOTTLEROCKET_x86_64, COS_CONTAINERD) registered
-				// in cloudimage.csv are not real CSP image IDs — they are EKS/GKE internal type keywords.
+				// K8s image type identifiers (EKS AMI types, GKE image families, TKE OS names,
+				// ACK image_type names) registered in cloudimage.csv are not real CSP image IDs.
 				// CSP lookup via CB-Spider will always fail for these, so skip enrichment.
-				skipCSPLookup := tmpImageInfo.IsKubernetesImage &&
-					(strings.EqualFold(csp.ResolveCloudPlatform(providerName), csp.AWS) || strings.EqualFold(csp.ResolveCloudPlatform(providerName), csp.GCP))
+				skipCSPLookup := tmpImageInfo.IsKubernetesImage && usesTypeIdentifierK8sImage(providerName)
 
 				if !skipCSPLookup {
 					// Try to enrich with CSP lookup (optional)

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -275,6 +275,14 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 	}
 	fillK8sNodeGroupInfoListFromK8sNodeGroupReqList(&tbK8sCInfo.K8sNodeGroupList, &req.K8sNodeGroupList)
 
+	// Mark the first node group as initial for CSPs where the initial node group
+	// is lifecycle-bound to the cluster and cannot be deleted independently.
+	if managed, _ := common.GetK8sInitialNodeGroupManagedByCluster(connConfig.ProviderName); managed {
+		if len(tbK8sCInfo.K8sNodeGroupList) > 0 {
+			tbK8sCInfo.K8sNodeGroupList[0].IsInitialNodeGroup = true
+		}
+	}
+
 	err = createK8sClusterInfo(nsId, *tbK8sCInfo)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Create a K8sCluster(%s)", k8sClusterId)
@@ -737,10 +745,11 @@ func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *m
 			if err = validateK8sImageForProvider(nsId, connConfig.ProviderName, u.ImageId); err != nil {
 				return emptyObj, err
 			}
-			// Resolve provider-specific "latest image" (currently Alibaba-only)
-			// right before passing the CSP image name to cb-spider, so that
-			// VM creation does not break on deprecated/removed image IDs.
-			spImgName = ResolveLatestCspImageNameForVMCreation(ctx, nsId, tbK8sCInfo.ConnectionName, u.ImageId, spImgName)
+			// K8s node pools use CSP-specific image_type aliases (e.g. Alibaba "AliyunLinux3"),
+			// not ECS/VM image IDs. ResolveLatestCspImageNameForVMCreation converts the alias to
+			// an ECS ID that ACK rejects with "does not support cgroup v2". Pass the original
+			// user-specified ImageId directly so Spider can route it correctly via image_type.
+			spImgName = u.ImageId
 		}
 	}
 
@@ -868,6 +877,21 @@ func RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, option string) (bo
 	if err != nil {
 		log.Err(err).Msgf("Failed to Remove K8sNodeGroup(k8scluster=%s)", k8sClusterId)
 		return false, err
+	}
+
+	// Protect initial node group from independent deletion for CSPs where it is
+	// lifecycle-bound to the cluster (e.g., Alibaba ACK, Tencent TKE).
+	if ngConnConfig, connErr := common.GetConnConfig(tbK8sCInfo.ConnectionName); connErr == nil {
+		if managed, _ := common.GetK8sInitialNodeGroupManagedByCluster(ngConnConfig.ProviderName); managed {
+			for _, ng := range tbK8sCInfo.K8sNodeGroupList {
+				if ng.Name == k8sNodeGroupName && ng.IsInitialNodeGroup {
+					return false, fmt.Errorf(
+						"node group '%s' is the initial node group of cluster '%s' and cannot be deleted independently for provider '%s'. Delete the cluster to remove it",
+						k8sNodeGroupName, k8sClusterId, ngConnConfig.ProviderName,
+					)
+				}
+			}
+		}
 	}
 
 	// Create Request body for RemoveK8sNodeGroup of CB-Spider


### PR DESCRIPTION
## Summary

- Register Alibaba ACK image_type identifiers (`AliyunLinux3ContainerOptimized`, `Ubuntu`) in `cloudimage.csv` and add Alibaba to `usesTypeIdentifierK8sImage`/`skipCSPLookup` in `image.go` so ACK aliases are recognized as K8s node images without CSP lookup
- Fix `AddK8sNodeGroup` to pass the original image alias directly to Spider instead of the resolved ECS image ID
- Skip deletion of Alibaba ACK initial node group in k8scluster.go — ACK does not allow deleting the cluster-lifecycle-managed node group at the CSP level, so TB now mirrors this behavior via the initialNodeGroupManagedByCluster flag
- Fix K8s cluster label API calls to Spider — Spider expects resource type "cluster" but TB was passing "k8scluster", causing label operations to fail