### PR TITLE
Generalize VM/K8s object models by unifying cluster and node group types

### DIFF
--- a/src/core/infra/autopilot.go
+++ b/src/core/infra/autopilot.go
@@ -500,7 +500,7 @@ func CreateInfraAutopilot(ctx context.Context, nsId string, req *model.InfraAuto
 	//
 	// Cleanup: after every provision call, failed/undefined VMs are refined out of
 	// the infra so that subsequent attempts start with a clean slate.
-	provision := func(ngReq model.CreateNodeGroupDynamicReq) (int, error) {
+	provision := func(ngReq model.NodeGroupDynamicReq) (int, error) {
 		refineFailed := func() {
 			infraMu.Lock()
 			ok := infraCreated
@@ -521,7 +521,7 @@ func CreateInfraAutopilot(ctx context.Context, nsId string, req *model.InfraAuto
 		infraOnce.Do(func() {
 			thisIsFirstCall = true
 			singleReq := baseInfraReq
-			singleReq.NodeGroups = []model.CreateNodeGroupDynamicReq{ngReq}
+			singleReq.NodeGroups = []model.NodeGroupDynamicReq{ngReq}
 			result, err := CreateInfraDynamic(ctx, nsId, &singleReq, "")
 			infraMu.Lock()
 			if err != nil {
@@ -728,7 +728,7 @@ func provisionNodeSpec(
 	policy model.AutopilotPolicy,
 	plan *model.NodeSpecReview, // pre-computed plan from ReviewInfraAutopilot; nil = derive on the fly
 	onAttempt func(model.ProvisioningAttempt), // called after each attempt; may be nil
-	provision func(model.CreateNodeGroupDynamicReq) (int, error),
+	provision func(model.NodeGroupDynamicReq) (int, error),
 ) (*model.NodeSpecResult, []model.ProvisioningAttempt, error) {
 
 	specResult := &model.NodeSpecResult{
@@ -1176,7 +1176,7 @@ func provisionNodeSpec(
 						}
 					}
 
-					actualRunning, provErr := provision(model.CreateNodeGroupDynamicReq{
+					actualRunning, provErr := provision(model.NodeGroupDynamicReq{
 						Name:          task.ngName,
 						NodeGroupSize: task.requested,
 						SpecId:        spec.Id,
@@ -1452,7 +1452,7 @@ func provisionNodeSpec(
 
 		attempt.NodeGroupName = nodeGroupName
 
-		ngReq := model.CreateNodeGroupDynamicReq{
+		ngReq := model.NodeGroupDynamicReq{
 			Name:          nodeGroupName,
 			NodeGroupSize: requested,
 			SpecId:        spec.Id,

--- a/src/core/infra/loadbalance.go
+++ b/src/core/infra/loadbalance.go
@@ -110,7 +110,7 @@ func CreateMcSwNlb(nsId string, infraId string, req *model.NLBReq, option string
 		specId = recommendedSpec
 	}
 
-	nodeGroupDynamicReq := model.CreateNodeGroupDynamicReq{Name: nodeGroupName, SpecId: specId, ImageId: imageId, NodeGroupSize: nodeGroupSize}
+	nodeGroupDynamicReq := model.NodeGroupDynamicReq{Name: nodeGroupName, SpecId: specId, ImageId: imageId, NodeGroupSize: nodeGroupSize}
 	infraDynamicReq.NodeGroups = append(infraDynamicReq.NodeGroups, nodeGroupDynamicReq)
 
 	infraInfo, err := CreateInfraDynamic(common.NewDefaultContext(), nsId, &infraDynamicReq, "")

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -311,7 +311,7 @@ func buildImplicitClusterId(node model.NodeInfo) string {
 	return fmt.Sprintf("nogroup--%s", nodeGroupId)
 }
 
-func normalizeImplicitClusterInfo(cluster *model.InfraClusterInfo) {
+func normalizeImplicitClusterInfo(cluster *model.ClusterInfo) {
 	cluster.ConnectionNames = sortAndCompactStrings(cluster.ConnectionNames)
 	cluster.ProviderNames = sortAndCompactStrings(cluster.ProviderNames)
 	cluster.RegionNames = sortAndCompactStrings(cluster.RegionNames)
@@ -328,18 +328,18 @@ func normalizeImplicitClusterInfo(cluster *model.InfraClusterInfo) {
 	}
 }
 
-func buildImplicitClusterInfoFromNodes(infraId string, nodeInfoList []model.NodeInfo) []model.InfraClusterInfo {
+func buildImplicitClusterInfoFromNodes(infraId string, nodeInfoList []model.NodeInfo) []model.ClusterInfo {
 	if len(nodeInfoList) == 0 {
-		return []model.InfraClusterInfo{}
+		return []model.ClusterInfo{}
 	}
 
-	clustersByKey := map[string]*model.InfraClusterInfo{}
+	clustersByKey := map[string]*model.ClusterInfo{}
 
 	for _, node := range nodeInfoList {
 		groupKey := buildImplicitClusterGroupKey(node)
 		cluster, exists := clustersByKey[groupKey]
 		if !exists {
-			cluster = &model.InfraClusterInfo{
+			cluster = &model.ClusterInfo{
 				Id:                        buildImplicitClusterId(node),
 				Name:                      buildImplicitClusterId(node),
 				InfraId:                   infraId,
@@ -362,7 +362,7 @@ func buildImplicitClusterInfoFromNodes(infraId string, nodeInfoList []model.Node
 		cluster.RegionNames = appendNonEmptyString(cluster.RegionNames, node.Region.Region)
 	}
 
-	clusterList := make([]model.InfraClusterInfo, 0, len(clustersByKey))
+	clusterList := make([]model.ClusterInfo, 0, len(clustersByKey))
 	for _, cluster := range clustersByKey {
 		normalizeImplicitClusterInfo(cluster)
 		clusterList = append(clusterList, *cluster)
@@ -377,7 +377,7 @@ func buildImplicitClusterInfoFromNodes(infraId string, nodeInfoList []model.Node
 
 // ListInfraClusterInfo returns implicit cluster views synthesized at query-time from Infra Nodes.
 // No persistent cluster object is created or maintained.
-func ListInfraClusterInfo(nsId string, infraId string) ([]model.InfraClusterInfo, error) {
+func ListInfraClusterInfo(nsId string, infraId string) ([]model.ClusterInfo, error) {
 	check, err := CheckInfra(nsId, infraId)
 	if err != nil {
 		log.Error().Err(err).Msg("Cannot check Infra existence")
@@ -397,7 +397,7 @@ func ListInfraClusterInfo(nsId string, infraId string) ([]model.InfraClusterInfo
 }
 
 // GetInfraClusterInfo returns a single implicit cluster view synthesized at query-time.
-func GetInfraClusterInfo(nsId string, infraId string, clusterId string) (*model.InfraClusterInfo, error) {
+func GetInfraClusterInfo(nsId string, infraId string, clusterId string) (*model.ClusterInfo, error) {
 	if err := common.CheckString(clusterId); err != nil {
 		log.Error().Err(err).Msg("invalid clusterId")
 		return nil, err
@@ -532,12 +532,12 @@ func ExtractInfraDynamicReqFromInfraInfo(nsId string, infraId string) (*model.In
 		nodeGroupMap[sgId] = append(nodeGroupMap[sgId], node)
 	}
 
-	var nodeGroups []model.CreateNodeGroupDynamicReq
+	var nodeGroups []model.NodeGroupDynamicReq
 	for _, sgId := range nodeGroupOrder {
 		nodes := nodeGroupMap[sgId]
 		// Use the first Node in each nodegroup as the representative spec
 		rep := nodes[0]
-		sg := model.CreateNodeGroupDynamicReq{
+		sg := model.NodeGroupDynamicReq{
 			Name:           sgId,
 			NodeGroupSize:  len(nodes),
 			Label:          filterOutSystemLabels(rep.Label),

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -1558,7 +1558,7 @@ func CreateInfraDynamic(ctx context.Context, nsId string, req *model.InfraDynami
 
 	for i, k := range nodeGroupReqs {
 		wg.Add(1)
-		go func(index int, nodeGroupReq model.CreateNodeGroupDynamicReq) {
+		go func(index int, nodeGroupReq model.NodeGroupDynamicReq) {
 			defer wg.Done()
 
 			// Acquire semaphore
@@ -1627,7 +1627,7 @@ func CreateInfraDynamic(ctx context.Context, nsId string, req *model.InfraDynami
 		resultChan := make(chan nodeResult, len(nodeGroupReqs))
 
 		// Group nodeGroupReqs by connectionName for sequential processing
-		connectionGroups := make(map[string][]model.CreateNodeGroupDynamicReq)
+		connectionGroups := make(map[string][]model.NodeGroupDynamicReq)
 
 		// First, determine the connection name for each nodeGroup
 		for _, nodeGroupReq := range nodeGroupReqs {
@@ -1678,7 +1678,7 @@ func CreateInfraDynamic(ctx context.Context, nsId string, req *model.InfraDynami
 		// Process each connection group in parallel, but VMs within each group sequentially
 		for connectionName, nodeGroupsInConnection := range connectionGroups {
 			wg.Add(1)
-			go func(connName string, nodeGroups []model.CreateNodeGroupDynamicReq) {
+			go func(connName string, nodeGroups []model.NodeGroupDynamicReq) {
 				defer wg.Done()
 
 				log.Info().Msgf("Processing %d NodeGroups for connection '%s' sequentially", len(nodeGroups), connName)
@@ -1938,7 +1938,7 @@ func ValidateInfraDynamicReq(ctx context.Context, nsId string, req *model.InfraD
 }
 
 // reviewSingleNodeGroupDynamicReq reviews and validates a single VM dynamic request
-func reviewSingleNodeGroupDynamicReq(ctx context.Context, nodeGroupDynamicReq model.CreateNodeGroupDynamicReq, deployOption string) (model.ReviewNodeGroupDynamicReqInfo, *model.SpecInfo, bool, bool, float64) {
+func reviewSingleNodeGroupDynamicReq(ctx context.Context, nodeGroupDynamicReq model.NodeGroupDynamicReq, deployOption string) (model.ReviewNodeGroupDynamicReqInfo, *model.SpecInfo, bool, bool, float64) {
 
 	credentialHolder := common.CredentialHolderFromContext(ctx)
 	nodeReview := model.ReviewNodeGroupDynamicReqInfo{
@@ -2590,7 +2590,7 @@ func ReviewSpecImagePair(ctx context.Context, specId, imageId, rootDiskType, zon
 }
 
 // ReviewSingleNodeGroupDynamicReq reviews and validates a single VM dynamic request and returns comprehensive review information
-func ReviewSingleNodeGroupDynamicReq(ctx context.Context, nsId string, req *model.CreateNodeGroupDynamicReq) (*model.ReviewNodeGroupDynamicReqInfo, error) {
+func ReviewSingleNodeGroupDynamicReq(ctx context.Context, nsId string, req *model.NodeGroupDynamicReq) (*model.ReviewNodeGroupDynamicReqInfo, error) {
 	log.Debug().Msgf("Starting single VM dynamic request review for: %s", req.Name)
 
 	// Basic validation
@@ -2699,7 +2699,7 @@ func ReviewInfraDynamicReq(ctx context.Context, nsId string, req *model.InfraDyn
 	// Validate each VM request in parallel
 	for i, nodeGroupReq := range req.NodeGroups {
 		wg.Add(1)
-		go func(index int, nodeGroupDynamicReq model.CreateNodeGroupDynamicReq) {
+		go func(index int, nodeGroupDynamicReq model.NodeGroupDynamicReq) {
 			defer wg.Done()
 
 			// Global cap (safety net across all CSPs).
@@ -2980,7 +2980,7 @@ func CreateSystemInfraDynamic(option string) (*model.InfraInfo, error) {
 		}
 		for _, v := range connections.Connectionconfig {
 
-			nodeGroupDynamicReq := &model.CreateNodeGroupDynamicReq{}
+			nodeGroupDynamicReq := &model.NodeGroupDynamicReq{}
 			nodeGroupDynamicReq.ImageId = "ubuntu22.04"                // temporal default value. will be changed
 			nodeGroupDynamicReq.SpecId = "aws-ap-northeast-2-t2-small" // temporal default value. will be changed
 
@@ -3025,7 +3025,7 @@ func CreateSystemInfraDynamic(option string) (*model.InfraInfo, error) {
 }
 
 // CreateInfraNodeGroupDynamic is func to create requested VM in a dynamic way and add it to Infra
-func CreateInfraNodeGroupDynamic(ctx context.Context, nsId string, infraId string, req *model.CreateNodeGroupDynamicReq) (*model.InfraInfo, error) {
+func CreateInfraNodeGroupDynamic(ctx context.Context, nsId string, infraId string, req *model.NodeGroupDynamicReq) (*model.InfraInfo, error) {
 
 	emptyInfra := &model.InfraInfo{}
 	nodeGroupId := req.Name
@@ -3055,7 +3055,7 @@ func CreateInfraNodeGroupDynamic(ctx context.Context, nsId string, infraId strin
 }
 
 // checkCommonResAvailableForNodeGroupDynamicReq is func to check common resources availability for NodeGroupDynamicReq
-func checkCommonResAvailableForNodeGroupDynamicReq(ctx context.Context, req *model.CreateNodeGroupDynamicReq, nsId string) error {
+func checkCommonResAvailableForNodeGroupDynamicReq(ctx context.Context, req *model.NodeGroupDynamicReq, nsId string) error {
 
 	credentialHolder := common.CredentialHolderFromContext(ctx)
 
@@ -3210,7 +3210,7 @@ func waitForVNetReady(ctx context.Context, nsId string, vNetId string) error {
 }
 
 // getNodeGroupReqFromDynamicReq is func to getNodeGroupReqFromDynamicReq with created resource tracking
-func getNodeGroupReqFromDynamicReq(ctx context.Context, nsId string, req *model.CreateNodeGroupDynamicReq) (*NodeReqWithCreatedResources, error) {
+func getNodeGroupReqFromDynamicReq(ctx context.Context, nsId string, req *model.NodeGroupDynamicReq) (*NodeReqWithCreatedResources, error) {
 
 	reqID := common.RequestIDFromContext(ctx)
 	credentialHolder := common.CredentialHolderFromContext(ctx)
@@ -4468,66 +4468,87 @@ func getK8sRecommendVersion(providerName, regionName, reqVersion string) (string
 	return recVersion, nil
 }
 
-// checkCommonResAvailableForK8sClusterDynamicReq is func to check common resources availability for K8sClusterDynamicReq
-func checkCommonResAvailableForK8sClusterDynamicReq(ctx context.Context, dReq *model.K8sClusterDynamicReq) error {
-	specInfo, err := resource.GetSpec(model.SystemCommonNs, dReq.SpecId)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return err
+// checkCommonResAvailableForK8sClusterDynamicReq is func to check common resources availability for ClusterDynamicReq
+func checkCommonResAvailableForK8sClusterDynamicReq(ctx context.Context, dReq *model.ClusterDynamicReq) error {
+	// If no NodeGroups, return error
+	if len(dReq.NodeGroups) == 0 {
+		return fmt.Errorf("K8sCluster requires at least one NodeGroup")
 	}
 
-	connName := specInfo.ConnectionName
-	// If ConnectionName is specified by the request, Use ConnectionName from the request
-	if dReq.ConnectionName != "" {
-		connName = dReq.ConnectionName
-	}
-
-	// validate the GetConnConfig for spec
-	connConfig, err := common.GetConnConfig(connName)
-	if err != nil {
-		err := fmt.Errorf("Failed to get ConnectionName (%s) for Spec (%s) is not found.", connName, dReq.SpecId)
-		log.Error().Err(err).Msg("")
-		return err
-	}
-
-	niDesignation, err := common.GetK8sNodeImageDesignation(connConfig.ProviderName)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-	}
-
-	if niDesignation == false {
-		// if node image designation is not supported by CSP, auto-correct ImageId to "default"
-		if !(strings.EqualFold(dReq.ImageId, "default") || strings.EqualFold(dReq.ImageId, "")) {
-			log.Warn().Msgf("NodeImageDesignation is not supported by CSP(%s). ImageId '%s' will be replaced with 'default'", connConfig.ProviderName, dReq.ImageId)
-			dReq.ImageId = "default"
-		}
-	}
-
-	// In K8sCluster, allows dReq.ImageId to be set to "default" or ""
-	if strings.EqualFold(dReq.ImageId, "default") ||
-		strings.EqualFold(dReq.ImageId, "") {
-		// do nothing
-	} else {
-		// Check if the image is available (DB or CSP) and auto-register if needed
-		_, isAutoRegistered, err := resource.EnsureImageAvailable(ctx, model.SystemCommonNs, connName, dReq.ImageId)
+	// We can determine the ConnectionName from the first NodeGroup or root ConnectionName
+	connName := dReq.ConnectionName
+	if connName == "" {
+		// If root ConnectionName is empty, get from the first NodeGroup's spec
+		firstSpecId := dReq.NodeGroups[0].SpecId
+		specInfo, err := resource.GetSpec(model.SystemCommonNs, firstSpecId)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to get the Image from the CSP")
+			log.Error().Err(err).Msg("")
 			return err
 		}
-		if isAutoRegistered {
-			log.Info().Msgf("Image '%s' was auto-registered from CSP for K8sCluster", dReq.ImageId)
+		connName = specInfo.ConnectionName
+	}
+
+	// Loop and check each node group
+	for i := range dReq.NodeGroups {
+		ng := &dReq.NodeGroups[i]
+		_, err := resource.GetSpec(model.SystemCommonNs, ng.SpecId)
+		if err != nil {
+			log.Error().Err(err).Msg("")
+			return err
+		}
+
+		ngConnName := connName
+		if ng.ConnectionName != "" {
+			ngConnName = ng.ConnectionName
+		} else {
+			ng.ConnectionName = connName
+		}
+
+		connConfig, err := common.GetConnConfig(ngConnName)
+		if err != nil {
+			err := fmt.Errorf("Failed to get ConnectionName (%s) for Spec (%s) is not found.", ngConnName, ng.SpecId)
+			log.Error().Err(err).Msg("")
+			return err
+		}
+
+		niDesignation, err := common.GetK8sNodeImageDesignation(connConfig.ProviderName)
+		if err != nil {
+			log.Error().Err(err).Msg("")
+		}
+
+		if niDesignation == false {
+			// if node image designation is not supported by CSP, auto-correct ImageId to "default"
+			if !(strings.EqualFold(ng.ImageId, "default") || strings.EqualFold(ng.ImageId, "")) {
+				log.Warn().Msgf("NodeImageDesignation is not supported by CSP(%s). ImageId '%s' will be replaced with 'default'", connConfig.ProviderName, ng.ImageId)
+				ng.ImageId = "default"
+			}
+		}
+
+		// In K8sCluster, allows ng.ImageId to be set to "default" or ""
+		if strings.EqualFold(ng.ImageId, "default") ||
+			strings.EqualFold(ng.ImageId, "") {
+			// do nothing
+		} else {
+			// Check if the image is available (DB or CSP) and auto-register if needed
+			_, isAutoRegistered, err := resource.EnsureImageAvailable(ctx, model.SystemCommonNs, ngConnName, ng.ImageId)
+			if err != nil {
+				log.Error().Err(err).Msg("Failed to get the Image from the CSP")
+				return err
+			}
+			if isAutoRegistered {
+				log.Info().Msgf("Image '%s' was auto-registered from CSP for K8sCluster", ng.ImageId)
+			}
 		}
 	}
 
 	return nil
 }
 
-// checkCommonResAvailableForK8sNodeGroupDynamicReq is func to check common resources availability for K8sNodeGroupDynamicReq
-func checkCommonResAvailableForK8sNodeGroupDynamicReq(ctx context.Context, connName string, dReq *model.K8sNodeGroupDynamicReq) error {
-	k8sClusterDReq := &model.K8sClusterDynamicReq{
-		SpecId:         dReq.SpecId,
-		ImageId:        dReq.ImageId,
+// checkCommonResAvailableForK8sNodeGroupDynamicReq is func to check common resources availability for NodeGroupDynamicReq
+func checkCommonResAvailableForK8sNodeGroupDynamicReq(ctx context.Context, connName string, dReq *model.NodeGroupDynamicReq) error {
+	k8sClusterDReq := &model.ClusterDynamicReq{
 		ConnectionName: connName,
+		NodeGroups:     []model.NodeGroupDynamicReq{*dReq},
 	}
 
 	err := checkCommonResAvailableForK8sClusterDynamicReq(ctx, k8sClusterDReq)
@@ -4535,24 +4556,45 @@ func checkCommonResAvailableForK8sNodeGroupDynamicReq(ctx context.Context, connN
 		return err
 	}
 
+	// Sync back any auto-corrected fields (like ImageId)
+	*dReq = k8sClusterDReq.NodeGroups[0]
+
 	return nil
 }
 
-// getK8sClusterReqFromDynamicReq is func to get K8sClusterReq from K8sClusterDynamicReq
-func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *model.K8sClusterDynamicReq, skipVersionCheck bool) (*model.K8sClusterReq, error) {
+// getK8sClusterReqFromDynamicReq is func to get K8sClusterReq from ClusterDynamicReq
+func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *model.ClusterDynamicReq, skipVersionCheck bool) (*model.K8sClusterReq, error) {
 	reqID := common.RequestIDFromContext(ctx)
 	onDemand := true
 
 	emptyK8sReq := &model.K8sClusterReq{}
 	k8sReq := &model.K8sClusterReq{}
-	k8sngReq := &model.K8sNodeGroupReq{}
 
-	specInfo, err := resource.GetSpec(model.SystemCommonNs, dReq.SpecId)
+	if len(dReq.NodeGroups) == 0 {
+		return emptyK8sReq, fmt.Errorf("ClusterDynamicReq requires at least one NodeGroup")
+	}
+
+	// We use the first NodeGroup to resolve default ConnectionName and provider if root is empty
+	firstSpecId := dReq.NodeGroups[0].SpecId
+	specInfo, err := resource.GetSpec(model.SystemCommonNs, firstSpecId)
 	if err != nil {
 		log.Err(err).Msg("")
 		return emptyK8sReq, err
 	}
-	k8sngReq.SpecId = specInfo.Id
+
+	// If ConnectionName is specified by the request, Use ConnectionName from the request
+	k8sReq.ConnectionName = specInfo.ConnectionName
+	if dReq.ConnectionName != "" {
+		k8sReq.ConnectionName = dReq.ConnectionName
+	}
+
+	// validate the GetConnConfig for spec
+	connection, err := common.GetConnConfig(k8sReq.ConnectionName)
+	if err != nil {
+		err := fmt.Errorf("Failed to Get ConnectionName (%s) for Spec (%s) is not found.", k8sReq.ConnectionName, firstSpecId)
+		log.Err(err).Msg("")
+		return emptyK8sReq, err
+	}
 
 	var k8sRecVersion string
 	if skipVersionCheck {
@@ -4567,47 +4609,17 @@ func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *mode
 		log.Warn().Msgf("K8sCluster version validation skipped for version: %s (dynamic)", k8sRecVersion)
 	} else {
 		// Normal validation path
-		k8sRecVersion, err = getK8sRecommendVersion(specInfo.ProviderName, specInfo.RegionName, dReq.Version)
+		k8sRecVersion, err = getK8sRecommendVersion(connection.ProviderName, connection.RegionZoneInfoName, dReq.Version)
 		if err != nil {
 			log.Err(err).Msg("")
 			return emptyK8sReq, err
 		}
 	}
 
-	// If ConnectionName is specified by the request, Use ConnectionName from the request
-	k8sReq.ConnectionName = specInfo.ConnectionName
-	if dReq.ConnectionName != "" {
-		k8sReq.ConnectionName = dReq.ConnectionName
-	}
-
-	// validate the GetConnConfig for spec
-	connection, err := common.GetConnConfig(k8sReq.ConnectionName)
-	if err != nil {
-		err := fmt.Errorf("Failed to Get ConnectionName (%s) for Spec (%s) is not found.", k8sReq.ConnectionName, dReq.SpecId)
-		log.Err(err).Msg("")
-		return emptyK8sReq, err
-	}
-
 	k8sNgOnCreation, err := common.GetK8sNodeGroupsOnK8sCreation(connection.ProviderName)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Get Nodegroups on K8sCluster Creation")
 		return emptyK8sReq, err
-	}
-
-	// In K8sCluster, allows dReq.ImageId to be set to "default" or ""
-	if strings.EqualFold(dReq.ImageId, "default") ||
-		strings.EqualFold(dReq.ImageId, "") {
-		// do nothing
-	} else {
-		// Check if the image is available (DB or CSP) and auto-register if needed
-		_, isAutoRegistered, err := resource.EnsureImageAvailable(ctx, nsId, k8sReq.ConnectionName, dReq.ImageId)
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to get the Image from the CSP")
-			return emptyK8sReq, err
-		}
-		if isAutoRegistered {
-			log.Info().Msgf("Image '%s' was auto-registered from CSP for K8sCluster", dReq.ImageId)
-		}
 	}
 
 	// Default resource name has this pattern (nsId + "-shared-" + nodeReq.ConnectionName)
@@ -4641,11 +4653,11 @@ func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *mode
 
 	clientManager.UpdateRequestProgress(reqID, clientManager.ProgressInfo{Title: "Setting SSHKey:" + resourceName, Time: time.Now()})
 
-	k8sngReq.SshKeyId = resourceName
-	_, err = resource.GetResource(nsId, model.StrSSHKey, k8sngReq.SshKeyId)
+	sshKeyId := resourceName
+	_, err = resource.GetResource(nsId, model.StrSSHKey, sshKeyId)
 	if err != nil {
 		if !onDemand {
-			err := fmt.Errorf("Failed to get the SSHKey %s from %s", k8sngReq.SshKeyId, k8sReq.ConnectionName)
+			err := fmt.Errorf("Failed to get the SSHKey %s from %s", sshKeyId, k8sReq.ConnectionName)
 			log.Err(err).Msg("Failed to get the SSHKey")
 			return emptyK8sReq, err
 		}
@@ -4654,13 +4666,13 @@ func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *mode
 
 		err2 := resource.CreateSharedResource(ctx, nsId, model.StrSSHKey, k8sReq.ConnectionName)
 		if err2 != nil {
-			log.Err(err2).Msg("Failed to create new default SSHKey " + k8sngReq.SshKeyId + " from " + k8sReq.ConnectionName)
+			log.Err(err2).Msg("Failed to create new default SSHKey " + sshKeyId + " from " + k8sReq.ConnectionName)
 			return emptyK8sReq, err2
 		} else {
-			log.Info().Msg("Created new default SSHKey: " + k8sngReq.SshKeyId)
+			log.Info().Msg("Created new default SSHKey: " + sshKeyId)
 		}
 	} else {
-		log.Info().Msg("Found and utilize default SSHKey: " + k8sngReq.SshKeyId)
+		log.Info().Msg("Found and utilize default SSHKey: " + sshKeyId)
 	}
 
 	clientManager.UpdateRequestProgress(reqID, clientManager.ProgressInfo{Title: "Setting securityGroup:" + resourceName, Time: time.Now()})
@@ -4688,39 +4700,69 @@ func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *mode
 		log.Info().Msg("Found and utilize default securityGroup: " + securityGroup)
 	}
 
-	k8sngReq.Name = dReq.NodeGroupName
-	if k8sngReq.Name == "" {
-		k8sngReq.Name = common.GenUid()
+	// Process all NodeGroups from dReq
+	for _, ng := range dReq.NodeGroups {
+		k8sngReq := model.K8sNodeGroupReq{}
+		k8sngReq.Name = ng.Name
+		if k8sngReq.Name == "" {
+			k8sngReq.Name = common.GenUid()
+		}
+
+		ngSpecInfo, err := resource.GetSpec(model.SystemCommonNs, ng.SpecId)
+		if err != nil {
+			log.Err(err).Msg("")
+			return emptyK8sReq, err
+		}
+		k8sngReq.SpecId = ngSpecInfo.Id
+		k8sngReq.ImageId = ng.ImageId
+		k8sngReq.RootDiskType = ng.RootDiskType
+		k8sngReq.RootDiskSize = ng.RootDiskSize
+
+		// Verify ImageId availability if not default/empty
+		if !(strings.EqualFold(ng.ImageId, "default") || strings.EqualFold(ng.ImageId, "")) {
+			_, isAutoRegistered, err := resource.EnsureImageAvailable(ctx, nsId, k8sReq.ConnectionName, ng.ImageId)
+			if err != nil {
+				log.Error().Err(err).Msg("Failed to get the Image from the CSP")
+				return emptyK8sReq, err
+			}
+			if isAutoRegistered {
+				log.Info().Msgf("Image '%s' was auto-registered from CSP for K8sCluster", ng.ImageId)
+			}
+		}
+
+		k8sngReq.SshKeyId = sshKeyId
+		k8sngReq.OnAutoScaling = ng.OnAutoScaling
+		if k8sngReq.OnAutoScaling == "" {
+			k8sngReq.OnAutoScaling = "true"
+		}
+		k8sngReq.DesiredNodeSize = ng.DesiredNodeSize
+		if k8sngReq.DesiredNodeSize <= 0 {
+			k8sngReq.DesiredNodeSize = 1
+		}
+		k8sngReq.MinNodeSize = ng.MinNodeSize
+		if k8sngReq.MinNodeSize <= 0 {
+			k8sngReq.MinNodeSize = 1
+		}
+		k8sngReq.MaxNodeSize = ng.MaxNodeSize
+		if k8sngReq.MaxNodeSize <= 0 {
+			k8sngReq.MaxNodeSize = 2
+		}
+
+		if k8sNgOnCreation {
+			k8sReq.NodeGroups = append(k8sReq.NodeGroups, k8sngReq)
+		}
 	}
-	k8sngReq.RootDiskType = dReq.RootDiskType
-	k8sngReq.RootDiskSize = dReq.RootDiskSize
-	k8sngReq.OnAutoScaling = dReq.OnAutoScaling
-	if k8sngReq.OnAutoScaling == "" {
-		k8sngReq.OnAutoScaling = "true"
+
+	if !k8sNgOnCreation {
+		log.Info().Msg("Need to Add NodeGroups To Use This K8sCluster")
 	}
-	k8sngReq.DesiredNodeSize = dReq.DesiredNodeSize
-	if k8sngReq.DesiredNodeSize <= 0 {
-		k8sngReq.DesiredNodeSize = 1
-	}
-	k8sngReq.MinNodeSize = dReq.MinNodeSize
-	if k8sngReq.MinNodeSize <= 0 {
-		k8sngReq.MinNodeSize = 1
-	}
-	k8sngReq.MaxNodeSize = dReq.MaxNodeSize
-	if k8sngReq.MaxNodeSize <= 0 {
-		k8sngReq.MaxNodeSize = 2
-	}
+
 	k8sReq.Description = dReq.Description
 	k8sReq.Name = dReq.Name
 	if k8sReq.Name == "" {
 		k8sReq.Name = common.GenUid()
 	}
 	k8sReq.Version = k8sRecVersion
-	if k8sNgOnCreation {
-		k8sReq.K8sNodeGroupList = append(k8sReq.K8sNodeGroupList, *k8sngReq)
-	} else {
-		log.Info().Msg("Need to Add NodeGroups To Use This K8sCluster")
-	}
 	k8sReq.Label = dReq.Label
 
 	common.PrintJsonPretty(k8sReq)
@@ -4730,9 +4772,9 @@ func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *mode
 }
 
 // CreateK8sClusterDynamic is func to create K8sCluster obeject and deploy requested K8sCluster and NodeGroup in a dynamic way
-func CreateK8sClusterDynamic(ctx context.Context, nsId string, dReq *model.K8sClusterDynamicReq, deployOption string, skipVersionCheck bool) (*model.K8sClusterInfo, error) {
+func CreateK8sClusterDynamic(ctx context.Context, nsId string, dReq *model.ClusterDynamicReq, deployOption string, skipVersionCheck bool) (*model.ClusterInfo, error) {
 	reqID := common.RequestIDFromContext(ctx)
-	emptyK8sCluster := &model.K8sClusterInfo{}
+	emptyK8sCluster := &model.ClusterInfo{}
 	err := common.CheckString(nsId)
 	if err != nil {
 		log.Err(err).Msg("")
@@ -4801,8 +4843,8 @@ func CreateK8sClusterDynamic(ctx context.Context, nsId string, dReq *model.K8sCl
 	return resource.CreateK8sCluster(ctx, nsId, k8sReq, option, skipVersionCheck)
 }
 
-// getK8sNodeGroupReqFromDynamicReq is func to get K8sNodeGroupReq from K8sNodeGroupDynamicReq
-func getK8sNodeGroupReqFromDynamicReq(ctx context.Context, nsId string, k8sClusterInfo *model.K8sClusterInfo, dReq *model.K8sNodeGroupDynamicReq) (*model.K8sNodeGroupReq, error) {
+// getK8sNodeGroupReqFromDynamicReq is func to get K8sNodeGroupReq from NodeGroupDynamicReq
+func getK8sNodeGroupReqFromDynamicReq(ctx context.Context, nsId string, k8sClusterInfo *model.ClusterInfo, dReq *model.NodeGroupDynamicReq) (*model.K8sNodeGroupReq, error) {
 	reqID := common.RequestIDFromContext(ctx)
 	emptyK8sNgReq := &model.K8sNodeGroupReq{}
 	k8sNgReq := &model.K8sNodeGroupReq{}
@@ -4886,11 +4928,11 @@ func getK8sNodeGroupReqFromDynamicReq(ctx context.Context, nsId string, k8sClust
 }
 
 // CreateK8sNodeGroupDynamic is func to create K8sNodeGroup obeject and deploy requested K8sNodeGroup in a dynamic way
-func CreateK8sNodeGroupDynamic(ctx context.Context, nsId string, k8sClusterId string, dReq *model.K8sNodeGroupDynamicReq) (*model.K8sClusterInfo, error) {
+func CreateK8sNodeGroupDynamic(ctx context.Context, nsId string, k8sClusterId string, dReq *model.NodeGroupDynamicReq) (*model.ClusterInfo, error) {
 	reqID := common.RequestIDFromContext(ctx)
 	log.Debug().Msgf("reqID: %s, nsId: %s, k8sClusterId: %s, dReq: %v\n", reqID, nsId, k8sClusterId, dReq)
 
-	emptyK8sCluster := &model.K8sClusterInfo{}
+	emptyK8sCluster := &model.ClusterInfo{}
 
 	check, err := resource.CheckK8sCluster(nsId, k8sClusterId)
 	if err != nil {
@@ -4909,13 +4951,13 @@ func CreateK8sNodeGroupDynamic(ctx context.Context, nsId string, k8sClusterId st
 		return emptyK8sCluster, err
 	}
 
-	if tbK8sCInfo.Status != model.K8sClusterActive {
+	if tbK8sCInfo.Status != string(model.K8sClusterActive) {
 		err := fmt.Errorf("K8sCluster(%s) is not active status", k8sClusterId)
 		log.Err(err).Msgf("Failed to Create K8sNodeGroup(%s) in K8sCluster(%s) Dynamically", dReq.Name, k8sClusterId)
 		return emptyK8sCluster, err
 	}
 
-	for _, ngi := range tbK8sCInfo.K8sNodeGroupList {
+	for _, ngi := range tbK8sCInfo.NodeGroups {
 		if ngi.Name == dReq.Name {
 			err := fmt.Errorf("K8sNodeGroup(%s) already exists", dReq.Name)
 			log.Err(err).Msgf("Failed to Create K8sNodeGroup(%s) in K8sCluster(%s) Dynamically", dReq.Name, k8sClusterId)
@@ -5667,7 +5709,7 @@ func CreateK8sMultiClusterDynamic(ctx context.Context, nsId string, multiReq *mo
 		name           string // Store actual cluster name for error reporting
 		connectionName string // Connection name for error reporting
 		specId         string // Spec ID for error reporting
-		cluster        *model.K8sClusterInfo
+		cluster        *model.ClusterInfo
 		err            error
 	}
 	resultChan := make(chan clusterResult, len(multiReq.Clusters))
@@ -5677,7 +5719,7 @@ func CreateK8sMultiClusterDynamic(ctx context.Context, nsId string, multiReq *mo
 
 	// Launch goroutines for parallel creation
 	for i, clusterReq := range multiReq.Clusters {
-		go func(index int, req model.K8sClusterDynamicReq) {
+		go func(index int, req model.ClusterDynamicReq) {
 			// Generate unique request ID for each cluster
 			clusterCtx := common.WithRequestID(ctx, fmt.Sprintf("%s-cluster-%d", reqID, index))
 
@@ -5687,8 +5729,12 @@ func CreateK8sMultiClusterDynamic(ctx context.Context, nsId string, multiReq *mo
 				if req.Name == "" {
 					// Extract CSP name from specId (format: "provider+region+spec")
 					cspName := "unknown"
-					if req.SpecId != "" {
-						parts := strings.Split(req.SpecId, "+")
+					firstSpecId := ""
+					if len(req.NodeGroups) > 0 {
+						firstSpecId = req.NodeGroups[0].SpecId
+					}
+					if firstSpecId != "" {
+						parts := strings.Split(firstSpecId, "+")
 						if len(parts) > 0 {
 							cspName = parts[0]
 						}
@@ -5719,7 +5765,12 @@ func CreateK8sMultiClusterDynamic(ctx context.Context, nsId string, multiReq *mo
 				index:          index,
 				name:           req.Name, // Store actual name for error reporting
 				connectionName: req.ConnectionName,
-				specId:         req.SpecId,
+				specId: func() string {
+					if len(req.NodeGroups) > 0 {
+						return req.NodeGroups[0].SpecId
+					}
+					return ""
+				}(),
 				cluster:        cluster,
 				err:            err,
 			}
@@ -5727,7 +5778,7 @@ func CreateK8sMultiClusterDynamic(ctx context.Context, nsId string, multiReq *mo
 	}
 
 	// Collect results
-	results := make([]*model.K8sClusterInfo, len(multiReq.Clusters))
+	results := make([]*model.ClusterInfo, len(multiReq.Clusters))
 	var errors []string
 	var failedClusters []model.K8sClusterFailedInfo
 
@@ -5749,7 +5800,7 @@ func CreateK8sMultiClusterDynamic(ctx context.Context, nsId string, multiReq *mo
 
 	// Prepare response
 	multiInfo := &model.K8sMultiClusterInfo{
-		Clusters:       make([]model.K8sClusterInfo, 0, len(results)),
+		Clusters:       make([]model.ClusterInfo, 0, len(results)),
 		FailedClusters: failedClusters,
 	}
 

--- a/src/core/model/common.go
+++ b/src/core/model/common.go
@@ -337,7 +337,7 @@ var ResourceTypeRegistry = map[string]func() any{
 	StrNLB:           func() any { return &NLBInfo{} },
 	StrNode:          func() any { return &NodeInfo{} },
 	StrInfra:         func() any { return &InfraInfo{} },
-	StrK8s:           func() any { return &K8sClusterInfo{} },
+	StrK8s:           func() any { return &ClusterInfo{} },
 	StrNamespace:     func() any { return &NsInfo{} },
 	StrVPN:           func() any { return &VpnInfo{} },
 	StrGlobalDns:     func() any { return &GlobalDnsRecordInfo{} },

--- a/src/core/model/infra.go
+++ b/src/core/model/infra.go
@@ -185,7 +185,7 @@ type InfraInfo struct {
 	Node          []NodeInfo `json:"node"`
 
 	// Cluster is the list of implicit clusters synthesized at query-time from Nodes.
-	Cluster []InfraClusterInfo `json:"cluster,omitempty"`
+	Cluster []ClusterInfo `json:"cluster,omitempty"`
 
 	// List of IDs for new nodes. Return IDs if the nodes are newly added. This field should be used for return body only.
 	NewNodeList []string `json:"newNodeList"`
@@ -322,7 +322,7 @@ type InfraDynamicReq struct {
 	//     "label": {"role": "test", "csp": "gcp"}
 	//   }
 	// ]
-	NodeGroups []CreateNodeGroupDynamicReq `json:"nodeGroups" validate:"required"`
+	NodeGroups []NodeGroupDynamicReq `json:"nodeGroups" validate:"required"`
 
 	// PostCommand is for the command to bootstrap the Nodes
 	PostCommand InfraCmdReq `json:"postCommand"`
@@ -346,8 +346,8 @@ type InfraDynamicReq struct {
 	SgTemplateId string `json:"sgTemplateId,omitempty" example:"sg-default"`
 }
 
-// CreateNodeGroupDynamicReq is struct to get requirements to create a new server instance dynamically (with default resource option)
-type CreateNodeGroupDynamicReq struct {
+// NodeGroupDynamicReq is struct to get requirements to create a new server instance dynamically (with default resource option)
+type NodeGroupDynamicReq struct {
 	// NodeGroup name, actual Node name will be generated with -N postfix.
 	Name string `json:"name" example:"g1"`
 
@@ -383,6 +383,12 @@ type CreateNodeGroupDynamicReq struct {
 	// SgTemplateId overrides the Infra-level SgTemplateId for this NodeGroup.
 	// If empty, inherits the SgTemplateId from the parent InfraDynamicReq.
 	SgTemplateId string `json:"sgTemplateId,omitempty" example:""`
+
+	// K8s specific fields
+	OnAutoScaling   string `json:"onAutoScaling,omitempty" default:"true" example:"true"`
+	DesiredNodeSize int    `json:"desiredNodeSize,omitempty" example:"1"`
+	MinNodeSize     int    `json:"minNodeSize,omitempty" example:"1"`
+	MaxNodeSize     int    `json:"maxNodeSize,omitempty" example:"3"`
 }
 
 // InfraConnectionConfigCandidatesReq is struct for a request to check requirements to create a new Infra instance dynamically (with default resource option)
@@ -643,68 +649,9 @@ type SpiderVMInfo struct {
 	KeyValueList      []KeyValue
 }
 
-// NodeGroupInfo is struct to define an object that includes homogeneous Nodes
-type NodeGroupInfo struct {
-	// ResourceType is the type of the resource
-	ResourceType string `json:"resourceType"`
-
-	// Id is unique identifier for the object
-	Id string `json:"id" example:"aws-ap-southeast-1"`
-	// Uid is universally unique identifier for the object, used for labelSelector
-	Uid string `json:"uid,omitempty" example:"wef12awefadf1221edcf"`
-	// Name is human-readable string to represent the object
-	Name string `json:"name" example:"aws-ap-southeast-1"`
-
-	NodeId        []string `json:"nodeId"`
-	NodeGroupSize int      `json:"nodeGroupSize"`
-}
-
-// InfraClusterInfo is a lightweight, on-demand cluster view synthesized from Infra NodeGroups and Nodes.
-// A cluster is implicitly formed by NodeGroups that share the same network boundary (currently VNet-centric grouping).
-type InfraClusterInfo struct {
-	// Id is a deterministic cluster identifier generated from grouping attributes.
-	Id string `json:"id"`
-
-	// Name is a human-readable cluster name. Currently same as Id.
-	Name string `json:"name"`
-
-	// InfraId is the parent Infra ID.
-	InfraId string `json:"infraId"`
-
-	// VNetId is the shared VNet boundary used for implicit clustering.
-	VNetId string `json:"vNetId,omitempty"`
-
-	// ConnectionNames are unique connection names included in this cluster.
-	ConnectionNames []string `json:"connectionNames"`
-
-	// ProviderNames are unique CSP providers included in this cluster.
-	ProviderNames []string `json:"providerNames"`
-
-	// RegionNames are unique regions included in this cluster.
-	RegionNames []string `json:"regionNames"`
-
-	// NodeGroupIds are NodeGroups that belong to this implicit cluster.
-	NodeGroupIds []string `json:"nodeGroupIds"`
-
-	// NodeIds are Nodes that belong to this implicit cluster.
-	NodeIds []string `json:"nodeIds"`
-
-	// NodeGroupCount is the number of NodeGroups in this cluster.
-	NodeGroupCount int `json:"nodeGroupCount"`
-
-	// NodeCount is the number of Nodes in this cluster.
-	NodeCount int `json:"nodeCount"`
-
-	// RepresentativeNodeGroupId is a representative NodeGroup ID for quick inspection.
-	RepresentativeNodeGroupId string `json:"representativeNodeGroupId,omitempty"`
-
-	// RepresentativeNodeId is a representative Node ID for quick inspection.
-	RepresentativeNodeId string `json:"representativeNodeId,omitempty"`
-}
-
-// InfraClusterList is a response wrapper for listing implicit clusters in an Infra.
-type InfraClusterList struct {
-	Cluster []InfraClusterInfo `json:"cluster"`
+// ClusterList is a response wrapper for listing clusters.
+type ClusterList struct {
+	Cluster []ClusterInfo `json:"cluster"`
 }
 
 // InfraAssociatedResourceList is struct for associated resource IDs of an Infra
@@ -1055,7 +1002,7 @@ type AutoCondition struct {
 // AutoAction is struct for Infra auto-control action.
 type AutoAction struct {
 	ActionType          string                    `json:"actionType" example:"ScaleOut" enums:"ScaleOut,ScaleIn"`
-	NodeGroupDynamicReq CreateNodeGroupDynamicReq `json:"nodeGroupDynamicReq"`
+	NodeGroupDynamicReq NodeGroupDynamicReq `json:"nodeGroupDynamicReq"`
 
 	// PostCommand is field for providing command to Nodes after their creation. example:"wget https://raw.githubusercontent.com/cloud-barista/cb-tumblebug/main/scripts/setweb.sh -O ~/setweb.sh; chmod +x ~/setweb.sh; sudo ~/setweb.sh"
 	PostCommand   InfraCmdReq `json:"postCommand"`

--- a/src/core/model/k8scluster.go
+++ b/src/core/model/k8scluster.go
@@ -91,7 +91,7 @@ type K8sClusterReq struct {
 	SecurityGroupIds []string `json:"securityGroupIds" validate:"required" example:"sg-01"`
 
 	// (3) NodeGroupInfo List
-	K8sNodeGroupList []K8sNodeGroupReq `json:"k8sNodeGroupList"`
+	NodeGroups []K8sNodeGroupReq `json:"k8sNodeGroupList"`
 
 	// Fields for "Register existing K8sCluster" feature
 	// @description CspResourceId is required to register a k8s cluster from CSP (option=register)
@@ -203,7 +203,7 @@ type SpiderChangeAutoscaleSizeRes struct {
 
 // ChangeK8sNodeGroupAutoscaleSizeRes is a struct to handle 'Change K8sNodeGroup's Autoscale Size' response from CB-Tumblebug.
 type ChangeK8sNodeGroupAutoscaleSizeRes struct {
-	K8sNodeGroupInfo
+	NodeGroupInfo
 }
 
 // SpiderUpgradeClusterReq is a wrapper struct to create JSON body of 'Upgrade Cluster' request
@@ -299,8 +299,8 @@ type SpiderClusterInfo struct {
 	KeyValueList []KeyValue
 }
 
-// K8sClusterInfo is a struct that represents TB K8sCluster object.
-type K8sClusterInfo struct {
+// ClusterInfo is a struct that represents TB Cluster object (VM-based implicit cluster or K8s-based explicit cluster).
+type ClusterInfo struct {
 	// ResourceType is the type of the resource
 	ResourceType string `json:"resourceType"`
 
@@ -312,37 +312,54 @@ type K8sClusterInfo struct {
 
 	// Name is human-readable string to represent the object
 	Name           string `json:"name" example:"k8scluster01"`
-	ConnectionName string `json:"connectionName" example:"alibaba-ap-northeast-2"`
+	ConnectionName string `json:"connectionName,omitempty" example:"alibaba-ap-northeast-2"`
 
 	// ConnectionConfig shows connection info to cloud service provider
-	ConnectionConfig ConnConfig `json:"connectionConfig"`
+	ConnectionConfig ConnConfig `json:"connectionConfig,omitempty"`
 
-	Description string `json:"description" example:"My K8sCluster"`
+	Description string `json:"description,omitempty" example:"My Cluster"`
 
 	// Latest system message such as error message
-	SystemMessage string `json:"systemMessage" example:"Failed because ..." default:""` // systeam-given string message
+	SystemMessage string `json:"systemMessage,omitempty" example:"Failed because ..." default:""` // system-given string message
 
 	// Label is for describing the object by keywords
-	Label map[string]string `json:"label"`
+	Label map[string]string `json:"label,omitempty"`
 
-	// SystemLabel is for describing the Resource in a keyword (any string can be used) for special System purpose
-	SystemLabel string `json:"systemLabel" example:"Managed by CB-Tumblebug" default:""`
+	// SystemLabel is for describing the Resource in a keyword for special System purpose
+	SystemLabel string `json:"systemLabel,omitempty" example:"Managed by CB-Tumblebug" default:""`
 
 	// Version is for kubernetes version
-	Version string `json:"version" example:"1.30.1"` // Kubernetes Version, ex) 1.30.1
+	Version string `json:"version,omitempty" example:"1.30.1"` // Kubernetes Version, ex) 1.30.1
 
 	// Network is for describing network information about the cluster
-	Network K8sClusterNetworkInfo `json:"network"`
+	Network ClusterNetworkInfo `json:"network,omitempty"`
 
-	// K8sNodeGroupList is for describing network information about the cluster
-	K8sNodeGroupList []K8sNodeGroupInfo `json:"k8sNodeGroupList"`
-	AccessInfo       K8sAccessInfo      `json:"accessInfo"`
-	Addons           K8sAddonsInfo      `json:"addons"`
+	// NodeGroupIds is VM-specific reference
+	NodeGroupIds []string `json:"nodeGroupIds,omitempty"`
 
-	Status K8sClusterStatus `json:"status" example:"Active"` // Creating, Active, Inactive, Updating, Deleting
+	// NodeGroups is for describing NodeGroups in the cluster
+	NodeGroups []NodeGroupInfo `json:"nodeGroups,omitempty"`
+	AccessInfo K8sAccessInfo   `json:"accessInfo,omitempty"`
+	Addons     K8sAddonsInfo   `json:"addons,omitempty"`
 
-	CreatedTime  time.Time  `json:"createdTime" example:"1970-01-01T00:00:00.00Z"`
-	KeyValueList []KeyValue `json:"keyValueList"`
+	Status string `json:"status" example:"Active"` // VM: Running/Partial/Failed, K8s: Creating/Active/Inactive/Updating/Deleting
+
+	CreatedTime  time.Time  `json:"createdTime,omitempty" example:"1970-01-01T00:00:00.00Z"`
+	KeyValueList []KeyValue `json:"keyValueList,omitempty"`
+
+	// VM-specific implicit cluster fields
+	InfraId                   string   `json:"infraId,omitempty"`
+	ConnectionNames           []string `json:"connectionNames,omitempty"`
+	ProviderNames             []string `json:"providerNames,omitempty"`
+	RegionNames               []string `json:"regionNames,omitempty"`
+	NodeIds                   []string `json:"nodeIds,omitempty"`
+	RepresentativeNodeGroupId string   `json:"representativeNodeGroupId,omitempty"`
+	RepresentativeNodeId      string   `json:"representativeNodeId,omitempty"`
+
+	// Common summary fields (synthesized for VM clusters, native/configured for K8s clusters)
+	VNetId         string `json:"vNetId,omitempty"`
+	NodeGroupCount int    `json:"nodeGroupCount,omitempty"`
+	NodeCount      int    `json:"nodeCount,omitempty"`
 
 	// CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.
 	CspResourceName string `json:"cspResourceName,omitempty" example:"we12fawefadf1221edcf"`
@@ -350,7 +367,7 @@ type K8sClusterInfo struct {
 	// CspResourceId is resource identifier managed by CSP
 	CspResourceId string `json:"cspResourceId,omitempty" example:"csp-06eb41e14121c550a"`
 
-	SpiderViewK8sClusterDetail SpiderClusterInfo `json:"spiderViewK8sClusterDetail"`
+	SpiderViewK8sClusterDetail SpiderClusterInfo `json:"spiderViewK8sClusterDetail,omitempty"`
 }
 
 // SpiderNetworkInfo is a struct to handle Cluster Network information from the CB-Spider's REST API response
@@ -364,15 +381,12 @@ type SpiderNetworkInfo struct {
 	KeyValueList []KeyValue
 }
 
-// K8sClusterNetworkInfo is a struct to handle K8sCluster Network information from the CB-Tumblebug's REST API response
-type K8sClusterNetworkInfo struct {
-	VNetId           string   `json:"vNetId" example:"vpc-01"`
-	SubnetIds        []string `json:"subnetIds" example:"subnet-01"`
-	SecurityGroupIds []string `json:"securityGroupIds" example:"sg-01"`
-
-	// ---
-
-	KeyValueList []KeyValue `json:"keyValueList"`
+// ClusterNetworkInfo is a struct to handle Cluster Network information from the CB-Tumblebug's REST API response
+type ClusterNetworkInfo struct {
+	VNetId           string     `json:"vNetId,omitempty" example:"vpc-01"`
+	SubnetIds        []string   `json:"subnetIds,omitempty" example:"subnet-01"`
+	SecurityGroupIds []string   `json:"securityGroupIds,omitempty" example:"sg-01"`
+	KeyValueList     []KeyValue `json:"keyValueList,omitempty"`
 }
 
 // SpiderNodeGroupInfo is a struct to handle Cluster Node Group information from the CB-Spider's REST API response
@@ -401,39 +415,41 @@ type SpiderNodeGroupInfo struct {
 	KeyValueList []KeyValue `json:"KeyValueList,omitempty" validate:"omitempty"`
 }
 
-// K8sNodeGroupInfo is a struct to handle K8sCluster's Node Group information from the CB-Tumblebug's REST API response
-type K8sNodeGroupInfo struct {
+// NodeGroupInfo is a struct to handle Node Group information
+type NodeGroupInfo struct {
+	ResourceType string `json:"resourceType"` // "nodeGroup" | "k8sNodeGroup"
+
 	// Id is unique identifier for the object
 	Id string `json:"id" example:"aws-ap-southeast-1"`
+
+	// Uid is universally unique identifier for the object, used for labelSelector
+	Uid string `json:"uid,omitempty" example:"wef12awefadf1221edcf"`
 
 	// Name is human-readable string to represent the object
 	Name string `json:"name" example:"aws-ap-southeast-1"`
 
-	ImageId         string             `json:"imageId"`
-	SpecId          string             `json:"specId"`
-	RootDiskType    string             `json:"rootDiskType"`
-	RootDiskSize    int                `json:"rootDiskSize"`
-	SshKeyId        string             `json:"sshKeyId"`
-	OnAutoScaling   bool               `json:"onAutoScaling"`
-	DesiredNodeSize int                `json:"desiredNodeSize"`
-	MinNodeSize     int                `json:"minNodeSize"`
-	MaxNodeSize     int                `json:"maxNodeSize"`
-	Status          K8sNodeGroupStatus `json:"status" example:"Active"` // Creating, Active, Inactive, Updating, Deleting
-	K8sNodes        []K8sNodeInfo      `json:"k8sNodes"`
-	KeyValueList    []KeyValue         `json:"keyValueList"`
+	// VM specific fields
+	NodeId        []string `json:"nodeId,omitempty"`
+	NodeGroupSize int      `json:"nodeGroupSize,omitempty"`
 
-	// IsInitialNodeGroup indicates whether this node group was created during cluster creation.
-	// For some CSPs (Alibaba ACK, Tencent TKE), this node group cannot be deleted independently;
-	// it is automatically removed when the cluster is deleted.
-	IsInitialNodeGroup bool `json:"isInitialNodeGroup,omitempty"`
-
-	// CspResourceName is name assigned to the CSP resource. This name is internally used to handle the resource.
-	CspResourceName string `json:"cspResourceName,omitempty" example:"we12fawefadf1221edcf"`
-
-	// CspResourceId is resource identifier managed by CSP
-	CspResourceId string `json:"cspResourceId,omitempty" example:"csp-06eb41e14121c550a"`
-
-	SpiderViewK8sNodeGroupDetail SpiderNodeGroupInfo `json:"spiderViewK8sNodeGroupDetail"`
+	// Shared / K8s specific fields
+	ImageId            string              `json:"imageId,omitempty"`
+	SpecId             string              `json:"specId,omitempty"`
+	RootDiskType       string              `json:"rootDiskType,omitempty"`
+	RootDiskSize       int                 `json:"rootDiskSize,omitempty"`
+	SshKeyId           string              `json:"sshKeyId,omitempty"`
+	ConnectionName     string              `json:"connectionName,omitempty"`
+	OnAutoScaling      bool                `json:"onAutoScaling,omitempty"`
+	DesiredNodeSize    int                 `json:"desiredNodeSize,omitempty"`
+	MinNodeSize        int                 `json:"minNodeSize,omitempty"`
+	MaxNodeSize        int                 `json:"maxNodeSize,omitempty"`
+	Status             string              `json:"status,omitempty" example:"Active"` // VM Status (string) or K8sNodeGroupStatus (string wrapper)
+	K8sNodes           []K8sNodeInfo       `json:"k8sNodes,omitempty"`
+	KeyValueList       []KeyValue          `json:"keyValueList,omitempty"`
+	IsInitialNodeGroup bool                `json:"isInitialNodeGroup,omitempty"`
+	CspResourceName    string              `json:"cspResourceName,omitempty"`
+	CspResourceId      string              `json:"cspResourceId,omitempty"`
+	SpiderViewK8sNodeGroupDetail SpiderNodeGroupInfo `json:"spiderViewK8sNodeGroupDetail,omitempty"`
 }
 
 // K8sNodeInfo is a struct to handle K8sCluster's Node information
@@ -519,64 +535,24 @@ type CheckNodeDynamicReqInfo struct {
 
 }
 
-// K8sClusterDynamicReq is struct for requirements to create K8sCluster dynamically (with default resource option)
-type K8sClusterDynamicReq struct {
-	// K8sCluster name if it is not empty. Optional when used with namePrefix in multi-cluster creation.
-	Name string `json:"name" example:"k8scluster01"`
-
-	// K8s Clsuter version
-	Version string `json:"version,omitempty" example:"1.29"`
+// ClusterDynamicReq is struct for requirements to create Cluster dynamically (with default resource option)
+type ClusterDynamicReq struct {
+	// Cluster name if it is not empty. Optional when used with namePrefix in multi-cluster creation.
+	Name string `json:"name" validate:"required" example:"cluster01"`
 
 	// Label is for describing the object by keywords
 	Label map[string]string `json:"label,omitempty"`
 
 	Description string `json:"description,omitempty" example:"Description"`
 
-	// NodeGroup name if it is not empty
-	NodeGroupName string `json:"nodeGroupName,omitempty" example:"k8sng01"`
+	NodeGroups []NodeGroupDynamicReq `json:"nodeGroups" validate:"required"`
 
-	// SpecId is field for id of a spec in common namespace
-	SpecId string `json:"specId" validate:"required" example:"tencent+ap-seoul+S2.MEDIUM4"`
+	// K8s cluster version
+	Version string `json:"version,omitempty" example:"1.31"`
 
-	// ImageId is field for id of a image in common namespace
-	ImageId string `json:"imageId" validate:"required" example:"default, tencent+ap-seoul+ubuntu20.04"`
-
-	RootDiskType string `json:"rootDiskType,omitempty" example:"default, TYPE1, ..." default:"default"` // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_essd"], TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]
-	RootDiskSize int    `json:"rootDiskSize,omitempty" example:"30"`                                    // Root disk size in GB. 0 = use CSP default.
-
-	OnAutoScaling   string `json:"onAutoScaling,omitempty" default:"true" example:"true"`
-	DesiredNodeSize int    `json:"desiredNodeSize,omitempty" example:"1"`
-	MinNodeSize     int    `json:"minNodeSize,omitempty" example:"1"`
-	MaxNodeSize     int    `json:"maxNodeSize,omitempty" example:"3"`
-
-	// if ConnectionName is given, the VM tries to use associtated credential.
+	// if ConnectionName is given, the VM tries to use associated credential.
 	// if not, it will use predefined ConnectionName in Spec objects
 	ConnectionName string `json:"connectionName,omitempty" default:"tencent-ap-seoul"`
-}
-
-// K8sNodeGroupDynamicReq is struct for requirements to create K8sNodeGroup dynamically (with default resource option)
-type K8sNodeGroupDynamicReq struct {
-	// K8sNodeGroup name if it is not empty.
-	Name string `json:"name" validate:"required" example:"k8sng01"`
-
-	// Label is for describing the object by keywords
-	Label map[string]string `json:"label,omitempty"`
-
-	Description string `json:"description,omitempty" example:"Description"`
-
-	// SpecId is field for id of a spec in common namespace
-	SpecId string `json:"specId" validate:"required" example:"tencent+ap-seoul+S2.MEDIUM4"`
-
-	// ImageId is field for id of a image in common namespace
-	ImageId string `json:"imageId" validate:"required" example:"default, tencent+ap-seoul+ubuntu20.04"`
-
-	RootDiskType string `json:"rootDiskType,omitempty" example:"default, TYPE1, ..." default:"default"` // "", "default", "TYPE1", AWS: ["standard", "gp2", "gp3"], Azure: ["PremiumSSD", "StandardSSD", "StandardHDD"], GCP: ["pd-standard", "pd-balanced", "pd-ssd", "pd-extreme"], ALIBABA: ["cloud_efficiency", "cloud", "cloud_essd"], TENCENT: ["CLOUD_PREMIUM", "CLOUD_SSD"]
-	RootDiskSize int    `json:"rootDiskSize,omitempty" example:"30"`                                    // Root disk size in GB. 0 = use CSP default.
-
-	OnAutoScaling   string `json:"onAutoScaling,omitempty" default:"true" example:"true"`
-	DesiredNodeSize int    `json:"desiredNodeSize,omitempty" example:"1"`
-	MinNodeSize     int    `json:"minNodeSize,omitempty" example:"1"`
-	MaxNodeSize     int    `json:"maxNodeSize,omitempty" example:"3"`
 }
 
 // K8sClusterContainerCmdReq is struct for remote command
@@ -592,7 +568,7 @@ type K8sClusterContainerCmdResult struct {
 	Err     error  `json:"err"`
 }
 
-// K8sClusterContainerCmdResultMap is struct maps for K8sClusterContainerCmd Result
+// K8sClusterContainerCmdResults is struct maps for K8sClusterContainerCmd Result
 type K8sClusterContainerCmdResults struct {
 	Results []*K8sClusterContainerCmdResult `json:"results"`
 }
@@ -603,13 +579,13 @@ type K8sClusterContainerCmdResults struct {
 
 // K8sMultiClusterDynamicReq is a wrapper struct for creating multiple K8sClusters in parallel
 type K8sMultiClusterDynamicReq struct {
-	NamePrefix string                 `json:"namePrefix" example:"across"`
-	Clusters   []K8sClusterDynamicReq `json:"clusters" validate:"required,dive"`
+	NamePrefix string              `json:"namePrefix" example:"across"`
+	Clusters   []ClusterDynamicReq `json:"clusters" validate:"required,dive"`
 }
 
 // K8sMultiClusterInfo is a wrapper struct for multiple K8sCluster creation results
 type K8sMultiClusterInfo struct {
-	Clusters       []K8sClusterInfo       `json:"clusters"`
+	Clusters       []ClusterInfo          `json:"clusters"`
 	FailedClusters []K8sClusterFailedInfo `json:"failedClusters,omitempty"`
 }
 

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -100,66 +100,66 @@ func HandleK8sClusterAction(nsId string, k8sClusterId string, action string) (st
 	}
 }
 
-func createK8sClusterInfo(nsId string, tbK8sCInfo model.K8sClusterInfo) error {
-	log.Debug().Msgf("[Create K8sClusterInfo] %s", tbK8sCInfo.Id)
+func createK8sClusterInfo(nsId string, tbK8sCInfo model.ClusterInfo) error {
+	log.Debug().Msgf("[Create ClusterInfo] %s", tbK8sCInfo.Id)
 
 	k8sClusterId := tbK8sCInfo.Id
 	k := common.GenK8sClusterKey(nsId, k8sClusterId)
 	_, exists, err := kvstore.GetKv(k)
 	if err != nil {
-		err := fmt.Errorf("failed to create K8sClusterInfo(%s): %v", k8sClusterId, err)
+		err := fmt.Errorf("failed to create ClusterInfo(%s): %v", k8sClusterId, err)
 		return err
 	}
 
 	if exists {
-		err := fmt.Errorf("failed to create K8sClusterInfo(%s): already exists", k8sClusterId)
+		err := fmt.Errorf("failed to create ClusterInfo(%s): already exists", k8sClusterId)
 		return err
 	}
 
 	val, err := json.Marshal(&tbK8sCInfo)
 	if err != nil {
-		err := fmt.Errorf("failed to create K8sClusterInfo(%s): %v", k8sClusterId, err)
+		err := fmt.Errorf("failed to create ClusterInfo(%s): %v", k8sClusterId, err)
 		return err
 	}
 
 	err = kvstore.Put(k, string(val))
 	if err != nil {
-		err := fmt.Errorf("failed to create K8sClusterInfo(%s): %v", k8sClusterId, err)
+		err := fmt.Errorf("failed to create ClusterInfo(%s): %v", k8sClusterId, err)
 		return err
 	}
 
 	return nil
 }
 
-func getK8sClusterInfo(nsId, k8sClusterId string) (*model.K8sClusterInfo, error) {
-	//log.Debug().Msg("[Get K8sClusterInfo] " + k8sClusterId)
+func getK8sClusterInfo(nsId, k8sClusterId string) (*model.ClusterInfo, error) {
+	//log.Debug().Msg("[Get ClusterInfo] " + k8sClusterId)
 
-	emptyObj := &model.K8sClusterInfo{}
+	emptyObj := &model.ClusterInfo{}
 
 	k := common.GenK8sClusterKey(nsId, k8sClusterId)
 	kv, exists, err := kvstore.GetKv(k)
 	if err != nil {
-		err := fmt.Errorf("failed to get K8sClusterInfo(%s): %v", k8sClusterId, err)
+		err := fmt.Errorf("failed to get ClusterInfo(%s): %v", k8sClusterId, err)
 		return emptyObj, err
 	}
 
-	tbK8sCInfo := &model.K8sClusterInfo{}
+	tbK8sCInfo := &model.ClusterInfo{}
 	if !exists {
-		err := fmt.Errorf("failed to get K8sClusterInfo(%s): empty keyvalue", k8sClusterId)
+		err := fmt.Errorf("failed to get ClusterInfo(%s): empty keyvalue", k8sClusterId)
 		return emptyObj, err
 	}
 
 	err = json.Unmarshal([]byte(kv.Value), tbK8sCInfo)
 	if err != nil {
-		err := fmt.Errorf("failed to get K8sClusterInfo(%s): %v", k8sClusterId, err)
+		err := fmt.Errorf("failed to get ClusterInfo(%s): %v", k8sClusterId, err)
 		return emptyObj, err
 	}
 
 	return tbK8sCInfo, nil
 }
 
-// storeK8sClusterInfo is func to update K8sClusterInfo
-func storeK8sClusterInfo(nsId string, newTbK8sCInfo *model.K8sClusterInfo) {
+// storeK8sClusterInfo is func to update ClusterInfo
+func storeK8sClusterInfo(nsId string, newTbK8sCInfo *model.ClusterInfo) {
 	k8sClusterId := newTbK8sCInfo.Id
 
 	k := common.GenK8sClusterKey(nsId, k8sClusterId)
@@ -170,34 +170,34 @@ func storeK8sClusterInfo(nsId string, newTbK8sCInfo *model.K8sClusterInfo) {
 		return
 	}
 
-	oldTbK8sCInfo := &model.K8sClusterInfo{}
+	oldTbK8sCInfo := &model.ClusterInfo{}
 	json.Unmarshal([]byte(kv.Value), oldTbK8sCInfo)
 
 	if !reflect.DeepEqual(oldTbK8sCInfo, newTbK8sCInfo) {
 		val, _ := json.Marshal(newTbK8sCInfo)
 		err = kvstore.Put(k, string(val))
 		if err != nil {
-			err := fmt.Errorf("failed to update K8sClusterInfo(%s): %v", k8sClusterId, err)
+			err := fmt.Errorf("failed to update ClusterInfo(%s): %v", k8sClusterId, err)
 			log.Err(err).Msgf("nsId=%s", nsId)
 		}
 	}
 }
 
-// deleteK8sClusterInfo is func to delete K8sClusterInfo
+// deleteK8sClusterInfo is func to delete ClusterInfo
 func deleteK8sClusterInfo(nsId, k8sClusterId string) error {
-	log.Debug().Msg("[Delete K8sClusterInfo] " + k8sClusterId)
+	log.Debug().Msg("[Delete ClusterInfo] " + k8sClusterId)
 
 	// Get cluster info for UID (needed for label deletion)
 	k8sInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
-		log.Warn().Err(err).Msgf("K8sClusterInfo not found for %s, continuing with deletion", k8sClusterId)
+		log.Warn().Err(err).Msgf("ClusterInfo not found for %s, continuing with deletion", k8sClusterId)
 	}
 
 	// Delete cluster data from kvstore
 	k := common.GenK8sClusterKey(nsId, k8sClusterId)
 	err = kvstore.Delete(k)
 	if err != nil {
-		return fmt.Errorf("failed to delete K8sClusterInfo(%s): %v", k8sClusterId, err)
+		return fmt.Errorf("failed to delete ClusterInfo(%s): %v", k8sClusterId, err)
 	}
 
 	// Delete associated label
@@ -211,10 +211,10 @@ func deleteK8sClusterInfo(nsId, k8sClusterId string) error {
 }
 
 // CreateK8sCluster create a k8s cluster
-func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq, option string, skipVersionCheck bool) (*model.K8sClusterInfo, error) {
+func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq, option string, skipVersionCheck bool) (*model.ClusterInfo, error) {
 	log.Info().Msg("CreateK8sCluster")
 
-	emptyObj := &model.K8sClusterInfo{}
+	emptyObj := &model.ClusterInfo{}
 
 	k8sClusterId := req.Name
 
@@ -257,7 +257,7 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 		return emptyObj, err
 	}
 
-	tbK8sCInfo := &model.K8sClusterInfo{
+	tbK8sCInfo := &model.ClusterInfo{
 		ResourceType:     model.StrK8s,
 		Id:               k8sClusterId,
 		Uid:              uid,
@@ -267,19 +267,19 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 		Description:      req.Description,
 		Label:            req.Label,
 		SystemLabel:      req.SystemLabel,
-		Network: model.K8sClusterNetworkInfo{
+		Network: model.ClusterNetworkInfo{
 			VNetId:           req.VNetId,
 			SubnetIds:        req.SubnetIds,
 			SecurityGroupIds: req.SecurityGroupIds,
 		},
 	}
-	fillK8sNodeGroupInfoListFromK8sNodeGroupReqList(&tbK8sCInfo.K8sNodeGroupList, &req.K8sNodeGroupList)
+	fillK8sNodeGroupInfoListFromK8sNodeGroupReqList(&tbK8sCInfo.NodeGroups, &req.NodeGroups)
 
 	// Mark the first node group as initial for CSPs where the initial node group
 	// is lifecycle-bound to the cluster and cannot be deleted independently.
 	if managed, _ := common.GetK8sInitialNodeGroupManagedByCluster(connConfig.ProviderName); managed {
-		if len(tbK8sCInfo.K8sNodeGroupList) > 0 {
-			tbK8sCInfo.K8sNodeGroupList[0].IsInitialNodeGroup = true
+		if len(tbK8sCInfo.NodeGroups) > 0 {
+			tbK8sCInfo.NodeGroups[0].IsInitialNodeGroup = true
 		}
 	}
 
@@ -297,7 +297,7 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 			if tbK8sCInfo != nil {
 				err := deleteK8sClusterInfo(nsId, k8sClusterId)
 				if err != nil {
-					log.Err(err).Msgf("Failed to delete K8sClusterInfo: %s", k8sClusterId)
+					log.Err(err).Msgf("Failed to delete ClusterInfo: %s", k8sClusterId)
 				}
 			}
 		}
@@ -407,7 +407,7 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 	}
 
 	var spNodeGroupList []model.SpiderNodeGroupReqInfo
-	for _, v := range req.K8sNodeGroupList {
+	for _, v := range req.NodeGroups {
 		spName := v.Name
 		createErr = common.CheckString(spName)
 		if createErr != nil {
@@ -542,7 +542,7 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 		return emptyObj, createErr
 	}
 
-	// Update model.K8sClusterInfo object
+	// Update model.ClusterInfo object
 	updateK8sClusterInfoFromSpiderClusterInfo(tbK8sCInfo, &spClusterRes.SpiderClusterInfo)
 	tbK8sCInfo.SpiderViewK8sClusterDetail = spClusterRes.SpiderClusterInfo
 
@@ -617,10 +617,10 @@ func CheckK8sNodeGroup(nsId string, k8sClusterId string, k8sNodeGroupName string
 */
 
 // AddK8sNodeGroup adds a K8sNodeGroup
-func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *model.K8sNodeGroupReq) (*model.K8sClusterInfo, error) {
+func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *model.K8sNodeGroupReq) (*model.ClusterInfo, error) {
 	log.Info().Msg("AddK8sNodeGroup")
 
-	emptyObj := &model.K8sClusterInfo{}
+	emptyObj := &model.ClusterInfo{}
 
 	err := validate.Struct(u)
 	if err != nil {
@@ -644,7 +644,7 @@ func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *m
 		return emptyObj, err
 	}
 
-	// Get model.K8sClusterInfo from kvstore
+	// Get model.ClusterInfo from kvstore
 	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Add K8sNodeGroup(k8scluster=%s)", k8sClusterId)
@@ -779,21 +779,21 @@ func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *m
 		return emptyObj, err
 	}
 
-	// Update K8sClusterInfo.K8NodeGroupList - Add new nodegroup to existing list
+	// Update ClusterInfo.K8NodeGroupList - Add new nodegroup to existing list
 	var tbK8sNGReqList []model.K8sNodeGroupReq
 	tbK8sNGReqList = append(tbK8sNGReqList, *u)
 
 	// Create new nodegroup info and append to existing list
-	var newK8sNodeGroupInfoList []model.K8sNodeGroupInfo
-	newK8sNodeGroupInfoList = append(newK8sNodeGroupInfoList, tbK8sCInfo.K8sNodeGroupList...)
+	var newK8sNodeGroupInfoList []model.NodeGroupInfo
+	newK8sNodeGroupInfoList = append(newK8sNodeGroupInfoList, tbK8sCInfo.NodeGroups...)
 
 	// Add the new nodegroup
-	tbK8sNGInfo := model.K8sNodeGroupInfo{}
+	tbK8sNGInfo := model.NodeGroupInfo{}
 	fillK8sNodeGroupInfoFromK8sNodeGroupReq(&tbK8sNGInfo, u)
 	newK8sNodeGroupInfoList = append(newK8sNodeGroupInfoList, tbK8sNGInfo)
 
 	// Update the cluster's nodegroup list
-	tbK8sCInfo.K8sNodeGroupList = newK8sNodeGroupInfoList
+	tbK8sCInfo.NodeGroups = newK8sNodeGroupInfoList
 
 	spRootDiskSize := ""
 	if u.RootDiskSize > 0 {
@@ -841,7 +841,7 @@ func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *m
 		return emptyObj, err
 	}
 
-	// Update/Get model.K8sClusterInfo object to/from kvstore
+	// Update/Get model.ClusterInfo object to/from kvstore
 	updateK8sClusterInfoFromSpiderClusterInfo(tbK8sCInfo, &spClusterRes.SpiderClusterInfo)
 	tbK8sCInfo.SpiderViewK8sClusterDetail = spClusterRes.SpiderClusterInfo
 	storeK8sClusterInfo(nsId, tbK8sCInfo)
@@ -872,7 +872,7 @@ func RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, option string) (bo
 		return false, err
 	}
 
-	// Get model.K8sClusterInfo from kvstore
+	// Get model.ClusterInfo from kvstore
 	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Remove K8sNodeGroup(k8scluster=%s)", k8sClusterId)
@@ -883,7 +883,7 @@ func RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, option string) (bo
 	// lifecycle-bound to the cluster (e.g., Alibaba ACK, Tencent TKE).
 	if ngConnConfig, connErr := common.GetConnConfig(tbK8sCInfo.ConnectionName); connErr == nil {
 		if managed, _ := common.GetK8sInitialNodeGroupManagedByCluster(ngConnConfig.ProviderName); managed {
-			for _, ng := range tbK8sCInfo.K8sNodeGroupList {
+			for _, ng := range tbK8sCInfo.NodeGroups {
 				if ng.Name == k8sNodeGroupName && ng.IsInitialNodeGroup {
 					return false, fmt.Errorf(
 						"node group '%s' is the initial node group of cluster '%s' and cannot be deleted independently for provider '%s'. Delete the cluster to remove it",
@@ -969,7 +969,7 @@ func SetK8sNodeGroupAutoscaling(nsId string, k8sClusterId string, k8sNodeGroupNa
 		return emptyObj, err
 	}
 
-	// Get model.K8sClusterInfo from kvstore
+	// Get model.ClusterInfo from kvstore
 	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Set K8sNodeGroup Autoscaling(k8scluster=%s)", k8sClusterId)
@@ -978,10 +978,10 @@ func SetK8sNodeGroupAutoscaling(nsId string, k8sClusterId string, k8sNodeGroupNa
 	}
 
 	// Find the specific nodegroup
-	var tbK8sNGInfo *model.K8sNodeGroupInfo = nil
-	for i := range tbK8sCInfo.K8sNodeGroupList {
-		if tbK8sCInfo.K8sNodeGroupList[i].Name == k8sNodeGroupName {
-			tbK8sNGInfo = &tbK8sCInfo.K8sNodeGroupList[i]
+	var tbK8sNGInfo *model.NodeGroupInfo = nil
+	for i := range tbK8sCInfo.NodeGroups {
+		if tbK8sCInfo.NodeGroups[i].Name == k8sNodeGroupName {
+			tbK8sNGInfo = &tbK8sCInfo.NodeGroups[i]
 			break
 		}
 	}
@@ -1059,7 +1059,7 @@ func ChangeK8sNodeGroupAutoscaleSize(nsId string, k8sClusterId string, k8sNodeGr
 		return emptyObj, err
 	}
 
-	// Get model.K8sClusterInfo from kvstore
+	// Get model.ClusterInfo from kvstore
 	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Change K8sNodeGroup AutoscaleSize(k8scluster=%s)", k8sClusterId)
@@ -1067,10 +1067,10 @@ func ChangeK8sNodeGroupAutoscaleSize(nsId string, k8sClusterId string, k8sNodeGr
 	}
 
 	// Find the specific nodegroup
-	var tbK8sNGInfo *model.K8sNodeGroupInfo = nil
-	for i := range tbK8sCInfo.K8sNodeGroupList {
-		if tbK8sCInfo.K8sNodeGroupList[i].Name == k8sNodeGroupName {
-			tbK8sNGInfo = &tbK8sCInfo.K8sNodeGroupList[i]
+	var tbK8sNGInfo *model.NodeGroupInfo = nil
+	for i := range tbK8sCInfo.NodeGroups {
+		if tbK8sCInfo.NodeGroups[i].Name == k8sNodeGroupName {
+			tbK8sNGInfo = &tbK8sCInfo.NodeGroups[i]
 			break
 		}
 	}
@@ -1114,17 +1114,17 @@ func ChangeK8sNodeGroupAutoscaleSize(nsId string, k8sClusterId string, k8sNodeGr
 	storeK8sClusterInfo(nsId, tbK8sCInfo)
 
 	tbK8sCAutoscaleSizeRes := &model.ChangeK8sNodeGroupAutoscaleSizeRes{
-		K8sNodeGroupInfo: *tbK8sNGInfo,
+		NodeGroupInfo: *tbK8sNGInfo,
 	}
 
 	return tbK8sCAutoscaleSizeRes, nil
 }
 
 // GetK8sCluster retrives a k8s cluster information
-func GetK8sCluster(nsId string, k8sClusterId string) (*model.K8sClusterInfo, error) {
+func GetK8sCluster(nsId string, k8sClusterId string) (*model.ClusterInfo, error) {
 	//log.Debug().Msg("[Get K8sCluster] " + k8sClusterId)
 
-	emptyObj := &model.K8sClusterInfo{}
+	emptyObj := &model.ClusterInfo{}
 
 	check, err := CheckK8sCluster(nsId, k8sClusterId)
 	if err != nil {
@@ -1138,7 +1138,7 @@ func GetK8sCluster(nsId string, k8sClusterId string) (*model.K8sClusterInfo, err
 		return emptyObj, err
 	}
 
-	// Get model.K8sClusterInfo from kvstore
+	// Get model.ClusterInfo from kvstore
 	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Get K8sCluster(%s)", k8sClusterId)
@@ -1157,7 +1157,7 @@ func GetK8sCluster(nsId string, k8sClusterId string) (*model.K8sClusterInfo, err
 		return tbK8sCInfo, nil
 	}
 
-	// Update model.K8sClusterInfo from CB-Spider
+	// Update model.ClusterInfo from CB-Spider
 	client := clientManager.NewHttpClient()
 	client.SetTimeout(10 * time.Minute)
 	url := model.SpiderRestUrl + "/cluster/" + tbK8sCInfo.CspResourceName
@@ -1188,7 +1188,7 @@ func GetK8sCluster(nsId string, k8sClusterId string) (*model.K8sClusterInfo, err
 		return emptyObj, err
 	}
 
-	// Update/Get model.K8sClusterInfo object to/from kvstore
+	// Update/Get model.ClusterInfo object to/from kvstore
 	updateK8sClusterInfoFromSpiderClusterInfo(tbK8sCInfo, &spClusterRes.SpiderClusterInfo)
 	tbK8sCInfo.SpiderViewK8sClusterDetail = spClusterRes.SpiderClusterInfo
 	storeK8sClusterInfo(nsId, tbK8sCInfo)
@@ -1408,7 +1408,7 @@ func ListK8sCluster(nsId string, filterKey string, filterVal string) (any, error
 		return nil, err
 	}
 
-	tbK8sCInfoList := []model.K8sClusterInfo{}
+	tbK8sCInfoList := []model.ClusterInfo{}
 
 	for _, id := range k8sIdList {
 		k := common.GenK8sClusterKey(nsId, id)
@@ -1423,7 +1423,7 @@ func ListK8sCluster(nsId string, filterKey string, filterVal string) (any, error
 			return nil, err
 		}
 
-		storedTbK8sCInfo := model.K8sClusterInfo{}
+		storedTbK8sCInfo := model.ClusterInfo{}
 		err = json.Unmarshal([]byte(kv.Value), &storedTbK8sCInfo)
 		if err != nil {
 			log.Err(err).Msg("Failed to List K8sCluster")
@@ -1486,7 +1486,7 @@ func DeleteK8sCluster(nsId, k8sClusterId, option string) (bool, error) {
 		return false, err
 	}
 
-	// Get model.K8sClusterInfo object from kvstore
+	// Get model.ClusterInfo object from kvstore
 	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Delete K8sCluster(%s)", k8sClusterId)
@@ -1592,10 +1592,10 @@ func DeleteAllK8sCluster(nsId, subString, option string) (*model.IdList, error) 
 }
 
 // UpgradeK8sCluster upgrades an existing k8s cluster to the specified version
-func UpgradeK8sCluster(ctx context.Context, nsId string, k8sClusterId string, u *model.UpgradeK8sClusterReq, skipVersionCheck bool) (*model.K8sClusterInfo, error) {
+func UpgradeK8sCluster(ctx context.Context, nsId string, k8sClusterId string, u *model.UpgradeK8sClusterReq, skipVersionCheck bool) (*model.ClusterInfo, error) {
 	log.Info().Msg("UpgradeK8sCluster")
 
-	emptyObj := &model.K8sClusterInfo{}
+	emptyObj := &model.ClusterInfo{}
 
 	err := validate.Struct(u)
 	if err != nil {
@@ -1619,7 +1619,7 @@ func UpgradeK8sCluster(ctx context.Context, nsId string, k8sClusterId string, u 
 		return emptyObj, err
 	}
 
-	// Get model.K8sClusterInfo from kvstore
+	// Get model.ClusterInfo from kvstore
 	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Upgrade a K8sCluster(%s)", k8sClusterId)
@@ -1671,7 +1671,7 @@ func UpgradeK8sCluster(ctx context.Context, nsId string, k8sClusterId string, u 
 		return emptyObj, err
 	}
 
-	// Update/Get model.K8sClusterInfo object to/from kvstore
+	// Update/Get model.ClusterInfo object to/from kvstore
 	updateK8sClusterInfoFromSpiderClusterInfo(tbK8sCInfo, &spClusterRes.SpiderClusterInfo)
 	tbK8sCInfo.SpiderViewK8sClusterDetail = spClusterRes.SpiderClusterInfo
 	storeK8sClusterInfo(nsId, tbK8sCInfo)
@@ -1762,9 +1762,9 @@ func validateAtCreateK8sCluster(tbK8sClusterReq *model.K8sClusterReq, skipVersio
 	// Validate K8sNodeGroups On K8s Creation only if required by the CSP
 	if k8sNgOnCreation {
 		// CSP requires nodegroups at creation time (e.g., Azure, GCP, NHN, NCP)
-		if len(tbK8sClusterReq.K8sNodeGroupList) <= 0 {
+		if len(tbK8sClusterReq.NodeGroups) <= 0 {
 			err := fmt.Errorf("NodeGroups are required at K8sCluster creation for provider '%s'", connConfig.ProviderName)
-			log.Err(err).Msg("Need to Set One or more K8sNodeGroupList")
+			log.Err(err).Msg("Need to Set One or more NodeGroups")
 			return err
 		}
 
@@ -1778,7 +1778,7 @@ func validateAtCreateK8sCluster(tbK8sClusterReq *model.K8sClusterReq, skipVersio
 		// Validate naming rule only if a rule is defined
 		if k8sNgNamingRule != "" {
 			re := regexp.MustCompile(k8sNgNamingRule)
-			for i, ng := range tbK8sClusterReq.K8sNodeGroupList {
+			for i, ng := range tbK8sClusterReq.NodeGroups {
 				ngName := ng.Name
 
 				// Auto-fix common naming pattern: convert "ng-xxxxx" to "ngxxxxx" for CSPs that don't allow hyphens
@@ -1788,7 +1788,7 @@ func validateAtCreateK8sCluster(tbK8sClusterReq *model.K8sClusterReq, skipVersio
 					if re.MatchString(fixedName) {
 						log.Warn().Msgf("NodeGroup name(%s) contains hyphens not allowed by provider(%s). Auto-converting to: %s",
 							ngName, connConfig.ProviderName, fixedName)
-						tbK8sClusterReq.K8sNodeGroupList[i].Name = fixedName
+						tbK8sClusterReq.NodeGroups[i].Name = fixedName
 					} else {
 						err := fmt.Errorf("K8sNodeGroup's Name(%s) does not match naming rule(%s) for provider(%s)",
 							ngName, k8sNgNamingRule, connConfig.ProviderName)
@@ -1809,7 +1809,7 @@ func validateAtCreateK8sCluster(tbK8sClusterReq *model.K8sClusterReq, skipVersio
 		if !nodeImageDesignation {
 			// CSP does not support image designation (e.g., Azure, NCP)
 			// Check if user specified imageId when it's not allowed
-			for _, ng := range tbK8sClusterReq.K8sNodeGroupList {
+			for _, ng := range tbK8sClusterReq.NodeGroups {
 				if ng.ImageId != "" && ng.ImageId != "default" {
 					log.Warn().Msgf("Provider(%s) does not support image designation. ImageId(%s) will be ignored.",
 						connConfig.ProviderName, ng.ImageId)
@@ -1819,10 +1819,10 @@ func validateAtCreateK8sCluster(tbK8sClusterReq *model.K8sClusterReq, skipVersio
 		}
 	} else {
 		// CSP does not require nodegroups at creation time (e.g., AWS, Alibaba, Tencent)
-		if len(tbK8sClusterReq.K8sNodeGroupList) > 0 {
+		if len(tbK8sClusterReq.NodeGroups) > 0 {
 			err := fmt.Errorf("NodeGroups should not be specified at K8sCluster creation for provider '%s'. Use AddK8sNodeGroup API after cluster creation.",
 				connConfig.ProviderName)
-			log.Err(err).Msg("K8sNodeGroupList should be empty")
+			log.Err(err).Msg("NodeGroups should be empty")
 			return err
 		}
 	}
@@ -1936,24 +1936,24 @@ func TransferFileToK8sClusterContainer(nsId string, k8sClusterId string, k8sClus
 }
 
 func getKubeconfigFromK8sClusterInfo(nsId, k8sClusterId string) (string, error) {
-	log.Debug().Msg("[Get Kubeconfig from K8sClusterInfo] " + k8sClusterId)
+	log.Debug().Msg("[Get Kubeconfig from ClusterInfo] " + k8sClusterId)
 
 	tbK8sCInfo, err := getK8sClusterInfo(nsId, k8sClusterId)
 	if err != nil {
-		err = fmt.Errorf("failed to get kubeconfig from K8sClusterInfo(%s): %v", k8sClusterId, err)
+		err = fmt.Errorf("failed to get kubeconfig from ClusterInfo(%s): %v", k8sClusterId, err)
 		return "", err
 	}
 
-	if tbK8sCInfo.Status != model.K8sClusterActive {
+	if tbK8sCInfo.Status != string(model.K8sClusterActive) {
 		// Check K8sCluster's Status again
 		newTbK8sCInfo, err := GetK8sCluster(nsId, k8sClusterId)
 		if err != nil {
-			err = fmt.Errorf("failed to get kubeconfig from K8sClusterInfo(%s): %v", k8sClusterId, err)
+			err = fmt.Errorf("failed to get kubeconfig from ClusterInfo(%s): %v", k8sClusterId, err)
 			return "", err
 		}
 
-		if newTbK8sCInfo.Status != model.K8sClusterActive {
-			err = fmt.Errorf("failed to get kubeconfig from K8sClusterInfo(%s): K8sCluster is not active", k8sClusterId)
+		if newTbK8sCInfo.Status != string(model.K8sClusterActive) {
+			err = fmt.Errorf("failed to get kubeconfig from ClusterInfo(%s): K8sCluster is not active", k8sClusterId)
 			return "", err
 		}
 	}
@@ -2122,13 +2122,13 @@ func transferFileToK8sClusterContainer(nsId, k8sClusterId, k8sClusterPodName, k8
 	return result, nil
 }
 
-func updateK8sClusterNetworkInfoFromSpiderNetworkInfo(tbK8sCNInfo *model.K8sClusterNetworkInfo, spNetworkInfo *model.SpiderNetworkInfo) {
+func updateK8sClusterNetworkInfoFromSpiderNetworkInfo(tbK8sCNInfo *model.ClusterNetworkInfo, spNetworkInfo *model.SpiderNetworkInfo) {
 	tbKeyValueList := convertSpiderKeyValueListToTbKeyValueList(spNetworkInfo.KeyValueList)
 
 	tbK8sCNInfo.KeyValueList = tbKeyValueList
 }
 
-func updateK8sNodeGroupInfoFromSpiderNodeGroupInfo(tbK8sNGInfo *model.K8sNodeGroupInfo, spNGInfo *model.SpiderNodeGroupInfo) {
+func updateK8sNodeGroupInfoFromSpiderNodeGroupInfo(tbK8sNGInfo *model.NodeGroupInfo, spNGInfo *model.SpiderNodeGroupInfo) {
 	// Update basic identification info from Spider response
 	tbK8sNGInfo.Id = spNGInfo.IId.NameId
 	tbK8sNGInfo.Name = spNGInfo.IId.NameId
@@ -2150,7 +2150,7 @@ func updateK8sNodeGroupInfoFromSpiderNodeGroupInfo(tbK8sNGInfo *model.K8sNodeGro
 	tbK8sNGInfo.DesiredNodeSize = spNGInfo.DesiredNodeSize
 	tbK8sNGInfo.MinNodeSize = spNGInfo.MinNodeSize
 	tbK8sNGInfo.MaxNodeSize = spNGInfo.MaxNodeSize
-	tbK8sNGInfo.Status = convertSpiderNodeGroupStatusToK8sNodeGroupStatus(spNGInfo.Status)
+	tbK8sNGInfo.Status = string(convertSpiderNodeGroupStatusToK8sNodeGroupStatus(spNGInfo.Status))
 
 	tbK8sNGInfo.K8sNodes = []model.K8sNodeInfo{}
 	for _, v := range spNGInfo.Nodes {
@@ -2186,9 +2186,9 @@ func removeNodeGroupFromLocalClusterInfo(nsId, k8sClusterId, k8sNodeGroupName st
 	}
 
 	// Find and remove the node group
-	var updatedNodeGroups []model.K8sNodeGroupInfo
+	var updatedNodeGroups []model.NodeGroupInfo
 	found := false
-	for _, ng := range tbK8sCInfo.K8sNodeGroupList {
+	for _, ng := range tbK8sCInfo.NodeGroups {
 		if ng.Name != k8sNodeGroupName {
 			updatedNodeGroups = append(updatedNodeGroups, ng)
 		} else {
@@ -2202,7 +2202,7 @@ func removeNodeGroupFromLocalClusterInfo(nsId, k8sClusterId, k8sNodeGroupName st
 	}
 
 	// Update the cluster info with the new node group list
-	tbK8sCInfo.K8sNodeGroupList = updatedNodeGroups
+	tbK8sCInfo.NodeGroups = updatedNodeGroups
 
 	// Store the updated cluster info
 	storeK8sClusterInfo(nsId, tbK8sCInfo)
@@ -2219,13 +2219,13 @@ func convertSpiderKeyValueListToTbKeyValueList(spKeyValueList []model.KeyValue) 
 	return tbKeyValueList
 }
 
-func updateK8sClusterInfoFromSpiderClusterInfo(tbK8sCInfo *model.K8sClusterInfo, spCInfo *model.SpiderClusterInfo) {
+func updateK8sClusterInfoFromSpiderClusterInfo(tbK8sCInfo *model.ClusterInfo, spCInfo *model.SpiderClusterInfo) {
 	tbK8sCInfo.Version = spCInfo.Version
 	updateK8sClusterNetworkInfoFromSpiderNetworkInfo(&tbK8sCInfo.Network, &spCInfo.Network)
-	updateK8sNodeGroupInfoListFromSpiderNodeGroupInfoList(&tbK8sCInfo.K8sNodeGroupList, &spCInfo.NodeGroupList)
+	updateK8sNodeGroupInfoListFromSpiderNodeGroupInfoList(&tbK8sCInfo.NodeGroups, &spCInfo.NodeGroupList)
 	updateK8sAccessInfoFromSpiderAccessInfo(&tbK8sCInfo.AccessInfo, &spCInfo.AccessInfo)
 	updateK8sAddonsInfoFromSpiderAddonsInfo(&tbK8sCInfo.Addons, &spCInfo.Addons)
-	tbK8sCInfo.Status = convertSpiderClusterStatusToK8sClusterStatus(spCInfo.Status)
+	tbK8sCInfo.Status = string(convertSpiderClusterStatusToK8sClusterStatus(spCInfo.Status))
 	tbK8sCInfo.CreatedTime = spCInfo.CreatedTime
 	tbK8sCInfo.KeyValueList = convertSpiderKeyValueListToTbKeyValueList(spCInfo.KeyValueList)
 
@@ -2233,7 +2233,7 @@ func updateK8sClusterInfoFromSpiderClusterInfo(tbK8sCInfo *model.K8sClusterInfo,
 	tbK8sCInfo.CspResourceId = spCInfo.IId.SystemId
 }
 
-func fillK8sNodeGroupInfoFromK8sNodeGroupReq(tbK8sNGInfo *model.K8sNodeGroupInfo, tbK8sNGReq *model.K8sNodeGroupReq) {
+func fillK8sNodeGroupInfoFromK8sNodeGroupReq(tbK8sNGInfo *model.NodeGroupInfo, tbK8sNGReq *model.K8sNodeGroupReq) {
 	tbK8sNGInfo.Id = tbK8sNGReq.Name
 	tbK8sNGInfo.Name = tbK8sNGReq.Name
 	tbK8sNGInfo.ImageId = tbK8sNGReq.ImageId
@@ -2255,7 +2255,7 @@ func fillK8sNodeGroupInfoFromK8sNodeGroupReq(tbK8sNGInfo *model.K8sNodeGroupInfo
 	tbK8sNGInfo.MaxNodeSize = tbK8sNGReq.MaxNodeSize
 }
 
-func fillK8sNodeGroupInfoListFromK8sNodeGroupReqList(tbK8sNGInfoList *[]model.K8sNodeGroupInfo, tbK8sNGReqList *[]model.K8sNodeGroupReq) {
+func fillK8sNodeGroupInfoListFromK8sNodeGroupReqList(tbK8sNGInfoList *[]model.NodeGroupInfo, tbK8sNGReqList *[]model.K8sNodeGroupReq) {
 	var err error
 	if tbK8sNGInfoList == nil {
 		err = fmt.Errorf("invalid K8sNodeGroupInfoList")
@@ -2269,13 +2269,13 @@ func fillK8sNodeGroupInfoListFromK8sNodeGroupReqList(tbK8sNGInfoList *[]model.K8
 	}
 
 	for _, tbK8sNGReq := range *tbK8sNGReqList {
-		tbK8sNGInfo := model.K8sNodeGroupInfo{}
+		tbK8sNGInfo := model.NodeGroupInfo{}
 		fillK8sNodeGroupInfoFromK8sNodeGroupReq(&tbK8sNGInfo, &tbK8sNGReq)
 		*tbK8sNGInfoList = append(*tbK8sNGInfoList, tbK8sNGInfo)
 	}
 }
 
-func updateK8sNodeGroupInfoListFromSpiderNodeGroupInfoList(tbK8sNGInfoList *[]model.K8sNodeGroupInfo, spNGInfoList *[]model.SpiderNodeGroupInfo) {
+func updateK8sNodeGroupInfoListFromSpiderNodeGroupInfoList(tbK8sNGInfoList *[]model.NodeGroupInfo, spNGInfoList *[]model.SpiderNodeGroupInfo) {
 	var err error
 	if tbK8sNGInfoList == nil {
 		err = fmt.Errorf("invalid K8sNodeGroupInfoList")
@@ -2289,7 +2289,7 @@ func updateK8sNodeGroupInfoListFromSpiderNodeGroupInfoList(tbK8sNGInfoList *[]mo
 	}
 
 	// Make tbK8sNGInfoListNew without deleted NodeGroupInfo from tbK8sNGInfoList
-	var newList []model.K8sNodeGroupInfo
+	var newList []model.NodeGroupInfo
 	for _, tbK8sNGInfo := range *tbK8sNGInfoList {
 		found := false
 		for _, spNGInfo := range *spNGInfoList {
@@ -2303,8 +2303,8 @@ func updateK8sNodeGroupInfoListFromSpiderNodeGroupInfoList(tbK8sNGInfoList *[]mo
 		}
 	}
 
-	// Update recent SpiderNodeGroupInfo to K8sNodeGroupInfo
-	var absentList []model.K8sNodeGroupInfo
+	// Update recent SpiderNodeGroupInfo to NodeGroupInfo
+	var absentList []model.NodeGroupInfo
 	for _, spNGInfo := range *spNGInfoList {
 		found := false
 		for i := range newList {
@@ -2316,7 +2316,7 @@ func updateK8sNodeGroupInfoListFromSpiderNodeGroupInfoList(tbK8sNGInfoList *[]mo
 		}
 		if found == false {
 			// In case of removing the nodegroup
-			absentInfo := model.K8sNodeGroupInfo{}
+			absentInfo := model.NodeGroupInfo{}
 			updateK8sNodeGroupInfoFromSpiderNodeGroupInfo(&absentInfo, &spNGInfo)
 			absentList = append(absentList, absentInfo)
 		}

--- a/src/interface/rest/server/infra/manageInfo.go
+++ b/src/interface/rest/server/infra/manageInfo.go
@@ -485,7 +485,7 @@ func RestGetInfraGroupIds(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param infraId path string true "Infra ID" default(infra01)
-// @Success 200 {object} model.InfraClusterList
+// @Success 200 {object} model.ClusterList
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-request-id header string false "Custom request ID for tracking"
@@ -503,7 +503,7 @@ func RestGetInfraClusters(c echo.Context) error {
 		return clientManager.EndRequestWithLog(c, err, nil)
 	}
 
-	content := model.InfraClusterList{Cluster: result}
+	content := model.ClusterList{Cluster: result}
 	return clientManager.EndRequestWithLog(c, nil, content)
 }
 
@@ -517,7 +517,7 @@ func RestGetInfraClusters(c echo.Context) error {
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param infraId path string true "Infra ID" default(infra01)
 // @Param clusterId path string true "Cluster ID" default(vnet01)
-// @Success 200 {object} model.InfraClusterInfo
+// @Success 200 {object} model.ClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-request-id header string false "Custom request ID for tracking"

--- a/src/interface/rest/server/infra/provisioning.go
+++ b/src/interface/rest/server/infra/provisioning.go
@@ -435,7 +435,7 @@ func RestPostInfraDynamicReview(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID containing the target Infra" default(default)
 // @Param infraId path string true "Infra ID to which new nodes will be added" default(infra01)
-// @Param nodeGroupReq body model.CreateNodeGroupDynamicReq true "NodeGroup dynamic request specifying specId, imageId, and scaling parameters"
+// @Param nodeGroupReq body model.NodeGroupDynamicReq true "NodeGroup dynamic request specifying specId, imageId, and scaling parameters"
 // @Param x-credential-holder header string false "Credential holder ID to select which credentials to use for provisioning (default: system default holder)"
 // @Success 200 {object} model.InfraInfo "Updated Infra information including newly added nodes and current status"
 // @Failure 400 {object} model.SimpleMsg "Invalid node request or incompatible configuration parameters"
@@ -450,7 +450,7 @@ func RestPostInfraNodeGroupDynamic(c echo.Context) error {
 	nsId := c.Param("nsId")
 	infraId := c.Param("infraId")
 
-	req := &model.CreateNodeGroupDynamicReq{}
+	req := &model.NodeGroupDynamicReq{}
 	if err := c.Bind(req); err != nil {
 		return clientManager.EndRequestWithLog(c, err, nil)
 	}
@@ -495,7 +495,7 @@ func RestPostInfraNodeGroupDynamic(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID containing the target Infra" default(default)
 // @Param infraId path string true "Infra ID to which the node will be added" default(infra01)
-// @Param nodeGroupReq body model.CreateNodeGroupDynamicReq true "Request body to review node dynamic addition. Must include specId and imageId info. (ex: {name: web-servers, specId: aws+ap-northeast-2+t2.small, imageId: aws+ap-northeast-2+ubuntu22.04, nodeGroupSize: 2})"
+// @Param nodeGroupReq body model.NodeGroupDynamicReq true "Request body to review node dynamic addition. Must include specId and imageId info. (ex: {name: web-servers, specId: aws+ap-northeast-2+t2.small, imageId: aws+ap-northeast-2+ubuntu22.04, nodeGroupSize: 2})"
 // @Param x-request-id header string false "Custom request ID for tracking"
 // @Param x-credential-holder header string false "Credential holder ID to select which credentials to use for review (default: system default holder)"
 // @Success 200 {object} model.ReviewNodeGroupDynamicReqInfo "Comprehensive node addition review result with validation status, cost estimation, and recommendations"
@@ -509,7 +509,7 @@ func RestPostInfraDynamicNodeGroupNodeReview(c echo.Context) error {
 	nsId := c.Param("nsId")
 	infraId := c.Param("infraId")
 
-	req := &model.CreateNodeGroupDynamicReq{}
+	req := &model.NodeGroupDynamicReq{}
 	if err := c.Bind(req); err != nil {
 		log.Warn().Err(err).Msg("invalid request for Node dynamic addition review")
 		return clientManager.EndRequestWithLog(c, err, nil)

--- a/src/interface/rest/server/resource/k8scluster.go
+++ b/src/interface/rest/server/resource/k8scluster.go
@@ -159,7 +159,7 @@ func RestGetRequiredK8sSubnetCount(c echo.Context) error {
 // @Param option query string false "Option: [required params for register] connectionName, name, cspResourceId" Enums(register)
 // @Param skipVersionCheck query string false "Skip Kubernetes version validation (use for testing with unlisted versions)" default(false)
 // @Param k8sClusterReq body model.K8sClusterReq true "Details of the K8sCluster object"
-// @Success 200 {object} model.K8sClusterInfo
+// @Success 200 {object} model.ClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-request-id header string false "Custom request ID for tracking"
@@ -204,8 +204,8 @@ func RestPostK8sCluster(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster01)
-// @Param k8sClusterInfo body model.K8sClusterInfo true "Details of the K8sCluster object"
-// @Success 200 {object} model.K8sClusterInfo
+// @Param k8sClusterInfo body model.ClusterInfo true "Details of the K8sCluster object"
+// @Success 200 {object} model.ClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-request-id header string false "Custom request ID for tracking"
@@ -229,7 +229,7 @@ func RestPutK8sCluster(c echo.Context) error {
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster01)
 // @Param k8sNodeGroupReq body model.K8sNodeGroupReq true "Details of the K8sNodeGroup object"
-// @Success 200 {object} model.K8sClusterInfo
+// @Success 200 {object} model.ClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-request-id header string false "Custom request ID for tracking"
@@ -394,7 +394,7 @@ func RestPutChangeK8sNodeGroupAutoscaleSize(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster01)
-// @Success 200 {object} model.K8sClusterInfo
+// @Success 200 {object} model.ClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-request-id header string false "Custom request ID for tracking"
@@ -466,7 +466,7 @@ func RestGetK8sClusterKubeconfig(c echo.Context) error {
 
 // Response structure for RestGetAllK8sCluster
 type RestGetAllK8sClusterResponse struct {
-	K8sCluster []model.K8sClusterInfo `json:"K8sClusterInfo"`
+	K8sCluster []model.ClusterInfo `json:"ClusterInfo"`
 }
 
 // RestGetAllK8sCluster godoc
@@ -514,7 +514,7 @@ func RestGetAllK8sCluster(c echo.Context) error {
 
 		restGetAllK8sClusterResponse := RestGetAllK8sClusterResponse{}
 
-		restGetAllK8sClusterResponse.K8sCluster = resourceList.([]model.K8sClusterInfo) // type assertion (interface{} -> array)
+		restGetAllK8sClusterResponse.K8sCluster = resourceList.([]model.ClusterInfo) // type assertion (interface{} -> array)
 		return c.JSON(http.StatusOK, &restGetAllK8sClusterResponse)
 	}
 }
@@ -669,11 +669,11 @@ func RestPostK8sClusterDynamicCheckRequest(c echo.Context) error {
 // @Accept  json
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
-// @Param k8sClusterDyanmicReq body model.K8sClusterDynamicReq true "Request body to provision K8sCluster dynamically. <br> Must include specId and imageId info. <br> (ex: {name: k8scluster01, imageId: azure+koreacentral+ubuntu22.04, specId: azure+koreacentral+Standard_B2s}]}) <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
+// @Param k8sClusterDyanmicReq body model.ClusterDynamicReq true "Request body to provision K8sCluster dynamically. <br> Must include specId and imageId info. <br> (ex: {name: k8scluster01, imageId: azure+koreacentral+ubuntu22.04, specId: azure+koreacentral+Standard_B2s}]}) <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
 // @Param option query string false "Option for K8sCluster creation" Enums(hold)
 // @Param skipVersionCheck query string false "Skip Kubernetes version validation (use for testing with unlisted versions)" default(false)
 // @Param x-request-id header string false "Custom request ID"
-// @Success 200 {object} model.K8sClusterInfo
+// @Success 200 {object} model.ClusterInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-credential-holder header string false "Credential holder ID for selecting which credentials to use (default: system default holder)"
@@ -686,7 +686,7 @@ func RestPostK8sClusterDynamic(c echo.Context) error {
 	skipVersionCheckStr := c.QueryParam("skipVersionCheck")
 	skipVersionCheck := skipVersionCheckStr == "true"
 
-	req := &model.K8sClusterDynamicReq{}
+	req := &model.ClusterDynamicReq{}
 	if err := c.Bind(req); err != nil {
 		log.Warn().Err(err).Msg("invalid request")
 		return clientManager.EndRequestWithLog(c, err, nil)
@@ -783,9 +783,9 @@ func RestPostK8sMultiClusterDynamic(c echo.Context) error {
 // @Produce  json
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param k8sClusterId path string true "K8sCluster ID" default(k8scluster01)
-// @Param k8sNodeGroupDynamicReq body model.K8sNodeGroupDynamicReq true "Request body to provision K8sNodeGroup dynamically. <br> Must include specId and imageId info. <br> (ex: {name: k8sng01, imageId: azure+koreacentral+ubuntu22.04, specId: azure+koreacentral+Standard_B2s}]}) <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
+// @Param k8sNodeGroupDynamicReq body model.NodeGroupDynamicReq true "Request body to provision K8sNodeGroup dynamically. <br> Must include specId and imageId info. <br> (ex: {name: k8sng01, imageId: azure+koreacentral+ubuntu22.04, specId: azure+koreacentral+Standard_B2s}]}) <br> You can use /k8sClusterRecommendNode and /k8sClusterDynamicCheckRequest to get it. <br> Check the guide: https://github.com/cloud-barista/cb-tumblebug/discussions/1913"
 // @Param x-request-id header string false "Custom request ID"
-// @Success 200 {object} model.K8sNodeGroupInfo
+// @Success 200 {object} model.NodeGroupInfo
 // @Failure 404 {object} model.SimpleMsg
 // @Failure 500 {object} model.SimpleMsg
 // @Param x-credential-holder header string false "Credential holder ID for selecting which credentials to use (default: system default holder)"
@@ -796,7 +796,7 @@ func RestPostK8sNodeGroupDynamic(c echo.Context) error {
 	nsId := c.Param("nsId")
 	k8sClusterId := c.Param("k8sClusterId")
 
-	req := &model.K8sNodeGroupDynamicReq{}
+	req := &model.NodeGroupDynamicReq{}
 	if err := c.Bind(req); err != nil {
 		log.Warn().Err(err).Msg("invalid request")
 		return clientManager.EndRequestWithLog(c, err, nil)

--- a/src/interface/rest/server/resource/template.go
+++ b/src/interface/rest/server/resource/template.go
@@ -796,38 +796,37 @@ func RestPostK8sClusterExtractTemplate(c echo.Context) error {
 	return clientManager.EndRequestWithLog(c, nil, result)
 }
 
-// buildK8sMultiClusterDynamicReqFromCluster converts a K8sClusterInfo into a K8sMultiClusterDynamicReq
+// buildK8sMultiClusterDynamicReqFromCluster converts a ClusterInfo into a K8sMultiClusterDynamicReq
 // that can reproduce the cluster's configuration.
-func buildK8sMultiClusterDynamicReqFromCluster(clusterInfo *model.K8sClusterInfo) model.K8sMultiClusterDynamicReq {
-	clusterReq := model.K8sClusterDynamicReq{
+func buildK8sMultiClusterDynamicReqFromCluster(clusterInfo *model.ClusterInfo) model.K8sMultiClusterDynamicReq {
+	clusterReq := model.ClusterDynamicReq{
 		Name:           clusterInfo.Id,
 		Version:        clusterInfo.Version,
 		Description:    clusterInfo.Description,
 		ConnectionName: clusterInfo.ConnectionName,
 	}
 
-	if len(clusterInfo.K8sNodeGroupList) > 1 {
-		log.Warn().Msgf("extractTemplate: cluster '%s' has %d node groups; only the first will be included (K8sClusterDynamicReq supports one node group per entry)", clusterInfo.Id, len(clusterInfo.K8sNodeGroupList))
-	}
-	if len(clusterInfo.K8sNodeGroupList) > 0 {
-		ng := clusterInfo.K8sNodeGroupList[0]
-		clusterReq.NodeGroupName = ng.Name
-		clusterReq.SpecId = ng.SpecId
-		clusterReq.ImageId = ng.ImageId
-		clusterReq.RootDiskType = ng.RootDiskType
-		clusterReq.RootDiskSize = ng.RootDiskSize
-		clusterReq.DesiredNodeSize = ng.DesiredNodeSize
-		clusterReq.MinNodeSize = ng.MinNodeSize
-		clusterReq.MaxNodeSize = ng.MaxNodeSize
-		if ng.OnAutoScaling {
-			clusterReq.OnAutoScaling = "true"
-		} else {
-			clusterReq.OnAutoScaling = "false"
+	for _, ng := range clusterInfo.NodeGroups {
+		ngReq := model.NodeGroupDynamicReq{
+			Name:            ng.Name,
+			SpecId:          ng.SpecId,
+			ImageId:         ng.ImageId,
+			RootDiskType:    ng.RootDiskType,
+			RootDiskSize:    ng.RootDiskSize,
+			DesiredNodeSize: ng.DesiredNodeSize,
+			MinNodeSize:     ng.MinNodeSize,
+			MaxNodeSize:     ng.MaxNodeSize,
 		}
+		if ng.OnAutoScaling {
+			ngReq.OnAutoScaling = "true"
+		} else {
+			ngReq.OnAutoScaling = "false"
+		}
+		clusterReq.NodeGroups = append(clusterReq.NodeGroups, ngReq)
 	}
 
 	return model.K8sMultiClusterDynamicReq{
 		NamePrefix: clusterInfo.Id,
-		Clusters:   []model.K8sClusterDynamicReq{clusterReq},
+		Clusters:   []model.ClusterDynamicReq{clusterReq},
 	}
 }


### PR DESCRIPTION
## Summary

Generalizes VM/K8s object models by merging K8s-exclusive types into shared types.
The renamed/removed types and their replacements are listed below.

| Before | After | Action |
|---|---|---|
| `K8sClusterInfo` | `ClusterInfo` | Renamed, VM cluster fields added |
| `K8sNodeGroupInfo` | `NodeGroupInfo` | Renamed, VM node group fields added |
| `K8sClusterNetworkInfo` | `ClusterNetworkInfo` | Renamed |
| `K8sClusterDynamicReq` | `ClusterDynamicReq` | Renamed |
| `K8sNodeGroupDynamicReq` | ~~deleted~~ | Merged into `NodeGroupDynamicReq` |
| `CreateNodeGroupDynamicReq` | `NodeGroupDynamicReq` | Renamed, K8s fields added |
| `InfraClusterInfo` | ~~deleted~~ | Merged into `ClusterInfo` |

Verified on AWS, GCP, and Azure. UI-level testing was also performed with an updated cb-mapui, and a follow-up PR for cb-mapui will be submitted shortly. See [#2536](https://github.com/cloud-barista/cb-tumblebug/discussions/2536) for background.

---

## ⚠️ Breaking Changes

### 1. `POST /ns/{nsId}/k8sClusterDynamic` — Request body restructured

`specId`, `imageId`, `nodeGroupName` fields are now nested inside a `nodeGroups` array.

**Before**
```json
{
  "name": "cluster01",
  "connectionName": "aws-ap-northeast-2",
  "specId": "aws+ap-northeast-2+t3.medium",
  "imageId": "default",
  "nodeGroupName": "ng01"
}
```

**After (AWS)**
```json
{
  "name": "cluster01",
  "connectionName": "aws-ap-northeast-2",
  "nodeGroups": [
    {
      "name": "ng01",
      "specId": "aws+ap-northeast-2+t3.medium",
      "imageId": "default"
    }
  ]
}
```

**After (GCP)**
```json
{
  "name": "cluster01",
  "connectionName": "gcp-asia-northeast3",
  "version": "1.35.5-gke.1000004",
  "nodeGroups": [
    {
      "name": "ng01",
      "specId": "gcp+asia-northeast3+e2-standard-2",
      "imageId": "UBUNTU_CONTAINERD",
      "desiredNodeSize": 1,
      "minNodeSize": 1,
      "maxNodeSize": 3,
      "onAutoScaling": "false"
    }
  ]
}
```

**After (Azure)**
```json
{
  "name": "cluster01",
  "connectionName": "azure-koreacentral",
  "nodeGroups": [
    {
      "name": "ng01",
      "specId": "azure+koreacentral+standard_b4ms",
      "imageId": "default"
    }
  ]
}
```

---

### 2. `POST /ns/{nsId}/k8sCluster/{id}/k8sNodeGroupDynamic` — Request body unchanged, Go type renamed

The JSON request body structure is backward compatible. Only the internal Go type changes (`K8sNodeGroupDynamicReq` → `NodeGroupDynamicReq`), which affects consumers importing cb-tumblebug as a Go module.

**AWS**
```json
{
  "name": "ng02",
  "specId": "aws+ap-northeast-2+t3.medium",
  "imageId": "default"
}
```

**GCP**
```json
{
  "name": "ng02",
  "specId": "gcp+asia-northeast3+e2-standard-2",
  "imageId": "UBUNTU_CONTAINERD",
  "desiredNodeSize": 1,
  "minNodeSize": 1,
  "maxNodeSize": 3,
  "onAutoScaling": "false"
}
```

**Azure**
```json
{
  "name": "ng02",
  "specId": "azure+koreacentral+standard_b4ms",
  "imageId": "default",
  "desiredNodeSize": 1,
  "minNodeSize": 1,
  "maxNodeSize": 3,
  "onAutoScaling": "false"
}
```

---

### 3. All K8s Cluster API responses — `k8sNodeGroupList` field renamed to `nodeGroups`

Clients that parse the response body of any K8s cluster API (create, get, list) must update the field name.

```
Before: response.k8sNodeGroupList[...]
After:  response.nodeGroups[...]
```
