### PR TITLE
Add K8s MCP and agentgateway demo

### DIFF
--- a/scripts/usecases/mcp/README.md
+++ b/scripts/usecases/mcp/README.md
@@ -1,0 +1,68 @@
+# MCP + agentgateway demo usecase
+
+Expose in-cluster data services as **Model Context Protocol (MCP)** servers and
+federate them behind a single external endpoint with
+[agentgateway](https://agentgateway.dev) — so any MCP client (Claude Code,
+MCP Inspector, IDEs) can use them remotely.
+
+```
+[External MCP client: Claude Code / MCP Inspector]
+        │  streamable HTTP   http://<node-public-ip>:30900/mcp
+        ▼
+┌─ K8s namespace: mcp-demo ─────────────────────────────────┐
+│  agentgateway (NodePort 30900, admin UI 30901)            │
+│    ├─ target "api" → mcp-api :8000/mcp                    │
+│    │                   └─ REST → demo-api (FastAPI)       │
+│    └─ target "db"  → mcp-db  :8000/mcp                    │
+│                        └─ read-only SQL ↘                 │
+│                              postgres (+ web-shop data)   │
+└───────────────────────────────────────────────────────────┘
+```
+
+**Demo story**: both MCP servers reach the *same* PostgreSQL data through two
+governed paths — `api_*` tools are curated REST wrappers (the only write path,
+with stock checks), `db_*` tools give raw ad-hoc SQL but are read-only by
+policy. agentgateway federates both so the client sees one tool list
+(`api_list_products`, `db_query`, ...) on one endpoint.
+
+## Quickstart (on the K8s control plane)
+
+```bash
+./deploy-demo-db.sh        # PostgreSQL + sample web-shop data (namespace mcp-demo)
+./deploy-demo-api.sh       # FastAPI shop API backed by the DB
+./deploy-mcp-servers.sh    # MCP server (API) + MCP server (DB), streamable HTTP
+./deploy-agentgateway.sh   # federation gateway on NodePort 30900 (+UI 30901)
+./test-mcp-e2e.sh          # scripted demo: tools/list, SQL analysis, write governance
+```
+
+No GPU needed; CPU nodes are enough. All steps are available as the
+**"MCP (agentgateway)"** category in CB-MapUI's remote command popup
+(cluster build steps 1-4, MCP stack steps 5-10).
+
+## Connect from your machine
+
+Allow inbound `30900/tcp` (and `30901/tcp` for the UI) in the Security Group, then:
+
+```bash
+# Claude Code
+claude mcp add --transport http shop-demo http://<node-public-ip>:30900/mcp
+# then ask e.g.: "Find products with stock below 5 and show their recent orders"
+
+# MCP Inspector (browser UI)
+npx @modelcontextprotocol/inspector   # transport: Streamable HTTP, URL as above
+```
+
+The agentgateway admin UI (`http://<node-public-ip>:30901/ui/`) shows the
+federated targets and tool list.
+
+## Notes
+
+- Component versions: agentgateway `v1.3.1` (standalone mode, static config),
+  `postgres:16`, FastMCP 2.x.
+- The MCP servers are FastMCP apps with code in ConfigMaps (no image build).
+  For production Postgres access consider
+  [postgres-mcp](https://github.com/crystaldba/postgres-mcp) (Postgres MCP Pro).
+- The demo endpoint has **no authentication** — it is meant for short-lived
+  demo infra. For real use, add an agentgateway JWT/authorization policy and
+  TLS, or keep the port closed and tunnel.
+- Cleanup: `kubectl delete namespace mcp-demo`.

--- a/scripts/usecases/mcp/deploy-agentgateway.sh
+++ b/scripts/usecases/mcp/deploy-agentgateway.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+# agentgateway (standalone) federating the demo MCP servers behind one endpoint
+# External clients connect to NodePort 30900 (/mcp); admin UI on NodePort 30901
+# Prerequisites: deploy-mcp-servers.sh completed
+# Run on K8s control plane
+
+set -e
+
+NS="mcp-demo"
+AGW_VERSION="v1.3.1"
+MCP_NODEPORT="30900"
+UI_NODEPORT="30901"
+
+usage() {
+    echo "Usage: $0 [--version <tag>] [--nodeport <port>] [--ui-nodeport <port>]"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version) AGW_VERSION="$2"; shift 2 ;;
+        --nodeport) MCP_NODEPORT="$2"; shift 2 ;;
+        --ui-nodeport) UI_NODEPORT="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+echo "==== agentgateway Setup (${AGW_VERSION}, namespace: ${NS}) ===="
+
+for SVC in mcp-api mcp-db; do
+    kubectl -n ${NS} get svc ${SVC} > /dev/null 2>&1 || {
+        echo "ERROR: ${SVC} service not found in ${NS}. Run deploy-mcp-servers.sh first."; exit 1; }
+done
+
+# Federation config: two remote MCP targets, tools exposed as api_* and db_*
+cat <<EOF | kubectl -n ${NS} apply -f - > /dev/null
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentgateway-config
+data:
+  config.yaml: |
+    config:
+      adminAddr: "0.0.0.0:15000"
+    binds:
+    - port: 3000
+      listeners:
+      - routes:
+        - policies:
+            cors:
+              allowOrigins: ["*"]
+              allowHeaders: ["*"]
+          backends:
+          - mcp:
+              targets:
+              - name: api
+                mcp:
+                  host: http://mcp-api.${NS}.svc.cluster.local:8000/mcp
+              - name: db
+                mcp:
+                  host: http://mcp-db.${NS}.svc.cluster.local:8000/mcp
+EOF
+
+echo ""
+echo "=== Federation config (this is the entire gateway setup) ==="
+kubectl -n ${NS} get configmap agentgateway-config -o jsonpath='{.data.config\.yaml}' | sed 's/^/  /'
+
+cat <<EOF | kubectl -n ${NS} apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentgateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: agentgateway }
+  template:
+    metadata:
+      labels: { app: agentgateway }
+    spec:
+      containers:
+        - name: agentgateway
+          image: ghcr.io/agentgateway/agentgateway:${AGW_VERSION}
+          args: ["-f", "/config/config.yaml"]
+          ports:
+            - containerPort: 3000
+            - containerPort: 15000
+          readinessProbe:
+            tcpSocket: { port: 3000 }
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          configMap:
+            name: agentgateway-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentgateway
+spec:
+  type: NodePort
+  selector: { app: agentgateway }
+  ports:
+    - name: mcp
+      port: 3000
+      targetPort: 3000
+      nodePort: ${MCP_NODEPORT}
+    - name: ui
+      port: 15000
+      targetPort: 15000
+      nodePort: ${UI_NODEPORT}
+EOF
+
+echo ""
+echo "Waiting for agentgateway to start..."
+kubectl -n ${NS} rollout status deployment/agentgateway --timeout=5m > /dev/null
+
+# Verify through the NodePort (the same path external clients use)
+NODE_IP=$(hostname -I | awk '{print $1}')
+GW_URL="http://${NODE_IP}:${MCP_NODEPORT}/mcp"
+
+mcp_rpc() {
+    local SID="$1" BODY="$2"
+    local HDRS=(-H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream')
+    [ -n "$SID" ] && HDRS+=(-H "mcp-session-id: $SID")
+    curl -s --max-time 15 "${HDRS[@]}" "$GW_URL" -d "$BODY" | sed -n 's/^data: //p; /^{/p' | tail -1
+}
+
+echo ""
+echo "=== Verifying federated endpoint via NodePort (${GW_URL}) ==="
+SID=""
+for i in $(seq 1 12); do
+    SID=$(curl -si --max-time 15 "$GW_URL" \
+        -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"probe","version":"1.0"}}}' \
+        | grep -i '^mcp-session-id:' | tr -d '\r' | awk '{print $2}')
+    [ -n "$SID" ] && break
+    echo "  [$(date +%H:%M:%S)] gateway not answering yet; retrying..."
+    sleep 5
+done
+[ -n "$SID" ] || { echo "ERROR: initialize via gateway failed"; kubectl -n ${NS} logs deploy/agentgateway --tail=20; exit 1; }
+
+mcp_rpc "$SID" '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
+mcp_rpc "$SID" '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | python3 -c "
+import sys, json
+tools = json.load(sys.stdin)['result']['tools']
+names = [t['name'] for t in tools]
+print(f'  {len(tools)} federated tools:')
+for n in names:
+    print(f'    {n}')
+assert any(n.startswith('api_') for n in names), 'api_* tools missing'
+assert any(n.startswith('db_') for n in names), 'db_* tools missing'
+print('  OK: both api_* and db_* tool groups are federated')"
+
+echo ""
+echo "========================================"
+echo "SUCCESS: agentgateway is federating mcp-api + mcp-db"
+echo "========================================"
+echo ""
+echo "[MCP_ENDPOINT]"
+echo "http://<node-public-ip>:${MCP_NODEPORT}/mcp"
+echo ""
+echo "[AGENTGATEWAY_UI]"
+echo "http://<node-public-ip>:${UI_NODEPORT}/ui/"
+echo ""
+echo "External access checklist:"
+echo "  (1) Allow inbound ${MCP_NODEPORT}/tcp (and ${UI_NODEPORT}/tcp for the UI) in the Security Group"
+echo "  (2) Register in Claude Code:  claude mcp add --transport http shop-demo http://<node-public-ip>:${MCP_NODEPORT}/mcp"
+echo "  (3) Or inspect with:          npx @modelcontextprotocol/inspector  (Streamable HTTP)"
+echo "  (4) Demo endpoint has NO auth — delete the infra (or close the SG port) after the demo"
+echo ""
+echo "\$\$CMD[Check agentgateway](kubectl -n mcp-demo get pods -l app=agentgateway)"
+exit 0

--- a/scripts/usecases/mcp/deploy-demo-api.sh
+++ b/scripts/usecases/mcp/deploy-demo-api.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+# Demo REST API (FastAPI) for the MCP usecase (run on K8s control plane)
+# A small web-shop API backed by the demo PostgreSQL; later wrapped by an MCP server.
+# Prerequisites: deploy-demo-db.sh completed
+
+set -e
+
+NS="mcp-demo"
+DB_URI="postgresql://demo:demo1234@postgres:5432/demo"
+
+echo "==== Demo REST API Setup (FastAPI, namespace: ${NS}) ===="
+
+kubectl -n ${NS} get svc postgres > /dev/null 2>&1 || {
+    echo "ERROR: postgres service not found in ${NS}. Run deploy-demo-db.sh first."; exit 1; }
+
+# API code lives in a ConfigMap; no image build needed
+cat <<'EOF' | kubectl -n mcp-demo apply -f - > /dev/null
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-api-app
+data:
+  app.py: |
+    import os
+    from fastapi import FastAPI, HTTPException
+    from pydantic import BaseModel
+    import psycopg
+    from psycopg.rows import dict_row
+
+    DB = os.environ.get("DATABASE_URI", "postgresql://demo:demo1234@postgres:5432/demo")
+    app = FastAPI(title="Demo Shop API", version="1.0.0",
+                  description="Sample web-shop API for the CB-Tumblebug MCP usecase")
+
+    def q(sql, params=(), one=False):
+        with psycopg.connect(DB, row_factory=dict_row) as c:
+            rows = c.execute(sql, params).fetchall()
+        return (rows[0] if rows else None) if one else rows
+
+    @app.get("/healthz")
+    def healthz():
+        q("SELECT 1")
+        return {"ok": True}
+
+    @app.get("/products")
+    def list_products():
+        return q("SELECT * FROM products ORDER BY id")
+
+    @app.get("/products/{pid}")
+    def get_product(pid: int):
+        r = q("SELECT * FROM products WHERE id=%s", (pid,), one=True)
+        if not r:
+            raise HTTPException(404, "product not found")
+        return r
+
+    @app.get("/customers")
+    def list_customers():
+        return q("SELECT * FROM customers ORDER BY id")
+
+    @app.get("/orders")
+    def list_orders(customer_id: int | None = None):
+        sql = """SELECT o.id, o.customer_id, c.name AS customer, o.status, o.order_date,
+                        COALESCE(SUM(oi.quantity * oi.unit_price), 0) AS total
+                 FROM orders o JOIN customers c ON c.id = o.customer_id
+                 LEFT JOIN order_items oi ON oi.order_id = o.id
+                 {} GROUP BY o.id, c.name ORDER BY o.id"""
+        if customer_id:
+            return q(sql.format("WHERE o.customer_id=%s"), (customer_id,))
+        return q(sql.format(""))
+
+    @app.get("/orders/{oid}")
+    def get_order(oid: int):
+        o = q("""SELECT o.id, o.customer_id, c.name AS customer, o.status, o.order_date
+                 FROM orders o JOIN customers c ON c.id=o.customer_id WHERE o.id=%s""",
+              (oid,), one=True)
+        if not o:
+            raise HTTPException(404, "order not found")
+        o["items"] = q("""SELECT oi.product_id, p.name, oi.quantity, oi.unit_price
+                          FROM order_items oi JOIN products p ON p.id=oi.product_id
+                          WHERE oi.order_id=%s""", (oid,))
+        return o
+
+    class OrderIn(BaseModel):
+        customer_id: int
+        product_id: int
+        quantity: int = 1
+
+    @app.post("/orders", status_code=201)
+    def create_order(o: OrderIn):
+        with psycopg.connect(DB, row_factory=dict_row) as c:
+            with c.transaction():
+                p = c.execute("SELECT * FROM products WHERE id=%s FOR UPDATE",
+                              (o.product_id,)).fetchone()
+                if not p:
+                    raise HTTPException(404, "product not found")
+                if p["stock"] < o.quantity:
+                    raise HTTPException(409, f"insufficient stock ({p['stock']} left)")
+                c.execute("UPDATE products SET stock=stock-%s WHERE id=%s",
+                          (o.quantity, o.product_id))
+                oid = c.execute(
+                    "INSERT INTO orders (customer_id, status, order_date) "
+                    "VALUES (%s, 'pending', CURRENT_DATE) RETURNING id",
+                    (o.customer_id,)).fetchone()["id"]
+                c.execute("INSERT INTO order_items VALUES (%s, %s, %s, %s)",
+                          (oid, o.product_id, o.quantity, p["price"]))
+        return {"order_id": oid, "product": p["name"], "quantity": o.quantity,
+                "total": float(p["price"]) * o.quantity, "status": "pending"}
+EOF
+
+cat <<'EOF' | kubectl -n mcp-demo apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: demo-api }
+  template:
+    metadata:
+      labels: { app: demo-api }
+    spec:
+      containers:
+        - name: demo-api
+          image: python:3.11-slim
+          workingDir: /app
+          command: ["sh", "-c"]
+          args:
+            - pip install -q --root-user-action=ignore --disable-pip-version-check
+              fastapi uvicorn "psycopg[binary]" &&
+              uvicorn app:app --host 0.0.0.0 --port 8000
+          env:
+            - name: DATABASE_URI
+              value: postgresql://demo:demo1234@postgres:5432/demo
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet: { path: /healthz, port: 8000 }
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          configMap:
+            name: demo-api-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-api
+spec:
+  selector: { app: demo-api }
+  ports:
+    - port: 8000
+      targetPort: 8000
+EOF
+
+echo ""
+echo "Waiting for the API to start (pip install at boot; typically 1-2 min)..."
+kubectl -n ${NS} rollout status deployment/demo-api --timeout=5m > /dev/null
+
+CLUSTER_IP=$(kubectl -n ${NS} get svc demo-api -o jsonpath='{.spec.clusterIP}')
+echo ""
+echo "=== Smoke test: GET /products ==="
+curl -s --max-time 10 "http://${CLUSTER_IP}:8000/products" | python3 -c "
+import sys, json
+rows = json.load(sys.stdin)
+print(f'  {len(rows)} products; low stock items:')
+for r in rows:
+    if r['stock'] < 5:
+        print(f\"    #{r['id']} {r['name']} — stock {r['stock']}\")"
+
+echo ""
+echo "========================================"
+echo "SUCCESS: Demo Shop API is running"
+echo "========================================"
+echo "  In-cluster URL: http://demo-api.${NS}.svc.cluster.local:8000"
+echo "  OpenAPI spec:   http://demo-api.${NS}.svc.cluster.local:8000/openapi.json"
+echo ""
+echo "\$\$CMD[Check Demo API](kubectl -n mcp-demo get pods -l app=demo-api)"
+exit 0

--- a/scripts/usecases/mcp/deploy-demo-db.sh
+++ b/scripts/usecases/mcp/deploy-demo-db.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+# Demo PostgreSQL for the MCP usecase (run on K8s control plane)
+# Creates namespace mcp-demo and a Postgres instance seeded with web-shop sample data.
+# Designed for unattended execution via SSH or pipe (curl | bash)
+
+set -e
+
+NS="mcp-demo"
+PG_USER="demo"
+PG_PASS="demo1234"
+PG_DB="demo"
+
+echo "==== Demo PostgreSQL Setup (namespace: ${NS}) ===="
+
+# The PVC below needs a default StorageClass; install local-path if missing
+if ! kubectl get storageclass 2>/dev/null | grep -q "(default)"; then
+    echo "No default StorageClass found; installing local-path-provisioner..."
+    kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.30/deploy/local-path-storage.yaml
+    kubectl patch storageclass local-path -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+    kubectl -n local-path-storage rollout status deployment/local-path-provisioner --timeout=3m
+fi
+
+kubectl create namespace ${NS} 2>/dev/null || true
+
+# Sample data: a tiny web shop (customers / products / orders)
+cat <<'EOF' | kubectl -n mcp-demo apply -f - > /dev/null
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+data:
+  init.sql: |
+    CREATE TABLE customers (
+      id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT UNIQUE, country TEXT);
+    CREATE TABLE products (
+      id SERIAL PRIMARY KEY, name TEXT NOT NULL, category TEXT,
+      price NUMERIC(10,2) NOT NULL, stock INT NOT NULL);
+    CREATE TABLE orders (
+      id SERIAL PRIMARY KEY, customer_id INT REFERENCES customers(id),
+      status TEXT DEFAULT 'completed', order_date DATE NOT NULL);
+    CREATE TABLE order_items (
+      order_id INT REFERENCES orders(id), product_id INT REFERENCES products(id),
+      quantity INT NOT NULL, unit_price NUMERIC(10,2) NOT NULL);
+
+    INSERT INTO customers (name, email, country) VALUES
+      ('Ada Lovelace', 'ada@example.com', 'UK'),
+      ('Grace Hopper', 'grace@example.com', 'US'),
+      ('Alan Turing', 'alan@example.com', 'UK'),
+      ('Margaret Hamilton', 'margaret@example.com', 'US'),
+      ('Sejong Kim', 'sejong@example.com', 'KR'),
+      ('Linus Virtanen', 'linus@example.com', 'FI');
+
+    INSERT INTO products (name, category, price, stock) VALUES
+      ('Raspberry Pi 5 (8GB)', 'sbc', 79.99, 42),
+      ('Arduino Uno R4 WiFi', 'mcu', 27.50, 120),
+      ('Jetson Orin Nano Devkit', 'edge-ai', 499.00, 8),
+      ('Coral USB Accelerator', 'edge-ai', 59.99, 3),
+      ('ESP32 DevKit v1', 'mcu', 8.99, 200),
+      ('LoRaWAN Gateway', 'network', 189.00, 4),
+      ('NVMe SSD 2TB', 'storage', 149.00, 25),
+      ('10G Ethernet Switch', 'network', 899.00, 2),
+      ('USB Logic Analyzer', 'tools', 12.50, 60),
+      ('Edge AI Camera Module', 'edge-ai', 249.00, 15);
+
+    INSERT INTO orders (customer_id, status, order_date) VALUES
+      (1, 'completed', '2026-06-02'), (2, 'completed', '2026-06-05'),
+      (3, 'completed', '2026-06-11'), (1, 'completed', '2026-06-18'),
+      (4, 'completed', '2026-06-23'), (5, 'completed', '2026-06-29'),
+      (2, 'completed', '2026-07-03'), (6, 'completed', '2026-07-08'),
+      (3, 'completed', '2026-07-12'), (5, 'shipped',   '2026-07-17'),
+      (4, 'shipped',   '2026-07-21'), (1, 'pending',   '2026-07-24');
+
+    INSERT INTO order_items (order_id, product_id, quantity, unit_price) VALUES
+      (1, 1, 2, 79.99),  (1, 5, 5, 8.99),
+      (2, 3, 1, 499.00), (2, 4, 2, 59.99),
+      (3, 2, 3, 27.50),  (3, 9, 1, 12.50),
+      (4, 8, 1, 899.00),
+      (5, 6, 2, 189.00), (5, 5, 10, 8.99),
+      (6, 1, 1, 79.99),  (6, 7, 2, 149.00),
+      (7, 10, 1, 249.00),(7, 4, 1, 59.99),
+      (8, 5, 20, 8.99),  (8, 2, 2, 27.50),
+      (9, 3, 1, 499.00),
+      (10, 7, 1, 149.00),(10, 9, 2, 12.50),
+      (11, 10, 2, 249.00),
+      (12, 1, 1, 79.99), (12, 6, 1, 189.00);
+EOF
+
+cat <<EOF | kubectl -n ${NS} apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector:
+    matchLabels: { app: postgres }
+  template:
+    metadata:
+      labels: { app: postgres }
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: "${PG_USER}"
+            - name: POSTGRES_PASSWORD
+              value: "${PG_PASS}"
+            - name: POSTGRES_DB
+              value: "${PG_DB}"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "${PG_USER}"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: init
+              mountPath: /docker-entrypoint-initdb.d
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data
+        - name: init
+          configMap:
+            name: postgres-init
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector: { app: postgres }
+  ports:
+    - port: 5432
+      targetPort: 5432
+EOF
+
+echo ""
+echo "Waiting for PostgreSQL to become ready..."
+kubectl -n ${NS} rollout status deployment/postgres --timeout=5m > /dev/null
+
+for i in $(seq 1 12); do
+    kubectl -n ${NS} exec deploy/postgres -- pg_isready -U ${PG_USER} > /dev/null 2>&1 && break
+    sleep 5
+done
+
+echo ""
+echo "=== Seeded data ==="
+kubectl -n ${NS} exec deploy/postgres -- psql -U ${PG_USER} -d ${PG_DB} -c \
+  "SELECT 'customers' AS table, count(*) FROM customers
+   UNION ALL SELECT 'products', count(*) FROM products
+   UNION ALL SELECT 'orders', count(*) FROM orders
+   UNION ALL SELECT 'order_items', count(*) FROM order_items;"
+
+echo "========================================"
+echo "SUCCESS: PostgreSQL is running"
+echo "========================================"
+echo "  In-cluster URI: postgresql://${PG_USER}:${PG_PASS}@postgres.${NS}.svc.cluster.local:5432/${PG_DB}"
+echo "  (Note: init.sql only runs on first boot; delete PVC postgres-data to reseed)"
+echo ""
+echo "\$\$CMD[Check Postgres](kubectl -n mcp-demo get pods -l app=postgres)"
+exit 0

--- a/scripts/usecases/mcp/deploy-mcp-servers.sh
+++ b/scripts/usecases/mcp/deploy-mcp-servers.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+# Two demo MCP servers (run on K8s control plane), both streamable HTTP on :8000/mcp
+#   mcp-api : wraps the Demo Shop REST API as curated MCP tools (the write path)
+#   mcp-db  : exposes read-only SQL access to the demo PostgreSQL (the analysis path)
+# Prerequisites: deploy-demo-db.sh and deploy-demo-api.sh completed
+
+set -e
+
+NS="mcp-demo"
+
+echo "==== Demo MCP Servers Setup (namespace: ${NS}) ===="
+
+kubectl -n ${NS} get svc demo-api > /dev/null 2>&1 || {
+    echo "ERROR: demo-api service not found in ${NS}. Run deploy-demo-api.sh first."; exit 1; }
+
+# MCP server (API): curated tools that call the REST API — the governed write path
+cat <<'EOF' | kubectl -n mcp-demo apply -f - > /dev/null
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-api-app
+data:
+  server.py: |
+    import os
+    import httpx
+    from fastmcp import FastMCP
+
+    API = os.environ.get("API_BASE", "http://demo-api:8000")
+    mcp = FastMCP("demo-shop-api")
+
+    def get(path, **params):
+        r = httpx.get(f"{API}{path}", params=params or None, timeout=10)
+        r.raise_for_status()
+        return r.json()
+
+    @mcp.tool
+    def list_products() -> list:
+        """List all shop products with category, price, and current stock."""
+        return get("/products")
+
+    @mcp.tool
+    def get_product(product_id: int) -> dict:
+        """Get one product by id."""
+        return get(f"/products/{product_id}")
+
+    @mcp.tool
+    def list_customers() -> list:
+        """List all customers."""
+        return get("/customers")
+
+    @mcp.tool
+    def list_orders(customer_id: int | None = None) -> list:
+        """List orders with totals, optionally filtered by customer id."""
+        return get("/orders", **({"customer_id": customer_id} if customer_id else {}))
+
+    @mcp.tool
+    def get_order(order_id: int) -> dict:
+        """Get one order including its line items."""
+        return get(f"/orders/{order_id}")
+
+    @mcp.tool
+    def create_order(customer_id: int, product_id: int, quantity: int = 1) -> dict:
+        """Create an order (checks and decrements stock). The only write path in this demo."""
+        r = httpx.post(f"{API}/orders", timeout=10, json={
+            "customer_id": customer_id, "product_id": product_id, "quantity": quantity})
+        if r.status_code >= 400:
+            return {"error": r.status_code, "detail": r.json().get("detail", r.text)}
+        return r.json()
+
+    mcp.run(transport="http", host="0.0.0.0", port=8000, path="/mcp")
+EOF
+
+# MCP server (DB): read-only SQL tools straight to Postgres — the analysis path
+cat <<'EOF' | kubectl -n mcp-demo apply -f - > /dev/null
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-db-app
+data:
+  server.py: |
+    import os
+    import json
+    import psycopg
+    from psycopg.rows import dict_row
+    from fastmcp import FastMCP
+
+    DB = os.environ.get("DATABASE_URI", "postgresql://demo:demo1234@postgres:5432/demo")
+    # read-only transactions + 5s statement timeout enforced at the connection level
+    OPTS = "-c default_transaction_read_only=on -c statement_timeout=5000"
+    mcp = FastMCP("demo-postgres")
+
+    def run(sql, params=()):
+        with psycopg.connect(DB, row_factory=dict_row, options=OPTS) as c:
+            cur = c.execute(sql, params)
+            rows = cur.fetchmany(200) if cur.description else []
+        return json.loads(json.dumps(rows, default=str))
+
+    @mcp.tool
+    def list_tables() -> list:
+        """List tables in the demo database."""
+        return run("""SELECT table_name FROM information_schema.tables
+                      WHERE table_schema='public' ORDER BY table_name""")
+
+    @mcp.tool
+    def describe_table(table: str) -> list:
+        """Show the columns and types of a table."""
+        return run("""SELECT column_name, data_type, is_nullable
+                      FROM information_schema.columns
+                      WHERE table_schema='public' AND table_name=%s
+                      ORDER BY ordinal_position""", (table,))
+
+    @mcp.tool
+    def query(sql: str) -> list:
+        """Run a read-only SQL query (writes are rejected; 5s timeout, first 200 rows)."""
+        try:
+            return run(sql)
+        except Exception as e:
+            return [{"error": str(e).strip()}]
+
+    mcp.run(transport="http", host="0.0.0.0", port=8000, path="/mcp")
+EOF
+
+for APP in mcp-api mcp-db; do
+cat <<EOF | kubectl -n ${NS} apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${APP}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: ${APP} }
+  template:
+    metadata:
+      labels: { app: ${APP} }
+    spec:
+      containers:
+        - name: ${APP}
+          image: python:3.11-slim
+          workingDir: /app
+          command: ["sh", "-c"]
+          args:
+            - pip install -q --root-user-action=ignore --disable-pip-version-check
+              "fastmcp<3" httpx "psycopg[binary]" &&
+              python3 server.py
+          env:
+            - name: API_BASE
+              value: http://demo-api:8000
+            - name: DATABASE_URI
+              value: postgresql://demo:demo1234@postgres:5432/demo
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            tcpSocket: { port: 8000 }
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          configMap:
+            name: ${APP}-app
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${APP}
+spec:
+  selector: { app: ${APP} }
+  ports:
+    - port: 8000
+      targetPort: 8000
+EOF
+done
+
+echo ""
+echo "Waiting for MCP servers to start (pip install at boot; typically 1-2 min)..."
+kubectl -n ${NS} rollout status deployment/mcp-api --timeout=5m > /dev/null
+kubectl -n ${NS} rollout status deployment/mcp-db --timeout=5m > /dev/null
+
+# JSON-RPC helper for streamable HTTP (unwraps SSE-framed responses)
+mcp_rpc() {
+    local URL="$1" SID="$2" BODY="$3"
+    local HDRS=(-H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream')
+    [ -n "$SID" ] && HDRS+=(-H "mcp-session-id: $SID")
+    curl -s --max-time 15 "${HDRS[@]}" "$URL" -d "$BODY" | sed -n 's/^data: //p; /^{/p' | tail -1
+}
+
+mcp_check() {
+    local NAME="$1"
+    local URL="http://$(kubectl -n ${NS} get svc ${NAME} -o jsonpath='{.spec.clusterIP}'):8000/mcp"
+    local SID
+    SID=$(curl -si --max-time 15 "$URL" \
+        -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"probe","version":"1.0"}}}' \
+        | grep -i '^mcp-session-id:' | tr -d '\r' | awk '{print $2}')
+    [ -n "$SID" ] || { echo "ERROR: ${NAME} initialize failed"; exit 1; }
+    mcp_rpc "$URL" "$SID" '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
+    mcp_rpc "$URL" "$SID" '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | python3 -c "
+import sys, json
+tools = json.load(sys.stdin)['result']['tools']
+print(f'  ${NAME}: {len(tools)} tools -> ' + ', '.join(t['name'] for t in tools))"
+}
+
+echo ""
+echo "=== Verifying MCP handshake (initialize + tools/list) ==="
+mcp_check mcp-api
+mcp_check mcp-db
+
+echo ""
+echo "========================================"
+echo "SUCCESS: Both MCP servers are serving (streamable HTTP)"
+echo "========================================"
+echo "  mcp-api: http://mcp-api.${NS}.svc.cluster.local:8000/mcp"
+echo "  mcp-db:  http://mcp-db.${NS}.svc.cluster.local:8000/mcp"
+echo "  Next: deploy-agentgateway.sh federates both behind one external endpoint"
+echo ""
+echo "\$\$CMD[Check MCP Servers](kubectl -n mcp-demo get pods -l 'app in (mcp-api,mcp-db)')"
+exit 0

--- a/scripts/usecases/mcp/test-mcp-e2e.sh
+++ b/scripts/usecases/mcp/test-mcp-e2e.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# End-to-end MCP demo through agentgateway (run on K8s control plane)
+# Shows the two access paths to the same data: curated API tools vs read-only SQL
+# Prerequisites: deploy-agentgateway.sh completed
+
+set -e
+
+NS="mcp-demo"
+MCP_NODEPORT="30900"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --nodeport) MCP_NODEPORT="$2"; shift 2 ;;
+        *) echo "Usage: $0 [--nodeport <port>]"; exit 1 ;;
+    esac
+done
+
+NODE_IP=$(hostname -I | awk '{print $1}')
+GW_URL="http://${NODE_IP}:${MCP_NODEPORT}/mcp"
+
+cat <<'BANNER'
+┌────────────────────────────────────────────────────────────┐
+│ MCP E2E DEMO · one gateway, two paths to the same data     │
+│  api_* tools : curated REST wrappers — the governed        │
+│                write path (create_order checks stock)      │
+│  db_*  tools : raw SQL — powerful ad-hoc analysis,         │
+│                but READ-ONLY by policy                     │
+└────────────────────────────────────────────────────────────┘
+BANNER
+
+mcp_rpc() {
+    local SID="$1" BODY="$2"
+    local HDRS=(-H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream')
+    [ -n "$SID" ] && HDRS+=(-H "mcp-session-id: $SID")
+    curl -s --max-time 20 "${HDRS[@]}" "$GW_URL" -d "$BODY" | sed -n 's/^data: //p; /^{/p' | tail -1
+}
+
+# Unwraps a tools/call result (structuredContent or JSON text content) and pretty-prints
+show_result() {
+    python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+if 'error' in d:
+    print('  RPC error:', d['error'].get('message')); sys.exit(1)
+r = d['result']
+obj = r.get('structuredContent')
+if obj is None and r.get('content'):
+    try: obj = json.loads(r['content'][0]['text'])
+    except Exception: obj = r['content'][0]['text']
+if isinstance(obj, dict) and set(obj) == {'result'}:
+    obj = obj['result']
+rows = obj if isinstance(obj, list) else [obj]
+for row in rows[:12]:
+    if isinstance(row, dict):
+        print('  ' + ' | '.join(f'{k}: {v}' for k, v in row.items()))
+    else:
+        print('  ' + str(row))
+if isinstance(obj, list) and len(obj) > 12:
+    print(f'  ... ({len(obj)} rows total)')"
+}
+
+call_tool() {  # $1=tool name, $2=arguments json
+    mcp_rpc "$SID" "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":$2}}"
+}
+
+echo ""
+echo "[1/5] Connecting to the federated endpoint: ${GW_URL}"
+SID=$(curl -si --max-time 15 "$GW_URL" \
+    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"e2e-demo","version":"1.0"}}}' \
+    | grep -i '^mcp-session-id:' | tr -d '\r' | awk '{print $2}')
+[ -n "$SID" ] || { echo "ERROR: initialize failed. Run deploy-agentgateway.sh first."; exit 1; }
+mcp_rpc "$SID" '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
+
+mcp_rpc "$SID" '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | python3 -c "
+import sys, json
+tools = json.load(sys.stdin)['result']['tools']
+print(f'  {len(tools)} tools federated behind ONE endpoint:')
+for t in tools:
+    print(f\"    {t['name']:24s} {(t.get('description') or '').strip().splitlines()[0][:58]}\")"
+
+echo ""
+echo "[2/5] API path — api_list_products (curated tool):"
+call_tool api_list_products '{}' | show_result
+
+echo ""
+echo "[3/5] SQL path — db_query: ad-hoc revenue analysis the API never anticipated:"
+SQL="SELECT p.name, SUM(oi.quantity) AS units, SUM(oi.quantity*oi.unit_price) AS revenue FROM order_items oi JOIN products p ON p.id=oi.product_id GROUP BY p.name ORDER BY revenue DESC LIMIT 5"
+echo "  > ${SQL}"
+call_tool db_query "{\"sql\": \"${SQL}\"}" | show_result
+
+echo ""
+echo "[4/5] SQL path is READ-ONLY — a write via db_query gets rejected:"
+echo "  > UPDATE products SET stock = 0"
+call_tool db_query '{"sql": "UPDATE products SET stock = 0"}' | show_result
+
+echo ""
+echo "[5/5] Writes go through the governed API path — api_create_order:"
+BEFORE=$(call_tool db_query '{"sql": "SELECT stock FROM products WHERE id=5"}')
+echo "  stock of product #5 before:"; echo "$BEFORE" | show_result
+call_tool api_create_order '{"customer_id": 5, "product_id": 5, "quantity": 2}' | show_result
+echo "  stock of product #5 after (verified via the SQL path):"
+call_tool db_query '{"sql": "SELECT stock FROM products WHERE id=5"}' | show_result
+
+echo ""
+echo "========================================"
+echo "E2E DEMO COMPLETE"
+echo "========================================"
+echo "  Same data, two governed paths, one MCP endpoint — that is agentgateway federation."
+echo "  Connect your own client:  claude mcp add --transport http shop-demo http://<node-public-ip>:${MCP_NODEPORT}/mcp"
+echo ""
+echo "\$\$CMD[Check MCP stack](kubectl -n mcp-demo get pods)"
+exit 0


### PR DESCRIPTION
# MCP + agentgateway demo usecase

Expose in-cluster data services as **Model Context Protocol (MCP)** servers and
federate them behind a single external endpoint with
[agentgateway](https://agentgateway.dev) — so any MCP client (Claude Code,
MCP Inspector, IDEs) can use them remotely.

```
[External MCP client: Claude Code / MCP Inspector]
        │  streamable HTTP   http://<node-public-ip>:30900/mcp
        ▼
┌─ K8s namespace: mcp-demo ─────────────────────────────────┐
│  agentgateway (NodePort 30900, admin UI 30901)            │
│    ├─ target "api" → mcp-api :8000/mcp                    │
│    │                   └─ REST → demo-api (FastAPI)       │
│    └─ target "db"  → mcp-db  :8000/mcp                    │
│                        └─ read-only SQL ↘                 │
│                              postgres (+ web-shop data)   │
└───────────────────────────────────────────────────────────┘
```