### PR TITLE
Enhance node status for register and reconcile

### DIFF
--- a/src/core/infra/control.go
+++ b/src/core/infra/control.go
@@ -1459,12 +1459,40 @@ func CheckAllowedTransition(nsId string, infraId string, nodeId model.OptionalPa
 // crashed/restarted server typically leaves behind.
 func transientNodeStatus(status string) bool {
 	return strings.EqualFold(status, model.StatusCreating) ||
+		strings.EqualFold(status, model.StatusRegistering) ||
+		strings.EqualFold(status, model.StatusReconciling) ||
 		strings.EqualFold(status, model.StatusTerminating) ||
 		strings.EqualFold(status, model.StatusSuspending) ||
 		strings.EqualFold(status, model.StatusResuming) ||
 		strings.EqualFold(status, model.StatusRebooting) ||
 		strings.EqualFold(status, model.StatusUndefined) ||
 		status == ""
+}
+
+// isDiscoveryAction reports whether a TargetAction is discovery-type (Register /
+// Reconcile): its target is the resource's actual CSP state, not a fixed Running.
+// Completion is therefore observation-based (see FetchNodeStatus late-binding).
+func isDiscoveryAction(action string) bool {
+	return strings.EqualFold(action, model.ActionRegister) ||
+		strings.EqualFold(action, model.ActionReconcile)
+}
+
+// discoveryTransientStatus maps a discovery-type action to the operational status
+// held while the CSP state is still unresolved.
+func discoveryTransientStatus(action string) string {
+	if strings.EqualFold(action, model.ActionReconcile) {
+		return model.StatusReconciling
+	}
+	return model.StatusRegistering
+}
+
+// isStableObservedStatus reports whether status is a live, manageable CSP state that
+// a discovery-type action can successfully complete on. Terminated/Terminating are
+// deliberately excluded: a dying/soon-purged resource is not a valid onboarding target
+// and is settled as Failed instead (see FetchNodeStatus discovery handling).
+func isStableObservedStatus(status string) bool {
+	return strings.EqualFold(status, model.StatusRunning) ||
+		strings.EqualFold(status, model.StatusSuspended)
 }
 
 // settleInfraTargetAction clears Infra-level TargetAction/TargetStatus once
@@ -1781,6 +1809,17 @@ func reconcileInfraForward(nsId, infraId string) (string, error) {
 
 		postCh := make(chan fetchResult, len(rescuedIds))
 		for _, id := range rescuedIds {
+			// Move the rescued node into the Reconciling operational state before the
+			// follow-up status fetch. Without this the node is still Failed (a stable
+			// state) and FetchNodeStatus would short-circuit the CSP call, leaving the
+			// status stale. ActionReconcile is discovery-type, so the fetch late-binds
+			// TargetStatus to the actual CSP state (Running, Suspended, ...).
+			if nodeObj, gerr := GetNodeObject(nsId, infraId, id); gerr == nil {
+				nodeObj.Status = model.StatusReconciling
+				nodeObj.TargetAction = model.ActionReconcile
+				nodeObj.TargetStatus = model.StatusRunning
+				UpdateNodeInfo(nsId, infraId, nodeObj)
+			}
 			go func(nid string) {
 				fetched, ferr := FetchNodeStatus(nsId, infraId, nid)
 				postCh <- fetchResult{nodeId: nid, status: fetched.Status, err: ferr}

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -1158,8 +1158,8 @@ func GetInfraStatus(nsId string, infraId string) (*model.InfraStatusInfo, error)
 		return infraStatus.Node[i].Id < infraStatus.Node[j].Id
 	})
 
-	statusFlag := []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-	statusFlagStr := []string{model.StatusFailed, model.StatusSuspended, model.StatusRunning, model.StatusTerminated, model.StatusCreating, model.StatusSuspending, model.StatusResuming, model.StatusRebooting, model.StatusTerminating, model.StatusRegistering, model.StatusUndefined}
+	statusFlag := []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	statusFlagStr := []string{model.StatusFailed, model.StatusSuspended, model.StatusRunning, model.StatusTerminated, model.StatusCreating, model.StatusSuspending, model.StatusResuming, model.StatusRebooting, model.StatusTerminating, model.StatusRegistering, model.StatusUndefined, model.StatusReconciling}
 	for _, v := range infraStatus.Node {
 
 		switch v.Status {
@@ -1183,6 +1183,8 @@ func GetInfraStatus(nsId string, infraId string) (*model.InfraStatusInfo, error)
 			statusFlag[8]++
 		case model.StatusRegistering:
 			statusFlag[9]++
+		case model.StatusReconciling:
+			statusFlag[11]++
 		case model.StatusUndefined:
 			statusFlag[10]++
 			log.Debug().Msgf("Node %s in Infra %s has Undefined status (orphan candidate; run action=reconcile to rescue or action=refine to remove)", v.Id, infraId)
@@ -1212,6 +1214,8 @@ func GetInfraStatus(nsId string, infraId string) (*model.InfraStatusInfo, error)
 	// server crash) and is not authoritative here; rely on TargetAction/TargetStatus, which are
 	// kept current by control actions (Create/Continue/Withdraw/Refine/etc.).
 	isCreating := strings.Contains(infraTmp.TargetAction, model.ActionCreate) ||
+		strings.Contains(infraTmp.TargetAction, model.ActionRegister) ||
+		strings.Contains(infraTmp.TargetAction, model.ActionReconcile) ||
 		strings.Contains(infraTmp.TargetStatus, model.StatusRunning)
 
 	// Check if Infra is in a stable state (all Nodes have same stable status)
@@ -1291,6 +1295,7 @@ func GetInfraStatus(nsId string, infraId string) (*model.InfraStatusInfo, error)
 	infraStatus.StatusCount.CountTerminating = statusFlag[8]
 	infraStatus.StatusCount.CountRegistering = statusFlag[9]
 	infraStatus.StatusCount.CountUndefined = statusFlag[10]
+	infraStatus.StatusCount.CountReconciling = statusFlag[11]
 
 	// Recovery/fallback handling for TargetAction completion
 	// Primary completion should happen in actual control actions (control.go, provisioning.go)
@@ -1319,11 +1324,14 @@ func GetInfraStatus(nsId string, infraId string) (*model.InfraStatusInfo, error)
 		for _, v := range infraStatus.Node {
 			// Check completion based on action type
 			switch infraTargetAction {
-			case model.ActionCreate:
+			case model.ActionCreate, model.ActionRegister, model.ActionReconcile:
 				// Final states: Running, Failed, Terminated, Suspended, Undefined.
 				// Undefined means the creation attempt ended without VM identity (Spider 500);
 				// it is an orphan candidate handled by action=reconcile, not a pending state.
-				if v.Status == model.StatusCreating || v.Status == model.StatusRegistering || v.Status == "" {
+				// Register/Reconcile (discovery-type) share this shape: done once a node
+				// leaves its operational transient state, whatever the observed end state.
+				if v.Status == model.StatusCreating || v.Status == model.StatusRegistering ||
+					v.Status == model.StatusReconciling || v.Status == "" {
 					isDone = false
 					pendingNodesCount++
 				}
@@ -1420,7 +1428,7 @@ func GetInfraStatus(nsId string, infraId string) (*model.InfraStatusInfo, error)
 				}
 			}
 
-			if allNodesFailed && infraTargetAction == model.ActionCreate {
+			if allNodesFailed && (infraTargetAction == model.ActionCreate || isDiscoveryAction(infraTargetAction)) {
 				// All Nodes failed during creation - mark Infra as Failed
 				log.Error().Msgf("Infra %s: All Nodes failed during creation - setting Infra status to Failed", infraId)
 				infraStatus.TargetAction = model.ActionComplete
@@ -1915,8 +1923,11 @@ func FetchNodeStatus(nsId string, infraId string, nodeId string) (model.NodeStat
 		shouldSkipCSPCall = true
 	}
 
-	// Skip CSP API call if cspResourceName is empty (Node not properly created)
-	if nodeInfo.CspResourceName == "" && nodeInfo.TargetAction != model.ActionCreate {
+	// Skip CSP API call if cspResourceName is empty (Node not properly created).
+	// Create and discovery-type actions (Register/Reconcile) are exempt: their nodes
+	// may legitimately have an empty cspResourceName while still resolving.
+	if nodeInfo.CspResourceName == "" && nodeInfo.TargetAction != model.ActionCreate &&
+		!isDiscoveryAction(nodeInfo.TargetAction) {
 		// A Terminate action on a node that was never created at CSP (empty cspResourceName)
 		// has nothing to terminate — promote to Terminated immediately so the infra can proceed.
 		if nodeInfo.TargetAction == model.ActionTerminate {
@@ -1943,7 +1954,8 @@ func FetchNodeStatus(nsId string, infraId string, nodeId string) (model.NodeStat
 
 	cspResourceName := nodeInfo.CspResourceName
 
-	if (nodeInfo.TargetAction != model.ActionCreate && nodeInfo.TargetAction != model.ActionTerminate) && cspResourceName == "" {
+	if (nodeInfo.TargetAction != model.ActionCreate && nodeInfo.TargetAction != model.ActionTerminate &&
+		!isDiscoveryAction(nodeInfo.TargetAction)) && cspResourceName == "" {
 		err = fmt.Errorf("cspResourceName is empty (NodeId: %s)", nodeId)
 		log.Error().Err(err).Msg("")
 		return statusInfo, err
@@ -2189,6 +2201,15 @@ applyStatus:
 		}
 	}
 
+	// Discovery-type actions (Register/Reconcile): while the CSP state is not yet
+	// resolved (Undefined), hold the operational status (Registering/Reconciling)
+	// instead of flipping to Creating. The actual state is late-bound below once a
+	// recognized status is observed.
+	if isDiscoveryAction(nodeStatusTmp.TargetAction) &&
+		strings.EqualFold(callResult.Status, model.StatusUndefined) {
+		callResult.Status = discoveryTransientStatus(nodeStatusTmp.TargetAction)
+	}
+
 	// Fallback: if the CSP (or Spider) returned Undefined but the node already has a
 	// PublicIP, the CSP committed to creating the VM — preserve Creating to avoid a
 	// false Undefined flip while the VM is still booting or the CSP API is slow.
@@ -2300,6 +2321,24 @@ applyStatus:
 
 	// TODO: Alibaba Undefined status error is not resolved yet.
 	// (After Terminate action. "status": "Undefined", "targetStatus": "None", "targetAction": "None")
+
+	// Discovery-type actions (Register/Reconcile) have no fixed target. They complete
+	// once the resource resolves to a real end state:
+	//   - live (Running/Suspended): late-bind TargetStatus to it so the standard
+	//     finalization below (TargetStatus==Status) records the actual state.
+	//   - terminated/terminating: not a manageable target (and about to be purged by
+	//     the CSP) — settle directly as Failed so refine removes it, avoiding a ghost.
+	if isDiscoveryAction(nodeStatusTmp.TargetAction) {
+		if isStableObservedStatus(nodeStatusTmp.Status) {
+			nodeStatusTmp.TargetStatus = nodeStatusTmp.Status
+		} else if strings.EqualFold(nodeStatusTmp.Status, model.StatusTerminated) ||
+			strings.EqualFold(nodeStatusTmp.Status, model.StatusTerminating) {
+			nodeStatusTmp.Status = model.StatusFailed
+			nodeStatusTmp.TargetStatus = model.StatusComplete
+			nodeStatusTmp.TargetAction = model.ActionComplete
+			nodeStatusTmp.SystemMessage = "target CSP resource is terminated; cannot be managed (run refine to remove)"
+		}
+	}
 
 	//if TargetStatus == CurrentStatus, record to finialize the control operation
 	if nodeStatusTmp.TargetStatus == nodeStatusTmp.Status {

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -223,9 +223,18 @@ func createNodeGroup(ctx context.Context, nsId, infraId string, nodeRequest *mod
 }
 
 // createInfraObject creates the Infra object with proper error handling
-func createInfraObject(ctx context.Context, nsId, infraId string, req *model.InfraReq, uid string) error {
+func createInfraObject(ctx context.Context, nsId, infraId string, req *model.InfraReq, uid string, option string) error {
 	log.Info().Msg("Creating Infra object")
 	key := common.GenInfraKey(nsId, infraId, "")
+
+	// Register is a discovery-type action: keep the Infra-level TargetAction consistent
+	// with its Nodes (which use ActionRegister) so discovery-aware Infra logic triggers.
+	initStatus := model.StatusCreating
+	initTargetAction := model.ActionCreate
+	if option == "register" {
+		initStatus = model.StatusRegistering
+		initTargetAction = model.ActionRegister
+	}
 
 	infraInfo := model.InfraInfo{
 		ResourceType:    model.StrInfra,
@@ -233,8 +242,8 @@ func createInfraObject(ctx context.Context, nsId, infraId string, req *model.Inf
 		Name:            req.Name,
 		Uid:             uid,
 		Description:     req.Description,
-		Status:          model.StatusCreating,
-		TargetAction:    model.ActionCreate,
+		Status:          initStatus,
+		TargetAction:    initTargetAction,
 		TargetStatus:    model.StatusRunning,
 		InstallMonAgent: req.InstallMonAgent,
 		SystemLabel:     req.SystemLabel,
@@ -717,13 +726,16 @@ func CreateInfraGroupNode(ctx context.Context, nsId string, infraId string, node
 		nodeInfoData.PublicIP = ""
 		nodeInfoData.PublicDNS = ""
 
-		// Set initial status based on whether this is a registration (CspResourceId is set)
+		// Set initial status based on whether this is a registration (CspResourceId is set).
+		// Register is a discovery-type action (ActionRegister): its target is the resource's
+		// actual CSP state, resolved via late-binding in FetchNodeStatus.
 		if nodeRequest.CspResourceId != "" {
 			nodeInfoData.Status = model.StatusRegistering
+			nodeInfoData.TargetAction = model.ActionRegister
 		} else {
 			nodeInfoData.Status = model.StatusCreating
+			nodeInfoData.TargetAction = targetAction
 		}
-		nodeInfoData.TargetAction = targetAction
 		nodeInfoData.TargetStatus = targetStatus
 
 		nodeInfoData.ConnectionName = nodeRequest.ConnectionName
@@ -817,9 +829,11 @@ func CreateInfraGroupNode(ctx context.Context, nsId string, infraId string, node
 
 	infraTmp.Status = infraStatusTmp.Status
 
-	// More robust completion check for Create action
+	// More robust completion check for Create/Register action.
+	// Register (discovery-type) shares this path: it also completes when every Node
+	// reaches a final state — but that final state may be Running, Suspended, etc.
 	isCreateCompleted := false
-	if infraTmp.TargetAction == model.ActionCreate {
+	if infraTmp.TargetAction == model.ActionCreate || infraTmp.TargetAction == model.ActionRegister {
 		// For Create action, check if all VMs are in final states (including Failed)
 		// Final states: Running, Failed, Terminated, Suspended
 		// Transitional states: Creating, Undefined, empty string
@@ -834,7 +848,7 @@ func CreateInfraGroupNode(ctx context.Context, nsId string, infraId string, node
 			// StatusUndefined is NOT treated as pending here — it means the creation
 			// attempt is done (Spider returned 500 with no VM identity). The node is
 			// an orphan candidate; run action=reconcile to rescue or action=refine to remove.
-			if node.Status == model.StatusCreating || node.Status == model.StatusRegistering || node.Status == "" {
+			if node.Status == model.StatusCreating || node.Status == model.StatusRegistering || node.Status == model.StatusReconciling || node.Status == "" {
 				allNodesInFinalState = false
 				pendingCount++
 			} else {
@@ -1002,6 +1016,10 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 			infraTmp.Status = model.StatusCreating
 			infraTmp.TargetAction = model.ActionCreate
 			infraTmp.TargetStatus = model.StatusRunning
+			if option == "register" {
+				infraTmp.Status = model.StatusRegistering
+				infraTmp.TargetAction = model.ActionRegister
+			}
 			UpdateInfraInfo(nsId, infraTmp)
 		}
 	} else {
@@ -1009,7 +1027,7 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 		if !exists {
 			log.Debug().Msgf("Infra '%s' does not exist, creating new one", infraId)
 			// Create Infra object first
-			if err := createInfraObject(ctx, nsId, infraId, req, uid); err != nil {
+			if err := createInfraObject(ctx, nsId, infraId, req, uid, option); err != nil {
 				return nil, fmt.Errorf("failed to create Infra object: %w", err)
 			}
 		} else {
@@ -1061,10 +1079,14 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 				break
 			}
 
-			// Set initial status based on option (create vs register)
+			// Set initial status and action based on option (create vs register).
+			// Register is a discovery-type action (ActionRegister): its target is the
+			// resource's actual CSP state, resolved via late-binding in FetchNodeStatus.
 			initialStatus := model.StatusCreating
+			initialTargetAction := model.ActionCreate
 			if option == "register" {
 				initialStatus = model.StatusRegistering
+				initialTargetAction = model.ActionRegister
 			}
 
 			nodeInfo := model.NodeInfo{
@@ -1073,7 +1095,7 @@ func CreateInfra(ctx context.Context, nsId string, req *model.InfraReq, option s
 				PublicIP:         "",
 				PublicDNS:        "",
 				Status:           initialStatus,
-				TargetAction:     model.ActionCreate,
+				TargetAction:     initialTargetAction,
 				TargetStatus:     model.StatusRunning,
 				ConnectionName:   nodeGroupReq.ConnectionName,
 				ConnectionConfig: connectionConfig,
@@ -1538,7 +1560,7 @@ func CreateInfraDynamic(ctx context.Context, nsId string, req *model.InfraDynami
 	uid := common.GenUid()
 	infraId := req.Name
 
-	if err := createInfraObject(ctx, nsId, infraId, &infraReq, uid); err != nil {
+	if err := createInfraObject(ctx, nsId, infraId, &infraReq, uid, ""); err != nil {
 		addErrorToHistory("Infra Object Creation", err.Error())
 		return emptyInfra, err
 	}

--- a/src/core/model/infra.go
+++ b/src/core/model/infra.go
@@ -38,6 +38,15 @@ const (
 	// ActionRefine is const for Refine
 	ActionRefine string = "Refine"
 
+	// ActionRegister is const for Register (onboarding an existing CSP resource).
+	// A discovery-type action: the target state is the resource's actual CSP state
+	// (may be Running, Suspended, ...), not a fixed Running like ActionCreate.
+	ActionRegister string = "Register"
+
+	// ActionReconcile is const for Reconcile (re-syncing a Node with CSP truth).
+	// Also a discovery-type action, sharing ActionRegister's completion semantics.
+	ActionReconcile string = "Reconcile"
+
 	// ActionComplete is const for Complete
 	ActionComplete string = "None"
 )
@@ -78,6 +87,9 @@ const (
 
 	// StatusRegistering is const for Registering (when registering existing CSP Node)
 	StatusRegistering string = "Registering"
+
+	// StatusReconciling is const for Reconciling (when re-syncing a Node with CSP truth)
+	StatusReconciling string = "Reconciling"
 
 	// StatusUndefined is const for Undefined
 	StatusUndefined string = "Undefined"
@@ -902,6 +914,9 @@ type StatusCountInfo struct {
 
 	// CountRegistering is for counting Registering
 	CountRegistering int `json:"countRegistering"`
+
+	// CountReconciling is for counting Reconciling
+	CountReconciling int `json:"countReconciling"`
 
 	// CountUndefined is for counting Undefined
 	CountUndefined int `json:"countUndefined"`


### PR DESCRIPTION
introduces “discovery-type” Infra/Node actions to better represent onboarding (register) and re-sync (reconcile) flows, where the desired end state is the CSP’s observed truth (e.g., Running or Suspended) rather than a fixed target.

**Changes:**
- Added new action/status constants: `ActionRegister`, `ActionReconcile`, and `StatusReconciling`.
- Updated provisioning and status-completion logic to treat Register/Reconcile as discovery-type operations (late-binding final status in `FetchNodeStatus`).
- Extended Infra status aggregation and transient-state detection to include Reconciling and discovery-type semantics.