### PR TITLE
enhance(rdbms): filter EOL engine versions in capability info

### DIFF
--- a/assets/rdbmsinfo.yaml
+++ b/assets/rdbmsinfo.yaml
@@ -437,8 +437,11 @@ dbms:
         defaultPort: 3306
         referenceEngineVersion: "8.4"
         referenceDBInstanceSpec: multitenant
-        note: "Storage is managed automatically by IBM Cloud. Reference values per CB-Spider's
-          rdbms-mysql-test README (verified Available, 2026-08-03)."
+        deprecatedVersions: []
+        endOfLifeVersions:
+          - "8.0" # EOL: July 29, 2026. Provisioning disabled by IBM Cloud ("mysql version 8.0 is no longer available").
+          - "5.7" # EOL: April 26, 2024. Service discontinued by IBM Cloud.
+        note: "Storage is managed automatically by IBM Cloud. MySQL v5.7 (EOL 2024-04-26) and v8.0 (EOL 2026-07-29) reached official End of Life and are rejected by IBM Cloud for new deployments; v8.4 is the active supported version."
         
     databaseRequirements:
       note: "Database naming follows standard MySQL conventions"

--- a/docs/feature_guide/rdbms-management.md
+++ b/docs/feature_guide/rdbms-management.md
@@ -178,6 +178,7 @@ _(Note: OpenStack's local test environment currently does not have a MariaDB dat
 - **IBM**:
   - Provisions on the shared/multitenant platform with auto-managed storage (`SupportsStorageTypeSelection=false`).
   - Database CRUD uses `sqlFallback` and requires TLS connection.
+  - Active supported MySQL version is `8.4`. End-of-Life (EOL) versions (`5.7`, `8.0`) are rejected by IBM Cloud for new deployments and are filtered out via `endOfLifeVersions` in `assets/rdbmsinfo.yaml`.
 - **NCP**:
   - `StorageSize` is auto-managed (starts at 10GB and auto-scales up to 6000GB in 10GB increments); custom size inputs are ignored. Storage type defaults to `SSD`.
   - Assigns private VPC endpoints only (`*.vpc-cdb.ntruss.com`); direct external access requires manual public domain assignment via NCP console.

--- a/src/core/model/rdbms.go
+++ b/src/core/model/rdbms.go
@@ -110,6 +110,10 @@ type RDBMSDBMSRequirement struct {
 	// ReferenceDBInstanceSpec is CB-Spider's own test-verified dbInstanceSpec for this CSP/engine, preferred over the live /dbspec catalog's "smallest" pick.
 	ReferenceDBInstanceSpec string `yaml:"referenceDBInstanceSpec,omitempty"`
 	ReferenceDBSpec         string `yaml:"referenceDBSpec,omitempty"`
+	// DeprecatedVersions lists engine versions that are deprecated by the CSP and discouraged for new deployments.
+	DeprecatedVersions []string `yaml:"deprecatedVersions,omitempty" json:"deprecatedVersions,omitempty"`
+	// EndOfLifeVersions lists engine versions that have reached official End of Life (EOL) and cannot be provisioned.
+	EndOfLifeVersions []string `yaml:"endOfLifeVersions,omitempty" json:"endOfLifeVersions,omitempty"`
 }
 
 // RDBMSDatabaseRequirement is a CSP's "databaseRequirements" entry in assets/rdbmsinfo.yaml.

--- a/src/core/resource/rdbms.go
+++ b/src/core/resource/rdbms.go
@@ -261,6 +261,42 @@ func buildStorageTypeConstraints(st model.RDBMSStorageTypeConfig) string {
 	return strings.Join(parts, " ")
 }
 
+// filterSupportedVersions filters out engine versions marked as EndOfLife (EOL) in assets/rdbmsinfo.yaml.
+// This prevents provisioning failures when CSP metadata APIs return deprecated/EOL versions that the CSP no longer permits creating.
+func filterSupportedVersions(providerName, dbEngine string, liveVersions []string) []string {
+	if len(liveVersions) == 0 {
+		return liveVersions
+	}
+
+	provider, exists := common.RuntimeRDBMSInfo.DBMS[strings.ToLower(providerName)]
+	if !exists {
+		return liveVersions
+	}
+
+	reqmt, ok := provider.DBMSRequirements[strings.ToLower(dbEngine)]
+	if !ok || len(reqmt.EndOfLifeVersions) == 0 {
+		return liveVersions
+	}
+
+	eolSet := make(map[string]bool, len(reqmt.EndOfLifeVersions))
+	for _, v := range reqmt.EndOfLifeVersions {
+		eolSet[strings.ToLower(strings.TrimSpace(v))] = true
+	}
+
+	filtered := make([]string, 0, len(liveVersions))
+	for _, v := range liveVersions {
+		if !eolSet[strings.ToLower(strings.TrimSpace(v))] {
+			filtered = append(filtered, v)
+		}
+	}
+
+	// Fallback to live versions if all were filtered out to avoid an empty list
+	if len(filtered) == 0 {
+		return liveVersions
+	}
+	return filtered
+}
+
 // buildStorageTypeNotes enriches Spider's storageTypeOptions with display/description/constraint metadata from assets/rdbmsinfo.yaml.
 func buildStorageTypeNotes(providerName string, storageTypeOptions []string) []model.StorageTypeNote {
 	if _, exists := common.RuntimeRDBMSInfo.DBMS[strings.ToLower(providerName)]; !exists {
@@ -376,11 +412,12 @@ func GetRDBMSCapability(providerName, regionName, dbEngine string) (model.RDBMSC
 
 	// Map Spider response to Tumblebug lowerCamelCase model
 	response.Supports = model.RDBMSMetaInfo{
-		ProviderName:                     connConfig.ProviderName,
-		RegionName:                       connConfig.RegionZoneInfo.AssignedRegion,
-		ConnectionName:                   connConfig.ConfigName,
-		DBEngine:                         spiderMeta.DBEngine,
-		SupportedVersions:                spiderMeta.SupportedVersions,
+		ProviderName:   connConfig.ProviderName,
+		RegionName:     connConfig.RegionZoneInfo.AssignedRegion,
+		ConnectionName: connConfig.ConfigName,
+		DBEngine:       spiderMeta.DBEngine,
+		// Filter out versions marked as EndOfLife (EOL) in assets/rdbmsinfo.yaml
+		SupportedVersions:                filterSupportedVersions(connConfig.ProviderName, spiderMeta.DBEngine, spiderMeta.SupportedVersions),
 		DBInstanceSpecOptions:            spiderMeta.DBSpecOptions,
 		StorageTypeOptions:               spiderMeta.StorageTypeOptions,
 		StorageSizeRange:                 model.StorageSizeRange{Min: spiderMeta.StorageSizeRangeGB.Min, Max: spiderMeta.StorageSizeRangeGB.Max},


### PR DESCRIPTION
- Exclude End-of-Life (EOL) engine versions from capability responses
- Add IBM MySQL EOL version metadata and update guide