### PR TITLE
Initial support K8s deployment by kind

### DIFF
--- a/.github/workflows/k8s-smoke.yaml
+++ b/.github/workflows/k8s-smoke.yaml
@@ -1,0 +1,59 @@
+# Smoke-test the Helm chart on a kind cluster:
+# lint/template -> install -> all pods Ready -> readyz/livez respond.
+name: K8s Helm Chart Smoke Test
+
+on:
+  pull_request:
+    paths:
+      - "deployments/helm/**"
+      - ".github/workflows/k8s-smoke.yaml"
+  workflow_dispatch:
+
+jobs:
+  helm-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint and render chart
+        run: |
+          helm lint deployments/helm/cb-tumblebug
+          helm template cb-tumblebug deployments/helm/cb-tumblebug -n cb-tumblebug > /dev/null
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: cb-tumblebug
+
+      - name: Install chart
+        run: |
+          helm upgrade --install cb-tumblebug deployments/helm/cb-tumblebug \
+            --namespace cb-tumblebug --create-namespace --timeout 15m
+
+      - name: Wait for workloads
+        run: |
+          kubectl wait pods -l app.kubernetes.io/part-of=cb-tumblebug \
+            --for=condition=Ready -n cb-tumblebug --timeout=900s || {
+              kubectl get pods -n cb-tumblebug
+              kubectl describe pods -n cb-tumblebug | tail -100
+              exit 1
+            }
+
+      - name: Check health endpoints
+        run: |
+          kubectl port-forward -n cb-tumblebug svc/cb-tumblebug 11323:1323 &
+          sleep 3
+          curl -sf http://localhost:11323/tumblebug/livez
+          curl -sf http://localhost:11323/tumblebug/readyz
+          echo "readyz/livez OK"
+
+      - name: Show status on failure
+        if: failure()
+        run: |
+          kubectl get pods,svc,jobs -n cb-tumblebug
+          kubectl logs -n cb-tumblebug -l app=cb-tumblebug --tail=50 || true
+          kubectl logs -n cb-tumblebug job/openbao-init --tail=50 || true

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ src/testclient/test-clis/**/test-results/*
 
 # Object Storage test (local only)
 # (no additional exceptions)
+deployments/helm/cb-tumblebug/values-mcp.yaml

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,13 @@ swag swagger: ## Generate Swagger documentation
 # ===== Initialization =====
 SHELL := /bin/bash
 
-init: ## Run initialization sequence (`make init ARGS="-y"` for headless; needs MULTI_INIT_PWD or ~/.cloud-barista/.tmp_enc_key)
+init: ## Run initialization sequence (`make init ARGS="-y"` for headless; `TARGET=k8s` or `make k-init` for Kubernetes)
+ifeq ($(TARGET),k8s)
+	@$(MAKE) k-init
+else
 	@chmod +x ./init/multi-init.sh 2>/dev/null || true
 	@./init/multi-init.sh $(ARGS)
+endif
 
 init-profile: ## Maintainer-only: run make init with elapsed/memory profiling outputs under tmp/init-profile/
 	@chmod +x ./scripts/misc/init-profile.sh 2>/dev/null || true
@@ -114,11 +118,260 @@ restore-assets: ## Restore PostgreSQL database from assets backup (or FILE=<path
 	fi
 
 # ===== Utility Aliases =====
-up: ## Start all services (alias for compose)
+# TARGET=k8s switches up/init/down to the Kubernetes (Helm) deployment.
+# Default (no TARGET) keeps the existing docker compose behavior unchanged.
+up: ## Start all services (compose; `make up TARGET=k8s` or `make k-up` for Kubernetes)
+ifeq ($(TARGET),k8s)
+	@$(MAKE) k-up
+else
 	@$(MAKE) compose
+endif
 
-down: ## Quick stop (alias for compose-down)
+down: ## Quick stop (compose; `make down TARGET=k8s` or `make k-down` for Kubernetes)
+ifeq ($(TARGET),k8s)
+	@$(MAKE) k-down
+else
 	@$(MAKE) compose-down
+endif
+
+# ===== Kubernetes (Helm) Deployment =====
+# Short k-* commands mirror the compose verbs:
+#   up/down/init/ps/logs/clean-db+clean-all  ->  k-up/k-down/k-init/k-status(=k-ps)/k-logs/k-clean
+# Works against any cluster in the current kubeconfig context (kind is only the
+# local-dev fallback). Pin a context explicitly with: make k-up K8S_CONTEXT=<ctx>
+K8S_NAMESPACE ?= cb-tumblebug
+HELM_RELEASE ?= cb-tumblebug
+HELM_CHART := deployments/helm/cb-tumblebug
+K8S_INIT_PORT ?= 11323
+K8S_CONTEXT ?=
+KIND_CLUSTER_NAME ?= cb-tumblebug
+KUBECTL := kubectl$(if $(K8S_CONTEXT), --context $(K8S_CONTEXT))
+HELM := helm$(if $(K8S_CONTEXT), --kube-context $(K8S_CONTEXT))
+# Persistent local toggles (survive future k-up runs; gitignored)
+K8S_MCP_VALUES := deployments/helm/cb-tumblebug/values-mcp.yaml
+MCP_VALUES_FLAG = $(if $(wildcard $(K8S_MCP_VALUES)),-f $(K8S_MCP_VALUES))
+
+k-up: ## Install/upgrade the stack on Kubernetes (creates a kind cluster if no cluster is reachable)
+	@command -v helm >/dev/null || { echo "helm is required: https://helm.sh/docs/intro/install/"; exit 1; }
+	@command -v kubectl >/dev/null || { echo "kubectl is required"; exit 1; }
+	@if ! $(KUBECTL) cluster-info >/dev/null 2>&1; then \
+		if command -v kind >/dev/null; then \
+			echo "No reachable cluster. Creating kind cluster '$(KIND_CLUSTER_NAME)'..."; \
+			kind create cluster --name $(KIND_CLUSTER_NAME); \
+		else \
+			echo "No reachable Kubernetes cluster and 'kind' is not installed."; \
+			echo "Install kind (https://kind.sigs.k8s.io) or configure kubectl context."; \
+			exit 1; \
+		fi; \
+	fi
+	@# Show the install target; confirm when it is not a local kind cluster
+	@ctx="$(K8S_CONTEXT)"; [ -n "$$ctx" ] || ctx=$$(kubectl config current-context 2>/dev/null); \
+	server=$$($(KUBECTL) config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null); \
+	echo "Target cluster: context '$$ctx' ($$server), namespace '$(K8S_NAMESPACE)'"; \
+	case "$$ctx" in \
+		kind-*) ;; \
+		*) if [ -t 0 ]; then \
+			read -p "This is NOT a kind cluster. Install into it? (y/N): " ans; \
+			case "$$ans" in [yY]*) ;; *) echo "Aborted."; exit 1;; esac; \
+		else \
+			echo "WARNING: installing into a non-kind cluster (non-interactive mode; proceeding)"; \
+		fi ;; \
+	esac
+	@# Preflight: PVCs need a default StorageClass unless storageClassName values are given
+	@if ! echo '$(HELM_ARGS)' | grep -q storageClassName; then \
+		if ! $(KUBECTL) get storageclass 2>/dev/null | grep -q '(default)'; then \
+			echo "ERROR: this cluster has no default StorageClass — PVCs would stay Pending forever."; \
+			echo "  Fix one of:"; \
+			echo "   - mark a StorageClass as default (storageclass.kubernetes.io/is-default-class=true)"; \
+			echo "   - pass explicit classes: make k-up HELM_ARGS=\"--set etcd.storageClassName=<sc> --set tumblebugPostgres.storageClassName=<sc> --set spiderPostgres.storageClassName=<sc> --set openbao.storageClassName=<sc> --set terrarium.storageClassName=<sc>\""; \
+			exit 1; \
+		fi; \
+	fi
+	@# Preflight: warn if every node is control-plane-tainted (common on single-node kubeadm)
+	@total=$$($(KUBECTL) get nodes --no-headers 2>/dev/null | wc -l); \
+	tainted=$$($(KUBECTL) get nodes -o jsonpath='{range .items[*]}{range .spec.taints[*]}{.key}:{.effect} {end}{"\n"}{end}' 2>/dev/null | grep -c 'node-role.kubernetes.io/\(control-plane\|master\):NoSchedule' || true); \
+	if [ "$$total" -gt 0 ] && [ "$$tainted" -ge "$$total" ]; then \
+		echo "WARNING: all $$total node(s) carry the control-plane NoSchedule taint — pods will stay Pending."; \
+		echo "  Single-node cluster fix: kubectl taint nodes --all node-role.kubernetes.io/control-plane:NoSchedule-"; \
+	fi
+	@if $(HELM) status $(HELM_RELEASE) -n $(K8S_NAMESPACE) >/dev/null 2>&1; then \
+		rev=$$($(HELM) list -n $(K8S_NAMESPACE) --filter '^$(HELM_RELEASE)$$' 2>/dev/null | tail -1 | awk '{print $$3}'); \
+		echo "Existing release found (revision $$rev) — upgrading in place (pods restart only if templates changed)..."; \
+	else \
+		echo "No existing release — fresh install into namespace '$(K8S_NAMESPACE)'..."; \
+	fi
+	@# --reset-values: state comes only from chart defaults + current flags
+	@# (otherwise helm silently carries over user-supplied values from the previous revision)
+	@$(HELM) upgrade --install $(HELM_RELEASE) $(HELM_CHART) \
+		--namespace $(K8S_NAMESPACE) --create-namespace --timeout 10m \
+		--reset-values $(MCP_VALUES_FLAG) $(HELM_ARGS) || \
+		{ $(MAKE) --no-print-directory k-diagnose; exit 1; }
+	@echo ""
+	@echo "Waiting for pods to become Ready (timeout 10m)..."
+	@$(KUBECTL) wait pods -l app.kubernetes.io/part-of=cb-tumblebug \
+		--for=condition=Ready -n $(K8S_NAMESPACE) --timeout=600s || \
+		{ $(MAKE) --no-print-directory k-diagnose; exit 1; }
+	@$(MAKE) --no-print-directory k-status
+	@echo ""
+	@echo "Next: make k-init           (first deployment only — register credentials & load assets)"
+	@echo "      make k-port-forward   (port-forward API 1323 & MapUI 1324 to localhost)"
+
+# Internal: dump why the deployment is unhealthy (used by k-up failure paths)
+k-diagnose:
+	@echo ""
+	@echo "=== Deployment diagnostics (namespace $(K8S_NAMESPACE)) ==="
+	@echo "--- Pods not Running/Completed:"
+	@$(KUBECTL) get pods -n $(K8S_NAMESPACE) 2>/dev/null | grep -vE "Running|Completed" || echo "  (none)"
+	@echo "--- PVC status (Pending = no usable StorageClass?):"
+	@$(KUBECTL) get pvc -n $(K8S_NAMESPACE) 2>/dev/null || true
+	@echo "--- Recent Warning events:"
+	@$(KUBECTL) get events -n $(K8S_NAMESPACE) --field-selector type=Warning \
+		--sort-by=.lastTimestamp 2>/dev/null | tail -12 || true
+	@echo "--- openbao-init job logs (if any):"
+	@$(KUBECTL) logs -n $(K8S_NAMESPACE) job/openbao-init --tail=10 2>/dev/null || echo "  (no job logs)"
+	@echo "Check again later with: make k-status"
+
+k-init: ## Run initialization against the Kubernetes deployment (port-forward + headless-capable init)
+	@echo "Port-forwarding cb-tumblebug ($(K8S_INIT_PORT) -> 1323)..."
+	@$(KUBECTL) port-forward -n $(K8S_NAMESPACE) svc/cb-tumblebug $(K8S_INIT_PORT):1323 >/dev/null 2>&1 & \
+	PF_PID=$$!; \
+	trap "kill $$PF_PID 2>/dev/null" EXIT; \
+	sleep 2; \
+	chmod +x ./init/multi-init.sh 2>/dev/null || true; \
+	TUMBLEBUG_SERVER=localhost:$(K8S_INIT_PORT) \
+	ASSETS_PG_BACKEND=kubectl \
+	TB_K8S_NAMESPACE=$(K8S_NAMESPACE) \
+	./init/multi-init.sh $(ARGS)
+
+k-down: ## Uninstall the Helm release and wait for pods to terminate (PVCs/data are kept)
+	$(HELM) uninstall $(HELM_RELEASE) -n $(K8S_NAMESPACE) || true
+	@$(KUBECTL) delete job openbao-init -n $(K8S_NAMESPACE) --ignore-not-found 2>/dev/null || true
+	@$(MAKE) --no-print-directory k-port-forward-stop
+	@echo "Waiting for pods to terminate (timeout 2m)..."
+	@$(KUBECTL) wait --for=delete pods -l app.kubernetes.io/part-of=cb-tumblebug \
+		-n $(K8S_NAMESPACE) --timeout=120s 2>/dev/null || \
+		{ echo "Some pods are still terminating — check later with: make k-status"; }
+	@echo "Stopped. Data PVCs are kept (restart: make k-up). Full reset: make k-clean"
+
+k-clean: ## Full K8s reset: uninstall + delete PVCs and OpenBao key Secret
+	@$(HELM) uninstall $(HELM_RELEASE) -n $(K8S_NAMESPACE) 2>/dev/null || true
+	@$(KUBECTL) delete job openbao-init -n $(K8S_NAMESPACE) --ignore-not-found 2>/dev/null || true
+	$(KUBECTL) delete pvc --all -n $(K8S_NAMESPACE) 2>/dev/null || true
+	@echo "Waiting for PVC deletion to complete (prevents volume reuse races on the next k-up)..."
+	@$(KUBECTL) wait --for=delete pvc --all -n $(K8S_NAMESPACE) --timeout=180s 2>/dev/null || true
+	$(KUBECTL) delete secret openbao-keys -n $(K8S_NAMESPACE) 2>/dev/null || true
+	@$(MAKE) --no-print-directory k-port-forward-stop
+	@echo "Cleaned. Run 'make k-up' then 'make k-init' to re-deploy."
+	@echo "(a kind cluster is kept; remove with: kind delete cluster --name $(KIND_CLUSTER_NAME))"
+
+k-port-forward: ## Start port-forwards for API (1323) and MapUI (1324); idempotent (restarts stale ones)
+	@$(MAKE) --no-print-directory k-port-forward-stop
+	@$(KUBECTL) port-forward -n $(K8S_NAMESPACE) svc/cb-tumblebug 1323:1323 >/dev/null 2>&1 &
+	@$(KUBECTL) get svc cb-mapui -n $(K8S_NAMESPACE) >/dev/null 2>&1 && \
+		{ $(KUBECTL) port-forward -n $(K8S_NAMESPACE) svc/cb-mapui 1324:1324 >/dev/null 2>&1 & } || true
+	@sleep 2
+	@echo "Port-forwards started:"
+	@echo "  API / Swagger : http://localhost:1323/tumblebug/api"
+	@echo "  MapUI         : http://localhost:1324"
+	@echo "Stop with: make k-port-forward-stop"
+
+k-mcp-on: ## Enable the MCP server (persists across future k-up runs)
+	@printf 'mcp:\n  enabled: true\n' > $(K8S_MCP_VALUES)
+	@echo "MCP server enabled (persisted in $(K8S_MCP_VALUES)). Applying..."
+	@$(MAKE) --no-print-directory k-up
+	@echo ""
+	@echo "MCP endpoint: kubectl port-forward -n $(K8S_NAMESPACE) svc/cb-tumblebug-mcp-server 8000:8000"
+
+k-mcp-off: ## Disable the MCP server
+	@rm -f $(K8S_MCP_VALUES)
+	@echo "MCP server disabled. Applying..."
+	@$(MAKE) --no-print-directory k-up
+
+K8S_TOKEN_FILE ?= $(HOME)/.cloud-barista/k8s-admin.token
+
+k-token: ## Create an admin token file for K8s UIs like Headlamp (cluster-admin; local dev use)
+	@$(KUBECTL) create serviceaccount headlamp-admin -n kube-system 2>/dev/null || true
+	@$(KUBECTL) create clusterrolebinding headlamp-admin --clusterrole=cluster-admin \
+		--serviceaccount=kube-system:headlamp-admin 2>/dev/null || true
+	@printf '%s\n' \
+		'apiVersion: v1' \
+		'kind: Secret' \
+		'metadata:' \
+		'  name: headlamp-admin-token' \
+		'  namespace: kube-system' \
+		'  annotations:' \
+		'    kubernetes.io/service-account.name: headlamp-admin' \
+		'type: kubernetes.io/service-account-token' | $(KUBECTL) apply -f - >/dev/null
+	@mkdir -p $(dir $(K8S_TOKEN_FILE))
+	@for i in 1 2 3 4 5 6 7 8 9 10; do \
+		tok=$$($(KUBECTL) get secret headlamp-admin-token -n kube-system -o jsonpath='{.data.token}' 2>/dev/null | base64 -d); \
+		[ -n "$$tok" ] && { printf '%s' "$$tok" > $(K8S_TOKEN_FILE); break; }; \
+		sleep 1; \
+	done
+	@[ -s $(K8S_TOKEN_FILE) ] || { echo "Failed to obtain token — is the cluster reachable?"; exit 1; }
+	@chmod 600 $(K8S_TOKEN_FILE)
+	@$(KUBECTL) --token="$$(cat $(K8S_TOKEN_FILE))" get ns >/dev/null 2>&1 && \
+		echo "Admin token saved: $(K8S_TOKEN_FILE) (verified)" || \
+		echo "Admin token saved: $(K8S_TOKEN_FILE) (verification failed — check cluster)"
+	@echo "Use it to log in to Headlamp or other K8s UIs."
+	@echo "Note: cluster-admin, no expiry — local dev only. Revoke: $(KUBECTL) delete secret headlamp-admin-token -n kube-system"
+
+k-port-forward-stop: ## Stop port-forwards targeting namespace $(K8S_NAMESPACE) (others are untouched)
+	@pids=$$(ps -eo pid=,args= | awk '$$2 ~ /(^|\/)kubectl$$/ && $$3 == "port-forward" && / $(K8S_NAMESPACE) /{print $$1}' | xargs); \
+	if [ -n "$$pids" ]; then \
+		echo "Stopping port-forwards for namespace $(K8S_NAMESPACE) (PID: $$pids)"; \
+		kill $$pids 2>/dev/null || true; \
+	fi
+
+k-status: ## Show K8s deployment status (release/pods/services/port-forwards)
+	@if $(HELM) status $(HELM_RELEASE) -n $(K8S_NAMESPACE) >/dev/null 2>&1; then \
+		$(HELM) list -n $(K8S_NAMESPACE) --filter '^$(HELM_RELEASE)$$' 2>/dev/null | tail -1 | \
+			awk '{print "Helm release: " $$1 " (" $$8 ", revision " $$3 ", updated " $$4 " " $$5 ")"}'; \
+	else \
+		echo "Helm release: not installed — run 'make k-up'"; \
+	fi
+	@echo ""
+	@$(KUBECTL) get pods,svc -n $(K8S_NAMESPACE) 2>/dev/null || true
+	@echo ""
+	@echo "Active port-forwards (may be stale after pod restarts — refresh with: make k-port-forward):"
+	@pf=$$(ps -eo pid=,args= | awk '$$2 ~ /(^|\/)kubectl$$/ && $$3 == "port-forward"'); \
+	if [ -n "$$pf" ]; then \
+		echo "$$pf" | sed 's/^/  /'; \
+	else \
+		echo "  (none) — start with: make k-port-forward"; \
+	fi
+
+k-ps: ## Show K8s deployment status (alias for k-status)
+	@$(MAKE) --no-print-directory k-status
+
+k-logs: ## Show per-component log commands (`make k-logs C=cb-spider` to follow one)
+ifeq ($(C),)
+	@echo "Per-component logs (namespace: $(K8S_NAMESPACE)) — follow one with: make k-logs C=<name>"
+	@echo ""
+	@echo "  cb-tumblebug   $(KUBECTL) logs -n $(K8S_NAMESPACE) -f deploy/cb-tumblebug"
+	@echo "  cb-spider      $(KUBECTL) logs -n $(K8S_NAMESPACE) -f deploy/cb-spider"
+	@echo "  mc-terrarium   $(KUBECTL) logs -n $(K8S_NAMESPACE) -f deploy/mc-terrarium"
+	@echo "  cb-mapui       $(KUBECTL) logs -n $(K8S_NAMESPACE) -f deploy/cb-mapui"
+	@echo "  etcd           $(KUBECTL) logs -n $(K8S_NAMESPACE) -f sts/cb-tumblebug-etcd"
+	@echo "  tb-postgres    $(KUBECTL) logs -n $(K8S_NAMESPACE) -f sts/cb-tumblebug-postgres"
+	@echo "  sp-postgres    $(KUBECTL) logs -n $(K8S_NAMESPACE) -f sts/cb-spider-postgres"
+	@echo "  openbao        $(KUBECTL) logs -n $(K8S_NAMESPACE) -f openbao-0 -c openbao"
+	@echo "  openbao-init   $(KUBECTL) logs -n $(K8S_NAMESPACE) job/openbao-init"
+	@echo ""
+	@echo "  all (merged)   $(KUBECTL) logs -n $(K8S_NAMESPACE) -f -l app.kubernetes.io/part-of=cb-tumblebug --prefix --max-log-requests=10"
+else ifeq ($(C),etcd)
+	$(KUBECTL) logs -n $(K8S_NAMESPACE) -f sts/cb-tumblebug-etcd
+else ifeq ($(C),tb-postgres)
+	$(KUBECTL) logs -n $(K8S_NAMESPACE) -f sts/cb-tumblebug-postgres
+else ifeq ($(C),sp-postgres)
+	$(KUBECTL) logs -n $(K8S_NAMESPACE) -f sts/cb-spider-postgres
+else ifeq ($(C),openbao)
+	$(KUBECTL) logs -n $(K8S_NAMESPACE) -f openbao-0 -c openbao
+else ifeq ($(C),openbao-init)
+	$(KUBECTL) logs -n $(K8S_NAMESPACE) job/openbao-init
+else
+	$(KUBECTL) logs -n $(K8S_NAMESPACE) -f deploy/$(C)
+endif
 
 # ===== OpenBao Commands =====
 init-openbao: ## Initialize OpenBao (one-time setup: generate unseal key + root token)
@@ -183,6 +436,19 @@ help: ## Display this help screen
 	@echo "  \033[36minit-openbao\033[0m           Initialize OpenBao (one-time setup)"
 	@echo "  \033[36munseal\033[0m                 Unseal OpenBao (after container restart)"
 	@echo ""
+	@echo "☸️  Kubernetes (Helm):"
+	@echo -e "  \033[36mk-up\033[0m                   Install stack via Helm (auto-creates kind cluster if needed)"
+	@echo -e "  \033[36mk-init\033[0m                 Initialize the K8s deployment (port-forward + init flow)"
+	@echo -e "  \033[36mk-down\033[0m                 Uninstall Helm release (data kept)"
+	@echo -e "  \033[36mk-clean\033[0m                Full K8s reset (PVCs + OpenBao Secret)"
+	@echo -e "  \033[36mk-status (k-ps)\033[0m        Show K8s status (release/pods/services/port-forwards)"
+	@echo -e "  \033[36mk-logs\033[0m                 Per-component log commands (k-logs C=<name> to follow)"
+	@echo -e "  \033[36mk-port-forward\033[0m         Start port-forwards (API 1323, MapUI 1324; idempotent)"
+	@echo -e "  \033[36mk-port-forward-stop\033[0m    Stop port-forwards for the deployment namespace"
+	@echo -e "  \033[36mk-token\033[0m                Create admin token file for K8s UIs (e.g., Headlamp)"
+	@echo -e "  \033[36mk-mcp-on / k-mcp-off\033[0m   Enable/disable the MCP server (persistent toggle)"
+	@echo "  (aliases: make up/init/down TARGET=k8s)"
+	@echo ""
 	@echo "🧹 Cleanup:"
 	@echo "  \033[36mclean-db\033[0m               Clean database metadata (./init/cleanDB.sh)"
 	@echo "  \033[36mclean-all\033[0m              Stop containers + clean databases + OpenBao (requires re-init)"
@@ -205,4 +471,4 @@ help: ## Display this help screen
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # ===== PHONY targets (not actual files) =====
-.PHONY: default run clean clean-all swag swagger init init-profile compose compose-down logs status ps clean-db backup-assets restore-assets up down gen-cred enc-cred dec-cred bcrypt certs help
+.PHONY: default run clean clean-all swag swagger init init-profile compose compose-down logs status ps clean-db backup-assets restore-assets up down gen-cred enc-cred dec-cred bcrypt certs help k-up k-init k-down k-clean k-status k-ps k-logs k-port-forward k-port-forward-stop k-token k-mcp-on k-mcp-off k-diagnose

--- a/README.md
+++ b/README.md
@@ -144,6 +144,23 @@ make init
 
 > 💡 **New to CB-Tumblebug?** Follow the [detailed setup guide](#installation--setup-) below for comprehensive instructions.
 
+### Kubernetes Deployment (Beta) ☸️
+
+CB-Tumblebug can also run on Kubernetes via a Helm chart, using `k-` prefixed
+commands that mirror the compose verbs:
+
+```bash
+make k-up      # install the stack (auto-creates a kind cluster if none is reachable)
+make k-init    # register credentials & load assets (same flow as compose)
+make k-port-forward   # access API (1323) and MapUI (1324) on localhost
+```
+
+> ⚠️ **Beta feature**: the Kubernetes deployment and `make k-*` commands are
+> under active development — behavior and command names may change without
+> notice. Use with caution (docker compose remains the stable default).
+> See [deployments/helm/cb-tumblebug/README.md](deployments/helm/cb-tumblebug/README.md)
+> for prerequisites, operations, and troubleshooting.
+
 ---
 
 ## Prerequisites 🔧

--- a/deployments/helm/cb-tumblebug/Chart.yaml
+++ b/deployments/helm/cb-tumblebug/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: cb-tumblebug
+description: CB-Tumblebug multi-cloud infrastructure management stack (Tumblebug, Spider, Terrarium, MapUI, OpenBao, etcd, PostgreSQL)
+type: application
+version: 0.1.0
+appVersion: "0.12.27"
+keywords:
+  - cloud-barista
+  - multi-cloud
+home: https://github.com/cloud-barista/cb-tumblebug

--- a/deployments/helm/cb-tumblebug/README.md
+++ b/deployments/helm/cb-tumblebug/README.md
@@ -1,0 +1,127 @@
+# CB-Tumblebug Helm Chart
+
+Deploys the full CB-Tumblebug stack on Kubernetes: cb-tumblebug, cb-spider,
+mc-terrarium, cb-mapui, OpenBao, etcd, and two PostgreSQL instances — with the
+same topology and service names as the docker-compose deployment.
+
+## Prerequisites
+
+On a fresh machine (e.g., a new VM):
+
+| Tool | Needed for | Note |
+|---|---|---|
+| kubectl, helm | `make k-up` (always) | any recent version |
+| an existing K8s cluster (kubeconfig) — **or** Docker + kind | `make k-up` | with no reachable cluster, `k-up` auto-creates a kind cluster; kind itself requires Docker (`./scripts/installDocker.sh`) |
+| python ≥ 3.10, uv, openssl, curl | `make k-init` | same requirements as the compose `make init` |
+
+Credentials are prepared exactly like compose:
+`make gen-cred` → edit `~/.cloud-barista/credentials.yaml` → `make enc-cred`.
+
+For a single-VM **persistent** deployment, prefer a lightweight distribution
+such as k3s over kind (kind is a dev tool running the cluster inside Docker);
+once a kubeconfig exists, the flow below is identical.
+
+### Using an existing cluster (kubeadm etc.)
+
+`make k-up` targets **whatever your current kubeconfig context points at** —
+it shows the target and asks for confirmation when the context is not a kind
+cluster. Pin a context explicitly with `make k-up K8S_CONTEXT=<context>`
+(propagated to every helm/kubectl call of the k-* commands).
+
+Preflight checks will stop/warn you about the two most common existing-cluster
+pitfalls:
+
+- **No default StorageClass** (PVCs would stay Pending) — mark one as default,
+  or pass explicit classes via
+  `HELM_ARGS="--set etcd.storageClassName=<sc> --set tumblebugPostgres.storageClassName=<sc> ..."`.
+- **Single-node kubeadm control-plane taint** (pods would stay Pending) —
+  `kubectl taint nodes --all node-role.kubernetes.io/control-plane:NoSchedule-`.
+
+On failure, `k-up` automatically prints diagnostics (pending pods, PVC status,
+Warning events). `make k-token` creates a **cluster-admin** ServiceAccount —
+use it only on dedicated/local clusters.
+
+## Quick start
+
+```bash
+# From the repository root (creates a kind cluster if no cluster is reachable):
+make k-up
+
+# Register credentials and load assets (same flow as compose):
+make k-init          # interactive
+MULTI_INIT_PWD=... make k-init ARGS="-y"   # headless
+
+# Access (starts port-forwards; idempotent — restarts stale ones)
+make k-port-forward
+#   API / Swagger : http://localhost:1323/tumblebug/api
+#   MapUI         : http://localhost:1324
+```
+
+Or with Helm directly:
+
+```bash
+helm upgrade --install cb-tumblebug ./deployments/helm/cb-tumblebug \
+  --namespace cb-tumblebug --create-namespace
+```
+
+## How the pieces fit
+
+- **OpenBao bootstrap is automatic.** A post-install Job initializes OpenBao
+  (shares=1), stores the unseal key and root token in `Secret/openbao-keys`,
+  unseals, and enables KV v2 at `secret/`. An `unsealer` sidecar re-unseals
+  after every pod restart. cb-tumblebug and mc-terrarium reference the Secret
+  as a required env, so they intentionally stay in
+  `CreateContainerConfigError` until bootstrap completes.
+- **cb-tumblebug runs 1 replica with `strategy: Recreate`** — multi-replica is
+  not supported yet (in-process coordination state). Probes use
+  `/tumblebug/livez` (liveness) and `/tumblebug/readyz` with
+  `TB_READYZ_CHECK_DEPS=true` (readiness incl. etcd/PostgreSQL connectivity).
+- **cb-spider volumes follow the filesystem audit**
+  (docs/design/k8s-deployment.md §5.4): emptyDir for `log/`, `cache/`, `/tmp`.
+  If you use the KT/KTCLASSIC providers, their SG/VPC records are file-only —
+  mount PVCs for `cloud-driver-libs/.securitygroup-kt` and `.vpc-kt`.
+- **`make k-init`** port-forwards the API and reuses the standard
+  init flow; DB restore runs through `ASSETS_PG_BACKEND=kubectl`
+  (pod auto-detected via the `app=cb-tumblebug-postgres` label).
+
+## Profiles
+
+- `values.yaml` — dev defaults (kind/minikube, bundled datastores, default creds)
+- `values-prod.yaml` — production overlay example (real passwords, resources)
+
+## Operations
+
+```bash
+make k-status              # release/pods/services/port-forwards (alias: make k-ps)
+make k-down                # uninstall + wait for pod termination, keep data (PVCs)
+make k-clean               # full reset incl. PVCs + openbao-keys Secret
+make k-token               # admin token file for K8s UIs like Headlamp
+                           #   (~/.cloud-barista/k8s-admin.token; cluster-admin, dev only)
+```
+
+`Secret/openbao-keys` holds the unseal key and root token — back it up if the
+OpenBao data PVC matters to you; losing the Secret while keeping the PVC makes
+the vault unrecoverable (reset with `make k-clean`).
+
+## Troubleshooting
+
+- **`kubectl port-forward` fails with "address already in use":** a stale
+  port-forward from a previous session is still holding the port — they keep
+  listening even after their target pod is gone (e.g., after `make k-clean` /
+  `make k-up` recreated the stack). Just run `make k-port-forward` — it stops
+  the deployment's old forwards and starts fresh ones (`make k-status` lists
+  active forwards; `make k-port-forward-stop` stops them).
+- **cb-mapui stuck with no log output (then restarted by probes):** the Parcel
+  dev server needs inotify watchers; on shared/dev kernels (kind on WSL2 etc.)
+  the default `fs.inotify.max_user_instances=128` can be exhausted. Raise it on
+  the node: `sysctl -w fs.inotify.max_user_instances=512`.
+- **cb-tumblebug / mc-terrarium in `CreateContainerConfigError`:** normal until
+  the `openbao-init` Job stores `Secret/openbao-keys` (startup ordering).
+
+## Not included yet
+
+- External exposure via Gateway API (`Gateway`/`HTTPRoute`) + TLS — Phase 2;
+  Ingress is not planned (ingress-nginx EOL'd 2026-03; the Ingress API itself
+  remains usable with third-party controllers if you wire it manually)
+- Metabase dashboard; MCP server is `mcp.enabled: false` by default
+- Multi-replica / HA (Phase 3)

--- a/deployments/helm/cb-tumblebug/templates/_helpers.tpl
+++ b/deployments/helm/cb-tumblebug/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "cb.labels" -}}
+app.kubernetes.io/part-of: cb-tumblebug
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/deployments/helm/cb-tumblebug/templates/etcd.yaml
+++ b/deployments/helm/cb-tumblebug/templates/etcd.yaml
@@ -1,0 +1,78 @@
+# Single-member etcd (parity with docker-compose)
+apiVersion: v1
+kind: Service
+metadata:
+  name: cb-tumblebug-etcd
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: cb-tumblebug-etcd
+  ports:
+    - name: client
+      port: 2379
+    - name: peer
+      port: 2380
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cb-tumblebug-etcd
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  serviceName: cb-tumblebug-etcd
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cb-tumblebug-etcd
+  template:
+    metadata:
+      labels:
+        app: cb-tumblebug-etcd
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: etcd
+          image: {{ .Values.images.etcd }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command:
+            - /usr/local/bin/etcd
+            - --name=s1
+            - --data-dir=/etcd-data
+            - --listen-client-urls=http://0.0.0.0:2379
+            - --advertise-client-urls=http://0.0.0.0:2379
+            - --listen-peer-urls=http://0.0.0.0:2380
+            - --initial-advertise-peer-urls=http://0.0.0.0:2380
+            - --initial-cluster=s1=http://0.0.0.0:2380
+            - --initial-cluster-token=tkn
+            - --initial-cluster-state=new
+            - --log-level=info
+            - --logger=zap
+            - --log-outputs=stderr
+            - --auth-token=simple
+          ports:
+            - { name: client, containerPort: 2379 }
+            - { name: peer, containerPort: 2380 }
+          volumeMounts:
+            - { name: data, mountPath: /etcd-data }
+          readinessProbe:
+            exec:
+              command: ["/usr/local/bin/etcdctl", "endpoint", "health", "--endpoints=http://localhost:2379"]
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket: { port: 2379 }
+            periodSeconds: 15
+            failureThreshold: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.etcd.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.etcd.storage }}

--- a/deployments/helm/cb-tumblebug/templates/mapui.yaml
+++ b/deployments/helm/cb-tumblebug/templates/mapui.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.mapui.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: cb-mapui
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: cb-mapui
+  ports:
+    - name: http
+      port: 1324
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-mapui
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cb-mapui
+  template:
+    metadata:
+      labels:
+        app: cb-mapui
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: cb-mapui
+          image: {{ .Values.images.mapui }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - { name: http, containerPort: 1324 }
+          # Parcel dev server builds the bundle on start — allow several minutes
+          startupProbe:
+            tcpSocket: { port: http }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            tcpSocket: { port: http }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            tcpSocket: { port: http }
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 10
+          {{- with .Values.mapui.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deployments/helm/cb-tumblebug/templates/mcp.yaml
+++ b/deployments/helm/cb-tumblebug/templates/mcp.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: cb-tumblebug-mcp-server
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: cb-tumblebug-mcp-server
+  ports:
+    - name: http
+      port: 8000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-tumblebug-mcp-server
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cb-tumblebug-mcp-server
+  template:
+    metadata:
+      labels:
+        app: cb-tumblebug-mcp-server
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: mcp
+          image: {{ .Values.images.mcp }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - { name: http, containerPort: 8000 }
+          env:
+            - { name: TUMBLEBUG_API_BASE_URL, value: "http://cb-tumblebug:1323/tumblebug" }
+            - name: TUMBLEBUG_USERNAME
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_API_USERNAME } }
+            - name: TUMBLEBUG_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_API_PASSWORD } }
+            - { name: PYTHONUNBUFFERED, value: "1" }
+            - { name: MCP_SERVER_HOST, value: "0.0.0.0" }
+            - { name: MCP_SERVER_PORT, value: "8000" }
+            - { name: MCP_LOG_LEVEL, value: "INFO" }
+          readinessProbe:
+            tcpSocket: { port: http }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          {{- with .Values.mcp.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/deployments/helm/cb-tumblebug/templates/openbao-init-job.yaml
+++ b/deployments/helm/cb-tumblebug/templates/openbao-init-job.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.openbao.enabled }}
+# One-shot OpenBao bootstrap: sys/init -> store keys in Secret -> unseal -> KV v2 mount.
+# Post-install/upgrade hook; idempotent (skips init when already initialized).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao-init
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openbao-init
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+  # Restart token consumers after a fresh init (their VAULT_TOKEN env is frozen at container start)
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openbao-init
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openbao-init
+subjects:
+  - kind: ServiceAccount
+    name: openbao-init
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openbao-init
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 6
+  activeDeadlineSeconds: 600
+  template:
+    metadata:
+      labels:
+        app: openbao-init
+    spec:
+      serviceAccountName: openbao-init
+      restartPolicy: OnFailure
+      containers:
+        - name: init
+          image: {{ .Values.images.kubectl }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command:
+            - bash
+            - -ec
+            - |
+              BAO=http://openbao:8200
+
+              echo "Waiting for OpenBao API..."
+              until code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 $BAO/v1/sys/health) && [ "$code" != "000" ]; do
+                sleep 2
+              done
+
+              fresh_init=false
+              initialized=$(curl -s $BAO/v1/sys/init | jq -r .initialized)
+              if [ "$initialized" = "false" ]; then
+                echo "Initializing OpenBao (shares=1, threshold=1)..."
+                resp=$(curl -s -X POST -d '{"secret_shares":1,"secret_threshold":1}' $BAO/v1/sys/init)
+                key=$(echo "$resp" | jq -r '.keys_base64[0]')
+                token=$(echo "$resp" | jq -r '.root_token')
+                [ -n "$key" ] && [ "$key" != "null" ] || { echo "init failed: $resp"; exit 1; }
+                kubectl create secret generic openbao-keys \
+                  --from-literal=unseal-key="$key" \
+                  --from-literal=root-token="$token" \
+                  --dry-run=client -o yaml | kubectl apply -f -
+                echo "Stored unseal key + root token in Secret/openbao-keys"
+                fresh_init=true
+              else
+                echo "OpenBao already initialized."
+                kubectl get secret openbao-keys >/dev/null || {
+                  echo "ERROR: initialized but Secret/openbao-keys is missing (restore it or reset the openbao PVC)"; exit 1; }
+              fi
+
+              key=$(kubectl get secret openbao-keys -o jsonpath='{.data.unseal-key}' | base64 -d)
+              token=$(kubectl get secret openbao-keys -o jsonpath='{.data.root-token}' | base64 -d)
+
+              sealed=$(curl -s $BAO/v1/sys/seal-status | jq -r .sealed)
+              if [ "$sealed" = "true" ]; then
+                echo "Unsealing..."
+                curl -s -X POST -d "{\"key\":\"$key\"}" $BAO/v1/sys/unseal | jq -r '"sealed=" + (.sealed|tostring)'
+              fi
+
+              if ! curl -s -H "X-Vault-Token: $token" $BAO/v1/sys/mounts | jq -e '."secret/"' >/dev/null; then
+                echo "Enabling KV v2 at secret/..."
+                curl -s -X POST -H "X-Vault-Token: $token" \
+                  -d '{"type":"kv","options":{"version":"2"}}' $BAO/v1/sys/mounts/secret
+              fi
+
+              # Fresh init issued a new token; consumers hold VAULT_TOKEN frozen
+              # from container start, so restart them to pick it up
+              if [ "$fresh_init" = "true" ]; then
+                for d in cb-tumblebug mc-terrarium; do
+                  if kubectl get deploy "$d" >/dev/null 2>&1; then
+                    echo "Restarting deploy/$d to pick up the new token..."
+                    kubectl rollout restart "deploy/$d"
+                  fi
+                done
+              fi
+              echo "OpenBao bootstrap complete."
+{{- end }}

--- a/deployments/helm/cb-tumblebug/templates/openbao.yaml
+++ b/deployments/helm/cb-tumblebug/templates/openbao.yaml
@@ -1,0 +1,129 @@
+{{- if .Values.openbao.enabled }}
+# OpenBao with automated init (Job -> openbao-keys Secret) and auto-unseal
+# (sidecar re-unseals on every pod restart using the stored key).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openbao-config
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+data:
+  openbao-config.hcl: |
+    storage "file" {
+      path = "/openbao/data"
+    }
+    listener "tcp" {
+      address     = "0.0.0.0:8200"
+      tls_disable = true
+    }
+    disable_mlock = true
+    ui = true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openbao
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: openbao
+  ports:
+    - name: http
+      port: 8200
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openbao
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  serviceName: openbao
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openbao
+  template:
+    metadata:
+      labels:
+        app: openbao
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        # openbao image user uid/gid (fix PVC ownership without chown)
+        fsGroup: 1000
+      containers:
+        - name: openbao
+          image: {{ .Values.images.openbao }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args: ["server", "-config=/openbao/config/openbao-config.hcl"]
+          env:
+            - { name: BAO_ADDR, value: "http://0.0.0.0:8200" }
+            - { name: SKIP_SETCAP, value: "true" }
+          ports:
+            - { name: http, containerPort: 8200 }
+          volumeMounts:
+            - { name: data, mountPath: /openbao/data }
+            - { name: config, mountPath: /openbao/config, readOnly: true }
+          readinessProbe:
+            # Treat uninitialized/sealed as ready too — the init Job and the
+            # unsealer reach the API through the Service (avoids a bootstrap
+            # deadlock); clients tolerate the brief sealed window
+            httpGet: { path: "/v1/sys/health?uninitcode=204&sealedcode=204", port: http }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            # any API answer (incl. 501 uninitialized / 503 sealed) = process alive
+            tcpSocket: { port: http }
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+        - name: unsealer
+          # Re-unseals after every restart using the key stored by the init Job
+          image: {{ .Values.images.curl }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              # trap + interruptible sleep so SIGTERM stops the pod promptly
+              trap 'exit 0' TERM INT
+              while true; do
+                if [ -f /openbao-keys/unseal-key ]; then
+                  st=$(curl -s -m 3 http://127.0.0.1:8200/v1/sys/seal-status || true)
+                  case "$st" in
+                    *'"sealed":true'*)
+                      echo "unsealer: sealed, unsealing..."
+                      curl -s -m 5 -X POST \
+                        -d "{\"key\":\"$(cat /openbao-keys/unseal-key)\"}" \
+                        http://127.0.0.1:8200/v1/sys/unseal > /dev/null || true
+                      ;;
+                  esac
+                fi
+                sleep 10 &
+                wait $!
+              done
+          volumeMounts:
+            - { name: keys, mountPath: /openbao-keys, readOnly: true }
+      volumes:
+        - name: config
+          configMap:
+            name: openbao-config
+        - name: keys
+          secret:
+            secretName: openbao-keys
+            optional: true
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.openbao.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.openbao.storage }}
+{{- end }}

--- a/deployments/helm/cb-tumblebug/templates/secrets.yaml
+++ b/deployments/helm/cb-tumblebug/templates/secrets.yaml
@@ -1,0 +1,21 @@
+# API and database credentials (mirror of compose .env keys)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cb-stack-secret
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  TB_API_USERNAME: {{ .Values.auth.tbApiUsername | quote }}
+  TB_API_PASSWORD: {{ .Values.auth.tbApiPassword | quote }}
+  SP_API_USERNAME: {{ .Values.auth.spApiUsername | quote }}
+  SP_API_PASSWORD: {{ .Values.auth.spApiPassword | quote }}
+  TERRARIUM_API_USERNAME: {{ .Values.auth.terrariumApiUsername | quote }}
+  TERRARIUM_API_PASSWORD: {{ .Values.auth.terrariumApiPassword | quote }}
+  TB_POSTGRES_USER: {{ .Values.tumblebugPostgres.user | quote }}
+  TB_POSTGRES_PASSWORD: {{ .Values.tumblebugPostgres.password | quote }}
+  TB_POSTGRES_DATABASE: {{ .Values.tumblebugPostgres.database | quote }}
+  SP_POSTGRES_USER: {{ .Values.spiderPostgres.user | quote }}
+  SP_POSTGRES_PASSWORD: {{ .Values.spiderPostgres.password | quote }}
+  SP_POSTGRES_DATABASE: {{ .Values.spiderPostgres.database | quote }}

--- a/deployments/helm/cb-tumblebug/templates/spider-postgres.yaml
+++ b/deployments/helm/cb-tumblebug/templates/spider-postgres.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cb-spider-postgres
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: cb-spider-postgres
+  ports:
+    - name: postgres
+      port: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cb-spider-postgres
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  serviceName: cb-spider-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cb-spider-postgres
+  template:
+    metadata:
+      labels:
+        app: cb-spider-postgres
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.images.postgres }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+            - name: POSTGRES_USER
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_POSTGRES_USER } }
+            - name: POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_POSTGRES_PASSWORD } }
+            - name: POSTGRES_DB
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_POSTGRES_DATABASE } }
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - { name: postgres, containerPort: 5432 }
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/postgresql/data }
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            periodSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            tcpSocket: { port: 5432 }
+            periodSeconds: 15
+            failureThreshold: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.spiderPostgres.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.spiderPostgres.storage }}

--- a/deployments/helm/cb-tumblebug/templates/spider.yaml
+++ b/deployments/helm/cb-tumblebug/templates/spider.yaml
@@ -1,0 +1,103 @@
+# Volume/probe design follows the cb-spider filesystem audit
+# (docs/design/k8s-deployment.md §5.4):
+#  - emptyDir log/   : HTTP access log goes only to file (not stdout)
+#  - emptyDir cache/ : adminweb package init() fatals if uncreatable
+#  - emptyDir /tmp   : multipart >32MB spill
+#  - liveness on /spider/readyz: a failed first DB open is cached forever
+#    (sync.Once), so restart is the only recovery
+apiVersion: v1
+kind: Service
+metadata:
+  name: cb-spider
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: cb-spider
+  ports:
+    - name: http
+      port: 1024
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-spider
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: cb-spider
+  template:
+    metadata:
+      labels:
+        app: cb-spider
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: 30
+      initContainers:
+        # Four cb-spider packages panic in init() if the metadb is down at start
+        - name: wait-for-metadb
+          image: {{ .Values.images.postgres }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: ["sh", "-c", "until pg_isready -h cb-spider-postgres -p 5432 -U $PGUSER; do sleep 2; done"]
+          env:
+            - name: PGUSER
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_POSTGRES_USER } }
+      containers:
+        - name: cb-spider
+          image: {{ .Values.images.spider }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - { name: http, containerPort: 1024 }
+          env:
+            - { name: SERVER_ADDRESS, value: "0.0.0.0:1024" }
+            - { name: ADMINWEB, value: "OFF" }
+            - { name: ID_TRANSFORM_MODE, value: "OFF" }
+            - { name: SPIDER_LOG_LEVEL, value: {{ .Values.spider.logLevel | quote }} }
+            - { name: SPIDER_HISCALL_LOG_LEVEL, value: {{ .Values.spider.hiscallLogLevel | quote }} }
+            - name: SPIDER_USERNAME
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_API_USERNAME } }
+            - name: SPIDER_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_API_PASSWORD } }
+            - { name: SPIDER_METADB_ENDPOINT, value: "cb-spider-postgres:5432" }
+            - name: SPIDER_METADB_USER
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_POSTGRES_USER } }
+            - name: SPIDER_METADB_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_POSTGRES_PASSWORD } }
+            - name: SPIDER_METADB_DATABASE
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_POSTGRES_DATABASE } }
+            # DO NOT set CBSPIDER_ROOT / CBLOG_ROOT (baked in image; overriding breaks config paths)
+          volumeMounts:
+            - { name: log, mountPath: /root/go/src/github.com/cloud-barista/cb-spider/log }
+            - { name: cache, mountPath: /root/go/src/github.com/cloud-barista/cb-spider/cache }
+            - { name: tmp, mountPath: /tmp }
+          startupProbe:
+            httpGet: { path: /spider/readyz, port: http }
+            periodSeconds: 3
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet: { path: /spider/readyz, port: http }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet: { path: /spider/readyz, port: http }
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 12
+          {{- with .Values.spider.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: log
+          emptyDir: { sizeLimit: 512Mi }
+        - name: cache
+          emptyDir: { sizeLimit: 128Mi }
+        - name: tmp
+          emptyDir: { sizeLimit: 1Gi }

--- a/deployments/helm/cb-tumblebug/templates/terrarium.yaml
+++ b/deployments/helm/cb-tumblebug/templates/terrarium.yaml
@@ -1,0 +1,91 @@
+{{- if .Values.terrarium.enabled }}
+# OpenTofu state lives under /app/.terrarium -> PVC required
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mc-terrarium-state
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- with .Values.terrarium.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.terrarium.storage }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mc-terrarium
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: mc-terrarium
+  ports:
+    - name: http
+      port: 8055
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mc-terrarium
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mc-terrarium
+  template:
+    metadata:
+      labels:
+        app: mc-terrarium
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      securityContext:
+        # terrarium image runs as appuser (uid 1000); make the PVC writable
+        fsGroup: 1000
+      containers:
+        - name: mc-terrarium
+          image: {{ .Values.images.terrarium }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - { name: http, containerPort: 8055 }
+          env:
+            - { name: TERRARIUM_ROOT, value: "/app" }
+            - { name: TERRARIUM_LOGLEVEL, value: "info" }
+            - name: TERRARIUM_API_USERNAME
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TERRARIUM_API_USERNAME } }
+            - name: TERRARIUM_API_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TERRARIUM_API_PASSWORD } }
+            {{- if .Values.openbao.enabled }}
+            - { name: VAULT_ADDR, value: "http://openbao:8200" }
+            - name: VAULT_TOKEN
+              valueFrom: { secretKeyRef: { name: openbao-keys, key: root-token } }
+            {{- end }}
+          volumeMounts:
+            - { name: state, mountPath: /app/.terrarium }
+          readinessProbe:
+            httpGet: { path: /terrarium/readyz, port: http }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket: { port: http }
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          {{- with .Values.terrarium.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: mc-terrarium-state
+{{- end }}

--- a/deployments/helm/cb-tumblebug/templates/tumblebug-postgres.yaml
+++ b/deployments/helm/cb-tumblebug/templates/tumblebug-postgres.yaml
@@ -1,0 +1,71 @@
+# The "app: cb-tumblebug-postgres" label is relied on by
+# scripts/lib/pg-backend.sh (ASSETS_PG_BACKEND=kubectl auto-detection).
+apiVersion: v1
+kind: Service
+metadata:
+  name: cb-tumblebug-postgres
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: cb-tumblebug-postgres
+  ports:
+    - name: postgres
+      port: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cb-tumblebug-postgres
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  serviceName: cb-tumblebug-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cb-tumblebug-postgres
+  template:
+    metadata:
+      labels:
+        app: cb-tumblebug-postgres
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.images.postgres }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args: ["-c", "max_connections=500"]
+          env:
+            - name: POSTGRES_USER
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_POSTGRES_USER } }
+            - name: POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_POSTGRES_PASSWORD } }
+            - name: POSTGRES_DB
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_POSTGRES_DATABASE } }
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - { name: postgres, containerPort: 5432 }
+          volumeMounts:
+            - { name: data, mountPath: /var/lib/postgresql/data }
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            periodSeconds: 10
+            failureThreshold: 5
+          livenessProbe:
+            tcpSocket: { port: 5432 }
+            periodSeconds: 15
+            failureThreshold: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.tumblebugPostgres.storageClassName }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.tumblebugPostgres.storage }}

--- a/deployments/helm/cb-tumblebug/templates/tumblebug.yaml
+++ b/deployments/helm/cb-tumblebug/templates/tumblebug.yaml
@@ -1,0 +1,109 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cb-tumblebug
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: cb-tumblebug
+  ports:
+    - name: http
+      port: 1323
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cb-tumblebug
+  labels:
+    {{- include "cb.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  # Multi-replica is not supported yet (in-memory coordination state);
+  # Recreate also prevents old/new pods from overlapping during updates.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: cb-tumblebug
+  template:
+    metadata:
+      labels:
+        app: cb-tumblebug
+        {{- include "cb.labels" . | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.tumblebug.terminationGracePeriodSeconds }}
+      containers:
+        - name: cb-tumblebug
+          image: {{ .Values.images.tumblebug }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - { name: http, containerPort: 1323 }
+          env:
+            - { name: TB_ROOT_PATH, value: "/app" }
+            - { name: TB_SPIDER_REST_URL, value: "http://cb-spider:1024/spider" }
+            - { name: TB_ETCD_ENDPOINTS, value: "http://cb-tumblebug-etcd:2379" }
+            - { name: TB_TERRARIUM_REST_URL, value: "http://mc-terrarium:8055/terrarium" }
+            - { name: TB_POSTGRES_ENDPOINT, value: "cb-tumblebug-postgres:5432" }
+            - name: TB_POSTGRES_DATABASE
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_POSTGRES_DATABASE } }
+            - name: TB_POSTGRES_USER
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_POSTGRES_USER } }
+            - name: TB_POSTGRES_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_POSTGRES_PASSWORD } }
+            - name: TB_API_USERNAME
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_API_USERNAME } }
+            - name: TB_API_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TB_API_PASSWORD } }
+            - name: TB_SPIDER_USERNAME
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_API_USERNAME } }
+            - name: TB_SPIDER_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: SP_API_PASSWORD } }
+            - name: TB_TERRARIUM_API_USERNAME
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TERRARIUM_API_USERNAME } }
+            - name: TB_TERRARIUM_API_PASSWORD
+              valueFrom: { secretKeyRef: { name: cb-stack-secret, key: TERRARIUM_API_PASSWORD } }
+            - { name: TB_ALLOW_ORIGINS, value: {{ .Values.tumblebug.allowOrigins | quote }} }
+            {{- with .Values.tumblebug.selfEndpoint }}
+            - { name: TB_SELF_ENDPOINT, value: {{ . | quote }} }
+            {{- end }}
+            - { name: TB_LOGWRITER, value: {{ .Values.tumblebug.logWriter | quote }} }
+            - { name: TB_LOGFORMAT, value: {{ .Values.tumblebug.logFormat | quote }} }
+            - { name: TB_LOGLEVEL, value: {{ .Values.tumblebug.logLevel | quote }} }
+            - { name: TB_READYZ_CHECK_DEPS, value: {{ .Values.tumblebug.readyzCheckDeps | quote }} }
+            - { name: TB_SHUTDOWN_TIMEOUT_MS, value: {{ .Values.tumblebug.shutdownTimeoutMs | quote }} }
+            {{- if .Values.openbao.enabled }}
+            - { name: VAULT_ADDR, value: "http://openbao:8200" }
+            # Non-optional: the pod intentionally waits until the openbao-init
+            # Job has created Secret/openbao-keys (startup ordering).
+            - name: VAULT_TOKEN
+              valueFrom: { secretKeyRef: { name: openbao-keys, key: root-token } }
+            {{- end }}
+          volumeMounts:
+            - { name: log, mountPath: /app/log }
+          startupProbe:
+            httpGet: { path: /tumblebug/readyz, port: http }
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet: { path: /tumblebug/readyz, port: http }
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet: { path: /tumblebug/livez, port: http }
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 4
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
+          {{- with .Values.tumblebug.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: log
+          emptyDir: {}

--- a/deployments/helm/cb-tumblebug/values-prod.yaml
+++ b/deployments/helm/cb-tumblebug/values-prod.yaml
@@ -1,0 +1,35 @@
+# Production overlay example:
+#   helm upgrade --install cb-tumblebug ./deployments/helm/cb-tumblebug \
+#     -n cb-tumblebug --create-namespace -f values-prod.yaml
+#
+# Replace every CHANGE_ME. Consider external managed PostgreSQL/etcd
+# (point TB_*/SPIDER_METADB_* at them and disable the bundled statefulsets
+# by setting storage-less variants in a future chart revision).
+
+auth:
+  tbApiUsername: admin
+  tbApiPassword: CHANGE_ME
+  spApiUsername: admin
+  spApiPassword: CHANGE_ME
+  terrariumApiUsername: admin
+  terrariumApiPassword: CHANGE_ME
+
+tumblebugPostgres:
+  password: CHANGE_ME
+  storage: 20Gi
+
+spiderPostgres:
+  password: CHANGE_ME
+  storage: 10Gi
+
+tumblebug:
+  logLevel: info
+  logFormat: json
+  resources:
+    requests: { cpu: 500m, memory: 512Mi }
+    limits: { memory: 2Gi }
+
+spider:
+  resources:
+    requests: { cpu: 250m, memory: 256Mi }
+    limits: { memory: 1Gi }

--- a/deployments/helm/cb-tumblebug/values.yaml
+++ b/deployments/helm/cb-tumblebug/values.yaml
@@ -1,0 +1,85 @@
+# Default values = dev profile (kind/minikube parity with docker-compose).
+# For production overrides see values-prod.yaml.
+#
+# Service names intentionally match docker-compose container names
+# (cb-spider, cb-tumblebug-etcd, ...) so inter-service URLs are identical.
+# Install ONE release per namespace.
+
+images:
+  tumblebug: cloudbaristaorg/cb-tumblebug:0.12.27
+  spider: cloudbaristaorg/cb-spider:0.12.39
+  terrarium: cloudbaristaorg/mc-terrarium:0.1.4
+  mapui: cloudbaristaorg/cb-mapui:0.12.52
+  mcp: cloudbaristaorg/cb-tumblebug-mcp-server:0.12.26
+  etcd: gcr.io/etcd-development/etcd:v3.6.11
+  postgres: postgres:16-alpine
+  openbao: openbao/openbao:2.5.1
+  # Used by init/unseal jobs and wait-for-db initContainers
+  kubectl: alpine/k8s:1.31.13
+  curl: curlimages/curl:8.10.1
+
+imagePullPolicy: IfNotPresent
+
+# API credentials (same keys as compose .env). Override in production.
+auth:
+  tbApiUsername: default
+  tbApiPassword: default
+  spApiUsername: default
+  spApiPassword: default
+  terrariumApiUsername: default
+  terrariumApiPassword: default
+
+tumblebugPostgres:
+  user: tumblebug
+  password: tumblebug
+  database: tumblebug
+  storage: 5Gi
+  storageClassName: ""
+
+spiderPostgres:
+  user: spider
+  password: spider
+  database: cb_spider
+  storage: 2Gi
+  storageClassName: ""
+
+etcd:
+  storage: 2Gi
+  storageClassName: ""
+
+openbao:
+  enabled: true
+  storage: 1Gi
+  storageClassName: ""
+
+tumblebug:
+  # K8s-recommended settings (compose keeps its own defaults)
+  logWriter: stdout
+  logFormat: console
+  logLevel: debug
+  readyzCheckDeps: "true"
+  shutdownTimeoutMs: "300000"
+  terminationGracePeriodSeconds: 330
+  selfEndpoint: ""
+  allowOrigins: "*"
+  resources: {}
+
+spider:
+  logLevel: error
+  hiscallLogLevel: error
+  resources: {}
+
+terrarium:
+  enabled: true
+  storage: 1Gi
+  storageClassName: ""
+  resources: {}
+
+mapui:
+  enabled: true
+  resources: {}
+
+mcp:
+  # Requires a published cb-tumblebug-mcp-server image (compose builds it locally)
+  enabled: false
+  resources: {}

--- a/init/init.py
+++ b/init/init.py
@@ -166,7 +166,11 @@ def get_decryption_key():
 
     # 4. Prompt for password (up to 3 attempts)
     for attempt in range(3):
-        password = getpass(f"Enter the password of the encrypted credential to continue (attempt {attempt + 1}/3): ")
+        try:
+            password = getpass(f"Enter the password of the encrypted credential to continue (attempt {attempt + 1}/3): ")
+        except (KeyboardInterrupt, EOFError):
+            print(Fore.RED + "\nCancelled. Tip: save the key to ~/.cloud-barista/.tmp_enc_key (make enc-cred) for automatic decryption.")
+            sys.exit(1)
         decrypted_content, error = decrypt_credentials(ENC_FILE_PATH, password)
         if error is None:
             return decrypted_content
@@ -433,7 +437,15 @@ def print_openbao_warning(status):
         print(Fore.YELLOW + "  VAULT_TOKEN: set, but INVALID (rejected by OpenBao)")
 
     print(Fore.YELLOW + "  Impact: CB-Tumblebug features will not fully work.")
-    if not reachable:
+    # k-init (Kubernetes) sets TB_K8S_NAMESPACE; guidance differs from compose
+    k8s_ns = os.environ.get("TB_K8S_NAMESPACE")
+    if k8s_ns:
+        if not reachable or not initialized or sealed:
+            print(Fore.YELLOW + f"  Fix (k8s): check OpenBao bootstrap: kubectl logs -n {k8s_ns} job/openbao-init, then re-run: make k-up")
+        else:
+            # Token invalid — server env is stale vs Secret/openbao-keys
+            print(Fore.YELLOW + f"  Fix (k8s): kubectl rollout restart deploy/cb-tumblebug deploy/mc-terrarium -n {k8s_ns}")
+    elif not reachable:
         print(Fore.YELLOW + "  Fix: start OpenBao and services: make up")
     elif not initialized:
         print(Fore.YELLOW + "  Fix: initialize OpenBao: make init-openbao, then restart services: make up")

--- a/init/init.sh
+++ b/init/init.sh
@@ -170,6 +170,7 @@ fi
 echo
 echo "Running the application..."
 uv run init.py "$@"
+INIT_RC=$?
 
 # Stop monitoring if it was started
 if [[ ! -z "$MONITOR_PID" ]]; then
@@ -191,6 +192,9 @@ rm -rf uv.lock # Make it commented out if you want to keep the lock file
 
 echo
 echo "Environment cleanup complete."
+
+# Propagate init.py result so callers (multi-init.sh) don't report false success
+exit $INIT_RC
 
 # Return to the original directory
 popd > /dev/null

--- a/init/multi-init.sh
+++ b/init/multi-init.sh
@@ -15,12 +15,17 @@ if [ -n "$MULTI_INIT_PWD" ]; then
 elif [ -f "$HOME/.cloud-barista/.tmp_enc_key" ]; then
     echo "Using decryption key file: ~/.cloud-barista/.tmp_enc_key"
 elif [ -t 0 ]; then
+    echo "(Tip: save the key to ~/.cloud-barista/.tmp_enc_key via 'make enc-cred' to skip this prompt)"
     read -s -p "Enter the password for credentials.yaml.enc: " MULTI_INIT_PWD
     echo ""
+    if [ -z "$MULTI_INIT_PWD" ]; then
+        echo "No password entered — you will be prompted again during credential registration."
+    fi
 else
     echo "Warning: no password source available in non-interactive mode (set MULTI_INIT_PWD or ~/.cloud-barista/.tmp_enc_key)."
 fi
-export MULTI_INIT_PWD
+# Export only when non-empty (an empty value would trigger a doomed decrypt attempt)
+[ -n "$MULTI_INIT_PWD" ] && export MULTI_INIT_PWD || true
 
 # 1. Step 1 script execution code is deprecated (to be removed) for operational simplicity:
 #    CB-Tumblebug server registers credentials to OpenBao automatically during Step 2.


### PR DESCRIPTION
<img width="1073" height="628" alt="image" src="https://github.com/user-attachments/assets/a8d2c4e9-f703-47d8-8434-f21440a2578a" />

CB-Tumblebug now can also run on Kubernetes via a Helm chart, using `k-` prefixed
commands that mirror the compose verbs:

```bash
make k-up      # install the stack (auto-creates a kind cluster if none is reachable)
make k-init    # register credentials & load assets (same flow as compose)
make k-port-forward   # access API (1323) and MapUI (1324) on localhost
```

> ⚠️ **Beta feature**: the Kubernetes deployment and `make k-*` commands are
> under active development — behavior and command names may change without
> notice. Use with caution (docker compose remains the stable default).
> See [deployments/helm/cb-tumblebug/README.md](deployments/helm/cb-tumblebug/README.md)
> for prerequisites, operations, and troubleshooting.