### PR TITLE
fix(k8s): honor onAutoScaling and per-CSP limits when defaulting node sizes

### DIFF
--- a/assets/k8sclusterinfo.yaml
+++ b/assets/k8sclusterinfo.yaml
@@ -13,6 +13,14 @@
 #           - name: "1.30" [available version name (use double quotes)]
 #             id: "1.30" [available version name (use double quotes)]
 #     nodeGroupNamingRule: [regular expression or no restriction if empty]
+#     initialNodeGroupManagedByCluster: [true/false, default false]
+#       The node group created together with the cluster is lifecycle-bound to it and
+#       cannot be deleted independently via the node group API.
+#     autoScalingOffNodeSize: [{min: N, max: N}, default none]
+#       The node-size floor the CSP still demands while autoscaling is disabled.
+#       Most CSPs ignore Min/Max in that state - omit the key for those. Some even reject
+#       a non-zero MinNodeSize when autoscaling is off, so never set min unless the CSP
+#       demands it. A field left out keeps the value the client requested.
 #
 
 k8scluster:
@@ -136,6 +144,10 @@ k8scluster:
           min: 10
           max: 40
   nhn:
+    # CSP constraint: the NKS nodegroup API rejects max_node_count 0 (verified 2026-09-10,
+    # HTTP 400 "Value should be greater or equal to 1"). Min stays unset because the
+    # CB-Spider driver rejects a non-zero Min while autoscaling is off.
+    autoScalingOffNodeSize: {max: 1}
     nodeGroupsOnCreation: true
     nodeImageDesignation: true
     requiredSubnetCount: 1
@@ -161,6 +173,14 @@ k8scluster:
     nodeImageDesignation: true
     requiredSubnetCount: 1
     initialNodeGroupManagedByCluster: true
+    # Not a CSP constraint: TKE itself accepts MinSize 0 - its CreateClusterNodePool reference
+    # uses "MinSize":0 in the request example
+    # (https://intl.cloud.tencent.com/document/product/457/38781). The floor exists only
+    # because validateAtAddNodeGroup in the CB-Spider driver rejects anything below 1, while
+    # the driver forwards Min/Max/Desired to TKE as AutoScalingGroup parameters regardless of
+    # EnableAutoscale. Drop this once that check is fixed upstream. Nothing scales while
+    # autoscaling is off, so max needs no headroom.
+    autoScalingOffNodeSize: {min: 1, max: 1}
     version:
       # ServiceUnavailable
       - region: [ap-mumbai, eu-moscow, na-toronto]
@@ -202,6 +222,11 @@ k8scluster:
           min: 10
           max: 40
   ibm:
+    # Not a CSP constraint: the driver only sends Min/Max to IKS inside its
+    # `if OnAutoScaling` branch, so IKS never sees them while autoscaling is off. The floor
+    # exists solely because validateAtCreateCluster/validateAtAddNodeGroup reject anything
+    # below 1 with no OnAutoScaling guard. Drop this once that check is fixed upstream.
+    autoScalingOffNodeSize: {min: 1, max: 1}
     nodeGroupsOnCreation: true
     nodeImageDesignation: false
     requiredSubnetCount: 1

--- a/src/core/common/utility_k8s.go
+++ b/src/core/common/utility_k8s.go
@@ -249,8 +249,7 @@ func GetK8sInitialNodeGroupManagedByCluster(providerName string) (bool, error) {
 }
 
 // GetK8sAutoScalingOffNodeSize returns the node-size floor the CSP still demands while
-// autoscaling is disabled. Zero fields mean the CSP ignores Min/Max in that state, which is
-// the common case; see model.K8sClusterAutoScalingOffNodeSize for the CSPs that do not.
+// autoscaling is disabled, as configured per CSP in assets/k8sclusterinfo.yaml.
 func GetK8sAutoScalingOffNodeSize(providerName string) (model.K8sClusterAutoScalingOffNodeSize, error) {
 	providerName = strings.ToLower(providerName)
 

--- a/src/core/common/utility_k8s.go
+++ b/src/core/common/utility_k8s.go
@@ -248,6 +248,20 @@ func GetK8sInitialNodeGroupManagedByCluster(providerName string) (bool, error) {
 	return k8sClusterDetail.InitialNodeGroupManagedByCluster, nil
 }
 
+// GetK8sAutoScalingOffNodeSize returns the node-size floor the CSP still demands while
+// autoscaling is disabled. Zero fields mean the CSP ignores Min/Max in that state, which is
+// the common case; see model.K8sClusterAutoScalingOffNodeSize for the CSPs that do not.
+func GetK8sAutoScalingOffNodeSize(providerName string) (model.K8sClusterAutoScalingOffNodeSize, error) {
+	providerName = strings.ToLower(providerName)
+
+	k8sClusterDetail := getK8sClusterDetail(providerName)
+	if k8sClusterDetail == nil {
+		return model.K8sClusterAutoScalingOffNodeSize{}, fmt.Errorf("unsupported provider(%s) for kubernetes cluster", providerName)
+	}
+
+	return k8sClusterDetail.AutoScalingOffNodeSize, nil
+}
+
 // GetK8sNodeGroupNamingRule is func to get nodegroup's naming rule
 func GetK8sNodeGroupNamingRule(providerName string) (string, error) {
 	//

--- a/src/core/infra/provisioning_dynamic_k8s.go
+++ b/src/core/infra/provisioning_dynamic_k8s.go
@@ -205,39 +205,7 @@ func checkCommonResAvailableForK8sNodeGroupDynamicReq(ctx context.Context, connN
 	return nil
 }
 
-// applyK8sNodeGroupSizeDefaults resolves the autoscale fields for the dynamic creation paths
-// (k8sClusterDynamic / k8sNodeGroupDynamic), the only paths that substitute values the client
-// did not send.
-//
-// The rules, and why:
-//
-//   - A negative size is always an error. Nothing in CB-Tumblebug or the CB-Spider drivers
-//     gives a negative value meaning, so it can only be a client mistake; silently rewriting
-//     it hides the mistake from the caller.
-//
-//   - onAutoScaling written explicitly as "true" means the caller engaged with the scaling
-//     policy, so Min/Max become required. Picking a range on their behalf would be
-//     CB-Tumblebug deciding a policy that belongs to the caller.
-//
-//   - onAutoScaling omitted still defaults to "true", and Min/Max are then filled with 1/2 as
-//     before. The caller never asked for autoscaling, so demanding a range from them would
-//     break every existing request - the guide's own example sends neither field. Requiring
-//     Min/Max whenever autoscaling is on, explicit or not, is the intended end state; it is
-//     deferred so that callers get a release to migrate.
-//
-//   - onAutoScaling "false" leaves Min/Max alone. Substituting them is what made
-//     `onAutoScaling: "false"` impossible to express: MinNodeSize is a non-pointer int, so an
-//     omitted key and an explicit 0 are indistinguishable, and Azure, NHN and NCP reject a
-//     non-zero Min while autoscaling is off.
-//     See https://github.com/cloud-barista/cb-tumblebug/issues/2767
-//
-//   - offNodeSize carries the floor a CSP still demands in that state, from
-//     k8sclusterinfo.yaml. It is a CSP quirk the caller cannot be expected to know
-//     (Tencent and IBM validate Min/Max regardless of autoscaling; NHN's nodegroup API
-//     rejects max_node_count 0), so CB-Tumblebug absorbs it rather than surfacing it.
-//
-//   - DesiredNodeSize is always defaulted: Alibaba uses it while autoscaling is off, and
-//     Tencent requires it to be >= 1 in every case.
+// applyK8sNodeGroupSizeDefaults is func to resolve the autoscale fields for the dynamic creation paths
 func applyK8sNodeGroupSizeDefaults(ngReq *model.K8sNodeGroupReq, dReqOnAutoScaling string,
 	desiredNodeSize, minNodeSize, maxNodeSize int,
 	offNodeSize model.K8sClusterAutoScalingOffNodeSize) error {
@@ -491,9 +459,6 @@ func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *mode
 	}
 	k8sngReq.RootDiskType = dReq.RootDiskType
 	k8sngReq.RootDiskSize = dReq.RootDiskSize
-	// Tencent TKE demands Min/Max node size even while autoscaling is off; every other CSP
-	// either ignores them or rejects a non-zero Min in that state. Treat a lookup failure as
-	// false to avoid introducing a new failure path here.
 	offNodeSize, err := common.GetK8sAutoScalingOffNodeSize(connection.ProviderName)
 	if err != nil {
 		log.Warn().Err(err).Msgf("Failed to get AutoScalingOffNodeSize for provider(%s); assuming no floor", connection.ProviderName)
@@ -668,8 +633,7 @@ func getK8sNodeGroupReqFromDynamicReq(ctx context.Context, nsId string, k8sClust
 	k8sNgReq.RootDiskType = dReq.RootDiskType
 	k8sNgReq.RootDiskSize = dReq.RootDiskSize
 	// specInfo.ConnectionName is verified above to match the cluster's ConnectionName,
-	// so its ProviderName is the cluster's provider. See the note in
-	// applyK8sNodeGroupSizeDefaults for why a lookup failure is treated as false.
+	// so its ProviderName is the cluster's provider.
 	offNodeSize, err := common.GetK8sAutoScalingOffNodeSize(specInfo.ProviderName)
 	if err != nil {
 		log.Warn().Err(err).Msgf("Failed to get AutoScalingOffNodeSize for provider(%s); assuming no floor", specInfo.ProviderName)

--- a/src/core/infra/provisioning_dynamic_k8s.go
+++ b/src/core/infra/provisioning_dynamic_k8s.go
@@ -16,6 +16,7 @@ package infra
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -199,6 +200,101 @@ func checkCommonResAvailableForK8sNodeGroupDynamicReq(ctx context.Context, connN
 	err := checkCommonResAvailableForK8sClusterDynamicReq(ctx, k8sClusterDReq)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// applyK8sNodeGroupSizeDefaults resolves the autoscale fields for the dynamic creation paths
+// (k8sClusterDynamic / k8sNodeGroupDynamic), the only paths that substitute values the client
+// did not send.
+//
+// The rules, and why:
+//
+//   - A negative size is always an error. Nothing in CB-Tumblebug or the CB-Spider drivers
+//     gives a negative value meaning, so it can only be a client mistake; silently rewriting
+//     it hides the mistake from the caller.
+//
+//   - onAutoScaling written explicitly as "true" means the caller engaged with the scaling
+//     policy, so Min/Max become required. Picking a range on their behalf would be
+//     CB-Tumblebug deciding a policy that belongs to the caller.
+//
+//   - onAutoScaling omitted still defaults to "true", and Min/Max are then filled with 1/2 as
+//     before. The caller never asked for autoscaling, so demanding a range from them would
+//     break every existing request - the guide's own example sends neither field. Requiring
+//     Min/Max whenever autoscaling is on, explicit or not, is the intended end state; it is
+//     deferred so that callers get a release to migrate.
+//
+//   - onAutoScaling "false" leaves Min/Max alone. Substituting them is what made
+//     `onAutoScaling: "false"` impossible to express: MinNodeSize is a non-pointer int, so an
+//     omitted key and an explicit 0 are indistinguishable, and Azure, NHN and NCP reject a
+//     non-zero Min while autoscaling is off.
+//     See https://github.com/cloud-barista/cb-tumblebug/issues/2767
+//
+//   - offNodeSize carries the floor a CSP still demands in that state, from
+//     k8sclusterinfo.yaml. It is a CSP quirk the caller cannot be expected to know
+//     (Tencent and IBM validate Min/Max regardless of autoscaling; NHN's nodegroup API
+//     rejects max_node_count 0), so CB-Tumblebug absorbs it rather than surfacing it.
+//
+//   - DesiredNodeSize is always defaulted: Alibaba uses it while autoscaling is off, and
+//     Tencent requires it to be >= 1 in every case.
+func applyK8sNodeGroupSizeDefaults(ngReq *model.K8sNodeGroupReq, dReqOnAutoScaling string,
+	desiredNodeSize, minNodeSize, maxNodeSize int,
+	offNodeSize model.K8sClusterAutoScalingOffNodeSize) error {
+
+	if desiredNodeSize < 0 || minNodeSize < 0 || maxNodeSize < 0 {
+		return fmt.Errorf("node sizes must not be negative (desiredNodeSize=%d, minNodeSize=%d, maxNodeSize=%d)",
+			desiredNodeSize, minNodeSize, maxNodeSize)
+	}
+
+	onAutoScaling := true
+	autoScalingExplicit := dReqOnAutoScaling != ""
+	if autoScalingExplicit {
+		parsed, err := strconv.ParseBool(dReqOnAutoScaling)
+		if err != nil {
+			return fmt.Errorf("invalid onAutoScaling value %q: must be a boolean such as \"true\" or \"false\"", dReqOnAutoScaling)
+		}
+		onAutoScaling = parsed
+	}
+	ngReq.OnAutoScaling = strconv.FormatBool(onAutoScaling)
+
+	ngReq.DesiredNodeSize = desiredNodeSize
+	if ngReq.DesiredNodeSize <= 0 {
+		ngReq.DesiredNodeSize = 1
+	}
+
+	ngReq.MinNodeSize = minNodeSize
+	ngReq.MaxNodeSize = maxNodeSize
+
+	switch {
+	case onAutoScaling && autoScalingExplicit:
+		if ngReq.MinNodeSize <= 0 || ngReq.MaxNodeSize <= 0 {
+			return fmt.Errorf("minNodeSize and maxNodeSize are required when onAutoScaling is set to \"true\" explicitly "+
+				"(got minNodeSize=%d, maxNodeSize=%d); omit onAutoScaling to keep the defaults, or set it to \"false\"",
+				ngReq.MinNodeSize, ngReq.MaxNodeSize)
+		}
+	case onAutoScaling:
+		// onAutoScaling omitted: keep the historical defaults.
+		if ngReq.MinNodeSize <= 0 {
+			ngReq.MinNodeSize = 1
+		}
+		if ngReq.MaxNodeSize <= 0 {
+			ngReq.MaxNodeSize = 2
+		}
+	default:
+		// Autoscaling off: Min/Max carry no meaning, so raise them only to the floor the CSP
+		// insists on. A zero field in offNodeSize means the CSP has no such requirement.
+		if ngReq.MinNodeSize < offNodeSize.Min {
+			ngReq.MinNodeSize = offNodeSize.Min
+		}
+		if ngReq.MaxNodeSize < offNodeSize.Max {
+			ngReq.MaxNodeSize = offNodeSize.Max
+		}
+	}
+
+	if ngReq.MinNodeSize > 0 && ngReq.MinNodeSize > ngReq.MaxNodeSize {
+		return fmt.Errorf("minNodeSize(%d) must not be greater than maxNodeSize(%d)",
+			ngReq.MinNodeSize, ngReq.MaxNodeSize)
 	}
 
 	return nil
@@ -395,21 +491,18 @@ func getK8sClusterReqFromDynamicReq(ctx context.Context, nsId string, dReq *mode
 	}
 	k8sngReq.RootDiskType = dReq.RootDiskType
 	k8sngReq.RootDiskSize = dReq.RootDiskSize
-	k8sngReq.OnAutoScaling = dReq.OnAutoScaling
-	if k8sngReq.OnAutoScaling == "" {
-		k8sngReq.OnAutoScaling = "true"
+	// Tencent TKE demands Min/Max node size even while autoscaling is off; every other CSP
+	// either ignores them or rejects a non-zero Min in that state. Treat a lookup failure as
+	// false to avoid introducing a new failure path here.
+	offNodeSize, err := common.GetK8sAutoScalingOffNodeSize(connection.ProviderName)
+	if err != nil {
+		log.Warn().Err(err).Msgf("Failed to get AutoScalingOffNodeSize for provider(%s); assuming no floor", connection.ProviderName)
+		offNodeSize = model.K8sClusterAutoScalingOffNodeSize{}
 	}
-	k8sngReq.DesiredNodeSize = dReq.DesiredNodeSize
-	if k8sngReq.DesiredNodeSize <= 0 {
-		k8sngReq.DesiredNodeSize = 1
-	}
-	k8sngReq.MinNodeSize = dReq.MinNodeSize
-	if k8sngReq.MinNodeSize <= 0 {
-		k8sngReq.MinNodeSize = 1
-	}
-	k8sngReq.MaxNodeSize = dReq.MaxNodeSize
-	if k8sngReq.MaxNodeSize <= 0 {
-		k8sngReq.MaxNodeSize = 2
+	if err := applyK8sNodeGroupSizeDefaults(k8sngReq, dReq.OnAutoScaling,
+		dReq.DesiredNodeSize, dReq.MinNodeSize, dReq.MaxNodeSize, offNodeSize); err != nil {
+		log.Err(err).Msg("Failed to apply K8sNodeGroup size defaults")
+		return emptyK8sReq, err
 	}
 	k8sReq.Description = dReq.Description
 	k8sReq.Name = dReq.Name
@@ -574,21 +667,18 @@ func getK8sNodeGroupReqFromDynamicReq(ctx context.Context, nsId string, k8sClust
 	}
 	k8sNgReq.RootDiskType = dReq.RootDiskType
 	k8sNgReq.RootDiskSize = dReq.RootDiskSize
-	k8sNgReq.OnAutoScaling = dReq.OnAutoScaling
-	if k8sNgReq.OnAutoScaling == "" {
-		k8sNgReq.OnAutoScaling = "true"
+	// specInfo.ConnectionName is verified above to match the cluster's ConnectionName,
+	// so its ProviderName is the cluster's provider. See the note in
+	// applyK8sNodeGroupSizeDefaults for why a lookup failure is treated as false.
+	offNodeSize, err := common.GetK8sAutoScalingOffNodeSize(specInfo.ProviderName)
+	if err != nil {
+		log.Warn().Err(err).Msgf("Failed to get AutoScalingOffNodeSize for provider(%s); assuming no floor", specInfo.ProviderName)
+		offNodeSize = model.K8sClusterAutoScalingOffNodeSize{}
 	}
-	k8sNgReq.DesiredNodeSize = dReq.DesiredNodeSize
-	if k8sNgReq.DesiredNodeSize <= 0 {
-		k8sNgReq.DesiredNodeSize = 1
-	}
-	k8sNgReq.MinNodeSize = dReq.MinNodeSize
-	if k8sNgReq.MinNodeSize <= 0 {
-		k8sNgReq.MinNodeSize = 1
-	}
-	k8sNgReq.MaxNodeSize = dReq.MaxNodeSize
-	if k8sNgReq.MaxNodeSize <= 0 {
-		k8sNgReq.MaxNodeSize = 2
+	if err := applyK8sNodeGroupSizeDefaults(k8sNgReq, dReq.OnAutoScaling,
+		dReq.DesiredNodeSize, dReq.MinNodeSize, dReq.MaxNodeSize, offNodeSize); err != nil {
+		log.Err(err).Msg("Failed to apply K8sNodeGroup size defaults")
+		return emptyK8sNgReq, err
 	}
 	k8sNgReq.Description = dReq.Description
 	k8sNgReq.Label = dReq.Label

--- a/src/core/model/config.go
+++ b/src/core/model/config.go
@@ -71,7 +71,7 @@ type ExtractPatterns struct {
 
 // CloudImageIgnoreConfig represents the structure of cloudimage_ignore.yaml
 type CloudImageIgnoreConfig struct {
-	Global GlobalIgnorePatterns             `yaml:"global"`
+	Global GlobalIgnorePatterns              `yaml:"global"`
 	CSPs   map[string]CSPImageIgnorePatterns `yaml:"csps,omitempty"`
 }
 
@@ -199,17 +199,34 @@ type K8sClusterRequiredSubnetCount struct {
 
 // K8sClusterDetail is structure for kubernetes cluster detail information
 type K8sClusterDetail struct {
-	NodeGroupsOnCreation             bool                        `mapstructure:"nodeGroupsOnCreation" json:"nodegroups_on_creation"`
-	NodeImageDesignation             bool                        `mapstructure:"nodeImageDesignation" json:"node_image_designation"`
-	RequiredSubnetCount              int                         `mapstructure:"requiredSubnetCount" json:"required_subnet_count"`
-	NodeGroupNamingRule              string                      `mapstructure:"nodeGroupNamingRule" json:"nodegroup_naming_rule"`
+	NodeGroupsOnCreation bool   `mapstructure:"nodeGroupsOnCreation" json:"nodegroups_on_creation"`
+	NodeImageDesignation bool   `mapstructure:"nodeImageDesignation" json:"node_image_designation"`
+	RequiredSubnetCount  int    `mapstructure:"requiredSubnetCount" json:"required_subnet_count"`
+	NodeGroupNamingRule  string `mapstructure:"nodeGroupNamingRule" json:"nodegroup_naming_rule"`
 	// InitialNodeGroupManagedByCluster indicates that the initial node group created during
 	// cluster creation is lifecycle-bound to the cluster and cannot be deleted independently
 	// via the node group API (e.g., Alibaba ACK, Tencent TKE).
-	InitialNodeGroupManagedByCluster bool                        `mapstructure:"initialNodeGroupManagedByCluster" json:"initial_nodegroup_managed_by_cluster"`
-	Version                          []K8sClusterVersionDetail   `mapstructure:"version" json:"versions"`
-	NodeImage                        []K8sClusterNodeImageDetail `mapstructure:"nodeImage" json:"node_images"`
-	RootDisk                         []K8sClusterRootDiskDetail  `mapstructure:"rootDisk" json:"root_disks"`
+	InitialNodeGroupManagedByCluster bool `mapstructure:"initialNodeGroupManagedByCluster" json:"initial_nodegroup_managed_by_cluster"`
+	// AutoScalingOffNodeSize carries the node-size floor a CSP still demands while
+	// autoscaling is disabled, for the CSPs that reject 0 in that state. Omitted (both
+	// fields zero) means the CSP ignores Min/Max when autoscaling is off - the common case.
+	AutoScalingOffNodeSize K8sClusterAutoScalingOffNodeSize `mapstructure:"autoScalingOffNodeSize" json:"autoscaling_off_node_size"`
+	Version                []K8sClusterVersionDetail        `mapstructure:"version" json:"versions"`
+	NodeImage              []K8sClusterNodeImageDetail      `mapstructure:"nodeImage" json:"node_images"`
+	RootDisk               []K8sClusterRootDiskDetail       `mapstructure:"rootDisk" json:"root_disks"`
+}
+
+// K8sClusterAutoScalingOffNodeSize is the node-size floor a CSP requires while autoscaling
+// is disabled. Min/Max node size are meaningless in that state for most CSPs, but a few still
+// validate them, and they disagree on what they demand:
+//   - Tencent TKE / IBM IKS: Min and Max must both be >= 1, autoscaling state ignored.
+//   - NHN NKS: the nodegroup API rejects max_node_count 0, while Min must stay 0 because the
+//     driver rejects a non-zero Min when autoscaling is off.
+//
+// A zero field means "leave the requested value alone".
+type K8sClusterAutoScalingOffNodeSize struct {
+	Min int `mapstructure:"min" json:"min,omitempty"`
+	Max int `mapstructure:"max" json:"max,omitempty"`
 }
 
 // K8sClusterVersionDetail is structure for kubernetes cluster version detail information

--- a/src/core/model/config.go
+++ b/src/core/model/config.go
@@ -207,9 +207,7 @@ type K8sClusterDetail struct {
 	// cluster creation is lifecycle-bound to the cluster and cannot be deleted independently
 	// via the node group API (e.g., Alibaba ACK, Tencent TKE).
 	InitialNodeGroupManagedByCluster bool `mapstructure:"initialNodeGroupManagedByCluster" json:"initial_nodegroup_managed_by_cluster"`
-	// AutoScalingOffNodeSize carries the node-size floor a CSP still demands while
-	// autoscaling is disabled, for the CSPs that reject 0 in that state. Omitted (both
-	// fields zero) means the CSP ignores Min/Max when autoscaling is off - the common case.
+	// AutoScalingOffNodeSize is the node-size floor the CSP requires while autoscaling is off.
 	AutoScalingOffNodeSize K8sClusterAutoScalingOffNodeSize `mapstructure:"autoScalingOffNodeSize" json:"autoscaling_off_node_size"`
 	Version                []K8sClusterVersionDetail        `mapstructure:"version" json:"versions"`
 	NodeImage              []K8sClusterNodeImageDetail      `mapstructure:"nodeImage" json:"node_images"`
@@ -217,12 +215,7 @@ type K8sClusterDetail struct {
 }
 
 // K8sClusterAutoScalingOffNodeSize is the node-size floor a CSP requires while autoscaling
-// is disabled. Min/Max node size are meaningless in that state for most CSPs, but a few still
-// validate them, and they disagree on what they demand:
-//   - Tencent TKE / IBM IKS: Min and Max must both be >= 1, autoscaling state ignored.
-//   - NHN NKS: the nodegroup API rejects max_node_count 0, while Min must stay 0 because the
-//     driver rejects a non-zero Min when autoscaling is off.
-//
+// is disabled. Which CSPs need one, and why, is in assets/k8sclusterinfo.yaml.
 // A zero field means "leave the requested value alone".
 type K8sClusterAutoScalingOffNodeSize struct {
 	Min int `mapstructure:"min" json:"min,omitempty"`

--- a/src/core/resource/k8s_cluster.go
+++ b/src/core/resource/k8s_cluster.go
@@ -219,6 +219,13 @@ func CreateK8sCluster(ctx context.Context, nsId string, req *model.K8sClusterReq
 		return emptyObj, err
 	}
 
+	for i := range req.K8sNodeGroupList {
+		if err := normalizeK8sNodeGroupOnAutoScaling(&req.K8sNodeGroupList[i]); err != nil {
+			log.Err(err).Msgf("Failed to Create a K8sCluster(%s)", k8sClusterId)
+			return emptyObj, err
+		}
+	}
+
 	check, err := CheckK8sCluster(nsId, k8sClusterId)
 	if err != nil {
 		log.Err(err).Msgf("Failed to Create a K8sCluster(%s)", k8sClusterId)
@@ -620,6 +627,11 @@ func AddK8sNodeGroup(ctx context.Context, nsId string, k8sClusterId string, u *m
 			return emptyObj, err
 		}
 
+		return emptyObj, err
+	}
+
+	if err := normalizeK8sNodeGroupOnAutoScaling(u); err != nil {
+		log.Err(err).Msgf("Failed to Add K8sNodeGroup(k8scluster=%s)", k8sClusterId)
 		return emptyObj, err
 	}
 
@@ -1978,6 +1990,33 @@ func updateK8sClusterInfoFromSpiderClusterInfo(tbK8sCInfo *model.K8sClusterInfo,
 	tbK8sCInfo.CspResourceId = spCInfo.IId.SystemId
 }
 
+// normalizeK8sNodeGroupOnAutoScaling canonicalizes K8sNodeGroupReq.OnAutoScaling in place so
+// that every downstream consumer - the TB metadata and the value forwarded to CB-Spider -
+// agrees on a single "true"/"false" string.
+//
+// An empty value takes the documented default of "true". A value that is not a boolean is
+// rejected rather than silently coerced: previously TB recorded such a value as true while
+// forwarding the raw string to CB-Spider, so the recorded state and the actual cluster could
+// diverge.
+//
+// This runs on the shared creation path, so it applies to both the dynamic and non-dynamic
+// endpoints.
+func normalizeK8sNodeGroupOnAutoScaling(tbK8sNGReq *model.K8sNodeGroupReq) error {
+	if tbK8sNGReq.OnAutoScaling == "" {
+		tbK8sNGReq.OnAutoScaling = "true"
+		return nil
+	}
+
+	on, err := strconv.ParseBool(tbK8sNGReq.OnAutoScaling)
+	if err != nil {
+		return fmt.Errorf("invalid onAutoScaling value %q for K8sNodeGroup(%s): must be a boolean such as \"true\" or \"false\"",
+			tbK8sNGReq.OnAutoScaling, tbK8sNGReq.Name)
+	}
+
+	tbK8sNGReq.OnAutoScaling = strconv.FormatBool(on)
+	return nil
+}
+
 func fillK8sNodeGroupInfoFromK8sNodeGroupReq(tbK8sNGInfo *model.K8sNodeGroupInfo, tbK8sNGReq *model.K8sNodeGroupReq) {
 	tbK8sNGInfo.Id = tbK8sNGReq.Name
 	tbK8sNGInfo.Name = tbK8sNGReq.Name
@@ -1987,13 +2026,9 @@ func fillK8sNodeGroupInfoFromK8sNodeGroupReq(tbK8sNGInfo *model.K8sNodeGroupInfo
 	tbK8sNGInfo.RootDiskSize = tbK8sNGReq.RootDiskSize
 	tbK8sNGInfo.SshKeyId = tbK8sNGReq.SshKeyId
 
-	// Convert string to appropriate types with better error handling
-	if on, err := strconv.ParseBool(tbK8sNGReq.OnAutoScaling); err == nil {
-		tbK8sNGInfo.OnAutoScaling = on
-	} else {
-		log.Warn().Msgf("Failed to parse OnAutoScaling '%s', defaulting to true", tbK8sNGReq.OnAutoScaling)
-		tbK8sNGInfo.OnAutoScaling = true
-	}
+	// OnAutoScaling is normalized to "true"/"false" by normalizeK8sNodeGroupOnAutoScaling
+	// before this point, so parsing cannot fail here.
+	tbK8sNGInfo.OnAutoScaling, _ = strconv.ParseBool(tbK8sNGReq.OnAutoScaling)
 
 	tbK8sNGInfo.DesiredNodeSize = tbK8sNGReq.DesiredNodeSize
 	tbK8sNGInfo.MinNodeSize = tbK8sNGReq.MinNodeSize


### PR DESCRIPTION
## Summary

<details>
<summary><b>🇰🇷 한국어</b></summary>

CB-Tumblebug은 `onAutoScaling: "false"`일 때 몇몇 CSP 들의 제약사항으로 인해 CSP 구분 없이 `MinNodeSize`/`MaxNodeSize`를 임의로 설정해 왔습니다. 다만 이 요구사항이 CSP 마다 갈립니다. 
- **Azure/NHN/NCP는 `MinNodeSize`가 0이어야 하고**(0이 아니면 거부), **Tencent/IBM은 `MinNodeSize`와 `MaxNodeSize` 둘 다 1 이상을 요구합니다.**
- NHN은 여기에 더해 **노드그룹 추가 시 `MaxNodeSize`만 1 이상**을 요구합니다. 

이슈에 보고된 Azure/NHN, 보고되지 않았으나 동일하게 실패하던 NCP 와 Tencent/IBM까지 포함해 해당 문제를 해결했습니다.

- **Min/Max 기본값이 `OnAutoScaling`과 CSP를 함께 보고 결정됩니다.** autoscaling이 꺼져 있으면 Min/Max를
  `1`/`2`로 덮어쓰지 않고, 그 상태에서도 값을 요구하는 CSP만 `assets/k8sclusterinfo.yaml`의
  `autoScalingOffNodeSize` 하한까지 채웁니다. 

- **불리언이 아닌 `onAutoScaling`(예: `"yes"`), 음수 크기, `min > max`가 에러가 됩니다. ** 
  기존에는 `"yes"`를 보내면 CB-Tumblebug은 autoscaling이 켜진 것으로 처리했습니다.

- **동작 변경:** `onAutoScaling: "true"`를 **명시하면 Min/Max가 필수**가 됩니다. 스케일링 범위를
  CB-Tumblebug이 대신 정하는 것은 적절하지 않다고 판단했습니다. 다만 `onAutoScaling` 값 입력을 생략하면 
  기존처럼 `onAutoScaling: "true"`, Min/Max 는 `1`/`2`로 유지됩니다. 
  추후에는 `onAutoScaling: true`인 경우라면 항상 Min/Max를 요구하도록 수정하는것이 최종 목표이며, 
  기존 api 사용자들을 고려해 해당 수정은 미뤘습니다.

- **실 CSP 검증 완료** (`onAutoScaling: "false"`): 문제가 되었던 모든 CSP 대상으로 검증 완료
  
</details>

<details>
<summary><b>🇺🇸 English</b></summary>

<br>CB-Tumblebug has been setting `MinNodeSize`/`MaxNodeSize` for every CSP alike, because a few of them demand values even when `onAutoScaling: "false"`. That demand, however, differs from CSP to CSP. 
- **Azure, NHN and NCP require `MinNodeSize` to be 0** (anything else is rejected), while **Tencent and IBM require both `MinNodeSize` and `MaxNodeSize` to be at least 1.
- ** NHN adds one more: **only `MaxNodeSize` must be at least 1 when adding a nodegroup.** 

This fixes the reported Azure and NHN, along with NCP which failed the same way but went unreported, and Tencent and IBM.

- **The default Min/Max values ​​are determined by considering both `OnAutoScaling` and the CSP.** 
  With autoscaling off, Min/Max  are no longer rewritten to `1`/`2`;  
  only the CSPs that still demand a value in that state are
  raised to the `autoScalingOffNodeSize` floor in `assets/k8sclusterinfo.yaml`.

- **Invalid input is now rejected.** A non-boolean `onAutoScaling` (e.g. `"yes"`), a negative
  size, or `min > max` returns an error. A value like `"yes"` used to pass through and be recorded as `true`
  on CB-Tumblebug's behalf.

- **Behavior change:** setting `onAutoScaling: "true"` **explicitly now requires Min/Max**. Picking
  a scaling range on the caller's behalf is not CB-Tumblebug's call. Omitting `onAutoScaling`
  keeps the previous behavior - `onAutoScaling: "true"` with Min/Max of `1`/`2`.
  Requiring Min/Max whenever `onAutoScaling: true` is the eventual goal; it is deferred out of
  consideration for existing API users.

- **Verified against live CSPs** with `onAutoScaling: "false"`: every affected CSP was covered.

</details>

Fixes #2767