### PR TITLE
Add minNodeGroupCount constraint to prevent deleting the last node group on Azure AKS and GCP GKE

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -7,6 +7,11 @@
 #     nodeGroupsOnCreation: [true/false]
 #     nodeImageDesignation: [true/false]
 #     requiredSubnetCount: [required number of subnets to create a kubernetes cluster, default value is 1]
+#     initialNodeGroupManagedByCluster: [true/false, default false] if true, the initial node group is
+#       lifecycle-bound to the cluster and cannot be deleted independently (e.g., Alibaba ACK, Tencent TKE)
+#     minNodeGroupCount: [minimum number of node groups that must remain in a cluster, default 0 (no constraint)]
+#       if > 0, deleting a node group when count is at or below this value is rejected before calling the CSP
+#       (e.g., Azure AKS and GCP GKE require at least 1 node pool at all times)
 #     version:
 #       - region: [region1, region2, common(special keyword: most of regions)]
 #         available:
@@ -49,6 +54,7 @@ k8scluster:
     nodeImageDesignation: false
     requiredSubnetCount: 1
     nodeGroupNamingRule: ^[a-z][a-z0-9]*$
+    minNodeGroupCount: 1
     version:
       - region: [westeurope,westus]
         available: # Updated: 2026-06-24 (verified with learn.microsoft.com/azure/aks/supported-kubernetes-versions + github.com/Azure/AKS/releases)
@@ -84,6 +90,7 @@ k8scluster:
     nodeGroupsOnCreation: true
     nodeImageDesignation: true
     requiredSubnetCount: 1
+    minNodeGroupCount: 1
     version:
       - region: [common]
         # ref: https://cloud.google.com/kubernetes-engine/docs/release-notes-stable

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -1758,6 +1758,18 @@ func GetAvailableK8sNodeImage(providerName string, regionName string) (*[]model.
 	return nil, fmt.Errorf("no available kubernetes cluster node image for region(%s) of provider(%s)", regionName, providerName)
 }
 
+// GetK8sDefaultNodeImage returns the default K8s node image id for a given provider and region.
+// The default is defined as the first entry of the available list in the nodeImage section of
+// k8sclusterinfo.yaml. Returns ("", nil) when no nodeImage section is defined for the CSP/region
+// (e.g. NHN uses dynamic UUIDs) — callers should fall back to Spider delegation in that case.
+func GetK8sDefaultNodeImage(providerName, regionName string) (string, error) {
+	available, err := GetAvailableK8sNodeImage(providerName, regionName)
+	if err != nil || available == nil || len(*available) == 0 {
+		return "", nil // nodeImage not defined for this CSP/region → Spider fallback
+	}
+	return (*available)[0].Id, nil // first entry = default
+}
+
 // GetK8sNodeGroupsOnK8sCreation is func to get whether nodegroups are required during the k8scluster creation
 func GetK8sNodeGroupsOnK8sCreation(providerName string) (bool, error) {
 	//
@@ -1863,19 +1875,6 @@ func GetK8sInitialNodeGroupManagedByCluster(providerName string) (bool, error) {
 	}
 
 	return k8sClusterDetail.InitialNodeGroupManagedByCluster, nil
-}
-
-// GetK8sMinNodeGroupCount returns the minimum number of node groups that must remain
-// in a cluster for the given provider. Returns 0 if there is no minimum constraint.
-func GetK8sMinNodeGroupCount(providerName string) (int, error) {
-	providerName = strings.ToLower(providerName)
-
-	k8sClusterDetail := getK8sClusterDetail(providerName)
-	if k8sClusterDetail == nil {
-		return 0, fmt.Errorf("unsupported provider(%s) for kubernetes cluster", providerName)
-	}
-
-	return k8sClusterDetail.MinNodeGroupCount, nil
 }
 
 // GetK8sNodeGroupNamingRule is func to get nodegroup's naming rule

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -1865,6 +1865,19 @@ func GetK8sInitialNodeGroupManagedByCluster(providerName string) (bool, error) {
 	return k8sClusterDetail.InitialNodeGroupManagedByCluster, nil
 }
 
+// GetK8sMinNodeGroupCount returns the minimum number of node groups that must remain
+// in a cluster for the given provider. Returns 0 if there is no minimum constraint.
+func GetK8sMinNodeGroupCount(providerName string) (int, error) {
+	providerName = strings.ToLower(providerName)
+
+	k8sClusterDetail := getK8sClusterDetail(providerName)
+	if k8sClusterDetail == nil {
+		return 0, fmt.Errorf("unsupported provider(%s) for kubernetes cluster", providerName)
+	}
+
+	return k8sClusterDetail.MinNodeGroupCount, nil
+}
+
 // GetK8sNodeGroupNamingRule is func to get nodegroup's naming rule
 func GetK8sNodeGroupNamingRule(providerName string) (string, error) {
 	//

--- a/src/core/model/config.go
+++ b/src/core/model/config.go
@@ -203,10 +203,8 @@ type K8sClusterDetail struct {
 	NodeImageDesignation             bool                        `mapstructure:"nodeImageDesignation" json:"node_image_designation"`
 	RequiredSubnetCount              int                         `mapstructure:"requiredSubnetCount" json:"required_subnet_count"`
 	NodeGroupNamingRule              string                      `mapstructure:"nodeGroupNamingRule" json:"nodegroup_naming_rule"`
-	// InitialNodeGroupManagedByCluster indicates that the initial node group created during
-	// cluster creation is lifecycle-bound to the cluster and cannot be deleted independently
-	// via the node group API (e.g., Alibaba ACK, Tencent TKE).
 	InitialNodeGroupManagedByCluster bool                        `mapstructure:"initialNodeGroupManagedByCluster" json:"initial_nodegroup_managed_by_cluster"`
+	MinNodeGroupCount                int                         `mapstructure:"minNodeGroupCount" json:"min_nodegroup_count"`
 	Version                          []K8sClusterVersionDetail   `mapstructure:"version" json:"versions"`
 	NodeImage                        []K8sClusterNodeImageDetail `mapstructure:"nodeImage" json:"node_images"`
 	RootDisk                         []K8sClusterRootDiskDetail  `mapstructure:"rootDisk" json:"root_disks"`

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -425,16 +425,8 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 		} else {
 			// CSP supports image designation (e.g., AWS, GCP, Alibaba, NHN, Tencent)
 			if v.ImageId == "" || v.ImageId == "default" {
-				// Resolve default node image from k8sclusterinfo.yaml nodeImage section.
-				// Falls back to "" (Spider delegation) for CSPs without a static nodeImage entry (e.g. NHN).
-				defaultImg, imgErr := common.GetK8sDefaultNodeImage(connConfig.ProviderName, connConfig.RegionDetail.RegionName)
-				if imgErr == nil && defaultImg != "" {
-					spImgName = defaultImg
-					log.Info().Msgf("Using default K8s node image: %s (k8sclusterinfo.yaml)", spImgName)
-				} else {
-					spImgName = ""
-					log.Info().Msgf("nodeImage not defined for provider(%s), Spider will apply its own default", connConfig.ProviderName)
-				}
+				// Leave empty; the Spider driver will apply its own default for the given provider.
+				spImgName = ""
 			} else {
 				spImgName, err = GetCspResourceName(nsId, model.StrImage, v.ImageId)
 				if spImgName == "" || err != nil {
@@ -728,16 +720,8 @@ func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *m
 	} else {
 		// CSP supports image designation (e.g., AWS, GCP, Alibaba, NHN, Tencent)
 		if u.ImageId == "" || u.ImageId == "default" {
-			// Resolve default node image from k8sclusterinfo.yaml nodeImage section.
-			// Falls back to "" (Spider delegation) for CSPs without a static nodeImage entry (e.g. NHN).
-			defaultImg, imgErr := common.GetK8sDefaultNodeImage(connConfig.ProviderName, connConfig.RegionDetail.RegionName)
-			if imgErr == nil && defaultImg != "" {
-				spImgName = defaultImg
-				log.Info().Msgf("Using default K8s node image: %s (k8sclusterinfo.yaml)", spImgName)
-			} else {
-				spImgName = ""
-				log.Info().Msgf("nodeImage not defined for provider(%s), Spider will apply its own default", connConfig.ProviderName)
-			}
+			// Leave empty; the Spider driver will apply its own default for the given provider.
+			spImgName = ""
 		} else {
 			spImgName, err = GetCspResourceName(nsId, model.StrImage, u.ImageId)
 			if spImgName == "" || err != nil {
@@ -908,7 +892,6 @@ func RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, option string) (bo
 				}
 			}
 		}
-
 	}
 
 	// Create Request body for RemoveK8sNodeGroup of CB-Spider
@@ -2404,3 +2387,4 @@ func validateK8sImageForProvider(nsId, providerName, imageId string) error {
 	}
 	return nil
 }
+

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -892,6 +892,17 @@ func RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, option string) (bo
 				}
 			}
 		}
+
+		// Enforce minimum node group count constraint for CSPs that require at least
+		// N node groups to remain in a cluster (e.g., Azure AKS, GCP GKE).
+		if minCount, _ := common.GetK8sMinNodeGroupCount(ngConnConfig.ProviderName); minCount > 0 {
+			if len(tbK8sCInfo.K8sNodeGroupList) <= minCount {
+				return false, fmt.Errorf(
+					"cannot delete node group '%s' from cluster '%s': provider '%s' requires at least %d node group(s) to remain",
+					k8sNodeGroupName, k8sClusterId, ngConnConfig.ProviderName, minCount,
+				)
+			}
+		}
 	}
 
 	// Create Request body for RemoveK8sNodeGroup of CB-Spider

--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -425,8 +425,16 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 		} else {
 			// CSP supports image designation (e.g., AWS, GCP, Alibaba, NHN, Tencent)
 			if v.ImageId == "" || v.ImageId == "default" {
-				// Leave empty; the Spider driver will apply its own default for the given provider.
-				spImgName = ""
+				// Resolve default node image from k8sclusterinfo.yaml nodeImage section.
+				// Falls back to "" (Spider delegation) for CSPs without a static nodeImage entry (e.g. NHN).
+				defaultImg, imgErr := common.GetK8sDefaultNodeImage(connConfig.ProviderName, connConfig.RegionDetail.RegionName)
+				if imgErr == nil && defaultImg != "" {
+					spImgName = defaultImg
+					log.Info().Msgf("Using default K8s node image: %s (k8sclusterinfo.yaml)", spImgName)
+				} else {
+					spImgName = ""
+					log.Info().Msgf("nodeImage not defined for provider(%s), Spider will apply its own default", connConfig.ProviderName)
+				}
 			} else {
 				spImgName, err = GetCspResourceName(nsId, model.StrImage, v.ImageId)
 				if spImgName == "" || err != nil {
@@ -720,8 +728,16 @@ func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *m
 	} else {
 		// CSP supports image designation (e.g., AWS, GCP, Alibaba, NHN, Tencent)
 		if u.ImageId == "" || u.ImageId == "default" {
-			// Leave empty; the Spider driver will apply its own default for the given provider.
-			spImgName = ""
+			// Resolve default node image from k8sclusterinfo.yaml nodeImage section.
+			// Falls back to "" (Spider delegation) for CSPs without a static nodeImage entry (e.g. NHN).
+			defaultImg, imgErr := common.GetK8sDefaultNodeImage(connConfig.ProviderName, connConfig.RegionDetail.RegionName)
+			if imgErr == nil && defaultImg != "" {
+				spImgName = defaultImg
+				log.Info().Msgf("Using default K8s node image: %s (k8sclusterinfo.yaml)", spImgName)
+			} else {
+				spImgName = ""
+				log.Info().Msgf("nodeImage not defined for provider(%s), Spider will apply its own default", connConfig.ProviderName)
+			}
 		} else {
 			spImgName, err = GetCspResourceName(nsId, model.StrImage, u.ImageId)
 			if spImgName == "" || err != nil {
@@ -893,16 +909,6 @@ func RemoveK8sNodeGroup(nsId, k8sClusterId, k8sNodeGroupName, option string) (bo
 			}
 		}
 
-		// Enforce minimum node group count constraint for CSPs that require at least
-		// N node groups to remain in a cluster (e.g., Azure AKS, GCP GKE).
-		if minCount, _ := common.GetK8sMinNodeGroupCount(ngConnConfig.ProviderName); minCount > 0 {
-			if len(tbK8sCInfo.K8sNodeGroupList) <= minCount {
-				return false, fmt.Errorf(
-					"cannot delete node group '%s' from cluster '%s': provider '%s' requires at least %d node group(s) to remain",
-					k8sNodeGroupName, k8sClusterId, ngConnConfig.ProviderName, minCount,
-				)
-			}
-		}
 	}
 
 	// Create Request body for RemoveK8sNodeGroup of CB-Spider
@@ -2398,4 +2404,3 @@ func validateK8sImageForProvider(nsId, providerName, imageId string) error {
 	}
 	return nil
 }
-


### PR DESCRIPTION
## Summary

Add `minNodeGroupCount` to `k8sclusterinfo.yaml` to prevent deletion of the last node group on CSPs that require at least one node group to remain at all times.


## Changes

- Added `minNodeGroupCount` field to `assets/k8sclusterinfo.yaml` (`azure: 1`, `gcp: 1`) and `K8sClusterDetail` struct; added `GetK8sMinNodeGroupCount()` in `utility.go` and a pre-check in `RemoveK8sNodeGroup` that blocks deletion at the TB level before reaching CB-Spider, returning a clear error instead of an opaque CSP 400 response

- Unlike the existing `initialNodeGroupManagedByCluster` constraint (Alibaba ACK / Tencent TKE — first node group cannot be deleted independently), `minNodeGroupCount` applies regardless of which node group is last; CSPs with no constraint default to `0` (no-op, backward compatible)

- Tested on **AWS, Azure, GCP** via test CLI and cb-mapui: cluster create → node group add/delete → cluster delete all passed; `minNodeGroupCount` guard correctly skips last node group deletion on Azure and GCP, leaving cleanup to cluster deletion

## Reference

- **Azure AKS constraint**: `OperationNotAllowed: "There has to be at least one agent pool."` (ref: [AKS node pool limitations](https://learn.microsoft.com/en-us/azure/aks/manage-node-pools)) 
- **GCP GKE constraint**: `code=400: Node pool is the last node pool in the cluster` (ref: [GKE delete node pool](https://cloud.google.com/kubernetes-engine/docs/how-to/node-pools#deleting_a_node_pool))
