### PR TITLE
Overall enhancement for existing CSP resource registration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,7 @@ k-up: ## Install/upgrade the stack on Kubernetes (creates a kind cluster if no c
 			printf '%b\n' '$(KD)MapUI popup params loaded from .env (override: values-local.yaml)$(KX)'; \
 		fi; \
 	fi
+	@[ -n "$(PF_DEFER)" ] || $(MAKE) --no-print-directory k-port-forward-save
 	@# --reset-values: state comes only from chart defaults + current flags
 	@# (otherwise helm silently carries over user-supplied values from the previous revision)
 	@$(HELM) upgrade --install $(HELM_RELEASE) $(HELM_CHART) \
@@ -316,6 +317,7 @@ k-up: ## Install/upgrade the stack on Kubernetes (creates a kind cluster if no c
 	fi
 	@echo ""
 	@$(MAKE) --no-print-directory k-info
+	@[ -n "$(PF_DEFER)" ] || $(MAKE) --no-print-directory k-port-forward-restore
 
 # Internal: dump why the deployment is unhealthy (used by k-up failure paths)
 k-diagnose:
@@ -652,6 +654,7 @@ mcp-budget-off: ## Disable spend limits
 	@printf '%b\n' 'Spend limits disabled.'
 
 k-build: ## Build LOCAL source and run it in the cluster (C=tb|mapui|mcp) — compose `--build` equivalent
+	@$(MAKE) --no-print-directory k-port-forward-save
 	@case "$(C)" in \
 		cb-tumblebug|tb)      canon="cb-tumblebug"; ctx="."; key="tumblebug"; deploy="cb-tumblebug" ;; \
 		cb-mapui|mapui)       canon="cb-mapui"; ctx="../cb-mapui"; key="mapui"; deploy="cb-mapui" ;; \
@@ -670,11 +673,12 @@ k-build: ## Build LOCAL source and run it in the cluster (C=tb|mapui|mcp) — co
 	docker build -t "$$img" "$$ctx2" && \
 	kind load docker-image --name $(KIND_CLUSTER_NAME) "$$img" && \
 	printf 'images:\n  %s: %s\n' "$$key2" "$$img" > deployments/helm/cb-tumblebug/values-dev-image-$$canon.yaml && \
-	$(MAKE) --no-print-directory k-up && \
+	$(MAKE) --no-print-directory k-up PF_DEFER=1 && \
 	echo "Restarting deploy/$$deploy2 to pick up the rebuilt image..." && \
 	$(KUBECTL) rollout restart deploy/$$deploy2 -n $(K8S_NAMESPACE) && \
 	$(KUBECTL) rollout status deploy/$$deploy2 -n $(K8S_NAMESPACE) --timeout=600s && \
 	echo "Local build active for $$canon (persists across k-up). Revert: make k-build-off C=$$canon"
+	@$(MAKE) --no-print-directory k-port-forward-restore
 
 k-build-off: ## Revert to published images (C=tb|mapui|mcp for one; omit C for all)
 	@case "$(C)" in \
@@ -689,6 +693,7 @@ k-build-off: ## Revert to published images (C=tb|mapui|mcp for one; omit C for a
 	@$(MAKE) --no-print-directory k-up
 
 k-assets: ## Apply LOCAL assets/ (cloudinfo.yaml etc.) to the cluster — compose bind-mount equivalent
+	@$(MAKE) --no-print-directory k-port-forward-save
 	@files="$(K8S_ASSETS_FILES)"; \
 	[ -n "$$files" ] || { echo "No assets/*.yaml or assets/*.csv found."; exit 1; }; \
 	total=$$(cat $$files | wc -c); \
@@ -706,22 +711,25 @@ k-assets: ## Apply LOCAL assets/ (cloudinfo.yaml etc.) to the cluster — compos
 	{ printf 'assetsOverride:\n  configMapName: %s\n  files:\n' "$(K8S_ASSETS_CM)"; \
 	  for f in $$files; do printf '    - %s\n' "$$(basename $$f)"; done; } > $(K8S_ASSETS_VALUES) && \
 	printf '%b\n' "$(KD)ConfigMap $(K8S_ASSETS_CM) updated ($$(echo $$files | wc -w) files, $$total bytes)$(KX)" && \
-	$(MAKE) --no-print-directory k-up && \
+	$(MAKE) --no-print-directory k-up PF_DEFER=1 && \
 	echo "Restarting deploy/cb-tumblebug to re-read the assets..." && \
 	$(KUBECTL) rollout restart deploy/cb-tumblebug -n $(K8S_NAMESPACE) && \
 	$(KUBECTL) rollout status deploy/cb-tumblebug -n $(K8S_NAMESPACE) --timeout=600s && \
 	echo "Local assets active (persists across k-up). Revert: make k-assets-off"
+	@$(MAKE) --no-print-directory k-port-forward-restore
 
 k-assets-off: ## Revert to the assets baked into the container image
 	@rm -f $(K8S_ASSETS_VALUES)
 	@echo "Reverting to image assets. Applying..."
-	@$(MAKE) --no-print-directory k-up
+	@$(MAKE) --no-print-directory k-port-forward-save
+	@$(MAKE) --no-print-directory k-up PF_DEFER=1
 	@$(KUBECTL) delete configmap $(K8S_ASSETS_CM) -n $(K8S_NAMESPACE) --ignore-not-found
 	@$(KUBECTL) rollout restart deploy/cb-tumblebug -n $(K8S_NAMESPACE)
 	@$(KUBECTL) rollout status deploy/cb-tumblebug -n $(K8S_NAMESPACE) --timeout=600s
+	@$(MAKE) --no-print-directory k-port-forward-restore
 
 k-gateway-forward: ## Port-forward the gateway entrypoint to localhost:8080 (+8443 when TLS is on; idempotent)
-	@pids=$$(ps -eo pid=,args= | awk '$$2 ~ /(^|\/)kubectl$$/ && $$3 == "port-forward" && /envoy-gateway-system/{print $$1}' | xargs); \
+	@pids=$$(ps -eo pid=,args= | awk '$$2 ~ /(^|\/)kubectl$$/ && / port-forward / && /envoy-gateway-system/{print $$1}' | xargs); \
 	[ -z "$$pids" ] || kill $$pids 2>/dev/null || true
 	@svc=$$($(KUBECTL) get svc -n envoy-gateway-system \
 		-l gateway.envoyproxy.io/owning-gateway-name=cb-tumblebug-gateway -o name 2>/dev/null | head -1); \
@@ -766,12 +774,30 @@ k-token: ## Create an admin token file for K8s UIs like Headlamp (cluster-admin;
 	@echo "Note: cluster-admin, no expiry — local dev only. Revoke: $(KUBECTL) delete secret headlamp-admin-token -n kube-system"
 
 k-port-forward-stop: ## Stop this deployment's port-forwards incl. the gateway entrypoint (others untouched)
-	@pids=$$(ps -eo pid=,args= | awk '$$2 ~ /(^|\/)kubectl$$/ && $$3 == "port-forward" && \
+	@pids=$$(ps -eo pid=,args= | awk '$$2 ~ /(^|\/)kubectl$$/ && / port-forward / && \
 		(/ $(K8S_NAMESPACE) / || (/envoy-gateway-system/ && /cb-tumblebug-gateway/)) {print $$1}' | xargs); \
 	if [ -n "$$pids" ]; then \
 		echo "Stopping port-forwards for this deployment (PID: $$pids)"; \
 		kill $$pids 2>/dev/null || true; \
 	fi
+
+# Internal: a port-forward is bound to one pod, so any rollout silently breaks it.
+# k-up/k-build save what is live beforehand and re-establish the same set afterwards.
+# Callers that restart pods again after k-up pass PF_DEFER=1 and restore themselves.
+K8S_PF_STATE := /tmp/.cb-tumblebug-port-forward.$(K8S_NAMESPACE)
+
+k-port-forward-save:
+	@rm -f $(K8S_PF_STATE); \
+	pf=$$(ps -eo pid=,args= | awk '$$2 ~ /(^|\/)kubectl$$/ && / port-forward /'); \
+	printf '%s\n' "$$pf" | grep -q " $(K8S_NAMESPACE) " && echo svc >> $(K8S_PF_STATE) || true; \
+	printf '%s\n' "$$pf" | grep -q "envoy-gateway-system" && echo gw >> $(K8S_PF_STATE) || true
+
+k-port-forward-restore:
+	@[ -f $(K8S_PF_STATE) ] || exit 0; \
+	printf '%b\n' '' '$(KD)Refreshing the port-forwards that were open before this run...$(KX)'; \
+	grep -qx svc $(K8S_PF_STATE) && $(MAKE) --no-print-directory k-port-forward || true; \
+	grep -qx gw $(K8S_PF_STATE) && $(MAKE) --no-print-directory k-gateway-forward || true; \
+	rm -f $(K8S_PF_STATE)
 
 K8S_DNS_SERVERS ?= 8.8.8.8 1.1.1.1
 
@@ -971,4 +997,4 @@ help: ## Display this help screen
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # ===== PHONY targets (not actual files) =====
-.PHONY: default run clean clean-all swag swagger init init-profile compose compose-down logs status ps clean-db backup-assets restore-assets up down gen-cred enc-cred dec-cred bcrypt certs help k-up k-init k-down k-clean k-status k-ps k-logs k-port-forward k-port-forward-stop k-token k-mcp-on k-mcp-off k-mcp-client-info k-info k-agentgateway-on k-agentgateway-off k-mcp-auth-on k-mcp-auth-off k-mcp-token k-gateway-on k-gateway-off k-gateway-tls-on k-gateway-tls-off k-gateway-forward k-build k-build-tb k-build-mapui k-build-mcp k-build-sp k-build-off k-assets k-assets-off k-diagnose k-preflight-host k-diagnose-host
+.PHONY: default run clean clean-all swag swagger init init-profile compose compose-down logs status ps clean-db backup-assets restore-assets up down gen-cred enc-cred dec-cred bcrypt certs help k-up k-init k-down k-clean k-status k-ps k-logs k-port-forward k-port-forward-stop k-port-forward-save k-port-forward-restore k-token k-mcp-on k-mcp-off k-mcp-client-info k-info k-agentgateway-on k-agentgateway-off k-mcp-auth-on k-mcp-auth-off k-mcp-token k-gateway-on k-gateway-off k-gateway-tls-on k-gateway-tls-off k-gateway-forward k-build k-build-tb k-build-mapui k-build-mcp k-build-sp k-build-off k-assets k-assets-off k-diagnose k-preflight-host k-diagnose-host

--- a/src/core/common/label/label.go
+++ b/src/core/common/label/label.go
@@ -478,7 +478,9 @@ func UpdateCSPResourceLabel(ctx context.Context, labelType, uid string, labels m
 			ctx = context.WithValue(ctx, model.CtxKeyCredentialHolder, cc.CredentialHolder)
 			handled, batchErr := cspdirect.TryBatchUpsertTags(ctx, cc.ProviderName, cc.RegionZoneInfo.AssignedRegion, cc.RegionZoneInfo.AssignedZone, cspResourceId, labelType, labels)
 			if batchErr != nil {
-				log.Warn().Err(batchErr).Str("provider", cc.ProviderName).Str("connectionName", connectionName).Msg("[Label] Direct CSP batch tag failed, falling back to CB-Spider")
+				// Best-effort tag sync with an automatic CB-Spider fallback below; not a
+				// registration failure, so keep it at debug to avoid a misleading warning.
+				log.Debug().Err(batchErr).Str("provider", cc.ProviderName).Str("connectionName", connectionName).Msg("[Label] direct CSP tag sync unavailable; using CB-Spider tag API instead")
 			}
 			if handled {
 				return
@@ -516,7 +518,7 @@ func UpdateCSPResourceLabel(ctx context.Context, labelType, uid string, labels m
 		// this is a best-effort operation, so we don't return an error if it fails
 		// drop if we meet the first error
 		if err != nil {
-			log.Info().Err(err).Msg("Cannot update CSP label/tag")
+			log.Info().Err(err).Msg("[Label] best-effort CSP tag sync failed; resource stays registered without CSP-side tags")
 			break
 		}
 	}

--- a/src/core/csp/aws/vmstatus.go
+++ b/src/core/csp/aws/vmstatus.go
@@ -17,7 +17,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
 	"github.com/cloud-barista/cb-tumblebug/src/core/model"
 	csptypes "github.com/cloud-barista/cb-tumblebug/src/core/model/csp"
@@ -59,8 +61,12 @@ func BatchDescribeInstanceStatuses(ctx context.Context, region string, instanceI
 		end := min(i+describeInstancesBatchSize, len(instanceIds))
 		batch := instanceIds[i:end]
 
+		// Filter by instance-id rather than InstanceIds: unknown or long-terminated ids are
+		// silently omitted from the result instead of failing the whole call with
+		// InvalidInstanceID.NotFound — so a "not found" reads as a clean omission (the
+		// existence signal callers rely on), while real errors still surface.
 		out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-			InstanceIds: batch,
+			Filters: []ec2types.Filter{{Name: aws.String("instance-id"), Values: batch}},
 		})
 		if err != nil {
 			return nil, fmt.Errorf("DescribeInstances failed (region=%s, ids=%d): %w", region, len(batch), err)

--- a/src/core/csp/azure/vmstatus.go
+++ b/src/core/csp/azure/vmstatus.go
@@ -15,13 +15,9 @@ package azure
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"strings"
-	"sync"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 
 	"github.com/cloud-barista/cb-tumblebug/src/core/csp"
@@ -62,19 +58,17 @@ func parseAzureArmID(armID string) (azureArmIDParts, error) {
 	}, nil
 }
 
-// azureStatusConcurrency is the maximum number of concurrent VM status calls
-// issued by BatchDescribeInstanceStatuses.  Azure has no native batch-status API,
-// so each VM requires an individual REST call.  Without a cap, calling this with
-// 200 VMs would launch 200 goroutines simultaneously, risking Azure API throttling
-// (HTTP 429) and connection-reset bursts on startup.
-const azureStatusConcurrency = 20
-
-// BatchDescribeInstanceStatuses queries Azure Compute for the given VM ARM resource IDs
-// and returns a map of armResourceID → TB status string.
+// BatchDescribeInstanceStatuses returns a map of the requested VM identifiers → TB status.
 //
-// VMs are fetched in parallel (up to azureStatusConcurrency concurrent calls) using
-// individual Get calls with InstanceView expansion (which returns the power state).
-// Azure has no batch-status API in the standard SDK.
+// It issues a single subscription-wide VirtualMachines ListAll with statusOnly=true, which
+// returns every VM's runtime InstanceView (power state) in one paged call, and matches each
+// requested identifier against that snapshot. Identifiers may be a full ARM resource ID or a
+// bare VM name — TB register records sometimes hold only the name — and both resolve because
+// the snapshot is keyed by ARM ID and by name.
+//
+// A requested VM absent from the snapshot is omitted from the result: the clean "not found"
+// signal callers treat as gone (the AWS handler follows the same contract). Using ListAll
+// rather than a per-VM Get also lets a bare name resolve without knowing its resource group.
 func BatchDescribeInstanceStatuses(ctx context.Context, region string, instanceIds []string) (map[string]string, error) {
 	if len(instanceIds) == 0 {
 		return map[string]string{}, nil
@@ -90,63 +84,40 @@ func BatchDescribeInstanceStatuses(ctx context.Context, region string, instanceI
 		return nil, fmt.Errorf("Azure vmstatus: failed to get VM client: %w", err)
 	}
 
-	// Fetch VMs in parallel, bounded by azureStatusConcurrency.
-	// Azure has no batch status API, so each VM needs an individual REST call.
-	// The semaphore prevents launching hundreds of goroutines simultaneously
-	// (e.g. at startup with 200 nodes), which would cause HTTP 429 / connection-reset bursts.
-	type vmResult struct {
-		armID  string
-		status string
-		err    error
-	}
-	ch := make(chan vmResult, len(instanceIds))
-	sem := make(chan struct{}, azureStatusConcurrency)
-
-	var wg sync.WaitGroup
-	for _, armID := range instanceIds {
-		wg.Add(1)
-		go func(id string) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			parts, perr := parseAzureArmID(id)
-			if perr != nil {
-				ch <- vmResult{armID: id, err: perr}
-				return
+	statusOnly := "true"
+	pager := vmClient.NewListAllPager(&armcompute.VirtualMachinesClientListAllOptions{StatusOnly: &statusOnly})
+	byKey := make(map[string]string)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			return nil, fmt.Errorf("Azure vmstatus: ListAll failed (region=%s): %w", region, perr)
+		}
+		for _, vm := range page.Value {
+			if vm == nil {
+				continue
 			}
-			expand := armcompute.InstanceViewTypesInstanceView
-			resp, gerr := vmClient.Get(ctx, parts.resourceGroup, parts.vmName,
-				&armcompute.VirtualMachinesClientGetOptions{Expand: &expand})
-			if gerr != nil {
-				var respErr *azcore.ResponseError
-				if errors.As(gerr, &respErr) && respErr.StatusCode == http.StatusNotFound {
-					ch <- vmResult{armID: id, status: model.StatusTerminated}
-					return
-				}
-				ch <- vmResult{armID: id, err: gerr}
-				return
+			status := azurePowerStateToTBStatus(vm.Properties)
+			if vm.ID != nil {
+				byKey[strings.ToLower(*vm.ID)] = status
 			}
-			ch <- vmResult{armID: id, status: azurePowerStateToTBStatus(resp.Properties)}
-		}(armID)
+			if vm.Name != nil {
+				byKey[strings.ToLower(*vm.Name)] = status
+			}
+		}
 	}
-
-	wg.Wait()
-	close(ch)
 
 	result := make(map[string]string, len(instanceIds))
-	var firstErr error
-	for r := range ch {
-		if r.err != nil {
-			if firstErr == nil {
-				firstErr = r.err
-			}
-			continue
+	for _, id := range instanceIds {
+		keys := []string{strings.ToLower(id)}
+		if parts, perr := parseAzureArmID(id); perr == nil {
+			keys = append(keys, strings.ToLower(parts.vmName))
 		}
-		result[r.armID] = r.status
-	}
-	if firstErr != nil && len(result) == 0 {
-		return nil, fmt.Errorf("Azure vmstatus: all requests failed; first error: %w", firstErr)
+		for _, k := range keys {
+			if s, ok := byKey[k]; ok {
+				result[id] = s
+				break
+			}
+		}
 	}
 
 	log.Trace().

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -2092,7 +2092,11 @@ func FetchNodeStatus(nsId string, infraId string, nodeId string) (model.NodeStat
 	// the Suspend/Resume/Reboot circuit breaker (see suspendResumeRebootFailStreak).
 	pollFailed := false
 
-	if nodeInfo.Status != model.StatusTerminated && cspResourceName != "" {
+	// Enter on a CspResourceId even when cspResourceName is empty: a register/discovery
+	// target on a batch-capable CSP resolves via the direct SDK by CspResourceId, so it
+	// must reach the SDK path below rather than being skipped (the Spider sub-path, which
+	// needs cspResourceName, is guarded separately).
+	if nodeInfo.Status != model.StatusTerminated && (cspResourceName != "" || nodeInfo.CspResourceId != "") {
 		// Direct SDK fast path: bypass Spider for CSPs with a registered BatchVMStatusFunc.
 		// Benefits: connection pooling, cached OAuth tokens, no extra Spider network hop.
 		// On failure we do NOT fall back to Spider: Spider calls the same CSP API, so a
@@ -2107,22 +2111,14 @@ func FetchNodeStatus(nsId string, infraId string, nodeId string) (model.NodeStat
 					callResult.Status = s
 					terminatingFailStreak.Delete(sdkStreakKey)
 					terminatingReTerminateSent.Delete(sdkStreakKey)
+					resetBatchNotFound(nsId, infraId, nodeId)
 					goto applyStatus
 				}
-				// Missing from a successful batch response: require the same consecutive-miss
-				// streak as SDK errors before promoting a Terminating node to Terminated.
-				callResult.Status = model.StatusUndefined
-				if nodeInfo.Status == model.StatusTerminating {
-					prev, _ := terminatingFailStreak.LoadOrStore(sdkStreakKey, 0)
-					streak := prev.(int) + 1
-					if streak >= terminatingFailStreakMax {
-						terminatingFailStreak.Delete(sdkStreakKey)
-						callResult.Status = model.StatusTerminated
-					} else {
-						terminatingFailStreak.Store(sdkStreakKey, streak)
-						callResult.Status = nodeInfo.Status
-					}
-				}
+				// Missing from a successful batch response: the CSP instance is gone. Advance
+				// the shared not-found streak and settle as Terminated once reached — uniform
+				// with the BatchSweeper, so the two paths agree instead of oscillating.
+				terminatingFailStreak.Delete(sdkStreakKey)
+				callResult.Status = recordBatchNotFound(nsId, infraId, nodeId)
 				goto applyStatus
 			}
 
@@ -2153,6 +2149,13 @@ func FetchNodeStatus(nsId string, infraId string, nodeId string) (model.NodeStat
 					terminatingFailStreak.Store(streakKey, streak)
 				}
 			}
+			goto applyStatus
+		}
+
+		// The Spider sub-path needs a cspResourceName. A node that reached here on a
+		// CspResourceId alone (batch-capable CSPs handled above; non-batch CSPs have no
+		// direct SDK) has nothing to query via Spider — leave the status as-is.
+		if cspResourceName == "" {
 			goto applyStatus
 		}
 
@@ -2446,14 +2449,15 @@ applyStatus:
 	// once the resource resolves to a real end state:
 	//   - live (Running/Suspended): late-bind TargetStatus to it so the standard
 	//     finalization below (TargetStatus==Status) records the actual state.
-	//   - terminated/terminating: not a manageable target (and about to be purged by
-	//     the CSP) — settle directly as Failed so refine removes it, avoiding a ghost.
+	//   - terminated/terminating: not a manageable target, but a real end state —
+	//     settle as Terminated (final, no longer re-polled) so refine removes it,
+	//     rather than mislabeling a gone resource as Failed.
 	if isDiscoveryAction(nodeStatusTmp.TargetAction) {
 		if isStableObservedStatus(nodeStatusTmp.Status) {
 			nodeStatusTmp.TargetStatus = nodeStatusTmp.Status
 		} else if strings.EqualFold(nodeStatusTmp.Status, model.StatusTerminated) ||
 			strings.EqualFold(nodeStatusTmp.Status, model.StatusTerminating) {
-			nodeStatusTmp.Status = model.StatusFailed
+			nodeStatusTmp.Status = model.StatusTerminated
 			nodeStatusTmp.TargetStatus = model.StatusComplete
 			nodeStatusTmp.TargetAction = model.ActionComplete
 			nodeStatusTmp.SystemMessage = "target CSP resource is terminated; cannot be managed (run refine to remove)"

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -4633,8 +4633,11 @@ func CreateNode(ctx context.Context, wg *sync.WaitGroup, nsId string, infraId st
 			} else {
 				instanceStatus, found := preCheckStatuses[nodeInfoData.CspResourceId]
 				if !found || strings.EqualFold(instanceStatus, model.StatusTerminated) {
+					// The direct SDK confirmed the instance is gone from the CSP (clean
+					// response, id absent) — a definitive not-found, so mark Terminated
+					// (not Failed): the record reflects reality and is a clean GC target.
 					msg := fmt.Sprintf("instance %s is not found or already terminated in CSP; skipping registration", nodeInfoData.CspResourceId)
-					nodeInfoData.Status = model.StatusFailed
+					nodeInfoData.Status = model.StatusTerminated
 					nodeInfoData.SystemMessage = msg
 					UpdateNodeInfo(nsId, infraId, *nodeInfoData)
 					log.Warn().Msgf("[register] %s", msg)

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -4878,18 +4878,15 @@ func CreateNode(ctx context.Context, wg *sync.WaitGroup, nsId string, infraId st
 
 	if option == "register" {
 		// Reconstuct resource IDs
-		// Spec
+		// Spec: resolve from DB, or fetch from the CSP and register on demand (as with Image).
 		if callResult.VMSpecName != "" {
-			resourceListInNs, err := resource.ListResource(model.SystemCommonNs, model.StrSpec, "csp_spec_name", callResult.VMSpecName)
+			specInfo, isAutoRegistered, err := resource.EnsureSpecAvailable(requestBody.ConnectionName, callResult.VMSpecName)
 			if err != nil {
-				log.Error().Err(err).Msg("Failed to list Spec")
+				log.Warn().Err(err).Msgf("Cannot resolve spec '%s' for registered VM; leaving spec unset", callResult.VMSpecName)
 			} else {
-				resourcesInNs := resourceListInNs.([]model.SpecInfo)
-				for _, res := range resourcesInNs {
-					if res.ConnectionName == requestBody.ConnectionName {
-						nodeInfoData.SpecId = res.Id
-						break
-					}
+				nodeInfoData.SpecId = specInfo.Id
+				if isAutoRegistered {
+					log.Info().Msgf("Auto-registered spec '%s' (ID: %s) from CSP during registration", callResult.VMSpecName, specInfo.Id)
 				}
 			}
 		}
@@ -4903,9 +4900,9 @@ func CreateNode(ctx context.Context, wg *sync.WaitGroup, nsId string, infraId st
 			imageInfo, isAutoRegistered, err := resource.EnsureImageAvailable(ctx, nsId, requestBody.ConnectionName, targetImageName)
 
 			if err != nil {
-				log.Error().Err(err).Msgf("Failed to ensure image availability: %s", targetImageName)
-				errMsg := fmt.Sprintf("Dependency Missing: Cannot find or register Image (CSP ID: %s) in TB.", targetImageName)
-				log.Error().Msg(errMsg)
+				// Best-effort: registration continues with the image left unset, so keep this a
+				// warning rather than an error that reads like a failed registration.
+				log.Warn().Err(err).Msgf("Cannot resolve image '%s' for registered VM; leaving image unset", targetImageName)
 			} else {
 				nodeInfoData.ImageId = imageInfo.Id
 

--- a/src/core/infra/statusagent.go
+++ b/src/core/infra/statusagent.go
@@ -119,6 +119,34 @@ func (a *NodeStatusAgent) startBatchSweeper(ctx context.Context) {
 }
 
 // runBatchSweep collects all PollNormal (Running) nodes that have a registered
+// batchNotFoundStreakMax is the number of consecutive not-found polls before a
+// batch-capable CSP node is settled as Terminated. At the 5-min sweep cadence this is
+// ~15 min; a clean direct-SDK omission is a reliable "gone" signal, so a small streak
+// only needs to guard against a rare transient batch omission.
+const batchNotFoundStreakMax = 3
+
+// recordBatchNotFound advances the shared not-found streak (stored on the node's
+// StatusEntry so the BatchSweeper and the individual FetchNodeStatus path agree) and
+// returns the status to apply: Terminated once the streak is reached — the CSP instance
+// is gone — else Undefined while the streak accrues.
+func recordBatchNotFound(nsId, infraId, nodeId string) string {
+	status := model.StatusUndefined
+	globalStatusStore.Update(nsId, infraId, nodeId, func(e *StatusEntry) {
+		e.NotFoundStreak++
+		if e.NotFoundStreak >= batchNotFoundStreakMax {
+			status = model.StatusTerminated
+		}
+	})
+	return status
+}
+
+// resetBatchNotFound clears the streak once the instance is seen present again.
+func resetBatchNotFound(nsId, infraId, nodeId string) {
+	globalStatusStore.Update(nsId, infraId, nodeId, func(e *StatusEntry) {
+		e.NotFoundStreak = 0
+	})
+}
+
 // batch SDK handler, groups them by (provider, credentialHolder, region), and
 // fires one SDK call per group. Results update StatusStore in-memory.
 // Nodes whose status changed are promoted to PollHigh so individual workers
@@ -202,8 +230,13 @@ func (a *NodeStatusAgent) runBatchSweep(ctx context.Context) {
 			updated := 0
 			for _, n := range grp {
 				newStatus, found := statuses[n.instanceId]
-				if !found {
-					newStatus = model.StatusUndefined
+				if found {
+					resetBatchNotFound(n.nsId, n.infraId, n.nodeId)
+				} else {
+					// A clean batch response without the id means the CSP instance is gone:
+					// advance the shared streak and settle as Terminated once reached, instead
+					// of leaving it Undefined forever (which keeps it polling / flip-flopping).
+					newStatus = recordBatchNotFound(n.nsId, n.infraId, n.nodeId)
 				}
 				globalStatusStore.Update(n.nsId, n.infraId, n.nodeId, func(e *StatusEntry) {
 					if e.Status != newStatus {

--- a/src/core/infra/statusstore.go
+++ b/src/core/infra/statusstore.go
@@ -79,6 +79,12 @@ type StatusEntry struct {
 	NextPollAt time.Time
 	Priority   PollPriority
 
+	// NotFoundStreak counts consecutive polls (from either the BatchSweeper or the
+	// individual FetchNodeStatus path) in which the CSP instance was absent from a
+	// successful direct-SDK response. Shared here so both writers advance one counter
+	// and agree; reaching batchNotFoundStreakMax settles the node as Terminated.
+	NotFoundStreak int
+
 	// Operation lock.
 	// Zero value = not locked.
 	// When set and within operationLockTTL, the daemon skips this node because

--- a/src/core/resource/spec.go
+++ b/src/core/resource/spec.go
@@ -2770,6 +2770,45 @@ func UpdateExistingSpecListByAvailableRegionZones(ctx context.Context, nsId stri
 	return result, nil
 }
 
+// EnsureSpecAvailable resolves a CSP spec (by its CSP spec name on the given connection) to
+// a TB SpecInfo, registering it into SystemCommonNs on demand when it is not already in the DB.
+// It mirrors EnsureImageAvailable so a discovered VM can be registered with a real spec instead
+// of an unresolved placeholder. The bool return reports whether the spec was auto-registered.
+// Price/cost is not fetched here (that is a connection-wide bulk operation); the on-demand spec
+// carries the canonical key, so the regular price-fetch flow fills its cost when it next runs.
+func EnsureSpecAvailable(connectionName, cspSpecName string) (model.SpecInfo, bool, error) {
+	if connectionName == "" {
+		return model.SpecInfo{}, false, fmt.Errorf("connectionName is required for EnsureSpecAvailable")
+	}
+	if cspSpecName == "" {
+		return model.SpecInfo{}, false, fmt.Errorf("cspSpecName is required for EnsureSpecAvailable")
+	}
+
+	connConfig, err := common.GetConnConfig(connectionName)
+	if err != nil {
+		return model.SpecInfo{}, false, fmt.Errorf("cannot GetConnConfig for %s: %w", connectionName, err)
+	}
+
+	// Same key the bulk fetch path uses, so an on-demand spec is indistinguishable from a
+	// fetched one and later price updates match it by key.
+	specKey := GetProviderRegionZoneResourceKey(connConfig.ProviderName, connConfig.RegionDetail.RegionName, "", cspSpecName)
+
+	if spec, err := GetSpec(model.SystemCommonNs, specKey); err == nil {
+		return spec, false, nil
+	}
+
+	log.Info().Msgf("Spec '%s' not in DB; fetching from CSP and registering on demand", specKey)
+	spec, err := RegisterSpecWithCspResourceId(model.SystemCommonNs, &model.SpecReq{
+		Name:           specKey,
+		ConnectionName: connectionName,
+		CspSpecName:    cspSpecName,
+	}, false)
+	if err != nil {
+		return model.SpecInfo{}, false, fmt.Errorf("failed to fetch/register spec '%s' from CSP: %w", cspSpecName, err)
+	}
+	return spec, true, nil
+}
+
 // RegisterSpecWithCspResourceId accepts spec creation request, creates and returns an TB spec object
 func RegisterSpecWithCspResourceId(nsId string, u *model.SpecReq, update bool) (model.SpecInfo, error) {
 


### PR DESCRIPTION
ref https://github.com/cloud-barista/cb-tumblebug/issues/2302

[fix(infra): converge registered-resource status to definitive end states](https://github.com/cloud-barista/cb-tumblebug/commit/d3974fe27a20d3292839ef0e8ef124dc8a854cba)
[fix(infra): register specs on demand and de-noise best-effort logs](https://github.com/cloud-barista/cb-tumblebug/commit/cc458ebd38d8c33579611893ee2e2269a3fe7992)

reduces Failed or Unknown or stale transition statuses.

<img width="710" height="479" alt="image" src="https://github.com/user-attachments/assets/e8f6eef2-33ea-40be-97e0-c9eda3a55bc1" />


and misc [Keep port-forwards alive across k8s rollouts](https://github.com/cloud-barista/cb-tumblebug/commit/97c63fdbffae8a483579f714f2cc0aacefb8eced)