### PR TITLE
Staging v0.13.1 with set-release-versions tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ restore-assets: ## Restore PostgreSQL database from assets backup (or FILE=<path
 		TB_K8S_NAMESPACE=$${TB_K8S_NAMESPACE:-$(K8S_NAMESPACE)} ./scripts/restore-assets.sh $(FILE); \
 	fi
 
+set-versions: ## Interactively set core component release versions (cb-tumblebug/cb-spider/cb-mapui/mc-terrarium) across compose + k8s
+	@chmod +x ./scripts/misc/set-release-versions.sh 2>/dev/null || true
+	@./scripts/misc/set-release-versions.sh
+
 # ===== Utility Aliases =====
 # TARGET=k8s switches up/init/down to the Kubernetes (Helm) deployment.
 # Default (no TARGET) keeps the existing docker compose behavior unchanged.
@@ -1068,4 +1072,4 @@ help: ## Display this help screen
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # ===== PHONY targets (not actual files) =====
-.PHONY: default run clean clean-all swag swagger init init-profile compose compose-down logs status ps clean-db backup-assets restore-assets up down gen-cred enc-cred dec-cred bcrypt certs help k-up k-init k-down k-clean k-status k-ps k-images k-logs k-port-forward k-port-forward-stop k-port-forward-save k-port-forward-restore k-token k-mcp-on k-mcp-off k-mcp-client-info k-info k-agentgateway-on k-agentgateway-off k-mcp-auth-on k-mcp-auth-off k-mcp-token k-gateway-on k-gateway-off k-gateway-tls-on k-gateway-tls-off k-gateway-forward k-build k-build-tb k-build-mapui k-build-mcp k-build-sp k-build-off k-assets k-assets-off k-observability-on k-observability-off k-diagnose k-preflight-host k-diagnose-host
+.PHONY: default run clean clean-all swag swagger init init-profile compose compose-down logs status ps clean-db backup-assets restore-assets up down set-versions gen-cred enc-cred dec-cred bcrypt certs help k-up k-init k-down k-clean k-status k-ps k-images k-logs k-port-forward k-port-forward-stop k-port-forward-save k-port-forward-restore k-token k-mcp-on k-mcp-off k-mcp-client-info k-info k-agentgateway-on k-agentgateway-off k-mcp-auth-on k-mcp-auth-off k-mcp-token k-gateway-on k-gateway-off k-gateway-tls-on k-gateway-tls-off k-gateway-forward k-build k-build-tb k-build-mapui k-build-mcp k-build-sp k-build-off k-assets k-assets-off k-observability-on k-observability-off k-diagnose k-preflight-host k-diagnose-host

--- a/deployments/helm/cb-tumblebug/Chart.yaml
+++ b/deployments/helm/cb-tumblebug/Chart.yaml
@@ -3,7 +3,7 @@ name: cb-tumblebug
 description: CB-Tumblebug multi-cloud infrastructure management stack (Tumblebug, Spider, Terrarium, MapUI, OpenBao, etcd, PostgreSQL)
 type: application
 version: 0.1.0
-appVersion: "0.13.0"
+appVersion: "0.13.1"
 keywords:
   - cloud-barista
   - multi-cloud

--- a/deployments/helm/cb-tumblebug/templates/spider.yaml
+++ b/deployments/helm/cb-tumblebug/templates/spider.yaml
@@ -25,7 +25,7 @@ metadata:
   labels:
     {{- include "cb.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.spider.replicas | default 1 }}
   strategy:
     type: Recreate
   selector:
@@ -38,6 +38,19 @@ spec:
         {{- include "cb.labels" . | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 30
+      {{- if gt (int (.Values.spider.replicas | default 1)) 1 }}
+      # Scaled out to share the outbound CSP-call load. Spread replicas across nodes (soft, so
+      # it still schedules when nodes < replicas) so the load lands on different hosts, not one.
+      # All replicas share the single cb-spider-postgres metadb (state is DB-backed; the
+      # bottleneck being distributed is CSP-call CPU/network, not the DB).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: cb-spider
+      {{- end }}
       initContainers:
         # Four cb-spider packages panic in init() if the metadb is down at start
         - name: wait-for-metadb

--- a/deployments/helm/cb-tumblebug/values.yaml
+++ b/deployments/helm/cb-tumblebug/values.yaml
@@ -6,11 +6,11 @@
 # Install ONE release per namespace.
 
 images:
-  tumblebug: cloudbaristaorg/cb-tumblebug:0.13.0
+  tumblebug: cloudbaristaorg/cb-tumblebug:0.13.1
   spider: cloudbaristaorg/cb-spider:0.13.0
   terrarium: cloudbaristaorg/mc-terrarium:0.1.4
-  mapui: cloudbaristaorg/cb-mapui:0.13.0
-  mcp: cloudbaristaorg/cb-tumblebug-mcp-server:0.12.26
+  mapui: cloudbaristaorg/cb-mapui:0.13.1
+  mcp: cloudbaristaorg/cb-tumblebug-mcp-server:0.13.1
   etcd: gcr.io/etcd-development/etcd:v3.6.11
   postgres: postgres:16-alpine
   openbao: openbao/openbao:2.5.1
@@ -84,6 +84,13 @@ tumblebug:
       memory: 8Gi
 
 spider:
+  # Number of cb-spider replicas. cb-spider is the outbound CSP-call worker; scaling it out
+  # spreads concurrent multi-CSP/region call load across nodes (requests round-robin per call
+  # because the client uses Connection: close). All replicas share one cb-spider-postgres.
+  # NOTE: multi-replica over a shared metadb is not yet a validated cb-spider mode — smoke-test
+  # (scale to 2-3, provision a multi-region infra, watch per-pod load + check for errors/dupes)
+  # before relying on it. Keep at 1 for the standard single-instance behavior.
+  replicas: 1
   logLevel: error
   hiscallLogLevel: error
   # Go GC soft target (no hard limit): in-flight VM creations hold ~15 MB each,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ x-default-healthcheck: &default-healthcheck
 services:
   # CB-Tumblebug
   cb-tumblebug:
-    image: cloudbaristaorg/cb-tumblebug:0.13.0
+    image: cloudbaristaorg/cb-tumblebug:0.13.1
     container_name: cb-tumblebug
     build:
       context: .
@@ -220,7 +220,7 @@ services:
   # CB-MapUI
   # This is the Map-based client for CB-Tumblebug.
   cb-mapui:
-    image: cloudbaristaorg/cb-mapui:0.13.0
+    image: cloudbaristaorg/cb-mapui:0.13.1
     container_name: cb-mapui
     # build:
     #   context: ../cb-mapui
@@ -252,7 +252,7 @@ services:
     # TB-MCP (Tumblebug Model Context Protocol Server)
     # This provides MCP interface for CB-Tumblebug to work with AI assistants like Claude
   cb-tumblebug-mcp-server:
-    # image: cloudbaristaorg/cb-tumblebug-mcp-server:0.12.14
+    # image: cloudbaristaorg/cb-tumblebug-mcp-server:0.13.1
     # needs to be aligned with the main CB-Tumblebug image version for consistency
     build:
       context: ./src/interface/mcp

--- a/scripts/misc/set-release-versions.sh
+++ b/scripts/misc/set-release-versions.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Interactively set the pinned release image versions of the core cb-tumblebug
+# components across BOTH deployment modes (docker compose + Helm/k8s).
+#
+# For each component it shows the current version and the most recent published
+# tags from Docker Hub, lets you pick one or type a custom version (e.g. a
+# not-yet-published staging tag for cb-tumblebug), then rewrites the version in
+# the files that actually pin it:
+#
+#   docker-compose*.yaml                          (image: cloudbaristaorg/<c>:<ver>)
+#   deployments/helm/cb-tumblebug/values.yaml     (images.<c>)
+#   deployments/helm/cb-tumblebug/Chart.yaml      (appVersion — cb-tumblebug only)
+#
+# Usage: make set-versions   (or: bash scripts/misc/set-release-versions.sh)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+VALUES="$REPO_ROOT/deployments/helm/cb-tumblebug/values.yaml"
+CHART="$REPO_ROOT/deployments/helm/cb-tumblebug/Chart.yaml"
+
+# Components (display order) and their Docker Hub repositories.
+COMPONENTS=(cb-tumblebug cb-spider cb-mapui mc-terrarium)
+declare -A DHREPO=(
+  [cb-tumblebug]=cloudbaristaorg/cb-tumblebug
+  [cb-spider]=cloudbaristaorg/cb-spider
+  [cb-mapui]=cloudbaristaorg/cb-mapui
+  [mc-terrarium]=cloudbaristaorg/mc-terrarium
+)
+
+compose_files() { ls "$REPO_ROOT"/docker-compose*.yaml 2>/dev/null; }
+
+# current_version <dockerRepo> — source of truth is values.yaml.
+current_version() {
+  grep -oE "$1:[0-9][A-Za-z0-9._-]*" "$VALUES" | head -1 | sed "s#$1:##"
+}
+
+# The MCP server image is published in lockstep with cb-tumblebug (same version tag —
+# see .github/workflows/continuous-delivery-mcp.yaml), so its pin tracks cb-tumblebug's.
+MCP_REPO=cloudbaristaorg/cb-tumblebug-mcp-server
+current_mcp() { grep -oE "$MCP_REPO:[0-9][A-Za-z0-9._-]*" "$VALUES" | head -1 | sed "s#$MCP_REPO:##"; }
+current_appversion() { grep -oE '^appVersion:[^#]*' "$CHART" | head -1 | sed -E 's#appVersion:[[:space:]]*"?([^" ]*)"?.*#\1#'; }
+
+# fetch_tags <dockerRepo> — recent semver tags (x.y.z[-suffix]), newest first.
+fetch_tags() {
+  curl -fsSL "https://hub.docker.com/v2/repositories/$1/tags?page_size=50&ordering=last_updated" 2>/dev/null \
+    | python3 -c "import json,sys,re
+try: d=json.load(sys.stdin)
+except Exception: sys.exit(0)
+tags=[t.get('name','') for t in d.get('results',[])]
+sem=[t for t in tags if re.match(r'^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?\$', t)]
+print('\n'.join(sem[:8]))" 2>/dev/null || true
+}
+
+# apply_component <dockerRepo> <newVer> — rewrite one component's pinned tag in compose+values.
+# Matches only a versioned tag ("<repo>:<digit>...") so cb-tumblebug never touches
+# cb-tumblebug-mcp-server. '#' delimiter avoids clashing with the '/' in the repo.
+apply_component() {
+  # shellcheck disable=SC2046
+  sed -i -E "s#($1):[0-9][A-Za-z0-9._-]*#\1:$2#g" $(compose_files) "$VALUES"
+}
+
+echo "Core component release versions (source of truth: helm values.yaml)"
+for c in "${COMPONENTS[@]}"; do
+  printf "  %-14s %s\n" "$c" "$(current_version "${DHREPO[$c]}")"
+done
+
+declare -A NEW
+for c in "${COMPONENTS[@]}"; do
+  repo="${DHREPO[$c]}"; cur="$(current_version "$repo")"
+  echo
+  echo "== $c  (current: $cur) =="
+  mapfile -t tags < <(fetch_tags "$repo")
+  if [ "${#tags[@]}" -gt 0 ]; then
+    echo "  recent published tags:"
+    for i in 0 1 2; do
+      [ -n "${tags[$i]:-}" ] || break
+      mark=""; [ "${tags[$i]}" = "$cur" ] && mark="  (current)"
+      printf "   %d) %s%s\n" "$((i+1))" "${tags[$i]}" "$mark"
+    done
+  else
+    echo "  (could not fetch tags from Docker Hub — offline? enter a version manually)"
+  fi
+  if [ "$c" = "cb-tumblebug" ]; then
+    echo "   c) custom version  (allowed even if not yet published — e.g. a staging tag)"
+    echo "   note: cb-tumblebug-mcp-server (currently $(current_mcp)) is kept at the same version (CI lockstep)"
+  else
+    echo "   c) custom version"
+  fi
+  echo "   s) skip (keep $cur)"
+  read -rp "  choose [1-3/c/s]: " ans
+  case "$ans" in
+    1|2|3) sel="${tags[$((ans-1))]:-}"
+           if [ -z "$sel" ]; then echo "  no such tag — keeping $cur"; NEW[$c]="$cur"; else NEW[$c]="$sel"; fi ;;
+    c|C)   read -rp "  custom version: " v; NEW[$c]="${v:-$cur}" ;;
+    *)     NEW[$c]="$cur"; echo "  keeping $cur" ;;
+  esac
+done
+
+echo
+# cb-tumblebug-mcp-server and Chart appVersion always follow the effective cb-tumblebug
+# version (lockstep). Using the effective version repairs existing drift even when the
+# cb-tumblebug tag itself is kept.
+TB_FINAL="${NEW[cb-tumblebug]}"
+
+echo "Planned changes:"
+changed=0
+for c in "${COMPONENTS[@]}"; do
+  cur="$(current_version "${DHREPO[$c]}")"; nv="${NEW[$c]}"
+  if [ "$nv" != "$cur" ]; then printf "  %-14s %s -> %s\n" "$c" "$cur" "$nv"; changed=1; fi
+done
+if [ "$(current_mcp)" != "$TB_FINAL" ]; then
+  printf "  %-14s %s -> %s  (tracks cb-tumblebug)\n" "mcp-server" "$(current_mcp)" "$TB_FINAL"; changed=1
+fi
+if [ "$(current_appversion)" != "$TB_FINAL" ]; then
+  printf "  %-14s %s -> %s  (Chart appVersion)\n" "appVersion" "$(current_appversion)" "$TB_FINAL"; changed=1
+fi
+if [ "$changed" = 0 ]; then echo "  (nothing to change)"; exit 0; fi
+
+echo
+read -rp "Apply to docker-compose*.yaml + helm values + Chart appVersion? [y/N]: " ok
+case "$ok" in [yY]*) ;; *) echo "Aborted (no files changed)."; exit 0 ;; esac
+
+for c in "${COMPONENTS[@]}"; do
+  cur="$(current_version "${DHREPO[$c]}")"; nv="${NEW[$c]}"
+  [ "$nv" = "$cur" ] && continue
+  apply_component "${DHREPO[$c]}" "$nv"
+  printf "  ✔ %-14s -> %s\n" "$c" "$nv"
+done
+# Lockstep dependents of cb-tumblebug (no-ops if already equal to TB_FINAL).
+if [ "$(current_mcp)" != "$TB_FINAL" ]; then
+  apply_component "$MCP_REPO" "$TB_FINAL"; printf "  ✔ %-14s -> %s\n" "mcp-server" "$TB_FINAL"
+fi
+if [ "$(current_appversion)" != "$TB_FINAL" ]; then
+  sed -i -E "s#^appVersion:.*#appVersion: \"$TB_FINAL\"#" "$CHART"; printf "  ✔ %-14s -> %s\n" "appVersion" "$TB_FINAL"
+fi
+
+echo
+echo "Done. Review the diff before committing:"
+echo "  git diff -- docker-compose*.yaml deployments/helm/cb-tumblebug/"


### PR DESCRIPTION
```
shson@DESKTOP-KTDT15E:~/go/src/github.com/cloud-barista/cb-tumblebug$ make set-versions 
Core component release versions (source of truth: helm values.yaml)
  cb-tumblebug   0.13.0
  cb-spider      0.13.0
  cb-mapui       0.13.0
  mc-terrarium   0.1.4

== cb-tumblebug  (current: 0.13.0) ==
  recent published tags:
   1) 0.13.0  (current)
   2) 0.12.30
   3) 0.12.29
   c) custom version  (allowed even if not yet published — e.g. a staging tag)
   note: cb-tumblebug-mcp-server (currently 0.12.26) is kept at the same version (CI lockstep)
   s) skip (keep 0.13.0)
  choose [1-3/c/s]: c
  custom version: 0.13.1

== cb-spider  (current: 0.13.0) ==
  recent published tags:
   1) 0.13.0  (current)
   2) 0.12.45
   3) 0.12.44
   c) custom version
   s) skip (keep 0.13.0)
  choose [1-3/c/s]: s
  keeping 0.13.0

== cb-mapui  (current: 0.13.0) ==
  recent published tags:
   1) 0.13.1
   2) 0.13.0  (current)
   3) 0.12.58
   c) custom version
   s) skip (keep 0.13.0)
  choose [1-3/c/s]: 1

== mc-terrarium  (current: 0.1.4) ==
  recent published tags:
   1) 0.1.4  (current)
   2) 0.1.3
   3) 0.1.2
   c) custom version
   s) skip (keep 0.1.4)
  choose [1-3/c/s]: 1

Planned changes:
  cb-tumblebug   0.13.0 -> 0.13.1
  cb-mapui       0.13.0 -> 0.13.1
  mcp-server     0.12.26 -> 0.13.1  (tracks cb-tumblebug)
  appVersion     0.13.0 -> 0.13.1  (Chart appVersion)

Apply to docker-compose*.yaml + helm values + Chart appVersion? [y/N]: y
  ✔ cb-tumblebug   -> 0.13.1
  ✔ cb-mapui       -> 0.13.1
  ✔ mcp-server     -> 0.13.1
  ✔ appVersion     -> 0.13.1

Done. Review the diff before committing:
  git diff -- docker-compose*.yaml deployments/helm/cb-tumblebug/
```