### PR TITLE
Harden LLM scripts for slow or restricted regions

### DIFF
--- a/init/templates/infra-usecase-llm-bench.json
+++ b/init/templates/infra-usecase-llm-bench.json
@@ -12,11 +12,10 @@
           "role": "observability"
         },
         "description": "CPU-based observability node (e2-standard-8, 8 vCPU, 32 GiB)",
-        "specId": "gcp+us-west3+e2-standard-8",
+        "specId": "gcp+europe-west1+e2-standard-8",
         "imageId": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20260820",
         "rootDiskType": "pd-standard",
-        "rootDiskSize": 200,
-        "zone": "us-west3-a"
+        "rootDiskSize": 200
       },
       {
         "name": "alibaba-nvidia-a10",
@@ -25,11 +24,11 @@
           "accelerator": "gpu"
         },
         "description": "NVIDIA A10 GPU node on Alibaba Cloud (ecs.gn7i-2x.8xlarge, 2x A10 24GB)",
-        "specId": "alibaba+cn-guangzhou+ecs.gn7i-2x.8xlarge",
+        "specId": "alibaba+ap-southeast-1+ecs.gn7i-2x.8xlarge",
         "imageId": "ubuntu_22_04_x64_20G_alibase_20260810.vhd",
         "rootDiskType": "cloud_auto",
         "rootDiskSize": 200,
-        "zone": "cn-guangzhou-b"
+        "zone": "ap-southeast-1b"
       },
       {
         "name": "alibaba-nvidia-l20",
@@ -38,11 +37,11 @@
           "accelerator": "gpu"
         },
         "description": "NVIDIA L20 GPU node on Alibaba Cloud (ecs.gn8is.4xlarge, 1x L20 48GB)",
-        "specId": "alibaba+cn-wulanchabu+ecs.gn8is.4xlarge",
+        "specId": "alibaba+ap-southeast-1+ecs.gn8is.4xlarge",
         "imageId": "ubuntu_22_04_x64_20G_alibase_20260810.vhd",
         "rootDiskType": "cloud_auto",
         "rootDiskSize": 200,
-        "zone": "cn-wulanchabu-b"
+        "zone": "ap-southeast-1c"
       },
       {
         "name": "aws-nvidia-l4",

--- a/scripts/usecases/llm/deployvLLM.sh
+++ b/scripts/usecases/llm/deployvLLM.sh
@@ -84,20 +84,20 @@ fi
 # Install system dependencies
 echo "Installing system dependencies..."
 export DEBIAN_FRONTEND=noninteractive
-sudo apt-get update -qq
+sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
 
 # Use Python 3.12 for both NVIDIA and AMD:
 #   - AMD pre-built ROCm wheels are Python 3.12 only (cp312)
 #   - vLLM 0.23+ docs quickstart recommends Python 3.12 for NVIDIA too
 # Ubuntu 22.04 ships Python 3.10 by default; add deadsnakes PPA when needed.
-sudo apt-get install -y python3-pip curl jq > /dev/null 2>&1
+sudo apt-get -o DPkg::Lock::Timeout=600 install -y python3-pip curl jq > /dev/null 2>&1
 if ! apt-cache show python3.12 > /dev/null 2>&1; then
   echo "  Adding deadsnakes PPA for python3.12..."
-  sudo apt-get install -y software-properties-common > /dev/null 2>&1
+  sudo apt-get -o DPkg::Lock::Timeout=600 install -y software-properties-common > /dev/null 2>&1
   sudo add-apt-repository -y ppa:deadsnakes/ppa > /dev/null 2>&1
-  sudo apt-get update -qq
+  sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
 fi
-sudo apt-get install -y python3.12 python3.12-venv python3.12-dev > /dev/null 2>&1
+sudo apt-get -o DPkg::Lock::Timeout=600 install -y python3.12 python3.12-venv python3.12-dev > /dev/null 2>&1
 PYTHON_BIN="python3.12"
 echo "Using $($PYTHON_BIN --version)"
 
@@ -263,7 +263,7 @@ if [ "$GPU_TYPE" = "nvidia" ] && ! command -v nvcc &>/dev/null && ! [ -x /usr/lo
       -o "$_kring" 2>/dev/null && \
       sudo dpkg -i --force-confdef --force-confold "$_kring" 2>/dev/null || true
     rm -f "$_kring"
-    sudo apt-get update -qq
+    sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
   fi
   # Pick the latest available cuda-nvcc package.
   # NVIDIA repo uses versioned names (cuda-nvcc-12-9) not just "cuda-nvcc".
@@ -272,7 +272,7 @@ if [ "$GPU_TYPE" = "nvidia" ] && ! command -v nvcc &>/dev/null && ! [ -x /usr/lo
   [ -z "$_nvcc_pkg" ] && _nvcc_pkg="cuda-nvcc"  # last-resort fallback
   echo "  Installing $_nvcc_pkg..."
   set +e
-  sudo apt-get install -y --no-install-recommends "$_nvcc_pkg" 2>&1 | tail -5
+  sudo apt-get -o DPkg::Lock::Timeout=600 install -y --no-install-recommends "$_nvcc_pkg" 2>&1 | tail -5
   _nvcc_exit=${PIPESTATUS[0]}
   set -e
   if [ $_nvcc_exit -ne 0 ]; then
@@ -292,7 +292,7 @@ if [ "$GPU_TYPE" = "nvidia" ] && ! command -v nvcc &>/dev/null && ! [ -x /usr/lo
   fi
   echo "  Installing $_curand_pkg (curand.h required by FlashInfer sampling JIT)..."
   set +e
-  sudo apt-get install -y --no-install-recommends "$_curand_pkg" 2>&1 | tail -3
+  sudo apt-get -o DPkg::Lock::Timeout=600 install -y --no-install-recommends "$_curand_pkg" 2>&1 | tail -3
   _curand_exit=$?
   set -e
   if [ $_curand_exit -ne 0 ]; then

--- a/scripts/usecases/llm/installGpuDriver.sh
+++ b/scripts/usecases/llm/installGpuDriver.sh
@@ -87,7 +87,8 @@ ROCM_VERSION="7.2.2"
 ROCM_BUILD="7.2.2.70202-1"
 
 # Common apt-get options
-APT_OPTS=(-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold")
+# Lock timeout: unattended-upgrades often holds dpkg right after boot
+APT_OPTS=(-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -o DPkg::Lock::Timeout=600)
 APT_INSTALL=(sudo DEBIAN_FRONTEND=noninteractive apt-get install -y "${APT_OPTS[@]}")
 APT_OPTS_STR="-y -q -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
 
@@ -172,7 +173,7 @@ done
 # Ensure lspci is available (not included in minimal OS images)
 if ! command -v lspci &>/dev/null; then
     echo "Installing pciutils (lspci not found, common on minimal images)..."
-    sudo apt-get update -qq && "${APT_INSTALL[@]}" pciutils
+    sudo apt-get -o DPkg::Lock::Timeout=600 update -qq && "${APT_INSTALL[@]}" pciutils
 fi
 
 if [ -z "$GPU_TYPE" ]; then
@@ -268,7 +269,7 @@ if [ "$GPU_TYPE" = "nvidia" ]; then
     echo ""
     echo "========== DKMS Prerequisites =========="
 
-    sudo apt-get update -qq
+    sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
 
     # Blacklist nouveau
     if ! grep -q "blacklist nouveau" /etc/modprobe.d/blacklist-nouveau.conf 2>/dev/null; then
@@ -348,7 +349,7 @@ EOF
     fi
     sudo dpkg -i --force-confdef --force-confold "$KEYRING_FILE" 2>/dev/null || sudo dpkg -i "$KEYRING_FILE"
     rm -f "$KEYRING_FILE"
-    sudo apt-get update -qq
+    sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
 
     # ----------------------------------------------------------
     # Detect vGPU vs bare-metal/passthrough
@@ -765,7 +766,7 @@ CUDA_ENV
         curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
             sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
             sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
-        sudo apt-get update -qq
+        sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
 
         echo "Installing nvidia-container-toolkit..."
         set +e
@@ -852,7 +853,7 @@ elif [ "$GPU_TYPE" = "amd" ]; then
     # ----------------------------------------------------------
     echo ""
     echo "========== Installing Dependencies =========="
-    sudo apt-get update -qq
+    sudo apt-get -o DPkg::Lock::Timeout=600 update -qq
     "${APT_INSTALL[@]}" \
         "linux-headers-$(uname -r)" \
         "linux-modules-extra-$(uname -r)" \

--- a/scripts/usecases/llm/servevLLM.sh
+++ b/scripts/usecases/llm/servevLLM.sh
@@ -101,6 +101,15 @@ if [ -z "$MODEL_NAME" ]; then
   usage
 fi
 
+# huggingface.co is unreachable from some regions (e.g. Alibaba China); use the mirror there.
+HF_ENDPOINT="${HF_ENDPOINT:-https://huggingface.co}"
+if ! curl -s -o /dev/null -m 10 "$HF_ENDPOINT/api/models/gpt2" && curl -s -o /dev/null -m 10 https://hf-mirror.com/api/models/gpt2; then
+  HF_ENDPOINT="https://hf-mirror.com"
+  export HF_HUB_DISABLE_XET=1   # Xet CAS downloads bypass the mirror and fail with 401
+  echo "huggingface.co unreachable; using $HF_ENDPOINT"
+fi
+export HF_ENDPOINT
+
 # Fail fast when the model is gated, private or missing; vLLM otherwise spends minutes
 # starting up before dying with a 401 traceback.
 check_hf_access() {
@@ -109,7 +118,7 @@ check_hf_access() {
   local -a auth=()
   [ -n "$HF_TOKEN" ] && auth=(-H "Authorization: Bearer $HF_TOKEN")
   code=$(curl -s -o /dev/null -w '%{http_code}' -m 20 "${auth[@]}" \
-    "https://huggingface.co/api/models/${model}" 2>/dev/null) || return 0
+    "$HF_ENDPOINT/api/models/${model}" 2>/dev/null) || return 0
   case "$code" in
     200) ;;
     404) echo "Error: model '$model' not found on HuggingFace (or private and the token has no access)."; return 1 ;;
@@ -118,7 +127,7 @@ check_hf_access() {
     *)   return 0 ;;
   esac
   code=$(curl -s -o /dev/null -w '%{http_code}' -m 20 -I "${auth[@]}" \
-    "https://huggingface.co/${model}/resolve/main/config.json" 2>/dev/null) || return 0
+    "$HF_ENDPOINT/${model}/resolve/main/config.json" 2>/dev/null) || return 0
   case "$code" in
     401) echo "Error: '$model' is a gated model. Pass --hf-token with a HuggingFace token whose account was granted access."; return 1 ;;
     403) echo "Error: the HuggingFace token has no access to '$model'. Request access at https://huggingface.co/$model"; return 1 ;;
@@ -145,7 +154,7 @@ VENV_PATH="$HOME/venv_vllm"
 LOG_FILE="$HOME/vllm-serve.log"
 PID_FILE="$HOME/vllm-serve.pid"
 MODEL_FILE="$HOME/vllm-serve.model"
-HEALTH_CHECK_TIMEOUT=300  # 5 minutes max wait for server startup
+HEALTH_CHECK_TIMEOUT=1800  # model download on a slow link can take well over 5 minutes
 HEALTH_CHECK_INTERVAL=5   # Check every 5 seconds
 
 # Detect GPU type

--- a/scripts/usecases/llm/telemetry/run_guidellm.sh
+++ b/scripts/usecases/llm/telemetry/run_guidellm.sh
@@ -177,6 +177,15 @@ if ! python3 -c "import ensurepip" >/dev/null 2>&1; then
   install_python_venv
 fi
 
+# huggingface.co is unreachable from some regions (e.g. Alibaba China); use the mirror there.
+HF_ENDPOINT="${HF_ENDPOINT:-https://huggingface.co}"
+if ! curl -s -o /dev/null -m 10 "$HF_ENDPOINT/api/models/gpt2" && curl -s -o /dev/null -m 10 https://hf-mirror.com/api/models/gpt2; then
+  HF_ENDPOINT="https://hf-mirror.com"
+  export HF_HUB_DISABLE_XET=1   # Xet CAS downloads bypass the mirror and fail with 401
+  echo "huggingface.co unreachable; using $HF_ENDPOINT"
+fi
+export HF_ENDPOINT
+
 WORK_DIR="$HOME/guidellm_bench"
 mkdir -p "$WORK_DIR"
 cd "$WORK_DIR"
@@ -272,15 +281,33 @@ run_benchmark() {
       # GuideLLM 0.7 needs a single split; loading a multi-split HF dataset without one
       # fails on a DatasetDict. Pick the smallest useful split (test > validation > train)
       # from the datasets-server unless --data-args already names one.
-      DATA_SOURCE=$(python3 - "$DATA" "${DATA_ARGS:-{\}}" <<'PY'
-import json, sys, urllib.request
-source, kwargs = sys.argv[1], json.loads(sys.argv[2])
+      DATA_SOURCE=$(python3 - "$DATA" "${DATA_ARGS:-{\}}" "$HF_ENDPOINT" <<'PY'
+import json, re, sys, urllib.request
+source, kwargs, endpoint = sys.argv[1], json.loads(sys.argv[2]), sys.argv[3]
+def get(url):
+    with urllib.request.urlopen(url, timeout=20) as r:
+        return json.load(r)
+def split_names():
+    try:  # datasets-server knows every split, but it has no mirror
+        splits = get(f"https://datasets-server.huggingface.co/splits?dataset={source}").get("splits", [])
+        return [s["split"] for s in splits if "name" not in kwargs or s["config"] == kwargs["name"]]
+    except Exception:
+        pass
+    info = get(f"{endpoint}/api/datasets/{source}")  # dataset card lists configs and data files
+    names = []
+    for cfg in (info.get("cardData") or {}).get("configs") or []:
+        if "name" in kwargs and cfg.get("config_name") != kwargs["name"]:
+            continue
+        names += [f["split"] for f in cfg.get("data_files", []) if isinstance(f, dict) and f.get("split")]
+    if not names:
+        for f in info.get("siblings", []):
+            m = re.match(r"(?:data/)?([A-Za-z0-9_]+?)(?:-\d{5}-of-\d{5}\S*)?\.(parquet|jsonl?|csv|arrow)$", f["rfilename"])
+            if m and m.group(1) not in names:
+                names.append(m.group(1))
+    return names
 if "split" not in kwargs:
     try:
-        with urllib.request.urlopen(f"https://datasets-server.huggingface.co/splits?dataset={source}", timeout=20) as r:
-            splits = [s for s in json.load(r).get("splits", [])
-                      if "name" not in kwargs or s["config"] == kwargs["name"]]
-        names = [s["split"] for s in splits]
+        names = split_names()
         if names and len(set(names)) > 1:
             for pref in ("test", "validation", "train"):
                 pick = next((n for n in names if n.startswith(pref)), None)


### PR DESCRIPTION
Wait for the dpkg lock instead of failing when unattended-upgrades runs right after boot. 

Fall back to hf-mirror.com (with Xet disabled) when huggingface.co is unreachable, resolve dataset splits from the dataset card when datasets-server is blocked, and allow 30 minutes for vLLM to start since a 3 GB model download alone exceeds the old 5-minute limit.

Count AMD GPUs by distinct index instead of rocm-smi output lines.