### PR TITLE
fix(reconcile): don't self-heal to Available unintentionally

### DIFF
--- a/src/core/reconcile/objectStorageReconcile.go
+++ b/src/core/reconcile/objectStorageReconcile.go
@@ -81,9 +81,21 @@ func (r *ObjectStorageReconciler) Reconcile(ctx context.Context, nsId string, re
 func (r *ObjectStorageReconciler) reconcileAvailable(nsId string, osInfo *model.ObjectStorageInfo, statusResp *model.CspResourceStatusResponse) (model.SimpleMsg, error) {
 	osKey := common.GenResourceKey(nsId, model.StrObjectStorage, osInfo.Id)
 	syncState := resource.GetResourceSyncState(osInfo.CspResourceName, osInfo.CspResourceId, *statusResp)
-
-	// Never fold SpMetaMissing into InSync — ApplySyncState leaves Status untouched for it, so this stays accurate.
-	resource.ApplySyncState(&osInfo.Conditions, &osInfo.Status, &osInfo.SystemMessage, syncState)
+	switch syncState {
+	case model.SyncStateInSync:
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
+	case model.SyncStateSpMetaMissing:
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Spider metadata missing; TB metadata preserved")
+	case model.SyncStateCspResourceMissing:
+		model.SetCondition(&osInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		osInfo.SystemMessage = "Reconcile Diagnostic: CSP resource missing."
+	case model.SyncStateTbMetaOnly:
+		model.SetCondition(&osInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		osInfo.SystemMessage = "Reconcile Diagnostic: Ghost metadata detected."
+	}
+	osInfo.Status = model.DeriveObjectStorageStatus(osInfo.Conditions)
 
 	val, err := json.Marshal(osInfo)
 	if err != nil {
@@ -111,7 +123,8 @@ func (r *ObjectStorageReconciler) reconcileFailed(nsId string, osInfo *model.Obj
 		}
 	}
 
-	if restoreOk {
+	switch {
+	case restoreOk:
 		prevReason, prevMessage := "", ""
 		if cond := model.GetCondition(osInfo.Conditions, model.ConditionReady); cond != nil {
 			prevReason = cond.Reason
@@ -124,13 +137,27 @@ func (r *ObjectStorageReconciler) reconcileFailed(nsId string, osInfo *model.Obj
 			restoredMsg = fmt.Sprintf("%s (previous failure: %s)", restoredMsg, prevMessage)
 		}
 		model.SetCondition(&osInfo.Conditions, model.ConditionReady, model.ConditionTrue, model.ReasonRestored, restoredMsg)
-		// Record Synced from the real syncState, not a hardcoded "Synchronized with CSP" — keeps SpMetaMissing visible during restore.
-		resource.ApplySyncState(&osInfo.Conditions, &osInfo.Status, &osInfo.SystemMessage, syncState)
-		// ApplySyncState won't set Status for SpMetaMissing, but CSP is confirmed alive here, so force Available.
-		osInfo.Status = model.StorageStatusAvailable
-	} else {
-		resource.ApplySyncState(&osInfo.Conditions, &osInfo.Status, &osInfo.SystemMessage, syncState)
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
+		osInfo.SystemMessage = ""
+
+	case syncState == model.SyncStateCspResourceMissing:
+		model.SetCondition(&osInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		osInfo.SystemMessage = "Reconcile Diagnostic: CSP resource missing."
+
+	case syncState == model.SyncStateTbMetaOnly:
+		model.SetCondition(&osInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		osInfo.SystemMessage = "Reconcile Diagnostic: Ghost metadata detected."
+
+	case syncState == model.SyncStateSpMetaMissing:
+		// Not authorized to restore — record the diagnosis only; Ready/Status/SystemMessage stay untouched.
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Spider metadata missing; TB metadata preserved")
+
+	default: // SyncStateInSync, not authorized to restore (sticky tombstone)
+		model.SetCondition(&osInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
 	}
+	osInfo.Status = model.DeriveObjectStorageStatus(osInfo.Conditions)
 
 	val, err := json.Marshal(osInfo)
 	if err != nil {

--- a/src/core/reconcile/rdbmsReconcile.go
+++ b/src/core/reconcile/rdbmsReconcile.go
@@ -94,9 +94,21 @@ func (r *RDBMSReconciler) Reconcile(ctx context.Context, nsId string, resourceId
 func (r *RDBMSReconciler) reconcileAvailable(nsId string, rdbmsInfo *model.RDBMSInfo, statusResp *model.CspResourceStatusResponse) (model.SimpleMsg, error) {
 	rdbmsKey := common.GenResourceKey(nsId, model.StrRDBMS, rdbmsInfo.Id)
 	syncState := resource.GetResourceSyncState(rdbmsInfo.CspResourceName, rdbmsInfo.CspResourceId, *statusResp)
-
-	// Never fold SpMetaMissing into InSync — ApplySyncState leaves Status untouched for it, so this stays accurate.
-	resource.ApplySyncState(&rdbmsInfo.Conditions, &rdbmsInfo.Status, &rdbmsInfo.SystemMessage, syncState)
+	switch syncState {
+	case model.SyncStateInSync:
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
+	case model.SyncStateSpMetaMissing:
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Spider metadata missing; TB metadata preserved")
+	case model.SyncStateCspResourceMissing:
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		rdbmsInfo.SystemMessage = "Reconcile Diagnostic: CSP resource missing."
+	case model.SyncStateTbMetaOnly:
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		rdbmsInfo.SystemMessage = "Reconcile Diagnostic: Ghost metadata detected."
+	}
+	rdbmsInfo.Status = model.DeriveRDBMSStatus(rdbmsInfo.Conditions)
 
 	val, err := json.Marshal(rdbmsInfo)
 	if err != nil {
@@ -124,7 +136,8 @@ func (r *RDBMSReconciler) reconcileFailed(nsId string, rdbmsInfo *model.RDBMSInf
 		}
 	}
 
-	if restoreOk {
+	switch {
+	case restoreOk:
 		prevReason, prevMessage := "", ""
 		if cond := model.GetCondition(rdbmsInfo.Conditions, model.ConditionReady); cond != nil {
 			prevReason = cond.Reason
@@ -137,13 +150,27 @@ func (r *RDBMSReconciler) reconcileFailed(nsId string, rdbmsInfo *model.RDBMSInf
 			restoredMsg = fmt.Sprintf("%s (previous failure: %s)", restoredMsg, prevMessage)
 		}
 		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionReady, model.ConditionTrue, model.ReasonRestored, restoredMsg)
-		// Record Synced from the real syncState, not a hardcoded "Synchronized with CSP" — keeps SpMetaMissing visible during restore.
-		resource.ApplySyncState(&rdbmsInfo.Conditions, &rdbmsInfo.Status, &rdbmsInfo.SystemMessage, syncState)
-		// ApplySyncState won't set Status for SpMetaMissing, but CSP is confirmed alive here, so force Available.
-		rdbmsInfo.Status = model.StorageStatusAvailable
-	} else {
-		resource.ApplySyncState(&rdbmsInfo.Conditions, &rdbmsInfo.Status, &rdbmsInfo.SystemMessage, syncState)
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
+		rdbmsInfo.SystemMessage = ""
+
+	case syncState == model.SyncStateCspResourceMissing:
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		rdbmsInfo.SystemMessage = "Reconcile Diagnostic: CSP resource missing."
+
+	case syncState == model.SyncStateTbMetaOnly:
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		rdbmsInfo.SystemMessage = "Reconcile Diagnostic: Ghost metadata detected."
+
+	case syncState == model.SyncStateSpMetaMissing:
+		// Not authorized to restore — record the diagnosis only; Ready/Status/SystemMessage stay untouched.
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Spider metadata missing; TB metadata preserved")
+
+	default: // SyncStateInSync, not authorized to restore (sticky tombstone)
+		model.SetCondition(&rdbmsInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
 	}
+	rdbmsInfo.Status = model.DeriveRDBMSStatus(rdbmsInfo.Conditions)
 
 	val, err := json.Marshal(rdbmsInfo)
 	if err != nil {

--- a/src/core/reconcile/vnetReconcile.go
+++ b/src/core/reconcile/vnetReconcile.go
@@ -111,9 +111,21 @@ func (r *VNetReconciler) reconcileAvailable(nsId string, vNetInfo *model.VNetInf
 	r.reconcileChildSubnets(nsId, vNetInfo, vpcStatusResp)
 
 	syncState := resource.GetResourceSyncState(vNetInfo.CspResourceName, vNetInfo.CspResourceId, *vpcStatusResp)
-
-	// Never fold SpMetaMissing into InSync — ApplySyncState leaves Status untouched for it, so this stays accurate.
-	resource.ApplySyncState(&vNetInfo.Conditions, &vNetInfo.Status, &vNetInfo.SystemMessage, syncState)
+	switch syncState {
+	case model.SyncStateInSync:
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
+	case model.SyncStateSpMetaMissing:
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Spider metadata missing; TB metadata preserved")
+	case model.SyncStateCspResourceMissing:
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		vNetInfo.SystemMessage = "Reconcile Diagnostic: CSP resource missing."
+	case model.SyncStateTbMetaOnly:
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		vNetInfo.SystemMessage = "Reconcile Diagnostic: Ghost metadata detected."
+	}
+	vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
 
 	val, err := json.Marshal(vNetInfo)
 	if err != nil {
@@ -147,7 +159,8 @@ func (r *VNetReconciler) reconcileFailed(nsId string, vNetInfo *model.VNetInfo, 
 		}
 	}
 
-	if restoreOk {
+	switch {
+	case restoreOk:
 		prevReason, prevMessage := "", ""
 		if cond := model.GetCondition(vNetInfo.Conditions, model.ConditionReady); cond != nil {
 			prevReason = cond.Reason
@@ -160,13 +173,27 @@ func (r *VNetReconciler) reconcileFailed(nsId string, vNetInfo *model.VNetInfo, 
 			restoredMsg = fmt.Sprintf("%s (previous failure: %s)", restoredMsg, prevMessage)
 		}
 		model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionTrue, model.ReasonRestored, restoredMsg)
-		// Record Synced from the real syncState, not a hardcoded "Synchronized with CSP" — keeps SpMetaMissing visible during restore.
-		resource.ApplySyncState(&vNetInfo.Conditions, &vNetInfo.Status, &vNetInfo.SystemMessage, syncState)
-		// ApplySyncState won't set Status for SpMetaMissing, but CSP is confirmed alive here, so force Available.
-		vNetInfo.Status = model.NetworkStatusAvailable
-	} else {
-		resource.ApplySyncState(&vNetInfo.Conditions, &vNetInfo.Status, &vNetInfo.SystemMessage, syncState)
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
+		vNetInfo.SystemMessage = ""
+
+	case syncState == model.SyncStateCspResourceMissing:
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Resource missing on CSP provider")
+		vNetInfo.SystemMessage = "Reconcile Diagnostic: CSP resource missing."
+
+	case syncState == model.SyncStateTbMetaOnly:
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Ghost metadata: resource absent on Spider and CSP")
+		vNetInfo.SystemMessage = "Reconcile Diagnostic: Ghost metadata detected."
+
+	case syncState == model.SyncStateSpMetaMissing:
+		// Not authorized to restore — record the diagnosis only; Ready/Status/SystemMessage stay untouched.
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(syncState), "Spider metadata missing; TB metadata preserved")
+
+	default: // SyncStateInSync, not authorized to restore (sticky tombstone)
+		model.SetCondition(&vNetInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
 	}
+	vNetInfo.Status = model.DeriveVNetStatus(vNetInfo.Conditions)
 
 	val, err := json.Marshal(vNetInfo)
 	if err != nil {

--- a/src/core/resource/common.go
+++ b/src/core/resource/common.go
@@ -4228,32 +4228,6 @@ func GetResourceSyncState(resourceName string, resourceSystemId string, statusRe
 	return model.SyncStateTbMetaOnly // Absent (TB: O, SP: X, CSP: X)
 }
 
-// ApplySyncState updates resource Conditions, Status, and SystemMessage in place based on ResourceSyncState.
-func ApplySyncState(conditions *[]model.Condition, status *string, sysMsg *string, syncState model.ResourceSyncState) {
-	reason := string(syncState)
-
-	switch syncState {
-	case model.SyncStateInSync:
-		model.SetCondition(conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
-		*status = model.ResourceStatusAvailable
-		*sysMsg = ""
-
-	case model.SyncStateCspResourceMissing:
-		model.SetCondition(conditions, model.ConditionSynced, model.ConditionFalse, reason, "Resource missing on CSP provider")
-		*status = model.ResourceStatusFailed
-		*sysMsg = "Reconcile Diagnostic: CSP resource missing."
-
-	case model.SyncStateSpMetaMissing:
-		model.SetCondition(conditions, model.ConditionSynced, model.ConditionFalse, reason, "Spider metadata missing; TB metadata preserved")
-		*sysMsg = "Reconcile Diagnostic: Spider metadata missing."
-
-	case model.SyncStateTbMetaOnly:
-		model.SetCondition(conditions, model.ConditionSynced, model.ConditionFalse, reason, "Ghost metadata: resource absent on Spider and CSP")
-		*status = model.ResourceStatusFailed
-		*sysMsg = "Reconcile Diagnostic: Ghost metadata detected."
-	}
-}
-
 // GetCspResourceStatusBatch retrieves resource status for multiple resource types in a single connection
 //
 // This is a convenience function that calls GetCspResourceStatus for multiple resource types

--- a/src/core/resource/objectStorage.go
+++ b/src/core/resource/objectStorage.go
@@ -793,52 +793,6 @@ func isObjStrgInfoUpdated(oldObjStrgInfo, newObjStrgInfo model.ObjectStorageInfo
 	return false
 }
 
-// markObjectStorageDeleteFailedThenReconcile persists the object storage as
-// Failed(DeletionFailed) and then diagnoses (and restores, if applicable)
-// its sync state against the CSP — the same non-destructive check the
-// ObjectStorageReconciler performs. It only ever calls kvstore.Put; it never
-// deletes metadata or calls Spider DELETE (see docs/feature_guide/
-// resource-reconciliation.md, "Spider Delete Behavior").
-//
-// `cause` is the original delete error; it populates both the Condition
-// message and SystemMessage. The caller decides what error to return.
-func markObjectStorageDeleteFailedThenReconcile(nsId, osId, objStrgKey string, objStrgInfo *model.ObjectStorageInfo, cause error) {
-	log.Error().Err(cause).Msg("")
-	// [Conditions] Deletion failed → mark as Failed to prevent stuck state
-	model.SetCondition(&objStrgInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, cause.Error())
-	objStrgInfo.Status = model.DeriveObjectStorageStatus(objStrgInfo.Conditions)
-	objStrgInfo.SystemMessage = cause.Error()
-
-	statusResp, fetchErr := GetCspResourceStatus(objStrgInfo.ConnectionName, model.StrObjectStorage)
-	if fetchErr != nil {
-		log.Warn().Err(fetchErr).Msgf("auto-diagnose after delete failure could not fetch CSP status for objectStorage %s/%s", nsId, osId)
-	} else {
-		syncState := GetResourceSyncState(objStrgInfo.CspResourceName, objStrgInfo.CspResourceId, statusResp)
-		if (syncState == model.SyncStateInSync || syncState == model.SyncStateSpMetaMissing) && model.ShouldRestoreToAvailable(objStrgInfo.Conditions) {
-			prevReason, prevMessage := "", ""
-			if cond := model.GetCondition(objStrgInfo.Conditions, model.ConditionReady); cond != nil {
-				prevReason = cond.Reason
-				prevMessage = cond.Message
-			}
-			restoredMsg := fmt.Sprintf("Restored from %s; CSP resource exists", prevReason)
-			if prevMessage != "" {
-				restoredMsg = fmt.Sprintf("%s (previous failure: %s)", restoredMsg, prevMessage)
-			}
-			model.SetCondition(&objStrgInfo.Conditions, model.ConditionReady, model.ConditionTrue, model.ReasonRestored, restoredMsg)
-			// Record Synced from the real syncState, not a hardcoded "Synchronized with CSP" — keeps SpMetaMissing visible during restore.
-			ApplySyncState(&objStrgInfo.Conditions, &objStrgInfo.Status, &objStrgInfo.SystemMessage, syncState)
-			// ApplySyncState won't set Status for SpMetaMissing, but CSP is confirmed alive here, so force Available.
-			objStrgInfo.Status = model.StorageStatusAvailable
-		} else {
-			ApplySyncState(&objStrgInfo.Conditions, &objStrgInfo.Status, &objStrgInfo.SystemMessage, syncState)
-		}
-	}
-
-	if failVal, marshalErr := json.Marshal(objStrgInfo); marshalErr == nil {
-		_ = kvstore.Put(objStrgKey, string(failVal))
-	}
-}
-
 // DeleteObjectStorage deletes the specified object storage (bucket) from the specified namespace.
 // If force is true, Spider force-deletes the bucket with all its contents.
 // If empty is true, Spider empties the bucket contents first, then deletes it.
@@ -937,7 +891,13 @@ func DeleteObjectStorage(nsId, osId string, force, empty bool) error {
 					opDesc = "EMPTY"
 				}
 				err = fmt.Errorf("%s failed for object storage %s: %w", opDesc, uid, delErr)
-				markObjectStorageDeleteFailedThenReconcile(nsId, osId, objStrgKey, &objStrgInfo, err)
+				log.Error().Err(err).Msg("")
+				model.SetCondition(&objStrgInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, err.Error())
+				objStrgInfo.Status = model.DeriveObjectStorageStatus(objStrgInfo.Conditions)
+				objStrgInfo.SystemMessage = err.Error()
+				if failVal, marshalErr := json.Marshal(objStrgInfo); marshalErr == nil {
+					_ = kvstore.Put(objStrgKey, string(failVal))
+				}
 				return err
 			}
 			// 404 → already deleted on CSP
@@ -970,7 +930,13 @@ func DeleteObjectStorage(nsId, osId string, force, empty bool) error {
 					if gateErr != nil {
 						cause = fmt.Errorf("object storage %s deletion unconfirmed: CSP existence check failed: %v (%w)", uid, gateErr, ErrDeletionUnconfirmed)
 					}
-					markObjectStorageDeleteFailedThenReconcile(nsId, osId, objStrgKey, &objStrgInfo, cause)
+					log.Error().Err(cause).Msg("")
+					model.SetCondition(&objStrgInfo.Conditions, model.ConditionReady, model.ConditionFalse, model.ReasonDeletionFailed, cause.Error())
+					objStrgInfo.Status = model.DeriveObjectStorageStatus(objStrgInfo.Conditions)
+					objStrgInfo.SystemMessage = cause.Error()
+					if failVal, marshalErr := json.Marshal(objStrgInfo); marshalErr == nil {
+						_ = kvstore.Put(objStrgKey, string(failVal))
+					}
 					return cause
 				}
 			}

--- a/src/core/resource/subnet.go
+++ b/src/core/resource/subnet.go
@@ -969,34 +969,43 @@ func syncSubnetState(nsId string, subnetInfo *model.SubnetInfo, vNetInfo *model.
 	subnetSyncState := GetResourceSyncState(subnetInfo.CspResourceName, subnetInfo.CspResourceId, subnetStatusResp)
 	log.Debug().Msgf("Subnet '%s' sync state: %q", subnetInfo.CspResourceName, subnetSyncState)
 
-	switch subnetSyncState {
-	case model.SyncStateInSync, model.SyncStateSpMetaMissing:
-		if model.ShouldRestoreToAvailable(subnetInfo.Conditions) {
-			prevReason, prevMessage := "", ""
-			if r := model.GetCondition(subnetInfo.Conditions, model.ConditionReady); r != nil {
-				prevReason = r.Reason
-				prevMessage = r.Message
-			}
-			restoredMsg := fmt.Sprintf("Restored from %s; CSP resource exists", prevReason)
-			if prevMessage != "" {
-				restoredMsg = fmt.Sprintf("%s (previous failure: %s)", restoredMsg, prevMessage)
-			}
-			model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionTrue, model.ReasonRestored, restoredMsg)
-			// Record Synced from the real syncState, not a hardcoded "Available" — keeps SpMetaMissing visible during restore.
-			ApplySyncState(&subnetInfo.Conditions, &subnetInfo.Status, &subnetInfo.SystemMessage, subnetSyncState)
-			// ApplySyncState won't set Status for SpMetaMissing, but CSP is confirmed alive here, so force Available.
-			subnetInfo.Status = model.NetworkStatusAvailable
-			ret.Message = fmt.Sprintf("subnet (%s) status restored to Available from %s; CSP resource exists", subnetInfo.Id, prevReason)
-		} else {
-			// Never fold SpMetaMissing into InSync — ApplySyncState leaves Status untouched for it, so this stays accurate.
-			ApplySyncState(&subnetInfo.Conditions, &subnetInfo.Status, &subnetInfo.SystemMessage, subnetSyncState)
-			ret.Message = fmt.Sprintf("subnet (%s) exists on CSP; metadata is consistent (no action needed)", subnetInfo.Id)
+	switch {
+	case (subnetSyncState == model.SyncStateInSync || subnetSyncState == model.SyncStateSpMetaMissing) &&
+		model.ShouldRestoreToAvailable(subnetInfo.Conditions):
+		prevReason, prevMessage := "", ""
+		if r := model.GetCondition(subnetInfo.Conditions, model.ConditionReady); r != nil {
+			prevReason = r.Reason
+			prevMessage = r.Message
 		}
+		restoredMsg := fmt.Sprintf("Restored from %s; CSP resource exists", prevReason)
+		if prevMessage != "" {
+			restoredMsg = fmt.Sprintf("%s (previous failure: %s)", restoredMsg, prevMessage)
+		}
+		model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionTrue, model.ReasonRestored, restoredMsg)
+		model.SetCondition(&subnetInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
+		subnetInfo.SystemMessage = ""
+		ret.Message = fmt.Sprintf("subnet (%s) status restored to Available from %s; CSP resource exists", subnetInfo.Id, prevReason)
 
-	case model.SyncStateCspResourceMissing, model.SyncStateTbMetaOnly:
-		ApplySyncState(&subnetInfo.Conditions, &subnetInfo.Status, &subnetInfo.SystemMessage, subnetSyncState)
+	case subnetSyncState == model.SyncStateCspResourceMissing || subnetSyncState == model.SyncStateTbMetaOnly:
+		msg := "Resource missing on CSP provider"
+		if subnetSyncState == model.SyncStateTbMetaOnly {
+			msg = "Ghost metadata: resource absent on Spider and CSP"
+		}
+		model.SetCondition(&subnetInfo.Conditions, model.ConditionReady, model.ConditionFalse, string(subnetSyncState), msg)
+		model.SetCondition(&subnetInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(subnetSyncState), msg)
+		subnetInfo.SystemMessage = "Reconcile Diagnostic: " + msg
 		ret.Message = fmt.Sprintf("subnet (%s) missing on CSP; marked as Failed", subnetInfo.Id)
+
+	case subnetSyncState == model.SyncStateSpMetaMissing:
+		// Not authorized to restore — record the diagnosis only; Ready/Status/SystemMessage stay untouched.
+		model.SetCondition(&subnetInfo.Conditions, model.ConditionSynced, model.ConditionFalse, string(subnetSyncState), "Spider metadata missing; TB metadata preserved")
+		ret.Message = fmt.Sprintf("subnet (%s) exists on CSP; metadata is consistent (no action needed)", subnetInfo.Id)
+
+	default: // SyncStateInSync, not authorized to restore
+		model.SetCondition(&subnetInfo.Conditions, model.ConditionSynced, model.ConditionTrue, model.ReasonAvailable, "Resource is in sync across all layers")
+		ret.Message = fmt.Sprintf("subnet (%s) exists on CSP; metadata is consistent (no action needed)", subnetInfo.Id)
 	}
+	subnetInfo.Status = model.DeriveSubnetStatus(subnetInfo.Conditions)
 
 	// Persist updated subnet info in KV store
 	if subnetKey != "" {

--- a/src/interface/rest/server/resource/objectStorage.go
+++ b/src/interface/rest/server/resource/objectStorage.go
@@ -317,6 +317,9 @@ func RestDeleteObjectStorage(c echo.Context) error {
 	err := resource.DeleteObjectStorage(nsId, osId, force, empty)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to delete object storage")
+		if _, recErr := reconcile.GetManager().RunReconcile(c.Request().Context(), nsId, model.StrObjectStorage, osId, nil); recErr != nil {
+			log.Warn().Err(recErr).Msgf("auto-reconcile failed for ObjectStorage: %s", osId)
+		}
 		if errors.Is(err, resource.ErrDeletionUnconfirmed) {
 			return clientManager.EndRequestWithLogAndStatus(c, err, nil, http.StatusConflict)
 		}


### PR DESCRIPTION
- Fix Status changing to Available unintentionally when CSP still has the resource
  - e.g. a failed deletion that should stay Failed, or a resource still being created
- Derive Status from Ready/Synced conditions for VNet, ObjectStorage, RDBMS, and Subnet
- Remove duplicated restore-diagnosis logic from ObjectStorage's delete path
- Trigger Reconcile automatically on ObjectStorage delete failure

ref) #2509 
