### PR TITLE
Update GKE and NCP NKS versions in k8sclusterinfo.yaml

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -188,13 +188,11 @@ k8scluster:
     nodeGroupNamingRule: '^[a-z][a-z0-9-]{1,18}[a-z0-9]$'
     version:
       - region: [common]
-        available:
+        available: # Updated: 2026-06-25 (NCP API confirmed: Available 1.34.3-nks.1, 1.33.4-nks.1)
+          - name: "1.34"
+            id: "1.34.3-nks.1"
           - name: "1.33"
             id: "1.33.4-nks.1"
-          - name: "1.32"
-            id: "1.32.8-nks.1"
-          - name: "1.31"
-            id: "1.31.7-nks.1"
     rootDisk:
       - region: [common]
         type:

--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -87,15 +87,15 @@ k8scluster:
     version:
       - region: [common]
         # ref: https://cloud.google.com/kubernetes-engine/docs/release-notes-stable
-        # Updated: 2026-02-19 (latest stable channel versions)
+        # Updated: 2026-06-25 (latest stable channel versions)
         # gcloud container get-server-config --region=asia-northeast3 --format=json | jq '{validMasterVersions, channels: [.channels[] | {channel, defaultVersion, validVersions}]}'
-        available: # stable channel versions as of 2026-02-19 (2026-R7)
+        available: # stable channel versions as of 2026-06-25
+          - name: "1.35"
+            id: "1.35.5-gke.1000004"
           - name: "1.34"
-            id: "1.34.3-gke.1051003"
+            id: "1.34.8-gke.1000000"
           - name: "1.33"
-            id: "1.33.5-gke.2172001"
-          - name: "1.32"
-            id: "1.32.11-gke.1038000"
+            id: "1.33.12-gke.1000000"
       - region: [africa-south1]
         # addnodegroup unavailble
     rootDisk:


### PR DESCRIPTION
## Summary

- Update GCP GKE Kubernetes versions to the latest stable release (v1.35, v1.34, v1.33) in k8sclusterinfo.yaml
- Update NCP NKS Kubernetes versions to the latest available release (v1.34, v1.33) in k8sclusterinfo.yaml
- Remove deprecated NCP NKS versions (v1.31, v1.32) no longer supported by NCP NKS
- Verify cluster functionality by successfully deploying an nginx application and validating external access for all updated versions