### PR TITLE
feat(k8s): relay cluster token expiration time

### DIFF
--- a/src/core/model/k8s_cluster.go
+++ b/src/core/model/k8s_cluster.go
@@ -480,6 +480,12 @@ type ExecCredential struct {
 // Mirrors the Kubernetes ExecCredentialStatus (client.authentication.k8s.io/v1).
 type ExecCredentialStatus struct {
 	Token string `json:"token"`
+
+	// ExpirationTimestamp is when the token stops being accepted, in RFC3339.
+	// It is relayed from CB-Spider and omitted when the CSP provides no expiry
+	// information, which the spec allows: clients then keep the credential until a 401
+	// forces a refresh.
+	ExpirationTimestamp *string `json:"expirationTimestamp,omitempty" example:"2026-09-02T05:15:00Z"`
 }
 
 // K8sClusterTokenResponse is the response struct for the K8sCluster token API.

--- a/src/interface/rest/server/resource/k8s_cluster.go
+++ b/src/interface/rest/server/resource/k8s_cluster.go
@@ -419,6 +419,10 @@ func RestGetK8sCluster(c echo.Context) error {
 // @Summary Get a token for K8sCluster access
 // @Description Get an access token for the specified K8sCluster.
 // @Description Only applicable to CSPs that use exec-based authentication (e.g., GCP GKE, AWS EKS).
+// @Description The response follows the Kubernetes ExecCredential format. Its
+// @Description expirationTimestamp tells the client when the token stops being accepted,
+// @Description so it can refresh before the token expires instead of after a 401.
+// @Description The field is omitted when the CSP provides no expiry information.
 // @Tags [Kubernetes] Cluster Management
 // @Accept  json
 // @Produce  json


### PR DESCRIPTION
## Summary

`ExecCredentialStatus` gains `expirationTimestamp`,  relayed from CB-Spider.

Verified end-to-end against live clusters on all three CSPs that issue tokens:
- GKE 1.35.5 reports 60.0 min (server-provided)
- EKS 1.35.7 reports 14.0 min (presign 15 min minus a 1-minute cushion)
- NKS 1.34.3 reports 4.0 min (240s constant).

`kubectl` authenticates successfully through the exec path on all three, 
confirming the added field does not disturb ExecCredential consumers.

Background: cloud-barista/cb-spider#1827
Driver-side change: cloud-barista/cb-spider#1828 (merged)