### PR TITLE
Compensate IBM cloud vm status undefined bug

### DIFF
--- a/src/core/infra/control.go
+++ b/src/core/infra/control.go
@@ -185,8 +185,19 @@ func HandleInfraAction(nsId string, infraId string, action string, force bool) (
 			// Remove Nodes in model.StatusFailed or model.StatusUndefined
 			log.Debug().Msgf("[nodeInfo.Status] %v", v.Status)
 			if strings.EqualFold(v.Status, model.StatusFailed) || strings.EqualFold(v.Status, model.StatusUndefined) {
-				// Delete Node sequentially for safety (for performance, need to use goroutine)
-				err := DelInfraNode(nsId, infraId, v.Id, "force")
+				// Decide deletion mode based on whether the node was actually created at CSP.
+				// A node with CspResourceName set has a live CSP resource — soft-delete it
+				// (termination attempted first) to avoid leaving orphaned CSP VMs that would
+				// block shared-resource (VNet/SG) cleanup with DependencyViolation errors.
+				// Nodes that were never created at CSP (empty CspResourceName) are safe to
+				// force-delete because there is nothing to terminate on the CSP side.
+				deleteOption := "force"
+				if nodeInfo, infoErr := GetNodeObject(nsId, infraId, v.Id); infoErr == nil && nodeInfo.CspResourceName != "" {
+					deleteOption = "" // soft: attempt CSP termination before removing CB-TB record
+					log.Debug().Msgf("[Refine] Node %s has CspResourceName=%s — using soft delete to avoid CSP orphan", v.Id, nodeInfo.CspResourceName)
+				}
+
+				err := DelInfraNode(nsId, infraId, v.Id, deleteOption)
 				if err != nil {
 					// A "does not exist" error means the node was already removed by a
 					// concurrent refine call — treat as already deleted and continue.

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -2064,6 +2064,22 @@ applyStatus:
 			callResult.Status = model.StatusFailed
 		}
 	}
+
+	// Fallback: if the CSP (or Spider) returned Undefined but the node already has a
+	// PublicIP, the CSP committed to creating the VM — preserve Creating to avoid a
+	// false Undefined flip while the VM is still booting or the CSP API is slow.
+	// This covers two gaps the TargetAction correction above cannot handle:
+	//   1. TargetAction was already cleared to ActionComplete (e.g. IBM: VM briefly
+	//      reached Running, action completed, then vmstatus API began timing out).
+	//   2. TargetAction is empty due to a concurrent goroutine clearing it before
+	//      the correction above is evaluated.
+	if strings.EqualFold(callResult.Status, model.StatusUndefined) &&
+		strings.EqualFold(nodeInfo.Status, model.StatusCreating) &&
+		nodeInfo.PublicIP != "" {
+		log.Debug().Msgf("[FetchNodeStatus] Node %s: PublicIP already assigned (%s), preserving Creating despite Undefined from CSP/Spider", nodeId, nodeInfo.PublicIP)
+		callResult.Status = model.StatusCreating
+	}
+
 	if strings.EqualFold(nodeStatusTmp.TargetAction, model.ActionTerminate) {
 		switch {
 		case strings.EqualFold(callResult.Status, model.StatusTerminated):


### PR DESCRIPTION

- cb-spider IBM driver returns unexpected VM status occasionally.
- this PR adjust the unexpected status based on the provisioning context.