### PR TITLE
update(compose): migrate CB-Spider to PostgreSQL metadata backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ POSTGRES_USER=tumblebug
 POSTGRES_PASSWORD=tumblebug
 POSTGRES_DB=tumblebug
 
+# CB-Spider PostgreSQL Credentials
+# Shared by cb-spider-postgres and cb-spider (SPIDER_METADB_URL).
+# CB-Spider stores its metadata here instead of the legacy SQLite meta_db.
+SP_POSTGRES_USER=spider
+SP_POSTGRES_PASSWORD=spider
+SP_POSTGRES_DB=cb_spider
+
 # CB-Tumblebug Metabase Dashboard
 # Admin account for Metabase web UI (http://localhost:3000)
 MB_ADMIN_EMAIL=admin1@your.org

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -140,7 +140,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-tumblebug}
       - POSTGRES_DB=${POSTGRES_DB:-tumblebug}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -148,7 +148,7 @@ services:
 
   # CB-Spider
   cb-spider:
-    image: cloudbaristaorg/cb-spider:0.12.35
+    image: cloudbaristaorg/cb-spider:0.12.37
     container_name: cb-spider
     # build:
     #   context: ../cb-spider
@@ -158,13 +158,16 @@ services:
     # Uncomment below if you want to access CB-Spider for remote
     # ports:
     #   - 1024:1024
+    depends_on:
+      cb-spider-postgres:
+        condition: service_healthy
     volumes:
-      - ./container-volume/cb-spider-container/meta_db/:/root/go/src/github.com/cloud-barista/cb-spider/meta_db/
       - ./container-volume/cb-spider-container/log/:/root/go/src/github.com/cloud-barista/cb-spider/log/
     environment:
       - SERVER_ADDRESS=0.0.0.0:1024
       - SPIDER_USERNAME=${SP_API_USERNAME:?Please set SP_API_USERNAME}
       - SPIDER_PASSWORD=${SP_API_PASSWORD:?Please set SP_API_PASSWORD}
+      - SPIDER_METADB_URL=postgresql://${SP_POSTGRES_USER:-spider}:${SP_POSTGRES_PASSWORD:-spider}@cb-spider-postgres:5432/${SP_POSTGRES_DB:-cb_spider}
       - SPIDER_LOG_LEVEL=error
       - SPIDER_HISCALL_LOG_LEVEL=error
       - ID_TRANSFORM_MODE=OFF
@@ -176,14 +179,37 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:1024/spider/readyz"]
       <<: *default-healthcheck
 
+  # CB-Spider PostgreSQL
+  # This is used for storing CB-Spider metadata (replaces the legacy SQLite-based meta_db).
+  cb-spider-postgres:
+    image: postgres:16-alpine
+    container_name: cb-spider-postgres
+    restart: always
+    networks:
+      - cloud-barista
+    # ports:
+    #   - 5433:5432  # Uncomment for direct DB access (pgAdmin, debugging). Not recommended in production.
+    volumes:
+      - ./container-volume/cb-spider-container/meta_db/postgres:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=${SP_POSTGRES_USER:-spider}
+      - POSTGRES_PASSWORD=${SP_POSTGRES_PASSWORD:-spider}
+      - POSTGRES_DB=${SP_POSTGRES_DB:-cb_spider}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   # CB-MapUI
   # This is the Map-based client for CB-Tumblebug.
   cb-mapui:
     image: cloudbaristaorg/cb-mapui:0.12.51
     container_name: cb-mapui
-    # build:
-    #   context: ../cb-mapui
-    #   dockerfile: Dockerfile
+    build:
+      context: ../cb-mapui
+      dockerfile: Dockerfile
     networks:
       - cloud-barista
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -207,9 +207,9 @@ services:
   cb-mapui:
     image: cloudbaristaorg/cb-mapui:0.12.51
     container_name: cb-mapui
-    build:
-      context: ../cb-mapui
-      dockerfile: Dockerfile
+    # build:
+    #   context: ../cb-mapui
+    #   dockerfile: Dockerfile
     networks:
       - cloud-barista
     ports:

--- a/scripts/backup-assets.sh
+++ b/scripts/backup-assets.sh
@@ -83,13 +83,13 @@ echo ""
 # Get database statistics
 echo -e "${YELLOW}Database Statistics:${NC}"
 docker exec "$CONTAINER_NAME" psql -U "$DB_USER" -d "$DB_NAME" -c "
-SELECT 
+SELECT
     schemaname,
-    tablename,
-    pg_size_pretty(pg_total_relation_size(schemaname||'.'||tablename)) AS size,
+    relname AS tablename,
+    pg_size_pretty(pg_total_relation_size(schemaname||'.'||relname)) AS size,
     n_tup_ins AS inserts
 FROM pg_stat_user_tables
-ORDER BY pg_total_relation_size(schemaname||'.'||tablename) DESC;
+ORDER BY pg_total_relation_size(schemaname||'.'||relname) DESC;
 " 2>/dev/null || true
 
 echo ""

--- a/scripts/restore-assets.sh
+++ b/scripts/restore-assets.sh
@@ -136,13 +136,13 @@ echo ""
 # Get restored database statistics
 echo -e "${YELLOW}Restored Database Statistics:${NC}"
 docker exec "$CONTAINER_NAME" psql -U "$DB_USER" -d "$DB_NAME" -c "
-SELECT 
-    schemaname,
-    tablename,
-    pg_size_pretty(pg_total_relation_size(schemaname||'.'||tablename)) AS size,
-    (SELECT COUNT(*) FROM pg_catalog.pg_class WHERE relname = tablename) AS exists
-FROM pg_stat_user_tables
-ORDER BY pg_total_relation_size(schemaname||'.'||tablename) DESC;
+SELECT
+    t.schemaname,
+    t.relname AS tablename,
+    pg_size_pretty(pg_total_relation_size(t.schemaname||'.'||t.relname)) AS size,
+    (SELECT COUNT(*) FROM pg_catalog.pg_class c WHERE c.relname = t.relname) AS exists
+FROM pg_stat_user_tables t
+ORDER BY pg_total_relation_size(t.schemaname||'.'||t.relname) DESC;
 " 2>/dev/null || true
 
 echo ""


### PR DESCRIPTION
- Add cb-spider-postgres service replacing SQLite meta_db
- Update CB-Spider to v0.12.37 with PostgreSQL connection
- Add PostgreSQL credentials to .env.example for CB-Spider
- Fix backup/restore scripts SQL queries for PostgreSQL stats

---

I am opening this as a Draft PR to verify the following.
For more details, please refer to the changes.

Note - The test to create infrastructure on AWS in MapUI has passed.

@seokho-son 
**Is it okay to upgrade to Spider v0.12.37?**

@powerkimhub 
**I suggest improving environment variables to prevent special character encoding errors.**
Is this possible?

(As-Is)
```
- SPIDER_METADB_URL=postgresql://${SP_POSTGRES_USER:-spider}:${SP_POSTGRES_PASSWORD:-spider}@cb-spider-postgres:5432/${SP_POSTGRES_DB:-cb_spider}
```

(To-Be)
```
- SPIDER_POSTGRES_ENDPOINT=cb-spider-postgres:5432
- SPIDER_POSTGRES_DATABASE=${SP_POSTGRES_DB:-cb_spider}
- SPIDER_POSTGRES_USER=${SP_POSTGRES_USER:-spider}
- SPIDER_POSTGRES_PASSWORD=${SP_POSTGRES_PASSWORD:-spider}
```

@seokho-son 
Please, review the script changes.

The updates are to resolve the following issue.

```
cb-tumblebug-postgres | 2026-07-21 02:11:14.343 UTC [70] FATAL: terminating connection due to administrator command
cb-tumblebug-postgres | 2026-07-21 02:11:14.343 UTC [120] FATAL: terminating connection due to administrator command
cb-tumblebug-postgres | 2026-07-21 02:11:14.344 UTC [118] FATAL: terminating connection due to administrator command
cb-tumblebug-postgres | 2026-07-21 02:11:14.343 UTC [119] FATAL: terminating connection due to administrator command
cb-tumblebug-postgres | 2026-07-21 02:11:14.442 UTC [56] LOG: checkpoint starting: immediate force wait
cb-tumblebug-postgres | 2026-07-21 02:11:14.506 UTC [56] LOG: checkpoint complete: wrote 43 buffers (0.3%); 1 WAL file(s) added, 0 removed, 0 recycled; write=0.006 s, sync=0.008 s, total=0.064 s; sync files=12, longest=0.003 s, average=0.001 s; distance=6228 kB, estimate=6228 kB; lsn=0/1F33D70, redo lsn=0/1F33D38
cb-tumblebug-postgres | 2026-07-21 02:11:26.653 UTC [186] ERROR: column "tablename" does not exist at character 30
cb-tumblebug-postgres | 2026-07-21 02:11:26.653 UTC [186] STATEMENT:
cb-tumblebug-postgres | SELECT
cb-tumblebug-postgres | schemaname,
cb-tumblebug-postgres | tablename,
cb-tumblebug-postgres | pg_size_pretty(pg_total_relation_size(schemaname||'.'||tablename)) AS size;
cb-tumblebug-postgres | (SELECT COUNT(*) FROM pg_catalog.pg_class WHERE relname = tablename) AS exists
cb-tumblebug-postgres | FROM pg_stat_user_tables
cb-tumblebug-postgres | ORDER BY pg_total_relation_size(schemaname||'.'||tablename) DESC;
cb-tumblebug-postgres |
```
