### PR TITLE
enhance(rdbms): verify OpenStack support and enhance test-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 - [📖 Overview](https://github.com/cloud-barista/cb-tumblebug/wiki/CB‐Tumblebug-Overview) | [✨ Features](https://github.com/cloud-barista/cb-tumblebug/tree/main/docs/feature_guide) | [🏗️ Architecture](https://github.com/cloud-barista/cb-tumblebug/wiki/CB‐Tumblebug-Architecture)
 - [☁️ Supported Cloud Providers & Resources](https://docs.google.com/spreadsheets/d/1idBoaTxEMzuVACKUIMIE9OY1rPO-7yZ0y7Rs1dBG0og/edit?usp=sharing)
 
-  ![Multi-Cloud Support Matrix](https://github.com/user-attachments/assets/8adfdac0-3382-4252-a864-ec5653417ec0)
+  ![Multi-Cloud Support Matrix](https://github.com/user-attachments/assets/24fe1c46-47c8-440f-828d-3996d76d1755)
 
   > 📌 **Note**: Reference only - functionality not guaranteed. Regular updates are made.  
   > Kubernetes support is currently WIP with limited features available.

--- a/src/testclient/test-clis/rdbms/README.md
+++ b/src/testclient/test-clis/rdbms/README.md
@@ -108,6 +108,14 @@ and fill those four fields explicitly for full control.
 go run . test
 ```
 
+**Using custom configuration file:**
+
+```bash
+go run . test -c test-config-openstack.yaml
+go run . test -c test-config-mysql.yaml
+go run . test -c test-config-mariadb.yaml
+```
+
 **Parallel** — all enabled test cases run concurrently:
 
 ```bash
@@ -147,7 +155,7 @@ If a step still fails (e.g. the RDBMS instance never left `Failed`), check
 
 ```bash
 curl -u "$TB_API_USERNAME:$TB_API_PASSWORD" -X DELETE \
-  "http://localhost:1323/tumblebug/ns/default/resources/rdbms/test-rdbms-aws?option=force"
+  "http://localhost:1323/tumblebug/ns/default/resources/rdbms/test-rdbms-openstack?option=force"
 ```
 
 ---
@@ -158,7 +166,8 @@ curl -u "$TB_API_USERNAME:$TB_API_PASSWORD" -X DELETE \
 go run . test [flags]
 
 Flags:
-  -n, --nsId string   Namespace ID (overrides config tumblebug.nsId)
-      --parallel      Run test cases in parallel (default: sequential)
-  -h, --help          Show help
+  -c, --config string   Config file path (default: test-config.yaml)
+  -n, --nsId string     Namespace ID (overrides config tumblebug.nsId)
+      --parallel        Run test cases in parallel (default: sequential)
+  -h, --help            Show help
 ```

--- a/src/testclient/test-clis/rdbms/app.go
+++ b/src/testclient/test-clis/rdbms/app.go
@@ -46,13 +46,17 @@ func init() {
 	tbApiBase = viper.GetString("tumblebug.endpoint") + "/tumblebug"
 }
 
-// setConfig loads settings from test-config.yaml and .env
-func setConfig() {
-	viper.SetConfigName("test-config")
-	viper.SetConfigType("yaml")
-	viper.AddConfigPath(".")
+// setConfig loads settings from a specified config file or test-config.yaml and .env
+func setConfig(cfgFile ...string) {
+	if len(cfgFile) > 0 && cfgFile[0] != "" {
+		viper.SetConfigFile(cfgFile[0])
+	} else {
+		viper.SetConfigName("test-config")
+		viper.SetConfigType("yaml")
+		viper.AddConfigPath(".")
+	}
 	if err := viper.ReadInConfig(); err != nil {
-		log.Fatal().Err(err).Msg("Error reading test-config.yaml")
+		log.Fatal().Err(err).Msg("Error reading config file")
 	}
 	log.Info().Msgf("Using config file: %s", viper.ConfigFileUsed())
 
@@ -161,6 +165,7 @@ func main() {
 		Short: "Run the full RDBMS lifecycle test for all enabled CSPs",
 		Run:   runBatchTest,
 	}
+	testCmd.Flags().StringP("config", "c", "", "Config file path (default: test-config.yaml)")
 	testCmd.Flags().StringP("nsId", "n", "", "Namespace ID (overrides config)")
 	testCmd.Flags().Bool("parallel", false, "Run test cases in parallel")
 
@@ -176,6 +181,12 @@ func main() {
 // Each test case's own steps always run sequentially, since RDBMS creation
 // depends on the vNet/subnet/securityGroup created earlier in the same case.
 func runBatchTest(cmd *cobra.Command, args []string) {
+	cfgFile, _ := cmd.Flags().GetString("config")
+	if cfgFile != "" {
+		setConfig(cfgFile)
+		tbApiBase = viper.GetString("tumblebug.endpoint") + "/tumblebug"
+	}
+
 	nsId, _ := cmd.Flags().GetString("nsId")
 	parallel, _ := cmd.Flags().GetBool("parallel")
 

--- a/src/testclient/test-clis/rdbms/template-test-config.yaml
+++ b/src/testclient/test-clis/rdbms/template-test-config.yaml
@@ -214,7 +214,7 @@ testCases:
     vmMemoryGiB: "4"
     vmImageId: ""
     vmSpecId: ""
-    execute: false
+    execute: true
 
   - rdbmsId: test-rdbms-ncp
     connectionName: ncp-kr


### PR DESCRIPTION
- Verify RDBMS lifecycle and data I/O on OpenStack for MySQL and MariaDB
- Enable OpenStack test case in RDBMS template configuration
- Update Multi-Cloud Support Matrix image in README

> [!NOTE]
> OpenStack RDBMS requires the next CB-Spider release (CB-Spider v0.13.3+).
