### PR TITLE
System support for unstable network environments

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       dockerfile: Dockerfile
     networks:
       - cloud-barista
+    # Uncomment below if CSP API calls fail with DNS errors (e.g., unreliable host DNS on WSL2 + VPN)
+    # dns: [8.8.8.8, 1.1.1.1]
     ports:
       - target: 1323
         published: 1323
@@ -155,6 +157,8 @@ services:
     #   dockerfile: Dockerfile
     networks:
       - cloud-barista
+    # Uncomment below if CSP API calls fail with DNS errors (e.g., unreliable host DNS on WSL2 + VPN)
+    # dns: [8.8.8.8, 1.1.1.1]
     # Uncomment below if you want to access CB-Spider for remote
     # ports:
     #   - 1024:1024
@@ -263,6 +267,8 @@ services:
     #   dockerfile: Dockerfile
     networks:
       - cloud-barista
+    # Uncomment below if CSP API calls fail with DNS errors (e.g., unreliable host DNS on WSL2 + VPN)
+    # dns: [8.8.8.8, 1.1.1.1]
     ports:
       - target: 8055
         published: 8055

--- a/src/core/common/client/client.go
+++ b/src/core/common/client/client.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -65,6 +66,44 @@ const (
 )
 
 const (
+	// Total attempts (initial + retries) for idempotent requests on transient errors.
+	transientErrorMaxAttempts = 3
+	// Backoff before the first retry, doubled on each subsequent retry (plus jitter).
+	transientErrorRetryBaseWait = 5 * time.Second
+)
+
+// transientErrorPatterns match momentary failures (network errors, CSP rate
+// limiting) worth retrying, from this client's transport or relayed in a 5xx
+// body by CB-Spider. The client's own response timeout is excluded: retrying
+// it costs the full timeout again. Matched case-insensitively; keep lowercase.
+var transientErrorPatterns = []string{
+	"connection reset by peer",
+	"connection refused",
+	"network is unreachable",
+	"server misbehaving", // DNS SERVFAIL
+	"i/o timeout",
+	"tls handshake timeout",
+	"sdk.timeouterror", // Alibaba SDK connect timeout
+	"unexpected eof",
+	"requestlimitexceeded",
+	"toomanyrequests",
+	"throttl",
+	"ratelimit",
+}
+
+// isTransientNetworkError reports whether the given error message (transport
+// error or upstream 5xx response body) indicates a retryable failure.
+func isTransientNetworkError(msg string) bool {
+	lowered := strings.ToLower(msg)
+	for _, pattern := range transientErrorPatterns {
+		if strings.Contains(lowered, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+const (
 	// VeryShortDuration is a duration for very short-term cache
 	VeryShortDuration = 1 * time.Second
 	// ShortDuration is a duration for short-term cache
@@ -76,11 +115,10 @@ const (
 	// VeryLongDuration is a duration for very long-term cache
 	VeryLongDuration = 300 * time.Second
 
-	// AvailabilityCheckTimeout is the per-request HTTP timeout used when probing
-	// whether a connection config is reachable via Spider. Kept separate from the
-	// cache-duration constants above because it controls network I/O, not caching.
-	// 20s is generous enough for slow CSPs while preventing indefinite hangs.
-	AvailabilityCheckTimeout = 20 * time.Second
+	// AvailabilityCheckTimeout is the per-request HTTP timeout for probing
+	// whether a connection config is reachable via Spider. Sized for the
+	// slowest CSPs (e.g., IBM key listing can take tens of seconds).
+	AvailabilityCheckTimeout = 60 * time.Second
 )
 
 // NoBody is a constant for empty body
@@ -427,20 +465,53 @@ func ExecuteHttpRequest[B any, T any](
 	var resp *resty.Response
 	var err error
 
-	// Execute HTTP method based on the given type
 	switch method {
-	case "GET":
-		resp, err = req.Get(url)
-	case "POST":
-		resp, err = req.Post(url)
-	case "PUT":
-		resp, err = req.Put(url)
-	case "DELETE":
-		resp, err = req.Delete(url)
-	case "HEAD":
-		resp, err = req.Head(url)
+	case "GET", "POST", "PUT", "DELETE", "HEAD":
 	default:
 		return nil, fmt.Errorf("unsupported rest method: %s", method)
+	}
+
+	// Execute HTTP method based on the given type
+	executeRequest := func() (*resty.Response, error) {
+		switch method {
+		case "GET":
+			return req.Get(url)
+		case "POST":
+			return req.Post(url)
+		case "PUT":
+			return req.Put(url)
+		case "DELETE":
+			return req.Delete(url)
+		default:
+			return req.Head(url)
+		}
+	}
+
+	// Retry idempotent (GET/HEAD) requests with backoff on transient failures.
+	// Non-idempotent methods are not retried: the upstream may have processed them.
+	maxAttempts := 1
+	if method == "GET" || method == "HEAD" {
+		maxAttempts = transientErrorMaxAttempts
+	}
+	for attempt := 1; ; attempt++ {
+		resp, err = executeRequest()
+
+		failureMsg := ""
+		if err != nil {
+			failureMsg = err.Error()
+		} else if resp.IsError() && resp.StatusCode() >= http.StatusInternalServerError {
+			failureMsg = string(resp.Body())
+		} else {
+			break
+		}
+		if attempt >= maxAttempts || !isTransientNetworkError(failureMsg) {
+			break
+		}
+		wait := transientErrorRetryBaseWait*time.Duration(1<<(attempt-1)) +
+			time.Duration(rand.Intn(2000))*time.Millisecond
+		log.Warn().Msgf("Transient network error on %s %s (attempt %d/%d), retrying in %v: %s",
+			method, cleanURL(url), attempt, maxAttempts, wait.Round(time.Millisecond), cleanErrorMessage(failureMsg))
+		time.Sleep(wait)
 	}
 
 	if err != nil {

--- a/src/core/csp/alibaba/availability.go
+++ b/src/core/csp/alibaba/availability.go
@@ -67,7 +67,7 @@ func (c *availabilityChecker) CheckInstance(ctx context.Context, q model.Availab
 		return model.AvailabilityResult{}, fmt.Errorf("failed to get Alibaba credentials: %w", err)
 	}
 
-	client, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
+	client, err := newECSClient(region, accessKeyID, accessKeySecret)
 	if err != nil {
 		return model.AvailabilityResult{}, fmt.Errorf("failed to create Alibaba ECS client for region %s: %w", region, err)
 	}

--- a/src/core/csp/alibaba/client.go
+++ b/src/core/csp/alibaba/client.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alibaba
+
+import (
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+)
+
+// newECSClient creates an ECS client with timeouts raised above the SDK
+// defaults (5s connect / 10s read), which are too tight for high-latency paths.
+func newECSClient(region, accessKeyID, accessKeySecret string) (*ecs.Client, error) {
+	client, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
+	if err != nil {
+		return nil, err
+	}
+	client.SetConnectTimeout(15 * time.Second)
+	client.SetReadTimeout(60 * time.Second)
+	return client, nil
+}

--- a/src/core/csp/alibaba/image.go
+++ b/src/core/csp/alibaba/image.go
@@ -137,7 +137,7 @@ func describeImageFromFamily(ctx context.Context, region, family string) (imageI
 		return "", "", fmt.Errorf("failed to get Alibaba credentials: %w", err)
 	}
 
-	client, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
+	client, err := newECSClient(region, accessKeyID, accessKeySecret)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create Alibaba ECS client for region %s: %w", region, err)
 	}

--- a/src/core/csp/alibaba/price.go
+++ b/src/core/csp/alibaba/price.go
@@ -63,7 +63,7 @@ func FetchNodePricesByRegionFiltered(ctx context.Context, region string, targetI
 		return model.SpiderCloudPrice{}, fmt.Errorf("failed to get Alibaba credentials: %w", err)
 	}
 
-	ecsClient, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
+	ecsClient, err := newECSClient(region, accessKeyID, accessKeySecret)
 	if err != nil {
 		return model.SpiderCloudPrice{}, fmt.Errorf("failed to create Alibaba ECS client for region %s: %w", region, err)
 	}
@@ -368,7 +368,7 @@ func FetchAvailableSpecListByRegion(ctx context.Context, region string, zoneID s
 		return model.SpiderSpecList{}, fmt.Errorf("failed to get Alibaba credentials: %w", err)
 	}
 
-	ecsClient, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
+	ecsClient, err := newECSClient(region, accessKeyID, accessKeySecret)
 	if err != nil {
 		return model.SpiderSpecList{}, fmt.Errorf("failed to create Alibaba ECS client for region %s: %w", region, err)
 	}

--- a/src/core/csp/alibaba/vmstatus.go
+++ b/src/core/csp/alibaba/vmstatus.go
@@ -45,7 +45,7 @@ func BatchDescribeInstanceStatuses(ctx context.Context, region string, instanceI
 		return nil, fmt.Errorf("Alibaba vmstatus: cannot get credentials: %w", err)
 	}
 
-	client, err := ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
+	client, err := newECSClient(region, accessKeyID, accessKeySecret)
 	if err != nil {
 		return nil, fmt.Errorf("Alibaba vmstatus: failed to create ECS client (region=%s): %w", region, err)
 	}

--- a/src/core/csp/aws/availability.go
+++ b/src/core/csp/aws/availability.go
@@ -36,8 +36,6 @@ import (
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
@@ -72,17 +70,7 @@ func (c *availabilityChecker) CheckInstance(ctx context.Context, q model.Availab
 		return model.AvailabilityResult{}, fmt.Errorf("failed to get AWS credentials: %w", err)
 	}
 
-	cfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithRegion(region),
-		awsconfig.WithCredentialsProvider(
-			awscreds.NewStaticCredentialsProvider(accessKey, secretKey, ""),
-		),
-	)
-	if err != nil {
-		return model.AvailabilityResult{}, fmt.Errorf("failed to create AWS config: %w", err)
-	}
-
-	client := ec2.NewFromConfig(cfg)
+	client := ec2.NewFromConfig(newConfig(region, accessKey, secretKey))
 
 	input := &ec2.DescribeInstanceTypeOfferingsInput{
 		LocationType: ec2types.LocationTypeAvailabilityZone,

--- a/src/core/csp/aws/client.go
+++ b/src/core/csp/aws/client.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
+)
+
+// awsMaxAttempts is the total attempts per AWS API call (SDK default is 3).
+const awsMaxAttempts = 4
+
+// newConfig returns an aws.Config with static credentials and a standard
+// retryer, shared by every direct AWS call path.
+func newConfig(region, accessKey, secretKey string) awssdk.Config {
+	return awssdk.Config{
+		Region:      region,
+		Credentials: awscreds.NewStaticCredentialsProvider(accessKey, secretKey, ""),
+		Retryer: func() awssdk.Retryer {
+			return retry.NewStandard(func(o *retry.StandardOptions) {
+				o.MaxAttempts = awsMaxAttempts
+			})
+		},
+	}
+}

--- a/src/core/csp/aws/price.go
+++ b/src/core/csp/aws/price.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/pricing"
 	pricetypes "github.com/aws/aws-sdk-go-v2/service/pricing/types"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -86,11 +85,7 @@ func FetchAllNodePrices(ctx context.Context) (map[string]model.SpiderCloudPrice,
 
 	// AWS Pricing API is only available at these 3 endpoints;
 	// "us-east-1" works for all AWS regions' pricing data.
-	cfg := awssdk.Config{
-		Region:      "us-east-1",
-		Credentials: awscreds.NewStaticCredentialsProvider(accessKey, secretKey, ""),
-	}
-	client := pricing.NewFromConfig(cfg)
+	client := pricing.NewFromConfig(newConfig("us-east-1", accessKey, secretKey))
 
 	// Filters mirror what Spider's AwsPriceInfoHandler applies, except we deliberately
 	// omit the regionCode filter to retrieve all regions in a single pass.

--- a/src/core/csp/aws/tag.go
+++ b/src/core/csp/aws/tag.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
@@ -56,11 +55,7 @@ func BatchUpsertTags(ctx context.Context, region, zone, cspResourceId, resourceT
 		return fmt.Errorf("failed to get AWS credentials: %w", err)
 	}
 
-	cfg := aws.Config{
-		Region:      region,
-		Credentials: credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
-	}
-	client := ec2.NewFromConfig(cfg)
+	client := ec2.NewFromConfig(newConfig(region, accessKey, secretKey))
 
 	// CB-Spider returns the key pair name as SystemId for sshKey resources.
 	// EC2 CreateTags requires the key-xxx resource ID, so resolve it first.

--- a/src/core/csp/aws/vmcontrol.go
+++ b/src/core/csp/aws/vmcontrol.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -45,11 +43,7 @@ func newEC2Client(ctx context.Context, region string) (*ec2.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("AWS vmcontrol: cannot get credentials: %w", err)
 	}
-	cfg := awssdk.Config{
-		Region:      region,
-		Credentials: awscreds.NewStaticCredentialsProvider(accessKey, secretKey, ""),
-	}
-	return ec2.NewFromConfig(cfg), nil
+	return ec2.NewFromConfig(newConfig(region, accessKey, secretKey)), nil
 }
 
 // BatchStopInstances issues StopInstances for the given instance IDs and returns

--- a/src/core/csp/aws/vmstatus.go
+++ b/src/core/csp/aws/vmstatus.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
@@ -53,11 +51,7 @@ func BatchDescribeInstanceStatuses(ctx context.Context, region string, instanceI
 		return nil, fmt.Errorf("AWS vmstatus: cannot get credentials: %w", err)
 	}
 
-	cfg := awssdk.Config{
-		Region:      region,
-		Credentials: awscreds.NewStaticCredentialsProvider(accessKey, secretKey, ""),
-	}
-	client := ec2.NewFromConfig(cfg)
+	client := ec2.NewFromConfig(newConfig(region, accessKey, secretKey))
 
 	result := make(map[string]string, len(instanceIds))
 

--- a/src/core/csp/tencent/availability.go
+++ b/src/core/csp/tencent/availability.go
@@ -45,7 +45,6 @@ import (
 	"github.com/rs/zerolog/log"
 
 	tcerrors "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
-	tcprofile "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
 	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
 
 	tccommon "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
@@ -77,9 +76,7 @@ func (c *availabilityChecker) CheckInstance(ctx context.Context, q model.Availab
 		return model.AvailabilityResult{}, fmt.Errorf("failed to get Tencent credentials: %w", err)
 	}
 
-	credential := tccommon.NewCredential(secretID, secretKey)
-	cpf := tcprofile.NewClientProfile()
-	client, err := cvm.NewClient(credential, region, cpf)
+	client, err := newCVMClient(region, secretID, secretKey)
 	if err != nil {
 		return model.AvailabilityResult{}, fmt.Errorf("failed to create Tencent CVM client for region %s: %w", region, err)
 	}

--- a/src/core/csp/tencent/client.go
+++ b/src/core/csp/tencent/client.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Cloud-Barista Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tencent
+
+import (
+	tccommon "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
+	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
+)
+
+// newCVMClient creates a CVM client with network-failure retry enabled.
+// All CVM calls here are read-only Describe* queries, so retry is safe.
+func newCVMClient(region, secretID, secretKey string) (*cvm.Client, error) {
+	credential := tccommon.NewCredential(secretID, secretKey)
+	cpf := profile.NewClientProfile()
+	cpf.NetworkFailureMaxRetries = 2
+	cpf.NetworkFailureRetryDuration = profile.ExponentialBackoff
+	cpf.UnsafeRetryOnConnectionFailure = true
+	return cvm.NewClient(credential, region, cpf)
+}

--- a/src/core/csp/tencent/vmstatus.go
+++ b/src/core/csp/tencent/vmstatus.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	tccommon "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
-	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
 	cvm "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm/v20170312"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
@@ -47,8 +45,7 @@ func BatchDescribeInstanceStatuses(ctx context.Context, region string, instanceI
 		return nil, fmt.Errorf("Tencent vmstatus: cannot get credentials: %w", err)
 	}
 
-	credential := tccommon.NewCredential(secretID, secretKey)
-	client, err := cvm.NewClient(credential, region, profile.NewClientProfile())
+	client, err := newCVMClient(region, secretID, secretKey)
 	if err != nil {
 		return nil, fmt.Errorf("Tencent vmstatus: failed to create CVM client (region=%s): %w", region, err)
 	}


### PR DESCRIPTION
In environments with unstable network paths (VPN, WSL2, corporate DNS), CSP API calls fail intermittently with transient errors 
- DNS SERVFAIL/timeouts, connection reset, connect timeouts, and per-second API rate limits. 
- A single transient failure during credential verification or spec fetch marks the whole connection/region as failed, even though the credential and network are actually fine moments later.

### Changes
- Common API client (clientManager): idempotent (GET/HEAD) requests are retried up to 2 times with exponential backoff + jitter when the failure matches a transient pattern
- AvailabilityCheckTimeout 20s → 60s: slow CSP auth paths (e.g., IBM key listing) exceeded 20s and caused spurious unverified results.
- Direct CSP SDK paths: per-provider client factory consolidation with retry/timeout policies
- docker-compose: documented optional dns: setting to bypass unreliable host DNS.

### Effect
- make init credential verification: 41 unverified connections → 2 (only genuine issues: an unreachable regional endpoint and an account-level catalog gap).
- Per run, 36+ transient failures were absorbed by retries with zero false positives; retried errors all fail fast, so added latency is seconds.
- No behavior change on stable networks; non-idempotent requests are never retried.