### PR TITLE
fix: propagate execution error in RemoteCommandToK8sClusterContainer

### DIFF
--- a/src/core/resource/k8scluster.go
+++ b/src/core/resource/k8scluster.go
@@ -1910,8 +1910,7 @@ func RemoteCommandToK8sClusterContainer(nsId string, k8sClusterId string, k8sClu
 	}
 
 	// Execute commands
-	results, err := runRemoteCommandToK8sClusterContainer(nsId, k8sClusterId, k8sClusterPodName, k8sClusterNamespace, k8sClusterContainerName, req.Command)
-	return results, nil
+	return runRemoteCommandToK8sClusterContainer(nsId, k8sClusterId, k8sClusterPodName, k8sClusterNamespace, k8sClusterContainerName, req.Command)
 }
 
 // TransferFileToK8sClusterContainer is func to transfer a file to specified Container in K8sCluster by Kubernetes API


### PR DESCRIPTION
Fixes #2705

**Problem**

`RemoteCommandToK8sClusterContainer` discarded the error returned by `runRemoteCommandToK8sClusterContainer` (`return results, nil`). Every server-side failure (invalid kubeconfig, client setup errors, failed exec stream) therefore returned HTTP 200 with `results: null`, indistinguishable from a successful call that produced no output.

**Solution**

Return the call result directly, matching `TransferFileToK8sClusterContainer` in the same file, which already surfaces its error this way. No REST-layer change is needed: `RestPostCmdK8sCluster` already passes the error to `EndRequestWithLog`, which maps it to 4xx/5xx.

**Result**

- One-line change in `src/core/resource/k8scluster.go`
- `go vet ./src/core/resource/` passes
- `go build ./...` (full module) passes
- The only caller of this function is the REST handler, so no other behavior is affected