### PR TITLE
Enhance Azure node control by direct call

### DIFF
--- a/src/core/csp/azure/vmcontrol.go
+++ b/src/core/csp/azure/vmcontrol.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
+	"github.com/cloud-barista/cb-tumblebug/src/core/model"
+	csptypes "github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
+	"github.com/rs/zerolog/log"
+)
+
+func init() {
+	csp.RegisterBatchVMControlHandlers(csptypes.Azure, csp.BatchVMControlHandlers{
+		Suspend: BatchSuspendInstances,
+		Resume:  BatchResumeInstances,
+		Reboot:  BatchRebootInstances,
+	})
+}
+
+// Terminate is intentionally not registered here: unlike the OS disk (created with
+// DeleteOption=Delete), the NIC and Public IP are not cascade-deleted when the VM
+// is deleted, so a correct Terminate needs the same follow-up NIC/PublicIP cleanup
+// CB-Spider's driver already does. Suspend/Resume/Reboot have no such cleanup
+// concern — they only change power state — so they are safe to bypass CB-Spider for.
+
+// azureControlConcurrency bounds concurrent Suspend/Resume/Reboot calls per batch, mirroring
+// azureStatusConcurrency in vmstatus.go: Azure has no batch control API, so each VM
+// requires an individual REST call, and an unbounded fan-out risks HTTP 429s.
+const azureControlConcurrency = 20
+
+// runBatchControl issues fn for each instance ARM ID (bounded by azureControlConcurrency)
+// and collects successes into a map of armID -> resultStatus. Failed instances are
+// omitted from the result map, matching BatchVMControlFunc's documented contract.
+func runBatchControl(ctx context.Context, instanceIds []string, resultStatus string,
+	fn func(ctx context.Context, vmClient *armcompute.VirtualMachinesClient, parts azureArmIDParts) error) (map[string]string, error) {
+
+	if len(instanceIds) == 0 {
+		return map[string]string{}, nil
+	}
+
+	creds, err := getCreds(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Azure vmcontrol: cannot get credentials: %w", err)
+	}
+	vmClient, err := getOrCreateVMClient(creds)
+	if err != nil {
+		return nil, fmt.Errorf("Azure vmcontrol: failed to get VM client: %w", err)
+	}
+
+	type ctrlResult struct {
+		armID string
+		err   error
+	}
+	ch := make(chan ctrlResult, len(instanceIds))
+	sem := make(chan struct{}, azureControlConcurrency)
+
+	var wg sync.WaitGroup
+	for _, armID := range instanceIds {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			parts, perr := parseAzureArmID(id)
+			if perr != nil {
+				ch <- ctrlResult{armID: id, err: perr}
+				return
+			}
+			ch <- ctrlResult{armID: id, err: fn(ctx, vmClient, parts)}
+		}(armID)
+	}
+	wg.Wait()
+	close(ch)
+
+	result := make(map[string]string, len(instanceIds))
+	var firstErr error
+	for r := range ch {
+		if r.err != nil {
+			if firstErr == nil {
+				firstErr = r.err
+			}
+			continue
+		}
+		result[r.armID] = resultStatus
+	}
+	if firstErr != nil && len(result) == 0 {
+		return nil, fmt.Errorf("Azure vmcontrol: all requests failed; first error: %w", firstErr)
+	}
+	return result, nil
+}
+
+// BatchSuspendInstances issues BeginPowerOff for each VM and returns immediately after
+// Azure accepts the request — it does not wait for the power-off to complete (unlike
+// CB-Spider's driver, which blocks on PollUntilDone). Completion is picked up by the
+// existing status poller (BatchDescribeInstanceStatuses) on its normal cadence.
+func BatchSuspendInstances(ctx context.Context, region string, instanceIds []string) (map[string]string, error) {
+	result, err := runBatchControl(ctx, instanceIds, model.StatusSuspending,
+		func(ctx context.Context, vmClient *armcompute.VirtualMachinesClient, parts azureArmIDParts) error {
+			_, err := vmClient.BeginPowerOff(ctx, parts.resourceGroup, parts.vmName, nil)
+			return err
+		})
+	if err == nil {
+		log.Debug().Str("region", region).Int("sent", len(instanceIds)).Int("accepted", len(result)).
+			Msg("[Azure] BatchSuspendInstances completed")
+	}
+	return result, err
+}
+
+// BatchResumeInstances issues BeginStart for each VM and returns immediately after
+// Azure accepts the request, for the same reason described in BatchSuspendInstances.
+func BatchResumeInstances(ctx context.Context, region string, instanceIds []string) (map[string]string, error) {
+	result, err := runBatchControl(ctx, instanceIds, model.StatusResuming,
+		func(ctx context.Context, vmClient *armcompute.VirtualMachinesClient, parts azureArmIDParts) error {
+			_, err := vmClient.BeginStart(ctx, parts.resourceGroup, parts.vmName, nil)
+			return err
+		})
+	if err == nil {
+		log.Debug().Str("region", region).Int("sent", len(instanceIds)).Int("accepted", len(result)).
+			Msg("[Azure] BatchResumeInstances completed")
+	}
+	return result, err
+}
+
+// BatchRebootInstances issues BeginRestart for each VM and returns immediately after
+// Azure accepts the request, for the same reason described in BatchSuspendInstances.
+// BeginRestart is Azure's native soft-reboot operation, not a Stop+Start cycle.
+func BatchRebootInstances(ctx context.Context, region string, instanceIds []string) (map[string]string, error) {
+	result, err := runBatchControl(ctx, instanceIds, model.StatusRebooting,
+		func(ctx context.Context, vmClient *armcompute.VirtualMachinesClient, parts azureArmIDParts) error {
+			_, err := vmClient.BeginRestart(ctx, parts.resourceGroup, parts.vmName, nil)
+			return err
+		})
+	if err == nil {
+		log.Debug().Str("region", region).Int("sent", len(instanceIds)).Int("accepted", len(result)).
+			Msg("[Azure] BatchRebootInstances completed")
+	}
+	return result, err
+}

--- a/src/core/csp/csp.go
+++ b/src/core/csp/csp.go
@@ -72,11 +72,11 @@ func GetBatchVMStatusHandler(provider string) (BatchVMStatusFunc, bool) {
 type BatchVMControlFunc func(ctx context.Context, region string, instanceIds []string) (map[string]string, error)
 
 // BatchVMControlHandlers groups bulk lifecycle control functions for a CSP.
-// Reboot is excluded — it is rare, order-sensitive, and not cost-effective to batch.
 type BatchVMControlHandlers struct {
 	Suspend   BatchVMControlFunc // e.g. AWS StopInstances
 	Resume    BatchVMControlFunc // e.g. AWS StartInstances
 	Terminate BatchVMControlFunc // e.g. AWS TerminateInstances
+	Reboot    BatchVMControlFunc // e.g. Azure BeginRestart
 }
 
 var (
@@ -93,7 +93,7 @@ func RegisterBatchVMControlHandlers(provider string, h BatchVMControlHandlers) {
 }
 
 // GetBatchVMControlHandler returns the bulk control function for the given provider and action.
-// action is case-insensitive: "suspend", "resume", or "terminate".
+// action is case-insensitive: "suspend", "resume", "terminate", or "reboot".
 func GetBatchVMControlHandler(provider, action string) (BatchVMControlFunc, bool) {
 	batchVMControlMu.RLock()
 	defer batchVMControlMu.RUnlock()
@@ -108,6 +108,8 @@ func GetBatchVMControlHandler(provider, action string) (BatchVMControlFunc, bool
 		return h.Resume, h.Resume != nil
 	case "terminate":
 		return h.Terminate, h.Terminate != nil
+	case "reboot":
+		return h.Reboot, h.Reboot != nil
 	default:
 		return nil, false
 	}

--- a/src/core/infra/control.go
+++ b/src/core/infra/control.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/core/resource"
+	"github.com/go-resty/resty/v2"
 	"github.com/rs/zerolog/log"
 )
 
@@ -534,7 +535,7 @@ func ControlNodesInParallel(nsId, infraId string, nodeList []string, action stri
 		}
 
 		// Register as bulk-eligible if the CSP has a bulk handler and the node has a CSP resource ID.
-		if action != model.ActionReboot && nodeInfo.CspResourceId != "" {
+		if nodeInfo.CspResourceId != "" {
 			if _, hasBulk := cspdirect.GetBatchVMControlHandler(providerName, action); hasBulk {
 				bulkEntries[nodeId] = bulkControlEntry{
 					nodeId:           nodeId,
@@ -592,34 +593,34 @@ func ControlNodesInParallel(nsId, infraId string, nodeList []string, action stri
 					defer func() { <-regionSemaphore }()
 
 					// Bulk SDK fast-path
-					// For Suspend/Resume/Terminate on CSPs with a registered bulk handler,
+					// For Suspend/Resume/Terminate/Reboot on CSPs with a registered bulk handler,
 					// send all nodes in this region in one (or a few) SDK call(s) instead
-					// of N individual Spider HTTP requests. Reboot always uses Spider.
-					spiderNodeIds := runBulkControlForRegion(nsId, infraId, providerName, regionName, nodeIdList, action, bulkEntries)
-					regionBulkHandled := len(nodeIdList) - len(spiderNodeIds)
-					nodeIdList = spiderNodeIds
+					// of N individual ControlNodeAsync dispatches.
+					individualNodeIds := runBulkControlForRegion(nsId, infraId, providerName, regionName, nodeIdList, action, bulkEntries)
+					regionBulkHandled := len(nodeIdList) - len(individualNodeIds)
+					nodeIdList = individualNodeIds
 					// End bulk SDK fast-path
 
-					// Pre-set transitional status for all Spider-path nodes before the
-					// semaphore-limited goroutines start. Without this, nodes waiting behind
+					// Pre-set transitional status for all individually-dispatched nodes before
+					// the semaphore-limited goroutines start. Without this, nodes waiting behind
 					// the semaphore continue to show their old status (Running/None/None)
 					// until ControlNodeAsync actually runs for them — which can take minutes
 					// on large Infras. This mirrors what applyBulkTransitionalStatus does
 					// for bulk-SDK nodes.
-					if action != model.ActionReboot {
-						for _, nodeId := range nodeIdList {
-							nodeObj, gerr := GetNodeObject(nsId, infraId, nodeId)
-							if gerr != nil {
-								continue
-							}
-							applyBulkTransitionalStatus(nsId, infraId, bulkControlEntry{
-								nodeId:   nodeId,
-								nodeInfo: nodeObj,
-							}, action)
+					for _, nodeId := range nodeIdList {
+						nodeObj, gerr := GetNodeObject(nsId, infraId, nodeId)
+						if gerr != nil {
+							continue
 						}
+						applyBulkTransitionalStatus(nsId, infraId, bulkControlEntry{
+							nodeId:   nodeId,
+							nodeInfo: nodeObj,
+						}, action)
 					}
 
-					// Step 4: Process remaining VMs via Spider with rate limiting
+					// Step 4: Process remaining VMs individually (ControlNodeAsync uses a direct-SDK
+					// call when one is registered for this provider+action, falling back to Spider
+					// otherwise), with rate limiting
 					nodeSemaphore := make(chan struct{}, maxNodesForRegion)
 					var nodeWg sync.WaitGroup
 					var nodeMutex sync.Mutex
@@ -715,14 +716,16 @@ func ControlNodesInParallel(nsId, infraId string, nodeList []string, action stri
 
 // runBulkControlForRegion sends a bulk SDK control action for all bulk-eligible nodes in one
 // region, grouped further by credentialHolder. Returns the node IDs that were NOT handled by
-// the bulk SDK (no handler registered, missing CspResourceId, or SDK call failed) so that
-// the caller can route them through the Spider per-node path.
+// the bulk SDK (no handler registered, missing CspResourceId, individual SDK call failed, or
+// whole SDK call failed) so that the caller can dispatch them individually via ControlNodeAsync
+// — which itself prefers the same direct-SDK handler when one exists, only actually falling
+// back to Spider for CSPs/actions with no direct handler registered.
 func runBulkControlForRegion(
 	nsId, infraId, providerName, regionName string,
 	nodeIdList []string,
 	action string,
 	bulkEntries map[string]bulkControlEntry,
-) (spiderFallback []string) {
+) (individualDispatch []string) {
 	handler, hasBulk := cspdirect.GetBatchVMControlHandler(providerName, action)
 	if !hasBulk {
 		return nodeIdList // no handler registered for this CSP+action
@@ -739,7 +742,7 @@ func runBulkControlForRegion(
 	for _, nodeId := range nodeIdList {
 		be, ok := bulkEntries[nodeId]
 		if !ok || be.cspResourceId == "" {
-			spiderFallback = append(spiderFallback, nodeId)
+			individualDispatch = append(individualDispatch, nodeId)
 			continue
 		}
 		k := groupKey{be.credentialHolder, be.cspRegion}
@@ -769,9 +772,9 @@ func runBulkControlForRegion(
 				Str("provider", providerName).
 				Str("region", hg.key.cspRegion).
 				Int("count", len(ids)).
-				Msgf("[BulkControl] %s SDK call failed; routing %d nodes to Spider fallback", action, len(ids))
+				Msgf("[BulkControl] %s SDK call failed; dispatching %d nodes individually", action, len(ids))
 			for _, be := range hg.entries {
-				spiderFallback = append(spiderFallback, be.nodeId)
+				individualDispatch = append(individualDispatch, be.nodeId)
 			}
 			continue
 		}
@@ -782,7 +785,13 @@ func runBulkControlForRegion(
 			idToEntry[be.cspResourceId] = be
 			newStatus, found := statuses[be.cspResourceId]
 			if !found {
-				newStatus = bulkTransitionalStatus(action)
+				// This VM's individual call within the batch was not accepted (the
+				// overall SDK call succeeded, but this instance was omitted from the
+				// result map). Dispatch it individually instead of assuming success —
+				// ControlNodeAsync retries via the same direct-SDK handler and correctly
+				// reports failure if it still doesn't succeed.
+				individualDispatch = append(individualDispatch, be.nodeId)
+				continue
 			}
 			globalStatusStore.Update(nsId, infraId, be.nodeId, func(e *StatusEntry) {
 				e.Status = newStatus
@@ -816,7 +825,7 @@ func runBulkControlForRegion(
 		}
 	}
 
-	return spiderFallback
+	return individualDispatch
 }
 
 // waitBulkTerminated polls the CSP until every instance in acceptedIds reports Terminated
@@ -892,6 +901,10 @@ func applyBulkTransitionalStatus(nsId, infraId string, be bulkControlEntry, acti
 		temp.TargetAction = model.ActionResume
 		temp.TargetStatus = model.StatusRunning
 		temp.Status = model.StatusResuming
+	case model.ActionReboot:
+		temp.TargetAction = model.ActionReboot
+		temp.TargetStatus = model.StatusRunning
+		temp.Status = model.StatusRebooting
 	}
 	UpdateNodeInfo(nsId, infraId, temp)
 	globalStatusStore.Update(nsId, infraId, be.nodeId, func(e *StatusEntry) {
@@ -901,21 +914,6 @@ func applyBulkTransitionalStatus(nsId, infraId string, be bulkControlEntry, acti
 		e.Priority = PollHigh
 		e.NextPollAt = time.Now()
 	})
-}
-
-// bulkTransitionalStatus returns the expected in-flight TB status for an action
-// when the CSP response does not include a per-instance status.
-func bulkTransitionalStatus(action string) string {
-	switch action {
-	case model.ActionSuspend:
-		return model.StatusSuspending
-	case model.ActionResume:
-		return model.StatusResuming
-	case model.ActionTerminate:
-		return model.StatusTerminating
-	default:
-		return model.StatusUndefined
-	}
 }
 
 // postBulkControlCleanup runs TB metadata cleanup after a successful bulk SDK control call.
@@ -1121,16 +1119,26 @@ func ControlNodeAsync(wg *sync.WaitGroup, nsId string, infraId string, nodeId st
 		e.NextPollAt = time.Now() // make PollHigh effective immediately
 	})
 
-	client := clientManager.NewHttpClient()
-	// NCP requires a slightly longer timeout due to its control plane characteristics
-	if csp.ResolveCloudPlatform(temp.ConnectionConfig.ProviderName) == csp.NCP {
-		client.SetTimeout(timeout + 10*time.Minute)
-	} else {
-		client.SetTimeout(timeout)
-	}
+	// Prefer a direct-SDK call over the Spider HTTP request when one is registered
+	// for this provider+action (e.g. Azure Suspend/Resume/Reboot) — this is also
+	// how nodes that fell through the bulk fast-path due to an individual failure
+	// (see runBulkControlForRegion's individualDispatch) get retried: they land
+	// here but still use the fast direct-SDK path rather than actually calling Spider.
+	directHandler, useDirect := cspdirect.GetBatchVMControlHandler(temp.ConnectionConfig.ProviderName, action)
+	useDirect = useDirect && temp.CspResourceId != ""
 
+	var client *resty.Client
 	requestBody := model.SpiderConnectionName{}
 	requestBody.ConnectionName = temp.ConnectionName
+	if !useDirect {
+		client = clientManager.NewHttpClient()
+		// NCP requires a slightly longer timeout due to its control plane characteristics
+		if csp.ResolveCloudPlatform(temp.ConnectionConfig.ProviderName) == csp.NCP {
+			client.SetTimeout(timeout + 10*time.Minute)
+		} else {
+			client.SetTimeout(timeout)
+		}
+	}
 
 	// Rate-limit concurrent Spider control calls to prevent RST storms at scale.
 	// Released immediately after the Spider call (before polling / cleanup) so the
@@ -1148,16 +1156,27 @@ func ControlNodeAsync(wg *sync.WaitGroup, nsId string, infraId string, nodeId st
 				nodeId, action, attempt, maxControlRetries+1, backoff, err)
 			time.Sleep(backoff)
 		}
-		_, err = clientManager.ExecuteHttpRequest(
-			client,
-			method,
-			url,
-			nil,
-			clientManager.SetUseBody(requestBody),
-			&requestBody,
-			&callResult,
-			clientManager.MediumDuration,
-		)
+		if useDirect {
+			sdkCtx := context.WithValue(context.Background(), model.CtxKeyCredentialHolder, temp.ConnectionConfig.CredentialHolder)
+			var statuses map[string]string
+			statuses, err = directHandler(sdkCtx, temp.ConnectionConfig.RegionDetail.RegionName, []string{temp.CspResourceId})
+			if err == nil {
+				if _, accepted := statuses[temp.CspResourceId]; !accepted {
+					err = fmt.Errorf("direct SDK call for %s did not accept VM %s", action, nodeId)
+				}
+			}
+		} else {
+			_, err = clientManager.ExecuteHttpRequest(
+				client,
+				method,
+				url,
+				nil,
+				clientManager.SetUseBody(requestBody),
+				&requestBody,
+				&callResult,
+				clientManager.MediumDuration,
+			)
+		}
 		if err == nil || !isTransientNetworkError(err) {
 			break
 		}


### PR DESCRIPTION
Current implementation of Azure VM instance suspend and resume by cb-spider
- requires too much pending before requesting it to Azure. (2 mins for each VM)
- this limit #2461 for CB-TB

This PR provide a thin layer to overcome pending situation especially for massive infra controls. (no pending at all)

Expected to reduce more than 10mins in a suspending operation for 100 VMs.

