### PR TITLE
Update supported Azure AKS Kubernetes versions in k8sclusterinfo.yaml

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -51,27 +51,27 @@ k8scluster:
     nodeGroupNamingRule: ^[a-z][a-z0-9]*$
     version:
       - region: [westeurope,westus]
-        available: # Updated: 2025-10-30 (verified with az aks get-versions)
+        available: # Updated: 2026-06-24 (verified with learn.microsoft.com/azure/aks/supported-kubernetes-versions + github.com/Azure/AKS/releases)
+          - name: "1.35"
+            id: "1.35.5"
+          - name: "1.34"
+            id: "1.34.8"
           - name: "1.33"
-            id: "1.33.3"
-          - name: "1.32"
-            id: "1.32.7"
-          - name: "1.31"
-            id: "1.31.11"
-          - name: "1.30"
-            id: "1.30.100"
+            id: "1.33.12"
+          # EOL versions (no longer supported for new cluster creation):
+          # 1.32 EOL: Mar 2026, 1.31 EOL: Nov 1 2025, 1.30 EOL: Aug 22 2025
       - region: [westindia]
         # no available version
       - region: [common]
         available:
+          - name: "1.35"
+            id: "1.35.5"
+          - name: "1.34"
+            id: "1.34.8"
           - name: "1.33"
-            id: "1.33.3"
-          - name: "1.32"
-            id: "1.32.7"
-          - name: "1.31"
-            id: "1.31.11"
-          - name: "1.30"
-            id: "1.30.100"
+            id: "1.33.12"
+          # EOL versions (no longer supported for new cluster creation):
+          # 1.32 EOL: Mar 2026, 1.31 EOL: Nov 1 2025, 1.30 EOL: Aug 22 2025
     rootDisk:
       - region: [common]
         type:


### PR DESCRIPTION
## Summary

- Update supported Azure AKS Kubernetes versions to 1.33, 1.34, and 1.35
- Verify version validity via successful parallel AKS provisioning, nginx deployment, and resource cleanup tests