### PR TITLE
enhance(rdbms): test MariaDB and enhance stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,9 +86,11 @@ uv.lock
 .env
 
 # test-cli: local configs and results (applies to all CLIs under test-clis/)
-src/testclient/test-clis/**/test-config.yaml
 src/testclient/test-clis/**/test-results/*
 !src/testclient/test-clis/**/test-results/.gitkeep
+src/testclient/test-clis/**/test-config*.yaml
+!src/testclient/test-clis/**/template-test-config.yaml
+src/testclient/test-clis/**/rdbms
 
 # VPN test (local only)
 # (no additional exceptions)

--- a/docs/feature_guide/rdbms-management.md
+++ b/docs/feature_guide/rdbms-management.md
@@ -4,13 +4,28 @@ CB-Tumblebug's RDBMS (managed relational database) feature: capability discovery
 lifecycle, logical database management, and CSP-specific defaults. Backed by CB-Spider's RDBMS
 API (v0.13.0+) — an implementation detail, not this document's focus (see References).
 
-## Feature Status
+## CSP-Wide Engine Support Matrix
+
+| CSP           | Provider Name | MySQL | MariaDB | Tested Reference Version (MySQL / MariaDB) | Primary Platform / Service                 |
+| :------------ | :------------ | :---: | :-----: | :----------------------------------------- | :----------------------------------------- |
+| **AWS**       | `aws`         |  ✅   |   ✅    | `8.0` / `10.6`                             | Amazon RDS (Multi-AZ SubnetGroup)          |
+| **Azure**     | `azure`       |  ✅   |   ❌    | `8.0.21` / —                               | Azure Database for MySQL Flexible Server   |
+| **GCP**       | `gcp`         |  ✅   |   ❌    | `8.0` / —                                  | Google Cloud SQL for MySQL                 |
+| **Alibaba**   | `alibaba`     |  ✅   |   ✅    | `8.0` / `10.6`                             | Alibaba Cloud ApsaraDB RDS                 |
+| **Tencent**   | `tencent`     |  ✅   |   ❌    | `8.0` / —                                  | TencentDB for MySQL                        |
+| **IBM**       | `ibm`         |  ✅   |   ❌    | `8.4` / —                                  | IBM Cloud Databases for MySQL              |
+| **NCP**       | `ncp`         |  ✅   |   ❌    | `8.0.36` / —                               | NAVER Cloud Platform Cloud DB for MySQL    |
+| **NHN**       | `nhn`         |  ✅   |   ✅    | `MYSQL_V8408` / `MARIADB_V101118`          | NHN Cloud RDS for MySQL / MariaDB          |
+| **OpenStack** | `openstack`   |  ✅   |   ✅    | `5.7.29` / `10.4`                          | OpenStack Trove _(local testing deferred)_ |
+| **KT Cloud**  | `kt`          |  ❌   |   ❌    | —                                          | _Unsupported (No managed DB service)_      |
+
+## Features
 
 | Feature                                                      | Status      | Location                                                                                                    |
 | ------------------------------------------------------------ | ----------- | ----------------------------------------------------------------------------------------------------------- |
 | Static, CSP-wide support matrix (`GetRDBMSSupport`)          | ✅          | [rdbms.go](../../src/core/resource/rdbms.go), [rdbms.go](../../src/interface/rest/server/resource/rdbms.go) |
 | Live, per-connection capability query (`GetRDBMSCapability`) | ✅          | [rdbms.go](../../src/core/resource/rdbms.go), [rdbms.go](../../src/interface/rest/server/resource/rdbms.go) |
-| Instance lifecycle (Create/List/Get/Delete)                  | ✅          | [rdbms.go](../../src/core/resource/rdbms.go), [rdbms.go](../../src/interface/rest/server/resource/rdbms.go) |
+| DB instance lifecycle (Create/List/Get/Delete)               | ✅          | [rdbms.go](../../src/core/resource/rdbms.go), [rdbms.go](../../src/interface/rest/server/resource/rdbms.go) |
 | Create-request validation (dry run, no side effects)         | ✅          | `ValidateRDBMSCreateRequest` in [rdbms.go](../../src/core/resource/rdbms.go)                                |
 | CSP admin username/password policy validation                | ✅          | `validateAdminCredentials` in [rdbms.go](../../src/core/resource/rdbms.go)                                  |
 | Spec-aware autoFillDefaults picker (vCPU/memory-based)       | ✅          | `pickSmallestDBSpec` in [rdbms.go](../../src/core/resource/rdbms.go)                                        |
@@ -19,67 +34,42 @@ API (v0.13.0+) — an implementation detail, not this document's focus (see Refe
 | Register/Unregister existing CSP RDBMS                       | Not Planned | —                                                                                                           |
 | Reconciliation                                               | ✅          | [rdbmsReconcile.go](../../src/core/reconcile/rdbmsReconcile.go)                                             |
 
-## Features
-
 - **Capability discovery**: check which engines/features a CSP supports.
   - Static, CSP-wide reference, no live call (`GET /rdbms/support`).
   - Live, per-connection: versions, spec/storage options, `Requires*`/`Supports*` flags
     (`GET /rdbms/capability`).
   - Typical flow: `/support` to pick a CSP/engine, then `/capability` for the target connection.
-- **Instance lifecycle**: create, inspect, and delete a managed instance.
+- **DB instance lifecycle**: create, inspect, and delete a managed DB instance.
   - Dry run, no provisioning (`POST .../rdbms/validate`).
-  - Create: resolves network names, validates against live capability data (see CSP-Specific
-    Capability Reference) and CSP admin-credential policy (see Admin Credential Constraints),
+  - Create: resolves network names, validates against live capability data (see [CSP Capability, Requirements & Constraints](#csp-capability-requirements--constraints)) and CSP admin-credential policy (see [Admin Credential Constraints](#admin-credential-constraints)),
     auto-fills the smallest usable `dbInstanceSpec` and a compatible storage type if requested, and
-    blocks server-side until the instance reaches `Available` (`POST .../rdbms`; see Creation and
-    Deletion Reliability for why).
+    blocks server-side until the DB instance reaches `Available` (`POST .../rdbms`; see
+    [RDBMS Management Stability Enhancement](#rdbms-management-stability-enhancement) for details).
   - Delete: confirms via two independent checks before clearing the kvstore record
-    (`DELETE .../rdbms/{rdbmsId}`; also in Creation and Deletion Reliability).
+    (`DELETE .../rdbms/{rdbmsId}`; also in [RDBMS Management Stability Enhancement](#rdbms-management-stability-enhancement)).
 - **Internal logical databases**: create, list, and delete logical databases inside an
-  `Available` instance.
+  `Available` DB instance.
   - Not a tracked Tumblebug resource — no kvstore entry, queried live
     (`POST`/`GET`/`DELETE .../rdbms/{rdbmsId}/database[/{dbName}]`).
   - Admin password required for create/delete, optional for list, and never persisted (masked
-    before it ever reaches a log line — same rule for the instance's own create-time admin
+    before it ever reaches a log line — same rule for the DB instance's own create-time admin
     password).
 - **Tag management**: uses the common
   [Label mechanism](../../src/core/common/label/label.go) instead of a dedicated tag API, like
   every other resource type.
-- **Registration** of an existing CSP instance is planned but not built, mirroring the
+- **Registration** of an existing CSP DB instance is planned but not built, mirroring the
   VNet/SecurityGroup register/deregister pattern.
 - **Reconciliation**: detects drift via the shared
   [resource-reconciliation.md](resource-reconciliation.md) contract; the creating/deleting repair
   paths are logging-only skeletons today (same as VNet/ObjectStorage). A `DeletionFailed`
-  instance only auto-restores to `Available` if it's auto-managed (`IsAutoManagedResource`) —
-  a user-owned instance's tombstone is sticky, and its recovery path is **TBD**
+  DB instance only auto-restores to `Available` if it's auto-managed (`IsAutoManagedResource`) —
+  a user-owned DB instance's tombstone is sticky, and its recovery path is **TBD**
   (`PUT .../restore` exists generically but isn't yet wired up for RDBMS; see Open Items
   in [resource-reconciliation.md](resource-reconciliation.md)).
 
-## Creation and Deletion Reliability
-
-Some CSPs run internal processing during create/delete that CB-Spider's own API can't observe or
-report accurately — this section covers the resulting defensive logic and which CSPs each part
-is for.
-
-- **Create (`ConfirmRDBMSCreated`)**: polls every 20s for up to 10 minutes (30 attempts) until `Available`.
-  - AWS: returns `Creating` immediately, needing the poll (RDS MySQL creation typically takes 5–7 minutes).
-  - IBM: returns `Creating` and variable creation time.
-  - Alibaba: can return `Error` transiently before settling into `Available`.
-
-- **Delete (`PollResourceFullyDeleted`)**: confirms deletion by checking both Spider and the CSP.
-  - NCP: Cloud DB instance teardown takes ~3-4 minutes and is actively confirmed via `OnlyCSPList` (`PollResourceDeletedOnCSP`, polled every 10s for up to 10 min).
-  - Alibaba: a real VPC/vSwitch attachment releases asynchronously (`DependencyViolation.Rds`).
-  - Tencent: VPC/subnet IP release lags instance deletion (`ResourceInUse`).
-
-- **Delete — CSP-specific stabilization buffer**: 10s normally
-  - Alibaba: 180s
-  - Tencent: 90s
-  - NCP: uses standard 10s buffer because dynamic `OnlyCSPList` polling actively tracks full CSP-side teardown.
-
 ## Usage Sequence (Tumblebug User Perspective)
 
-Scenario A is fully implemented; B/C describe the target flow for planned registration/audit
-features (see API Reference).
+Scenario A is fully implemented; B/C describe the target flow for planned registration/audit features (see [API Reference](#api-reference)).
 
 ```mermaid
 sequenceDiagram
@@ -99,19 +89,12 @@ sequenceDiagram
     User->>TB: 9. DELETE /ns/{nsId}/resources/rdbms/{rdbmsId}
 ```
 
-- **Scenario B — Register an existing CSP instance (planned)**: `POST /inspectResources` to find
-  CSP-only instances, then `POST .../rdbms/register` (CSP instance ID; `vNetId` auto-resolved if
-  omitted). `.../unregister` drops Tumblebug ownership without touching the CSP instance.
-- **Scenario C — Audit and clean up orphans (planned)**: `POST /inspectResources` returns
-  `onTumblebug`/`onCspOnly` lists; `DELETE /rdbms/cspOnly/{cspId}` removes a CSP-only orphan
-  directly (bypasses Tumblebug entirely — confirm the target first).
+- **Scenario B — Register an existing CSP DB instance (planned)**: `POST /inspectResources` to find CSP-only DB instances, then `POST .../rdbms/register` (CSP instance ID; `vNetId` auto-resolved if omitted). `.../unregister` drops Tumblebug ownership without touching the CSP DB instance.
+- **Scenario C — Audit and clean up orphans (planned)**: `POST /inspectResources` returns `onTumblebug`/`onCspOnly` lists; `DELETE /rdbms/cspOnly/{cspId}` removes a CSP-only orphan directly (bypasses Tumblebug entirely — confirm the target first).
 
 ## API Reference
 
-Where a generic mechanism already covers a need — `inspectResources` for CSP/Tumblebug-mapped
-listing, counting, and orphan detection (see
-[shared-resource-management.md](shared-resource-management.md)) — planned features reuse it
-instead of adding a parallel RDBMS-only API.
+Where a generic mechanism already covers a need — `inspectResources` for CSP/Tumblebug-mapped listing, counting, and orphan detection (see [shared-resource-management.md](shared-resource-management.md)) — planned features reuse it instead of adding a parallel RDBMS-only API.
 
 ### Implemented Endpoints
 
@@ -136,20 +119,15 @@ instead of adding a parallel RDBMS-only API.
 | DELETE | `/ns/{nsId}/resources/rdbms/{rdbmsId}/unregister` | `RestDeleteUnregisterRDBMS` |
 | DELETE | `/rdbms/cspOnly/{cspId}?connectionName=`          | `RestDeleteRDBMSCspOnly`    |
 
-`RestDeleteRDBMSCspOnly` is namespace-independent, destructive, admin-only (explicit confirmation
-required, logs caller/connection/CSP ID). No dedicated tag API was built — RDBMS instances use the
-common Label mechanism instead.
+`RestDeleteRDBMSCspOnly` is namespace-independent, destructive, admin-only (explicit confirmation required, logs caller/connection/CSP ID). No dedicated tag API was built — RDBMS instances use the common Label mechanism instead.
 
-## CSP-Specific Capability Reference
+## CSP Capability, Requirements & Constraints
 
-Reference only — `CreateRDBMS` always re-checks live capability data at request time rather than
-trusting a cached copy, since a stale reference could let an invalid request slip through and fail
-only after minutes of CSP provisioning.
+Reference values and per-CSP rules — `CreateRDBMS` always re-checks live capability data at request time rather than trusting a cached copy, since a stale reference could let an invalid request slip through and fail only after minutes of CSP provisioning.
 
 ### CSP Capability Summary (MySQL)
 
-`DB Op. Method` — `cspNativeApi` (CSP-native database API) or `sqlFallback` (direct SQL via the
-admin login; see [CSP-Specific Requirements and Constraints](#csp-specific-requirements-and-constraints) for the network-reachability caveat).
+`DB Op. Method` — `cspNativeApi` (CSP-native database API) or `sqlFallback` (direct SQL via the admin login; see [Direct SQL Connection & Reachability](#direct-sql-connection--reachability-external-vs-internal-vpc) for network-reachability details).
 
 | CSP       | Engine Version | DB Spec                                         | Storage            | Requires Subnet | Requires SG | Storage Type Selectable | Tag Support | DB Op. Method |
 | --------- | -------------- | ----------------------------------------------- | ------------------ | :-------------: | :---------: | :---------------------: | :---------: | ------------- |
@@ -163,13 +141,11 @@ admin login; see [CSP-Specific Requirements and Constraints](#csp-specific-requi
 | NCP       | 8.0.36         | SVR.VDBAS.AMD.STAND.C002.M008.NET.SSD.B050.G003 | CSP-managed        |       🟢        |     🔴      |           🔴            |     🔴      | cspNativeApi  |
 | NHN       | MYSQL_V8408    | m2.c2m4                                         | 20GB / General SSD |       🟢        |     🔴      |           🟢            |     🔴      | cspNativeApi  |
 
-Full per-CSP notes (password quirks, premium storage minimums): section 9 of the CB-Spider wiki's
-[RDBMS Management Guide](<https://github.com/cloud-barista/cb-spider/wiki/RDBMS%E2%80%90Management%E2%80%90Guide(KR)>).
+Full per-CSP notes (password quirks, premium storage minimums): section 9 of the CB-Spider wiki's [RDBMS Management Guide](<https://github.com/cloud-barista/cb-spider/wiki/RDBMS%E2%80%90Management%E2%80%90Guide(KR)>).
 
 ### CSP Capability Summary (MariaDB)
 
-Only 4 of 9 CSPs support MariaDB. Azure/GCP/Tencent/IBM/NCP don't list `mariadb` — use `mysql`
-there.
+Only 4 of 9 CSPs support MariaDB. Azure, GCP, Tencent, IBM, and NCP do not list `mariadb` — use `mysql` for those providers.
 
 | CSP       | Engine Version  | DB Spec              | Storage            | Result  | Duration |
 | --------- | --------------- | -------------------- | ------------------ | :-----: | -------: |
@@ -178,13 +154,41 @@ there.
 | NHN       | MARIADB_V101118 | m2.c2m4              | 20GB / General SSD | ✅ Pass |    10m8s |
 | OpenStack | 10.6            | m1.small             | 20GB / auto        | ❌ Fail |        — |
 
-(OpenStack's failure is a test-environment gap — no MariaDB datastore registered — not a driver
-limitation.)
+_(OpenStack's failure is a test-environment gap — no MariaDB datastore registered — not a driver limitation.)_
+
+### CSP-Specific Requirements and Constraints
+
+- **AWS**:
+  - Requires 2 subnets in distinct AZs (SubnetGroup) and a pre-existing Security Group.
+  - `io1`/`io2` storage types require `Iops >= 1000` and `StorageSize >= 100GB`.
+  - Database CRUD uses `sqlFallback` (direct SQL connection via admin login) — private DB instances require network reachability to the private endpoint.
+- **Azure**:
+  - `SupportsStorageTypeSelection=false` — storage SKU is auto-managed by Azure based on the compute tier.
+  - Enforces TLS encryption (`require_secure_transport=ON`); clients must connect with TLS enabled.
+- **GCP**:
+  - `StorageType` is bound to the machine series (`HYPERDISK_BALANCED` for C4A/N4 series, `PD_SSD`/`PD_HDD` for others) — pre-flight validation catches mismatches before provisioning.
+- **Alibaba**:
+  - Requires selecting a DB instance specification compatible with the target storage type (e.g. `mysql.n4.*` supports `cloud_essd`, while `local_ssd` requires `rds.mysql.*`).
+  - Network interface release lags DB instance deletion; teardown incorporates stabilization retry buffers (510s / 8.5 min).
+- **Tencent**:
+  - DBSpec memory size is specified in MB (e.g. `8000` for 8GB).
+  - Background ENI release lags DB instance deletion; teardown incorporates stabilization retry buffers (90s).
+- **IBM**:
+  - Provisions on the shared/multitenant platform with auto-managed storage (`SupportsStorageTypeSelection=false`).
+  - Database CRUD uses `sqlFallback` and requires TLS connection.
+- **NCP**:
+  - `StorageSize` is auto-managed (starts at 10GB and auto-scales up to 6000GB in 10GB increments); custom size inputs are ignored. Storage type defaults to `SSD`.
+  - Assigns private VPC endpoints only (`*.vpc-cdb.ntruss.com`); direct external access requires manual public domain assignment via NCP console.
+  - Full DB instance deletion is actively tracked via dynamic CSP-side polling (~3–4 min).
+- **NHN**:
+  - Requires dedicated RDS credentials (`User Access Key`, `Secret Access Key`, and engine AppKey).
+  - Returns a single public FQDN endpoint when `PublicAccess: true`. Access control is governed by NHN Cloud's dedicated **DB Security Group** (DB 보안 그룹) rather than standard VPC security groups.
+- **OpenStack**:
+  - Storage type is not reported after creation — verify provisioning success via `Available` status.
 
 ### Admin Credential Constraints
 
-Enforced client-side by `validateAdminCredentials` before Create reaches CB-Spider. `—` = no
-constraint recorded.
+Enforced client-side by `validateAdminCredentials` before Create reaches CB-Spider. `—` = no constraint recorded.
 
 | CSP       | Admin Username Constraint                                                                                                                                          | Admin Password Constraint               |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
@@ -222,42 +226,71 @@ About a caller's own application or test client connecting straight to the datab
 
 A connection mode that adapts either way (e.g. `go-sql-driver/mysql`'s `tls=preferred`) avoids TLS negotiation errors.
 
-## CSP-Specific Requirements and Constraints
+## RDBMS Management Stability Enhancement
 
-Account username and password rules are summarized in [Admin Credential Constraints](#admin-credential-constraints).
+Managed relational databases exhibit significant heterogeneity across CSPs regarding asynchronous provisioning latency, transient state transitions, and background resource release lag. CB-Tumblebug implements specialized defensive mechanisms to ensure end-to-end reliability for DB instance creation and teardown.
 
-- **AWS**:
-  - Requires 2 subnets in distinct AZs (SubnetGroup) and a pre-existing Security Group.
-  - `io1`/`io2` storage types require `Iops >= 1000` and `StorageSize >= 100GB`.
-  - Database CRUD uses `sqlFallback` (direct SQL connection via admin login) — private instances require network reachability to the private endpoint.
-- **Azure**:
-  - `SupportsStorageTypeSelection=false` — storage SKU is auto-managed by Azure based on the compute tier.
-  - Enforces TLS encryption (`require_secure_transport=ON`); clients must connect with TLS enabled.
-- **GCP**:
-  - `StorageType` is bound to the machine series (`HYPERDISK_BALANCED` for C4A/N4 series, `PD_SSD`/`PD_HDD` for others) — pre-flight validation catches mismatches before provisioning.
-- **Alibaba**:
-  - Requires selecting an instance specification compatible with the target storage type (e.g. `mysql.n4.*` supports `cloud_essd`, while `local_ssd` requires `rds.mysql.*`).
-  - Network interface release lags instance deletion; teardown incorporates stabilization retry buffers.
-- **Tencent**:
-  - DBSpec memory size is specified in MB (e.g. `8000` for 8GB).
-  - Background ENI release lags instance deletion; teardown incorporates stabilization retry buffers.
-- **IBM**:
-  - Provisions on the shared/multitenant platform with auto-managed storage (`SupportsStorageTypeSelection=false`).
-  - Database CRUD uses `sqlFallback` and requires TLS connection.
-- **NCP**:
-  - `StorageSize` is auto-managed (starts at 10GB and auto-scales up to 6000GB in 10GB increments); custom size inputs are ignored. Storage type defaults to `SSD`.
-  - Assigns private VPC endpoints only (`*.vpc-cdb.ntruss.com`); direct external access requires manual public domain assignment via NCP console.
-  - Full instance deletion is actively tracked via dynamic CSP-side polling (~3–4 min).
-- **NHN**:
-  - Requires dedicated RDS credentials (`User Access Key`, `Secret Access Key`, and engine AppKey).
-  - Returns a single public FQDN endpoint when `PublicAccess: true`. Access control is governed by NHN Cloud's dedicated **DB Security Group** (DB 보안 그룹) rather than standard VPC security groups.
-- **OpenStack**:
-  - Storage type is not reported after creation — verify provisioning success via `Available` status.
+### Creation Stability Enhancement
+
+DB instance creation blocks server-side until the DB instance reaches `Available` status on the CSP.
+
+```mermaid
+flowchart TD
+    Start(["POST /ns/{nsId}/resources/rdbms"]) --> Validate["Pre-flight Validation & Credential Check"]
+    Validate --> AutoFill["Auto-fill Defaults (Spec / Storage)"]
+    AutoFill --> PostSpider["Call CB-Spider POST /rdbms"]
+    PostSpider --> PollLoop["Poll GET /rdbms/{Uid}<br/>(Interval: 20s, Max: 30 attempts / 10 min)"]
+    PollLoop --> CheckStatus{"CSP Status?"}
+    CheckStatus -- "Available" --> Success["Save DB Instance Metadata to kvstore"]
+    Success --> ReturnOK(["Return 200 OK (Status: Available)"])
+    CheckStatus -- "Creating / Transient Error" --> CheckAttempts{"Attempts < 30?"}
+    CheckAttempts -- "Yes" --> Sleep["Wait 20s"] --> PollLoop
+    CheckAttempts -- "No (Timeout)" --> Fail["Mark Status: Failed"]
+    CheckStatus -- "Failed / Deleted" --> Fail
+    Fail --> ReturnFail(["Return Error / Failed"])
+```
+
+- **Creation Polling (`ConfirmRDBMSCreated`)**: Polls every 20s for up to 10 minutes (30 attempts) until `Available`.
+  - **AWS**: Returns `Creating` immediately; RDS MySQL/MariaDB creation typically requires 5–7 minutes.
+  - **IBM**: Returns `Creating` immediately with variable cloud database provisioning times.
+  - **Alibaba**: Can return `Error` transiently during initial cluster setup before settling into `Available`.
+
+### Deletion Stability Enhancement
+
+Deleting a DB instance confirms deletion via two-phase validation and applies CSP-specific post-delete stabilization buffers to prevent cascaded network teardown failures.
+
+```mermaid
+flowchart TD
+    Start(["DELETE /ns/{nsId}/resources/rdbms/{rdbmsId}"]) --> GetInfo["Lookup RDBMS Metadata from kvstore"]
+    GetInfo --> CallDelete["Call CB-Spider DELETE /rdbms/{Uid}"]
+    CallDelete --> Phase1["Phase 1: Poll Spider Record Deletion<br/>(GET /rdbms/{Uid}, 10s interval, max 30 attempts)"]
+    Phase1 --> Phase2{"CSP-Specific<br/>Active Check?"}
+    Phase2 -- "NCP (Cloud DB)" --> PollCSP["Phase 2: Poll OnlyCSPList<br/>(Actively verify teardown on NCP, ~3–4 min)"]
+    Phase2 -- "Other CSPs" --> Buffer["Apply Post-Delete Stabilization Buffer"]
+    PollCSP --> Buffer
+    Buffer --> BufferCheck{"Target CSP?"}
+    BufferCheck -- "Alibaba" --> WaitAlibaba["Wait 510s (8.5 min)<br/>VSwitch ENI Dependency Release"]
+    BufferCheck -- "Tencent" --> WaitTencent["Wait 90s (1.5 min)<br/>Subnet IP Release"]
+    BufferCheck -- "Default (AWS/Azure/GCP/etc.)" --> WaitDefault["Wait 10s"]
+    WaitAlibaba --> PurgeMeta["Purge RDBMS Metadata from kvstore"]
+    WaitTencent --> PurgeMeta
+    WaitDefault --> PurgeMeta
+    PurgeMeta --> ReturnDone(["Return 204 No Content"])
+```
+
+- **Deletion Confirmation (`PollResourceFullyDeleted`)**: Verifies deletion through two independent layers:
+  - **NCP**: Cloud DB instance teardown takes ~3–4 minutes and is actively tracked via dynamic CSP-side polling (`PollResourceDeletedOnCSP`, polled every 10s for up to 10 min).
+  - **Alibaba**: VPC/vSwitch attachments release asynchronously; deleting subnets immediately after instance deletion triggers `DependencyViolation.Rds`.
+  - **Tencent**: VPC/subnet IP releases lag instance deletion (`ResourceInUse`).
+- **Post-Delete Stabilization Buffers**:
+  - **Alibaba**: 510s (8.5 minutes) to ensure complete background VSwitch ENI detachment before subsequent subnet/VPC deletion.
+  - **Tencent**: 90s (1.5 minutes) for network interface release.
+  - **NCP**: 10s default buffer (full teardown is already confirmed by dynamic `OnlyCSPList` polling).
+  - **Default (AWS, Azure, GCP, IBM, OpenStack)**: 10s.
 
 ## References
 
-Background on CB-Spider's side of this integration (implementation detail, not part of
-Tumblebug's own API contract):
+Background on CB-Spider's side of this integration (implementation detail, not part of Tumblebug's own API contract):
 
 - [RDBMS‐Management‐Guide (KR)](<https://github.com/cloud-barista/cb-spider/wiki/RDBMS%E2%80%90Management%E2%80%90Guide(KR)>)
 - [CB-Spider RDBMS API Test README](https://github.com/cloud-barista/cb-spider/blob/master/test/rdbms-mysql-test/README.md)
@@ -267,21 +300,17 @@ Tumblebug's own API contract):
 
 ## Appendix: Tumblebug API → CB-Spider API Mapping
 
-Covers the 10 routes in Implemented Endpoints (planned endpoints excluded — their Spider-call
-shape isn't finalized). `{Uid}` is CB-Spider's own instance ID (`RDBMSInfo.Uid`), not the
-Tumblebug `rdbmsId`. 🔁 marks a field CB-Spider still calls `MasterUserName`/`MasterUserPassword`
-on the wire, translated to/from Tumblebug's `adminUserName`/`adminUserPassword` at the call site
-and never exposed as `Master*` to a Tumblebug API caller.
+Covers the 10 routes in Implemented Endpoints (planned endpoints excluded — their Spider-call shape isn't finalized). `{Uid}` is CB-Spider's own DB instance ID (`RDBMSInfo.Uid`), not the Tumblebug `rdbmsId`. 🔁 marks a field CB-Spider still calls `MasterUserName`/`MasterUserPassword` on the wire, translated to/from Tumblebug's `adminUserName`/`adminUserPassword` at the call site and never exposed as `Master*` to a Tumblebug API caller.
 
-| Tumblebug API                                  | CB-Spider API(s) Called                                                                                           | Notes                                                                     |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `GET /rdbms/support`                           | — (none)                                                                                                          | Static from `assets/rdbmsinfo.yaml`.                                      |
-| `GET /rdbms/capability`                        | `GET /rdbmsmetainfo` (required); `GET /dbspec`, `GET /rdbmsengine` (best-effort)                                  | Best-effort calls populate `dbInstanceSpecs`/`liveSupportedEngines` only. |
-| `POST .../rdbms/validate`                      | Same as `/capability`'s required call, plus `GET /dbspec` if autofilling `dbInstanceSpec`                         | Dry run — never reaches create/delete.                                    |
-| `POST .../rdbms`                               | Same as Validate, plus `POST /rdbms`; `GET /rdbms/{Uid}` (poll every 20s up to 10 min, through Creating or Error) | 🔁 in the create request body.                                            |
-| `GET .../rdbms` (list)                         | — (none)                                                                                                          | Served from kvstore.                                                      |
-| `GET .../rdbms/{rdbmsId}`                      | `GET /rdbms/{Uid}`                                                                                                | 🔁 in the response (password never returned).                             |
-| `DELETE .../rdbms/{rdbmsId}`                   | `DELETE /rdbms/{Uid}`; `GET /rdbms/{Uid}` + `GET /allrdbms` (dual verify)                                         | See Creation and Deletion Reliability.                                    |
-| `POST .../rdbms/{rdbmsId}/database`            | `GET /rdbms/{Uid}` (Status check); `POST /rdbms/{Uid}/databases`                                                  | 🔁 in the request body.                                                   |
-| `GET .../rdbms/{rdbmsId}/database`             | `GET /rdbms/{Uid}`; `GET /rdbms/{Uid}/databases`                                                                  | 🔁 via `X-Admin-User-Password` header.                                    |
-| `DELETE .../rdbms/{rdbmsId}/database/{dbName}` | `GET /rdbms/{Uid}`; `DELETE /rdbms/{Uid}/databases/{dbName}`                                                      | 🔁 via `X-Admin-User-Password` header.                                    |
+| Tumblebug API                                  | CB-Spider API(s) Called                                                                                           | Notes                                                                                  |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `GET /rdbms/support`                           | — (none)                                                                                                          | Static from `assets/rdbmsinfo.yaml`.                                                   |
+| `GET /rdbms/capability`                        | `GET /rdbmsmetainfo` (required); `GET /dbspec`, `GET /rdbmsengine` (best-effort)                                  | Best-effort calls populate `dbInstanceSpecs`/`liveSupportedEngines` only.              |
+| `POST .../rdbms/validate`                      | Same as `/capability`'s required call, plus `GET /dbspec` if autofilling `dbInstanceSpec`                         | Dry run — never reaches create/delete.                                                 |
+| `POST .../rdbms`                               | Same as Validate, plus `POST /rdbms`; `GET /rdbms/{Uid}` (poll every 20s up to 10 min, through Creating or Error) | 🔁 in the create request body.                                                         |
+| `GET .../rdbms` (list)                         | — (none)                                                                                                          | Served from kvstore.                                                                   |
+| `GET .../rdbms/{rdbmsId}`                      | `GET /rdbms/{Uid}`                                                                                                | 🔁 in the response (password never returned).                                          |
+| `DELETE .../rdbms/{rdbmsId}`                   | `DELETE /rdbms/{Uid}`; `GET /rdbms/{Uid}` + `GET /allrdbms` (dual verify)                                         | See [RDBMS Management Stability Enhancement](#rdbms-management-stability-enhancement). |
+| `POST .../rdbms/{rdbmsId}/database`            | `GET /rdbms/{Uid}` (Status check); `POST /rdbms/{Uid}/databases`                                                  | 🔁 in the request body.                                                                |
+| `GET .../rdbms/{rdbmsId}/database`             | `GET /rdbms/{Uid}`; `GET /rdbms/{Uid}/databases`                                                                  | 🔁 via `X-Admin-User-Password` header.                                                 |
+| `DELETE .../rdbms/{rdbmsId}/database/{dbName}` | `GET /rdbms/{Uid}`; `DELETE /rdbms/{Uid}/databases/{dbName}`                                                      | 🔁 via `X-Admin-User-Password` header.                                                 |

--- a/src/core/resource/rdbms.go
+++ b/src/core/resource/rdbms.go
@@ -482,7 +482,7 @@ var (
 	rdbmsCSPGoneInterval    = 30 * time.Second
 
 	rdbmsPostDeleteWaitDefault = 10 * time.Second
-	rdbmsPostDeleteWaitAlibaba = 180 * time.Second
+	rdbmsPostDeleteWaitAlibaba = 510 * time.Second
 	rdbmsPostDeleteWaitTencent = 90 * time.Second
 )
 
@@ -970,6 +970,7 @@ func ConfirmRDBMSCreated(rdbmsKey string, rdbmsInfo *model.RDBMSInfo) (spiderRDB
 	client := clientManager.NewHttpClient()
 	noBody := clientManager.NoBody
 	getUrl := fmt.Sprintf("%s/rdbms/%s?ConnectionName=%s", model.SpiderRestUrl, rdbmsInfo.Uid, rdbmsInfo.ConnectionName)
+	log.Info().Msgf("Waiting for RDBMS %s to reach Available state (polling every %s up to %s)...", rdbmsInfo.Id, rdbmsCreationPollInterval, rdbmsCreationTimeout)
 
 	for attempt := 1; attempt <= rdbmsCreationMaxAttempts; attempt++ {
 		var spResp spiderRDBMSInfo
@@ -987,6 +988,7 @@ func ConfirmRDBMSCreated(rdbmsKey string, rdbmsInfo *model.RDBMSInfo) (spiderRDB
 		if err = clientManager.HandleHttpResponse(restyResp, err); err != nil {
 			log.Warn().Err(err).Msgf("RDBMS %s status poll failed on attempt %d/%d; retrying", rdbmsInfo.Uid, attempt, rdbmsCreationMaxAttempts)
 		} else if spResp.Status == "Available" {
+			log.Info().Msgf("RDBMS %s reached Available state on attempt %d/%d", rdbmsInfo.Id, attempt, rdbmsCreationMaxAttempts)
 			return spResp, nil
 		} else {
 			log.Info().Msgf("RDBMS %s not yet Available (status: %s), attempt %d/%d; will poll again in %s", rdbmsInfo.Uid, spResp.Status, attempt, rdbmsCreationMaxAttempts, rdbmsCreationPollInterval)
@@ -1482,7 +1484,11 @@ func DeleteRDBMS(nsId, rdbmsId string, force bool) error {
 			// nothing was confirmed torn down, so there is no dependency release to wait for
 			postDeleteWait = 0
 		}
-		time.Sleep(postDeleteWait)
+		if postDeleteWait > 0 {
+			log.Info().Msgf("Waiting %s for CSP post-delete stabilization (%s) to release background network bindings...", postDeleteWait, rdbmsInfo.ConnectionConfig.ProviderName)
+			time.Sleep(postDeleteWait)
+			log.Info().Msgf("Post-delete stabilization wait of %s completed for %s (%s)", postDeleteWait, rdbmsInfo.ConnectionConfig.ProviderName, rdbmsId)
+		}
 
 	} else {
 		log.Warn().Msgf("RDBMS %s has no CSP resource (Uid is empty). Skipping Spider DELETE and removing metadata only.", rdbmsId)

--- a/src/testclient/test-clis/rdbms/app.go
+++ b/src/testclient/test-clis/rdbms/app.go
@@ -726,21 +726,21 @@ func runLifecycle(nsId string, tc TestCase, tbAuth map[string]string, supportMat
 		result.DeleteSGStatus = "Skipped (not created)"
 	}
 
-	// 13. Delete each Subnet (with retry for eventual consistency)
+	// 13. Delete each Subnet (with retry for eventual consistency across CSPs like Alibaba/Tencent)
 	if vNetId != "" && len(subnetIds) > 0 {
 		failed := 0
 		for _, subnetId := range subnetIds {
 			urlDeleteSubnet := fmt.Sprintf("%s/ns/%s/resources/vNet/%s/subnet/%s", tbApiBase, nsId, vNetId, subnetId)
 			var subErr error
-			for attempt := 1; attempt <= 3; attempt++ {
+			for attempt := 1; attempt <= 6; attempt++ {
 				_, subErr = callApi("DELETE", urlDeleteSubnet, tbAuth, nil, &logs, fmt.Sprintf("[%s] Delete Subnet %s", tc.RdbmsId, subnetId))
 				if subErr == nil || isNotFoundErr(subErr) {
 					subErr = nil
 					break
 				}
-				if attempt < 3 {
-					log.Info().Msgf("[%s] Delete Subnet %s attempt %d/3 returned error; waiting 15s...", tc.RdbmsId, subnetId, attempt)
-					time.Sleep(15 * time.Second)
+				if attempt < 6 {
+					log.Info().Msgf("[%s] Delete Subnet %s attempt %d/6 returned error; waiting 20s for CSP resource release...", tc.RdbmsId, subnetId, attempt)
+					time.Sleep(20 * time.Second)
 				}
 			}
 			if subErr != nil {
@@ -757,10 +757,10 @@ func runLifecycle(nsId string, tc TestCase, tbAuth map[string]string, supportMat
 		result.DeleteSubnetsStatus = "Skipped (no VNet)"
 	}
 
-	// 14. Delete vNet (with retry for eventual consistency on CSPs like NCP)
+	// 14. Delete vNet (with retry for eventual consistency on CSPs like Alibaba/NCP)
 	if vNetId != "" {
 		urlDeleteVNet := fmt.Sprintf("%s/ns/%s/resources/vNet/%s", tbApiBase, nsId, vNetId)
-		for attempt := 1; attempt <= 3; attempt++ {
+		for attempt := 1; attempt <= 6; attempt++ {
 			_, err = callApi("DELETE", urlDeleteVNet, tbAuth, nil, &logs, fmt.Sprintf("[%s] Delete VNet", tc.RdbmsId))
 			if err == nil {
 				result.DeleteVNetStatus = "Success"
@@ -768,16 +768,18 @@ func runLifecycle(nsId string, tc TestCase, tbAuth map[string]string, supportMat
 				break
 			} else if isNotFoundErr(err) {
 				result.DeleteVNetStatus = "Success (nothing to delete)"
-				log.Info().Msgf("[%s] Delete VNet: nothing to delete", tc.RdbmsId)
+				log.Info().Msgf("[%s] Delete VNet OK (already deleted)", tc.RdbmsId)
+				err = nil
 				break
 			}
-			if attempt < 3 {
-				log.Info().Msgf("[%s] Delete VNet attempt %d/3 returned error; waiting 15s for CSP interface release...", tc.RdbmsId, attempt)
-				time.Sleep(15 * time.Second)
-			} else {
-				result.DeleteVNetStatus = "Failed"
-				log.Error().Err(err).Msgf("[%s] Delete VNet failed", tc.RdbmsId)
+			if attempt < 6 {
+				log.Info().Msgf("[%s] Delete VNet attempt %d/6 returned error; waiting 20s...", tc.RdbmsId, attempt)
+				time.Sleep(20 * time.Second)
 			}
+		}
+		if err != nil {
+			result.DeleteVNetStatus = "Failed"
+			log.Error().Err(err).Msgf("[%s] Delete VNet failed", tc.RdbmsId)
 		}
 	} else {
 		result.DeleteVNetStatus = "Skipped (not created)"
@@ -954,9 +956,16 @@ func resolveAndReviewSpecAndImage(
 		if err == nil {
 			var searchResp model.SearchImageResponse
 			if jsonErr := json.Unmarshal(respBytes, &searchResp); jsonErr == nil && searchResp.ImageCount > 0 {
-				tc.VmImageId = searchResp.ImageList[0].Id
-				log.Info().Msgf("[%s] Discovered VM Image: %s (cspImage=%s, os=%s)",
-					tc.RdbmsId, searchResp.ImageList[0].Id, searchResp.ImageList[0].CspImageName, searchResp.ImageList[0].OSDistribution)
+				for _, img := range searchResp.ImageList {
+					if !img.IsKubernetesImage && !strings.Contains(strings.ToLower(img.InfraType), "k8s") && !strings.Contains(strings.ToLower(img.InfraType), "kubernetes") {
+						tc.VmImageId = img.Id
+						break
+					}
+				}
+				if tc.VmImageId == "" {
+					tc.VmImageId = searchResp.ImageList[0].Id
+				}
+				log.Info().Msgf("[%s] Discovered VM Image: %s", tc.RdbmsId, tc.VmImageId)
 			}
 		}
 		if tc.VmImageId == "" {
@@ -969,9 +978,16 @@ func resolveAndReviewSpecAndImage(
 			if err == nil {
 				var searchResp model.SearchImageResponse
 				if jsonErr := json.Unmarshal(respBytes, &searchResp); jsonErr == nil && searchResp.ImageCount > 0 {
-					tc.VmImageId = searchResp.ImageList[0].Id
-					log.Info().Msgf("[%s] Discovered Fallback VM Image: %s (cspImage=%s, os=%s)",
-						tc.RdbmsId, searchResp.ImageList[0].Id, searchResp.ImageList[0].CspImageName, searchResp.ImageList[0].OSDistribution)
+					for _, img := range searchResp.ImageList {
+						if !img.IsKubernetesImage && !strings.Contains(strings.ToLower(img.InfraType), "k8s") && !strings.Contains(strings.ToLower(img.InfraType), "kubernetes") {
+							tc.VmImageId = img.Id
+							break
+						}
+					}
+					if tc.VmImageId == "" {
+						tc.VmImageId = searchResp.ImageList[0].Id
+					}
+					log.Info().Msgf("[%s] Discovered Fallback VM Image: %s", tc.RdbmsId, tc.VmImageId)
 				}
 			}
 		}
@@ -987,34 +1003,37 @@ func resolveAndReviewSpecAndImage(
 		if !strings.Contains(specReviewId, "+") && providerName != "" && regionName != "" {
 			specReviewId = fmt.Sprintf("%s+%s+%s", providerName, regionName, tc.VmSpecId)
 		}
+		imageReviewId := tc.VmImageId
+		if !strings.Contains(imageReviewId, "+") && providerName != "" && regionName != "" {
+			imageReviewId = fmt.Sprintf("%s+%s+%s", providerName, regionName, tc.VmImageId)
+		}
 		reviewReq := map[string]any{
-			"specId":       specReviewId,
-			"imageId":      tc.VmImageId,
-			"rootDiskType": "default",
-			"zone":         zone,
+			"specId":  specReviewId,
+			"imageId": imageReviewId,
+			"zone":    zone,
 		}
 		urlReview := fmt.Sprintf("%s/specImagePairReview", tbApiBase)
-		respBytes, err := callApi("POST", urlReview, tbAuth, reviewReq, logs, fmt.Sprintf("[%s] Pre-flight Spec & Image Review", tc.RdbmsId))
-		if err != nil {
-			log.Warn().Err(err).Msgf("[%s] Spec & Image Review returned warning: %v", tc.RdbmsId, err)
-		} else {
-			var reviewResp model.SpecImagePairReviewResult
-			if jsonErr := json.Unmarshal(respBytes, &reviewResp); jsonErr == nil {
-				if reviewResp.IsValid {
-					log.Info().Msgf("[%s] Pre-flight Spec & Image Review OK: status=%s, valid=%t, cost=%s",
-						tc.RdbmsId, reviewResp.Status, reviewResp.IsValid, reviewResp.EstimatedCost)
+		respBytes, err := callApi("POST", urlReview, tbAuth, reviewReq, logs, fmt.Sprintf("[%s] Review Spec-Image Pair", tc.RdbmsId))
+		if err == nil {
+			var reviewResult model.SpecImagePairReviewResult
+			if jsonErr := json.Unmarshal(respBytes, &reviewResult); jsonErr == nil {
+				if reviewResult.ImageValidation.CspResourceId != "" {
+					log.Info().Msgf("[%s] Spec-Image Pair Review succeeded (valid=%v, status=%s, resolved CSP image=%s)",
+						tc.RdbmsId, reviewResult.IsValid, reviewResult.Status, reviewResult.ImageValidation.CspResourceId)
 				} else {
-					log.Warn().Msgf("[%s] Pre-flight Spec & Image Review warning: %s (errors=%v)",
-						tc.RdbmsId, reviewResp.Message, reviewResp.Errors)
+					log.Info().Msgf("[%s] Spec-Image Pair Review result: valid=%v, status=%s, msg=%s",
+						tc.RdbmsId, reviewResult.IsValid, reviewResult.Status, reviewResult.Message)
+				}
+				if !reviewResult.IsValid || reviewResult.Status == "Error" {
+					log.Warn().Msgf("[%s] Spec-Image Pair Review flagged issues: %s (errors: %v)",
+						tc.RdbmsId, reviewResult.Message, reviewResult.Errors)
 				}
 			}
 		}
 	}
+
 }
 
-// runInternalDataTest provisions a test VM in the same VNet and Subnet as the RDBMS,
-// then uses Tumblebug's Remote Command API to execute SQL queries directly against
-// the RDBMS private endpoint from inside the VPC network.
 func runInternalDataTest(
 	tbApiBase string,
 	nsId string,
@@ -1027,9 +1046,8 @@ func runInternalDataTest(
 	tbAuth map[string]string,
 	logs *[]ApiLog,
 ) (status string, err error) {
-	label := cspLabel(tc.RdbmsId)
-	sshKeyId := fmt.Sprintf("test-rdbms-sshkey-%s", label)
-	infraId := fmt.Sprintf("test-rdbms-infra-%s", label)
+	infraId := fmt.Sprintf("test-rdbms-infra-%s", tc.RdbmsId)
+	sshKeyId := fmt.Sprintf("test-rdbms-sshkey-%s", tc.RdbmsId)
 
 	// Ensure cleanup of test VM and SSHKey upon completion
 	defer func() {
@@ -1038,7 +1056,7 @@ func runInternalDataTest(
 
 		// Poll until test infra is fully terminated so CSP releases SecurityGroup/Subnet ENIs
 		urlGetInfra := fmt.Sprintf("%s/ns/%s/infra/%s", tbApiBase, nsId, infraId)
-		for attempt := 1; attempt <= 12; attempt++ {
+		for attempt := 1; attempt <= 18; attempt++ {
 			time.Sleep(5 * time.Second)
 			_, getErr := callApi("GET", urlGetInfra, tbAuth, nil, logs, fmt.Sprintf("[%s] Verify Infra Termination", tc.RdbmsId))
 			if getErr != nil && isNotFoundErr(getErr) {
@@ -1046,8 +1064,20 @@ func runInternalDataTest(
 			}
 		}
 
+		// Brief stabilization pause after VM termination to allow CSP-side key unbinding
+		time.Sleep(15 * time.Second)
+
+		// Delete SSHKey with retry (normal DELETE confirms genuine CSP-side keypair deletion)
 		urlDeleteSSH := fmt.Sprintf("%s/ns/%s/resources/sshKey/%s", tbApiBase, nsId, sshKeyId)
-		_, _ = callApi("DELETE", urlDeleteSSH, tbAuth, nil, logs, fmt.Sprintf("[%s] Teardown Test SSHKey", tc.RdbmsId))
+		for attempt := 1; attempt <= 4; attempt++ {
+			_, delErr := callApi("DELETE", urlDeleteSSH, tbAuth, nil, logs, fmt.Sprintf("[%s] Teardown Test SSHKey", tc.RdbmsId))
+			if delErr == nil || isNotFoundErr(delErr) {
+				break
+			}
+			if attempt < 4 {
+				time.Sleep(10 * time.Second)
+			}
+		}
 	}()
 
 	// 1. Create or retrieve SSH Key
@@ -1096,17 +1126,14 @@ func runInternalDataTest(
 		port = "3306"
 	}
 
-	// Give sshd a brief grace period to start accepting connections after VM reaches Running
-	time.Sleep(15 * time.Second)
+	// Give sshd and cloud-init sufficient grace period to start accepting connections after VM reaches Running
+	time.Sleep(50 * time.Second)
 
 	// 3. Send Remote Command via POST /ns/{nsId}/cmd/infra/{infraId}
 	sqlCmd := fmt.Sprintf("mysql -h %s -P %s -u %s -p'%s' %s -e \"DROP TABLE IF EXISTS tumblebug_internal_test; CREATE TABLE tumblebug_internal_test (id INT PRIMARY KEY, val VARCHAR(255)); INSERT INTO tumblebug_internal_test (id, val) VALUES (1, 'internal-test-ok'); SELECT val FROM tumblebug_internal_test WHERE id=1; DROP TABLE tumblebug_internal_test;\"",
 		host, port, tc.AdminUserName, tc.AdminUserPassword, dbName)
 
-	cmdUserName := ""
-	if strings.Contains(strings.ToLower(tc.ConnectionName), "alibaba") || strings.Contains(strings.ToLower(tc.ConnectionName), "tencent") {
-		cmdUserName = "root"
-	}
+	cmdUserName := "cb-user"
 
 	cmdReq := model.InfraCmdReq{
 		Command: []string{

--- a/src/testclient/test-clis/rdbms/template-test-config.yaml
+++ b/src/testclient/test-clis/rdbms/template-test-config.yaml
@@ -111,7 +111,7 @@ testCases:
     execute: true
 
   - rdbmsId: test-rdbms-alibaba
-    connectionName: alibaba-ap-northeast-1
+    connectionName: alibaba-ap-northeast-2
     vNetName: test-rdbms-vnet-alibaba
     cidrBlock: 10.3.0.0/16
     subnets:
@@ -129,7 +129,7 @@ testCases:
     highAvailability: false
     databaseName: sampledb
     internalDataIOTest: true
-    vmOSType: "Alibaba Cloud Linux 3"
+    vmOSType: "ubuntu 24.04"
     vmvCPU: "2"
     vmMemoryGiB: "4"
     vmImageId: ""


### PR DESCRIPTION
- Extend post-deletion stabilization buffer for Alibaba to prevent subnet deletion conflicts
- Add progress logging for long-running database creation and deletion wait stages
- Update RDBMS feature guide

<details>
  <summary>See the RDBMS Batch Test Summary — mariadb</summary>
  
| Step | mariadb-aws | mariadb-alibaba | mariadb-nhn |
| ---- | :--: | :--: | :--: |
| Create VNet | ✅ | ✅ | ✅ |
| Create SecurityGroup | ✅ | ✅ | ✅ |
| Support | ✅ | ✅ | ✅ |
| Capability | ✅ | ✅ | ✅ |
| Validate | ✅ | ✅ | ✅ |
| Create RDBMS | ✅ | ✅ | ✅ |
| Get RDBMS | ✅ | ✅ | ✅ |
| List RDBMS | ✅ | ✅ | ✅ |
| Create Database | ✅ | ✅ | ✅ |
| List Database | ✅ | ✅ | ✅ |
| Remote Data I/O Test | ✅ | ✅ | ✅ |
| Internal Data I/O Test | ✅ | ✅ | ✅ |
| Delete Database | ✅ | ✅ | ✅ |
| Delete RDBMS | ✅ | ✅ | ✅ |
| Delete SecurityGroup | ✅ | ✅ | ✅ |
| Delete Subnets | ✅ | ✅ | ✅ |
| Delete VNet | ✅ | ✅ | ✅ |
| **Overall** | ✅ | ✅ | ✅ |
  
</details>

See [RDBMS Management — Features and API Reference](https://github.com/cloud-barista/cb-tumblebug/blob/main/docs/feature_guide/rdbms-management.md) (after this is merged).
