### PR TITLE
Scale infra status/terminate/delete to over 7000 nodes without OOM

### DIFF
--- a/deployments/helm/cb-tumblebug/values.yaml
+++ b/deployments/helm/cb-tumblebug/values.yaml
@@ -82,9 +82,9 @@ tumblebug:
   # Memory limit contains request-history/status-cache growth on large infras
   resources:
     requests:
-      memory: 1Gi
+      memory: 2Gi
     limits:
-      memory: 8Gi
+      memory: 16Gi
 
 spider:
   # Number of cb-spider replicas. cb-spider is the outbound CSP-call worker; scaling it out

--- a/src/core/common/utility.go
+++ b/src/core/common/utility.go
@@ -265,6 +265,15 @@ func GenInfraNodeGroupKey(nsId string, infraId string, groupId string) string {
 
 }
 
+// GenInfraNodeDetailsKey generates the key for a Node's auxiliary details
+// (CSP raw metadata), stored separately from the Node record so status and bulk
+// reads/writes do not carry it.
+func GenInfraNodeDetailsKey(nsId string, infraId string, nodeId string) string {
+
+	return "/" + model.StrNamespace + "/" + nsId + "/" + model.StrInfra + "/" + infraId + "/" + model.StrNodeDetails + "/" + nodeId
+
+}
+
 // GenInfraPolicyKey is func to generate Infra policy key
 func GenInfraPolicyKey(nsId string, infraId string, nodeId string) string {
 	if nodeId != "" {

--- a/src/core/infra/manageInfo.go
+++ b/src/core/infra/manageInfo.go
@@ -321,10 +321,15 @@ func GetNodeGroup(nsId string, infraId string, nodeGroupId string) (model.NodeGr
 	nodeGroupInfo := model.NodeGroupInfo{}
 
 	key := common.GenInfraNodeGroupKey(nsId, infraId, nodeGroupId)
-	keyValue, _, err := kvstore.GetKv(key)
+	keyValue, exists, err := kvstore.GetKv(key)
 	if err != nil {
 		log.Error().Err(err).Msg("")
 		return nodeGroupInfo, err
+	}
+	// A missing key returns an empty value; without this check json.Unmarshal("")
+	// below fails and a not-found NodeGroup is misreported as a corrupted one.
+	if !exists {
+		return nodeGroupInfo, fmt.Errorf("no NodeGroup found (Key: %s)", key)
 	}
 	err = json.Unmarshal([]byte(keyValue.Value), &nodeGroupInfo)
 	if err != nil {
@@ -521,6 +526,61 @@ func GetInfraClusterInfo(nsId string, infraId string, clusterId string) (*model.
 }
 
 // GetInfraInfo is func to return Infra information with the current status update
+// nodeInfoFromEntry builds a lightweight NodeInfo (status + identity, no full
+// config/labels/details) from a StatusStore entry, for list/summary views.
+func nodeInfoFromEntry(e StatusEntry) model.NodeInfo {
+	return model.NodeInfo{
+		Id:              e.NodeId,
+		Name:            e.Name,
+		CspResourceName: e.CspResourceName,
+		CspResourceId:   e.CspResourceId,
+		ConnectionName:  e.ConnectionName,
+		Status:          e.Status,
+		TargetStatus:    e.TargetStatus,
+		TargetAction:    e.TargetAction,
+		PublicIP:        e.PublicIP,
+		PrivateIP:       e.PrivateIP,
+		SSHPort:         e.SSHPort,
+		Location:        e.Location,
+		MonAgentStatus:  e.MonAgentStatus,
+		CreatedTime:     e.CreatedTime,
+		SystemMessage:   e.SystemMessage,
+	}
+}
+
+// GetInfraInfoBrief returns an Infra summary served from the StatusAgent's
+// in-memory store: the Infra record (read once, no per-Node object reads) plus
+// per-Node status/identity from the store. It avoids GetInfraInfo's ~2N etcd
+// reads (a full Node object read + a label read per Node), which flood etcd when
+// clients poll the Infra list. Nodes carry status-level fields only; full config,
+// labels and CSP details are available via the single-Node/single-Infra APIs.
+func GetInfraInfoBrief(nsId string, infraId string) (*model.InfraInfo, error) {
+	keyValue, exists, err := kvstore.GetKv(common.GenInfraKey(nsId, infraId, ""))
+	if err != nil || !exists {
+		return nil, fmt.Errorf("the infra %s does not exist", infraId)
+	}
+	infraObj := model.InfraInfo{}
+	if err := json.Unmarshal([]byte(keyValue.Value), &infraObj); err != nil {
+		log.Error().Err(err).Msg("")
+		return nil, err
+	}
+
+	if status, serr := GetInfraStatus(nsId, infraId); serr == nil {
+		infraObj.Status = status.Status
+		infraObj.StatusCount = status.StatusCount
+	}
+
+	var nodes []model.NodeInfo
+	for _, e := range globalStatusStore.Snapshot() {
+		if e.NsId == nsId && e.InfraId == infraId {
+			nodes = append(nodes, nodeInfoFromEntry(e))
+		}
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].Id < nodes[j].Id })
+	infraObj.Node = nodes
+	return &infraObj, nil
+}
+
 func GetInfraInfo(nsId string, infraId string) (*model.InfraInfo, error) {
 
 	check, _ := CheckInfra(nsId, infraId)
@@ -904,7 +964,9 @@ func ListInfraInfo(nsId string, option string) ([]model.InfraInfo, error) {
 
 	for _, v := range infraList {
 
-		infraTmp, err := GetInfraInfo(nsId, v)
+		// Serve the list from the in-memory store (status-level nodes, no per-Node
+		// etcd object/label reads) so polling clients (e.g. mapui) do not flood etcd.
+		infraTmp, err := GetInfraInfoBrief(nsId, v)
 		if err != nil {
 			log.Error().Err(err).Msg("")
 			return nil, err
@@ -1189,6 +1251,59 @@ func GetNodeIdNameInDetail(nsId string, infraId string, nodeId string) (*model.I
 
 // [Infra and Node status management]
 
+// nodeStatusInfoFromEntry builds a NodeStatusInfo from a StatusStore entry.
+func nodeStatusInfoFromEntry(e StatusEntry) model.NodeStatusInfo {
+	return model.NodeStatusInfo{
+		Id:              e.NodeId,
+		Name:            e.Name,
+		CspResourceName: e.CspResourceName,
+		Status:          e.Status,
+		NativeStatus:    e.NativeStatus,
+		TargetStatus:    e.TargetStatus,
+		TargetAction:    e.TargetAction,
+		PublicIp:        e.PublicIP,
+		PrivateIp:       e.PrivateIP,
+		SSHPort:         e.SSHPort,
+		Location:        e.Location,
+		MonAgentStatus:  e.MonAgentStatus,
+		CreatedTime:     e.CreatedTime,
+		SystemMessage:   e.SystemMessage,
+	}
+}
+
+// nodeStatusesFromStore builds the node status list for an Infra from the
+// StatusAgent's in-memory store, which the daemon keeps fresh (batch sweep +
+// individual polls). This replaces a live per-node CSP fanout that materializes
+// N statuses and spawns N goroutines — the source of OOM on large infras.
+// Nodes not yet in the store (e.g. freshly provisioned before the first sweep)
+// fall back to their stored object, with no CSP call.
+func nodeStatusesFromStore(nsId, infraId string, nodeList []string) []model.NodeStatusInfo {
+	byId := make(map[string]StatusEntry, len(nodeList))
+	for _, e := range globalStatusStore.Snapshot() {
+		if e.NsId == nsId && e.InfraId == infraId {
+			byId[e.NodeId] = e
+		}
+	}
+
+	result := make([]model.NodeStatusInfo, 0, len(nodeList))
+	var missing []string
+	for _, nodeId := range nodeList {
+		if e, ok := byId[nodeId]; ok {
+			result = append(result, nodeStatusInfoFromEntry(e))
+		} else {
+			missing = append(missing, nodeId)
+		}
+	}
+	for _, nodeId := range missing {
+		nodeInfo, err := GetNodeObject(nsId, infraId, nodeId)
+		if err != nil {
+			continue
+		}
+		result = append(result, ConvertNodeInfoListToNodeStatusInfoList([]model.NodeInfo{nodeInfo})...)
+	}
+	return result
+}
+
 // GetInfraStatus is func to Get Infra Status
 func GetInfraStatus(nsId string, infraId string) (*model.InfraStatusInfo, error) {
 
@@ -1244,12 +1359,10 @@ func GetInfraStatus(nsId string, infraId string) (*model.InfraStatusInfo, error)
 		return &infraStatus, nil
 	}
 
-	// Fetch Node statuses with rate limiting by CSP and region
-	nodeStatusList, err := fetchNodeStatusesWithRateLimiting(nsId, infraId, nodeList)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return &model.InfraStatusInfo{}, err
-	}
+	// Serve node statuses from the StatusAgent's in-memory store instead of a live
+	// per-node CSP fanout: the daemon keeps the store fresh, and materializing N
+	// statuses + goroutines here OOMs on large infras.
+	nodeStatusList := nodeStatusesFromStore(nsId, infraId, nodeList)
 	// log.Debug().Msgf("Fetched %d VM statuses for Infra %s", len(nodeStatusList), infraId)
 	// log.Debug().Msgf("VM Status List: %+v", nodeStatusList)
 
@@ -2723,6 +2836,48 @@ func UpdateInfraInfo(nsId string, infraInfoData model.InfraInfo) {
 	}
 }
 
+// putNodeDetails stores a Node's auxiliary details (CSP raw metadata) under a
+// separate key so they are never carried by status/bulk Node reads and writes.
+func putNodeDetails(nsId, infraId, nodeId string, details []model.KeyValue) {
+	if nodeId == "" || len(details) == 0 {
+		return
+	}
+	val, err := json.Marshal(details)
+	if err != nil {
+		log.Error().Err(err).Msg("")
+		return
+	}
+	if err := kvstore.Put(common.GenInfraNodeDetailsKey(nsId, infraId, nodeId), string(val)); err != nil {
+		log.Error().Err(err).Msg("")
+	}
+}
+
+// GetNodeDetails returns a Node's auxiliary details from the separate details
+// key, or nil when none are stored.
+func GetNodeDetails(nsId, infraId, nodeId string) []model.KeyValue {
+	keyValue, exists, err := kvstore.GetKv(common.GenInfraNodeDetailsKey(nsId, infraId, nodeId))
+	if err != nil || !exists {
+		return nil
+	}
+	var details []model.KeyValue
+	if err := json.Unmarshal([]byte(keyValue.Value), &details); err != nil {
+		log.Error().Err(err).Msg("")
+		return nil
+	}
+	return details
+}
+
+// AttachNodeDetails fills AddtionalDetails for each Node from the separate
+// details key. Read APIs call this only when details are explicitly requested,
+// so default/bulk responses stay small.
+func AttachNodeDetails(nsId, infraId string, nodes []model.NodeInfo) {
+	for i := range nodes {
+		if d := GetNodeDetails(nsId, infraId, nodes[i].Id); d != nil {
+			nodes[i].AddtionalDetails = d
+		}
+	}
+}
+
 // UpdateNodeInfo is func to update Node Info
 func UpdateNodeInfo(nsId string, infraId string, nodeInfoData model.NodeInfo) {
 	// An empty node Id collapses GenInfraKey onto the parent infra key, so this
@@ -2730,6 +2885,12 @@ func UpdateNodeInfo(nsId string, infraId string, nodeInfoData model.NodeInfo) {
 	if nodeInfoData.Id == "" {
 		log.Warn().Msgf("UpdateNodeInfo skipped: empty node Id (Infra %s/%s)", nsId, infraId)
 		return
+	}
+	// Store auxiliary details separately and strip them from the Node record.
+	// nodeInfoData is a value copy, so this does not affect the caller.
+	if len(nodeInfoData.AddtionalDetails) > 0 {
+		putNodeDetails(nsId, infraId, nodeInfoData.Id, nodeInfoData.AddtionalDetails)
+		nodeInfoData.AddtionalDetails = nil
 	}
 	infraInfoMutex.Lock()
 	defer func() {
@@ -3448,21 +3609,22 @@ func DelInfra(nsId string, infraId string, option string) (model.IdList, error) 
 	}
 	for _, v := range nodeGroupList {
 		nodeGroupKey := common.GenInfraNodeGroupKey(nsId, infraId, v)
-		nodeGroupInfo, err := GetNodeGroup(nsId, infraId, v)
-		if err != nil {
-			log.Error().Err(err).Msg("Cannot get NodeGroup")
-			return deletedResources, err
-		}
+		// Read only to recover the Uid for label cleanup. A NodeGroup we cannot read
+		// (already gone or corrupted) must still be deleted — that is the goal here —
+		// so never let a read failure block the Infra deletion.
+		nodeGroupInfo, gerr := GetNodeGroup(nsId, infraId, v)
 
-		err = kvstore.Delete(nodeGroupKey)
-		if err != nil {
+		if err = kvstore.Delete(nodeGroupKey); err != nil {
 			log.Error().Err(err).Msg("")
 			return deletedResources, err
 		}
 		deletedResources.IdList = append(deletedResources.IdList, deleteStatus+"NodeGroup: "+v)
 
-		err = label.DeleteLabelObject(model.StrNodeGroup, nodeGroupInfo.Uid)
-		if err != nil {
+		if gerr != nil {
+			log.Warn().Err(gerr).Msgf("NodeGroup %s unreadable during delete; deleted its key, skipping label cleanup", v)
+			continue
+		}
+		if err = label.DeleteLabelObject(model.StrNodeGroup, nodeGroupInfo.Uid); err != nil {
 			log.Error().Err(err).Msg("")
 		}
 	}
@@ -3585,6 +3747,7 @@ func DelInfraNode(nsId string, infraId string, nodeId string, option string) err
 		return err
 	}
 	globalStatusStore.Delete(nsId, infraId, nodeId)
+	kvstore.Delete(common.GenInfraNodeDetailsKey(nsId, infraId, nodeId))
 
 	// remove empty NodeGroups
 	nodeGroup, err := ListNodeGroupId(nsId, infraId)

--- a/src/core/infra/provisioning.go
+++ b/src/core/infra/provisioning.go
@@ -4383,8 +4383,17 @@ func CreateNodeObject(wg *sync.WaitGroup, nsId string, infraId string, nodeInfoD
 	}
 	nodeInfoData.Location = configTmp.RegionDetail.Location
 
+	// Store auxiliary details under a separate key; keep them out of the Node
+	// record so status/bulk reads stay small. nodeInfoData is a pointer, so store
+	// a stripped copy rather than mutating the caller's object.
+	if len(nodeInfoData.AddtionalDetails) > 0 {
+		putNodeDetails(nsId, infraId, nodeInfoData.Id, nodeInfoData.AddtionalDetails)
+	}
+	nodeToStore := *nodeInfoData
+	nodeToStore.AddtionalDetails = nil
+
 	// Make VM object
-	val, _ := json.Marshal(nodeInfoData)
+	val, _ := json.Marshal(nodeToStore)
 	err = kvstore.Put(nodeKey, string(val))
 	if err != nil {
 		log.Error().Err(err).Msg("")

--- a/src/core/infra/statusagent.go
+++ b/src/core/infra/statusagent.go
@@ -106,7 +106,10 @@ func (a *NodeStatusAgent) startBatchSweeper(ctx context.Context) {
 	log.Info().Msg("[BatchSweeper] Initial delay elapsed — running first batch status sweep for batch-capable CSPs (AWS/GCP/Azure/Tencent/Alibaba)")
 	a.runBatchSweep(ctx)
 
-	ticker := time.NewTicker(pollIntervals[PollNormal])
+	// Tick at the transitional cadence so PollHigh nodes (Terminating, …) are swept
+	// promptly; PollNormal nodes are still effectively swept at their own interval
+	// because runBatchSweep honors each node's NextPollAt.
+	ticker := time.NewTicker(pollIntervals[PollHigh])
 	defer ticker.Stop()
 	for {
 		select {
@@ -153,13 +156,25 @@ func resetBatchNotFound(nsId, infraId, nodeId string) {
 // pick them up and persist the change to etcd via the full FetchNodeStatus path.
 func (a *NodeStatusAgent) runBatchSweep(ctx context.Context) {
 	type batchKey struct{ provider, credentialHolder, region string }
-	type batchNode struct{ nsId, infraId, nodeId, instanceId string }
+	type batchNode struct {
+		nsId, infraId, nodeId, instanceId string
+		targetAction                      string
+		priority                          PollPriority
+	}
 
 	now := time.Now()
 	groups := make(map[batchKey][]batchNode)
 
 	for _, e := range globalStatusStore.Snapshot() {
-		if e.Priority != PollNormal {
+		// Batch steady Running (PollNormal) and Terminating nodes. Polling a large
+		// Terminating set individually at 15 s issues one FetchNodeStatus (etcd read
+		// + alloc) per node per interval, which floods memory and OOMs; grouped SDK
+		// calls keep it bounded. Other transitional states (Suspending/Resuming/
+		// Rebooting/Creating) keep the individual path, which carries their own
+		// state-machine handling and stays small.
+		batchEligible := e.Priority == PollNormal ||
+			(e.Priority == PollHigh && strings.EqualFold(e.Status, model.StatusTerminating))
+		if !batchEligible {
 			continue
 		}
 		if e.IsOperationLocked() {
@@ -175,7 +190,7 @@ func (a *NodeStatusAgent) runBatchSweep(ctx context.Context) {
 			continue
 		}
 		key := batchKey{e.ProviderName, e.CredentialHolder, e.Region}
-		groups[key] = append(groups[key], batchNode{e.NsId, e.InfraId, e.NodeId, e.CspResourceId})
+		groups[key] = append(groups[key], batchNode{e.NsId, e.InfraId, e.NodeId, e.CspResourceId, e.TargetAction, e.Priority})
 	}
 
 	if len(groups) == 0 {
@@ -187,11 +202,14 @@ func (a *NodeStatusAgent) runBatchSweep(ctx context.Context) {
 	// Each node gets a small random jitter (up to 10 % of PollNormal) so that
 	// successive sweeps do not re-synchronise all nodes onto the same instant,
 	// avoiding a thundering-herd on the sweep after startup.
-	jitterRange := int64(pollIntervals[PollNormal] / 10) // 30 s for a 5-min interval
 	for _, nodes := range groups {
 		for _, n := range nodes {
-			jitter := time.Duration(rand.Int63n(jitterRange))
-			nextPoll := now.Add(pollIntervals[PollNormal] + jitter)
+			interval := pollIntervals[n.priority]
+			if interval == 0 {
+				interval = pollIntervals[PollNormal]
+			}
+			jitter := time.Duration(rand.Int63n(int64(interval/10) + 1))
+			nextPoll := now.Add(interval + jitter)
 			globalStatusStore.Update(n.nsId, n.infraId, n.nodeId, func(e *StatusEntry) {
 				e.NextPollAt = nextPoll
 			})
@@ -235,6 +253,13 @@ func (a *NodeStatusAgent) runBatchSweep(ctx context.Context) {
 				newStatus, found := statuses[n.instanceId]
 				if found {
 					resetBatchNotFound(n.nsId, n.infraId, n.nodeId)
+					// A node we are terminating stays Terminating while the CSP still
+					// reports it alive (AWS briefly returns running/shutting-down after
+					// TerminateInstances). Mirror FetchNodeStatus's TargetAction guard so
+					// the batch path does not flip it back to Running.
+					if strings.EqualFold(n.targetAction, model.ActionTerminate) {
+						newStatus = model.StatusTerminating
+					}
 				} else {
 					// A clean batch response without the id means the CSP instance is gone:
 					// advance the shared streak and settle as Terminated once reached, instead
@@ -254,6 +279,43 @@ func (a *NodeStatusAgent) runBatchSweep(ctx context.Context) {
 				updated++
 			}
 
+			// Safety net: nodes whose Terminate never reached the CSP stay present in
+			// the status response. Re-issue TerminateInstances for them in one grouped
+			// call so a large stuck set is drained without per-node fallbacks.
+			reTerminated := 0
+			if termHandler, ok := cspdirect.GetBatchVMControlHandler(k.provider, model.ActionTerminate); ok {
+				var stuckIds []string
+				for _, n := range grp {
+					if !strings.EqualFold(n.targetAction, model.ActionTerminate) {
+						continue
+					}
+					if _, alive := statuses[n.instanceId]; !alive {
+						continue // absent from a clean response = gone; settled as Terminated above
+					}
+					sk := n.nsId + "/" + n.infraId + "/" + n.nodeId
+					first, _ := terminatingHoldSince.LoadOrStore(sk, now)
+					if now.Sub(first.(time.Time)) < terminatingHoldReTerminateAfter {
+						continue // let the original Terminate take effect first
+					}
+					if last, seen := reTerminateLastSent.Load(sk); seen && now.Sub(last.(time.Time)) < reTerminateMinInterval {
+						continue // cooldown: don't re-terminate the same node every sweep
+					}
+					reTerminateLastSent.Store(sk, now)
+					stuckIds = append(stuckIds, n.instanceId)
+				}
+				if len(stuckIds) > 0 {
+					sdkCtx := context.WithValue(context.Background(), model.CtxKeyCredentialHolder, k.credentialHolder)
+					log.Info().Str("provider", k.provider).Str("region", k.region).Int("count", len(stuckIds)).
+						Msg("[BatchSweeper] re-issuing batch terminate for nodes the CSP still reports alive")
+					if _, err := termHandler(sdkCtx, k.region, stuckIds); err != nil {
+						log.Warn().Err(err).Str("provider", k.provider).Str("region", k.region).Int("count", len(stuckIds)).
+							Msg("[BatchSweeper] batch re-terminate failed; will retry next sweep")
+					} else {
+						reTerminated = len(stuckIds)
+					}
+				}
+			}
+
 			log.Debug().
 				Str("provider", k.provider).
 				Str("region", k.region).
@@ -261,6 +323,7 @@ func (a *NodeStatusAgent) runBatchSweep(ctx context.Context) {
 				Int("queried", len(ids)).
 				Int("found", len(statuses)).
 				Int("updated", updated).
+				Int("reTerminated", reTerminated).
 				Msg("[BatchSweeper] sweep complete")
 		}(key, nodes)
 	}
@@ -308,12 +371,15 @@ func (a *NodeStatusAgent) dispatchEligible() {
 			continue
 		}
 
-		// PollNormal nodes for CSPs with a registered batch handler are handled
-		// exclusively by runBatchSweep (one grouped SDK call per region).
-		// Dispatching them individually here would issue DescribeInstances(ids=1)
-		// per node — magnified by hundreds of nodes at startup, causing connection
-		// reset bursts from AWS.  Leave them for the batch sweeper.
-		if e.Priority == PollNormal && e.CspResourceId != "" {
+		// Batch-capable Running (PollNormal) and Terminating nodes are handled
+		// exclusively by runBatchSweep (one grouped SDK call per region). Dispatching
+		// them individually here would issue DescribeInstances(ids=1) per node —
+		// magnified by thousands of Terminating nodes it floods FetchNodeStatus and
+		// OOMs. Leave them for the batch sweeper; a status change there flips the node
+		// off PollNormal/PollHigh so this path picks it up once to persist the change.
+		if (e.Priority == PollNormal ||
+			(e.Priority == PollHigh && strings.EqualFold(e.Status, model.StatusTerminating))) &&
+			e.CspResourceId != "" {
 			if _, ok := cspdirect.GetBatchVMStatusHandler(e.ProviderName); ok {
 				continue
 			}
@@ -441,6 +507,7 @@ func (a *NodeStatusAgent) StartupScan() {
 
 	var urgent []nodeRef
 	var normal []nodeRef
+	var final []nodeRef
 
 	for _, nsId := range nsList {
 		infraIds, err := ListInfraId(nsId)
@@ -461,9 +528,17 @@ func (a *NodeStatusAgent) StartupScan() {
 					continue
 				}
 				ref := nodeRef{nsId: nsId, infraId: infraId, info: nodeInfo}
-				if nodeInfo.TargetAction != model.ActionComplete {
+				switch {
+				case strings.EqualFold(nodeInfo.Status, model.StatusTerminated) ||
+					strings.EqualFold(nodeInfo.Status, model.StatusFailed):
+					// Final states are immutable until deletion — never poll. Classify by
+					// status here: a terminated Node keeps TargetAction=Terminate as a
+					// finalize marker, so classifying by TargetAction would mis-mark every
+					// terminated Node as active and poll it (a large per-Node etcd read loop).
+					final = append(final, ref)
+				case nodeInfo.TargetAction != model.ActionComplete:
 					urgent = append(urgent, ref)
-				} else {
+				default:
 					normal = append(normal, ref)
 				}
 			}
@@ -473,7 +548,15 @@ func (a *NodeStatusAgent) StartupScan() {
 	log.Info().
 		Int("urgent", len(urgent)).
 		Int("normal", len(normal)).
+		Int("final", len(final)).
 		Msg("[NodeStatusAgent] StartupScan: scan complete")
+
+	// Final: Terminated/Failed Nodes — seed into the store (so status/list reads are
+	// served from memory) but never poll. buildStatusEntry sets PollSkip for these.
+	for _, ref := range final {
+		globalStatusStore.Set(ref.nsId, ref.infraId, ref.info.Id,
+			buildStatusEntry(ref.nsId, ref.infraId, ref.info))
+	}
 
 	// Urgent: nodes with a pending TargetAction — schedule immediately and warn.
 	// Also detect infras whose Terminate was interrupted by the last crash and

--- a/src/core/model/common.go
+++ b/src/core/model/common.go
@@ -308,6 +308,7 @@ const (
 	StrSpiderVM              string = "vm" // CB-Spider uses "vm" as the resource type for VMs
 	StrInfra                 string = "infra"
 	StrNodeGroup             string = "nodeGroup"
+	StrNodeDetails           string = "nodeDetails"
 	StrK8s                   string = "k8s"
 	StrK8sCluster            string = "k8sCluster"
 	StrKubernetes            string = "kubernetes"

--- a/src/interface/rest/server/infra/manageInfo.go
+++ b/src/interface/rest/server/infra/manageInfo.go
@@ -57,6 +57,7 @@ func isInfraClusterNotFoundError(err error) bool {
 // @Param nsId path string true "Namespace ID" default(default)
 // @Param infraId path string true "Infra ID" default(infra01)
 // @Param option query string false "Option" Enums(default, id, status, accessinfo)
+// @Param detail query bool false "Include per-Node AddtionalDetails (CSP raw metadata); default false"
 // @Param filterKey query string false "(For option=id) Field key for filtering (ex: connectionName)"
 // @Param filterVal query string false "(For option=id) Field value for filtering (ex: aws-ap-northeast-2)"
 // @Param accessInfoOption query string false "(For option=accessinfo) accessInfoOption (showSshKey)"
@@ -103,6 +104,11 @@ func RestGetInfra(c echo.Context) error {
 	} else {
 
 		result, err := infra.GetInfraInfo(nsId, infraId)
+		if err == nil && c.QueryParam("detail") == "true" {
+			// Per-Node auxiliary details are omitted by default; attach them only when
+			// detail=true is explicitly requested.
+			infra.AttachNodeDetails(nsId, infraId, result.Node)
+		}
 		return clientManager.EndRequestWithLog(c, err, result)
 
 	}
@@ -344,6 +350,7 @@ func RestGetAllNodeInNs(c echo.Context) error {
 // @Param infraId path string true "Infra ID" default(infra01)
 // @Param nodeId path string true "Node ID" default(g1-1)
 // @Param option query string false "Option for Infra" Enums(default, status, idsInDetail, accessinfo)
+// @Param detail query bool false "Include AddtionalDetails (CSP raw metadata) in the default Node response; default false"
 // @Param accessInfoOption query string false "(For option=accessinfo) accessInfoOption (showSshKey)"
 // @success 200 {object} JSONResult{[DEFAULT]=model.NodeInfo,[STATUS]=model.NodeStatusInfo,[IDNAME]=model.IdNameInDetailInfo} "Different return structures by the given option param"
 // @Failure 404 {object} model.SimpleMsg
@@ -375,6 +382,13 @@ func RestGetInfraNode(c echo.Context) error {
 
 	default:
 		result, err := infra.GetNodeObject(nsId, infraId, nodeId)
+		if err == nil && c.QueryParam("detail") == "true" {
+			// Auxiliary details (CSP raw metadata) are stored separately and omitted by
+			// default; attach them only when detail=true is explicitly requested.
+			if details := infra.GetNodeDetails(nsId, infraId, nodeId); details != nil {
+				result.AddtionalDetails = details
+			}
+		}
 		return clientManager.EndRequestWithLog(c, err, result)
 	}
 }


### PR DESCRIPTION
Large-scale infra ops (thousands of nodes) OOM-killed cb-tumblebug and overloaded etcd. 
Reworks the hot paths to be memory/etcd-bounded.

ref #2461

### Changes
- **StatusAgent**: batch-poll Terminating nodes + grouped re-terminate (was per-node poll storm → OOM, stuck terminates never re-delivered)
- **StatusAgent**: classify Terminated/Failed as final (PollSkip) — no more re-polling finalized nodes
- **Status/list reads**: serve `GetInfraStatus` and infra list from in-memory store, not per-node CSP/etcd fan-out (kills OOM + sustained etcd read load from polling clients)
- **Node record**: split CSP raw details to a separate key; omitted by default, opt-in via `detail=true` (shrinks every node read/write)
- **Guards**: reject empty-Id node/infra writes; respect not-found in status write-back; `GetNodeGroup` existence check; `DelInfra` tolerates an unreadable nodeGroup instead of aborting
- **Ops**: memory limit 8Gi → 16Gi

### Validated
- Terminate/delete of ~7,000 nodes: **16Gi OOM loop → 183–557Mi, no restart**
- Continuous etcd egress with mapui polling: **~184 MB/s → ~0**

<img width="1120" height="772" alt="image" src="https://github.com/user-attachments/assets/3b44064e-6117-45ff-b135-a17550bd6382" />
