### PR TITLE
Enhance hermes agent deployment error handling

### DIFF
--- a/scripts/usecases/llm/deployHermesAgent.sh
+++ b/scripts/usecases/llm/deployHermesAgent.sh
@@ -515,24 +515,62 @@ pre_download_hf_model() {
 
   log "Pre-downloading Hugging Face model with temporary HF token. The token will not be written to systemd or shell profiles."
 
-  sudo -u "$RUN_AS_USER" -H env \
-    HF_TOKEN="$HF_TOKEN_VALUE" \
-    HUGGING_FACE_HUB_TOKEN="$HF_TOKEN_VALUE" \
-    MODEL_NAME="$VLLM_MODEL" \
-    bash -lc "
-      set -e
-      source '$USER_HOME/venv_vllm/bin/activate'
-      python - <<'PY'
-import os
+  # Check available disk space: large FP8 models (e.g. 30B ≈ 32 GB) plus Xet's
+  # reconstruction temp files can require 2× model size during download.
+  local free_gb
+  free_gb=$(df -BG "$USER_HOME" | awk 'NR==2 {gsub(/G/,""); print $4+0}')
+  log "Available disk on $USER_HOME: ${free_gb} GB"
+  if [ "$free_gb" -lt 80 ]; then
+    log "⚠ WARNING: Only ${free_gb} GB free. A 30B FP8 model needs ~64 GB during download (model + Xet temp files)."
+    log "⚠ Consider expanding the disk or using a larger instance before proceeding."
+  fi
+
+  # Install hf-transfer (Rust-based downloader): bypasses the Python Xet/LFS
+  # stack, avoids 'Background writer channel closed' errors on large shards.
+  run_as_user "source '$USER_HOME/venv_vllm/bin/activate' && pip install -q hf-transfer"
+
+  local download_ok=false
+  local attempt
+  for attempt in 1 2 3; do
+    [ "$attempt" -gt 1 ] && { log "Retrying in 15s... (attempt $attempt/3)"; sleep 15; }
+    log "Download attempt $attempt/3 for $VLLM_MODEL ..."
+    if sudo -u "$RUN_AS_USER" -H env \
+        HF_TOKEN="$HF_TOKEN_VALUE" \
+        HUGGING_FACE_HUB_TOKEN="$HF_TOKEN_VALUE" \
+        HF_HUB_ENABLE_HF_TRANSFER="1" \
+        MODEL_NAME="$VLLM_MODEL" \
+        bash -lc "
+          set -e
+          source '$USER_HOME/venv_vllm/bin/activate'
+          python - <<'PY'
+import os, sys
 from huggingface_hub import snapshot_download
 repo_id = os.environ['MODEL_NAME']
 snapshot_download(repo_id=repo_id)
 print('Downloaded or verified Hugging Face cache for:', repo_id)
 PY
-    "
+        "; then
+      download_ok=true
+      break
+    fi
+    log "Download attempt $attempt failed."
+  done
 
   HF_TOKEN_VALUE=""
-  unset HF_TOKEN HUGGING_FACE_HUB_TOKEN
+  unset HF_TOKEN HUGGING_FACE_HUB_TOKEN 2>/dev/null || true
+
+  if [ "$download_ok" = "false" ]; then
+    log ""
+    log "⚠ WARNING: Pre-download of '$VLLM_MODEL' failed after 3 attempts."
+    log "⚠ Common causes: insufficient disk space (need ~2× model size), network"
+    log "⚠ interruption, or a Xet storage backend issue in huggingface_hub."
+    log "⚠ vLLM will attempt to download the model on first startup."
+    log "⚠ For gated models, add the following to /etc/systemd/system/vllm.service"
+    log "⚠ under [Service] before starting: Environment=HUGGING_FACE_HUB_TOKEN=<token>"
+    log ""
+    return 0  # non-fatal: continue deployment
+  fi
+
   log "Hugging Face pre-download completed. HF token cleared from the deploy script environment."
 }
 


### PR DESCRIPTION
To relief the following symptom. 
```
============================================================
[2026-07-01 04:00:56] START: Pre-download Hugging Face model if token is provided
============================================================
[2026-07-01 04:00:56] Pre-downloading Hugging Face model with temporary HF token. The token will not be written to systemd or shell profiles.

Fetching 14 files:   0%|          | 0/14 [00:00<?, ?it/s]
Fetching 14 files:  43%|████▎     | 6/14 [00:00<00:00, 54.06it/s]
Fetching 14 files:  43%|████▎     | 6/14 [00:19<00:00, 54.06it/s]
Fetching 14 files:  43%|████▎     | 6/14 [01:30<02:00, 15.02s/it]
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 88, in _inner_fn
    return fn(*args, **kwargs)
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/huggingface_hub/_snapshot_download.py", line 456, in snapshot_download
    thread_map(
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/tqdm/contrib/concurrent.py", line 69, in thread_map
    return _executor_map(ThreadPoolExecutor, fn, *iterables, **tqdm_kwargs)
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/tqdm/contrib/concurrent.py", line 51, in _executor_map
    return list(tqdm_class(ex.map(fn, *iterables, chunksize=chunksize), **kwargs))
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/tqdm/std.py", line 1181, in __iter__
    for obj in iterable:
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 621, in result_iterator
    yield _result_or_cancel(fs.pop())
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 319, in _result_or_cancel
    return fut.result(timeout)
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 458, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/huggingface_hub/_snapshot_download.py", line 436, in _inner_hf_hub_download
    hf_hub_download(  # type: ignore
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 88, in _inner_fn
    return fn(*args, **kwargs)
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1016, in hf_hub_download
    return _hf_hub_download_to_cache_dir(
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1238, in _hf_hub_download_to_cache_dir
    _download_to_tmp_and_move(
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1861, in _download_to_tmp_and_move
    xet_get(
  File "/home/cb-user/venv_vllm/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 566, in xet_get
    with session.new_file_download_group(
RuntimeError: Task error: File reconstruction error: Internal Writer Error: Background writer channel closed
[ERROR] line=518 command=sudo -u "$RUN_AS_USER" -H env HF_TOKEN="$HF_TOKEN_VALUE" HUGGING_FACE_HUB_TOKEN="$HF_TOKEN_VALUE" MODEL_NAME="$VLLM_MODEL" bash -lc "
      set -e
      source '$USER_HOME/venv_vllm/bin/activate'
      python - <<'PY'
import os
from huggingface_hub import snapshot_download
repo_id = os.environ['MODEL_NAME']
snapshot_download(repo_id=repo_id)
print('Downloaded or verified Hugging Face cache for:', repo_id)
PY
    " exit=1
Log: /tmp/hermes-agent-deploy-20260701-035711.log
```